### PR TITLE
on deploy, remove any existing manifest.yml symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ push: require_env_stub ## push the Docker image to Docker Hub
 	docker push $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)
 
 deploy: require_env_stub ## Deploy the docker image to gov.uk PaaS
+	ls -l ./manifest.yml && rm ./manifest.yml
 	ln -s ./config/manifests/$(env_stub)-manifest.yml ./manifest.yml
 	cf push $(APP_NAME)-$(env_stub) --docker-image $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)
 	rm ./manifest.yml


### PR DESCRIPTION
### Context

In the `deploy` make task, if the `cf push` fails for any reason, the temporary `manifest.yml` symlink will remain, making any subsequent `deploy` fail until it's manually removed.

### Changes proposed in this pull request

in the deploy task, test to see if manifest.yml exists, and unlink it if it does

### Guidance to review

