### PR TITLE
Make pagination look like Find  / gov.uk

### DIFF
--- a/app/views/mno/recipients/index.html.erb
+++ b/app/views/mno/recipients/index.html.erb
@@ -9,16 +9,6 @@
 <% else %>
   <%= govuk_button_link_to 'Download requests as CSV', sort: params[:sort], dir: params[:dir], format: :csv %>
 
-  <div class="govuk-body govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <span class="pagination-item-count">
-        <%= pagy_info(@pagination, "requests").html_safe %>
-      </span>
-      <%- if @pagination.pages > 1 %>
-        <%= pagy_nav(@pagination).html_safe %>
-      <%- end %>
-    </div>
-  </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= form_for @recipients_form, url: bulk_update_mno_recipients_path, method: :put do |f| %>
@@ -67,6 +57,11 @@
           <%= f.govuk_submit 'Update' %>
         </div>
       <% end %>
+    </div>
+  </div>
+  <div class="govuk-body govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_next_page.html.erb
+++ b/app/views/shared/_next_page.html.erb
@@ -1,0 +1,13 @@
+<li class="pub-c-pagination__item pub-c-pagination__item--next">
+  <%- next_link = request.parameters.merge( pagination.vars[:page_param] => pagination.next ) %>
+  <%= link_to next_link, rel: 'next', remote: remote, class: "pub-c-pagination__link govuk-link" do %>
+    <span class="pub-c-pagination__link-title">
+      Next page
+      <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+        <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg>
+    </span>
+    <span class="govuk-visually-hidden">:</span>
+    <span class="pub-c-pagination__link-label"><%= pagination.page + 1 %> of <%= pagination.pages %></span>
+  <% end %>
+</li>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,0 +1,6 @@
+<nav class="pub-c-pagination" role="navigation" aria-label="Pagination">
+  <ul class="pub-c-pagination__list">
+    <%= render partial: 'shared/prev_page', locals: {pagination: local_assigns[:pagination], remote: local_assigns[:remote]} if pagination.prev.present? %>
+    <%= render partial: 'shared/next_page', locals: {pagination: local_assigns[:pagination], remote: local_assigns[:remote]} if pagination.next.present? %>
+  </ul>
+</nav>

--- a/app/views/shared/_prev_page.html.erb
+++ b/app/views/shared/_prev_page.html.erb
@@ -1,0 +1,13 @@
+<li class="pub-c-pagination__item pub-c-pagination__item--previous">
+  <%- prev_link = request.parameters.merge( pagination.vars[:page_param] => pagination.prev) %>
+  <%= link_to prev_link, rel: 'prev', remote: remote, class: "pub-c-pagination__link govuk-link" do %>
+    <span class="pub-c-pagination__link-title">
+      <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+        <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+      </svg>
+      Previous page
+    </span>
+    <span class="govuk-visually-hidden">:</span>
+    <span class="pub-c-pagination__link-label"><%= pagination.page - 1 %> of <%= pagination.pages %></span>
+  <% end %>
+</li>

--- a/app/webpacker/styles/pagination.scss
+++ b/app/webpacker/styles/pagination.scss
@@ -1,6 +1,100 @@
-.pagination-item-count {
-  float: left;
+// TODO rewrite this to use more of GOVUK Frontend  mixin and styling
+
+.pub-c-pagination {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: -15px;
+  margin-right: -15px;
 }
-.pagination {
+
+.pub-c-pagination__list {
+  margin: 0;
+  padding: 0;
+}
+
+.pub-c-pagination__list:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.pub-c-pagination__item {
+  font-family: "GDS Transport", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
+  float: left;
+  list-style: none;
+  text-align: right;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+@media (min-width: 641px) {
+  .pub-c-pagination__item {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+.pub-c-pagination__link {
+  display: block;
+  padding: 15px;
+  text-decoration: none;
+}
+
+.pub-c-pagination__link-title {
+  font-family: "GDS Transport", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 20px;
+  line-height: 1.1111111111;
+  display: block;
+}
+
+@media (min-width: 641px) {
+  .pub-c-pagination__link-title {
+    font-size: 27px;
+    line-height: 1.25;
+  }
+}
+
+.pub-c-pagination__item--previous {
+  float: left;
+  text-align: left;
+}
+
+@media (max-width: 640px) {
+  .pub-c-pagination__item--previous {
+    float: none;
+    width: 100%;
+  }
+}
+
+.pub-c-pagination__item--next {
   float: right;
+  text-align: right;
+}
+
+@media (max-width: 640px) {
+  .pub-c-pagination__item--next {
+    float: none;
+    width: 100%;
+  }
+}
+
+.pub-c-pagination__link-icon {
+  display: inline-block;
+  margin-bottom: 1px;
+  height: 0.482em;
+  width: 0.63em;
+}
+
+.pub-c-pagination__link-label {
+  display: inline-block;
+  margin-top: 0.1em;
+  text-decoration: underline;
 }

--- a/spec/features/mno/mno_recipients_spec.rb
+++ b/spec/features/mno/mno_recipients_spec.rb
@@ -98,7 +98,7 @@ RSpec.feature 'MNO Requests view', type: :feature do
 
     it 'shows all/none checkbox when on subsequent pages' do
       click_on('Next')
-      expect { page.find('input#all-rows') }.not_to raise_error(Capybara::ElementNotFound)
+      expect { page.find('input#all-rows') }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### Context

The default pagination provided by Pagy's helpers looks very ... default pagination, and not in -keeping with other gov.uk sites like Find Postgraduate Teacher Training (and gov.uk itself)

### Changes proposed in this pull request

Make pagination look like other gov.uk sites

Before:

<img width="1025" alt="Screen Shot 2020-06-18 at 23 27 05" src="https://user-images.githubusercontent.com/134501/85077919-42722900-b1bb-11ea-98d6-b9387951075e.png">

After:

<img width="1039" alt="Screen Shot 2020-06-18 at 23 23 24" src="https://user-images.githubusercontent.com/134501/85077785-04750500-b1bb-11ea-88e0-d40a2ce7a783.png">


### Guidance to review

The default number of items per page is 20. You'll need to create more than 20 recipients for your MNO user (with `FakeDataService.generate!`) and/or pass a lower number as a param (say `&items=4`)
