### PR TITLE
Fix issue with all/none links showing instead of checkboxes on paginated pages

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,11 +2,9 @@ require.context('govuk-frontend/govuk/assets');
 
 import '../styles/application.scss';
 import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
 Rails.start();
-Turbolinks.start();
 initAll();
 
 require('jquery')

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "jquery": "3.5.1",
     "rails-ujs": ">=5.2.4",
     "serialize-javascript": ">=3.0.0",
-    "set-value": ">=3.0.2",
-    "turbolinks": ">=5.2.0"
+    "set-value": ">=3.0.2"
   },
   "devDependencies": {
     "webpack-dev-server": ">=3.11.0"

--- a/spec/features/mno/mno_recipients_spec.rb
+++ b/spec/features/mno/mno_recipients_spec.rb
@@ -84,4 +84,21 @@ RSpec.feature 'MNO Requests view', type: :feature do
       expect_download(content_type: 'text/csv')
     end
   end
+
+  context 'with multiple pages of recipients' do
+    before do
+      create_list(:recipient, 25, status: 'requested', mobile_network: mno_user.mobile_network)
+      sign_in_as mno_user
+      click_on 'Your requests'
+    end
+
+    it 'shows pagination' do
+      expect(page).to have_link('Next')
+    end
+
+    it 'shows all/none checkbox when on subsequent pages' do
+      click_on('Next')
+      expect { page.find('input#all-rows') }.not_to raise_error(Capybara::ElementNotFound)
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,7 +3922,7 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.5.1:
+jquery@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
@@ -7118,11 +7118,6 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
-
-turbolinks@>=5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
### Context

Testing showed that after clicking a pagination link, the all/none links were shown rather than the checkbox. Investigation showed that the `$(document).ready` event was not firing after clicking a link, but was fine when you refresh the page.

### Changes proposed in this pull request

Fix the problem by removing turbolinks

### Guidance to review

