### PR TITLE
Add FeatureFlag service & implement static_guidance_only feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-  before_action :populate_user_from_session!
+  before_action :populate_user_from_session!, :check_static_guidance_only_feature_flag!
 
   include Pagy::Backend
 
@@ -29,5 +29,11 @@ private
     session[:return_url] = request.url
     flash[:error] = 'You must sign in to access that page'
     redirect_to new_sign_in_token_path
+  end
+
+  def check_static_guidance_only_feature_flag!
+    if FeatureFlag.active?(:static_guidance_only)
+      render 'errors/not_found', status: :not_found unless request.path == guidance_page_path
+    end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,0 +1,29 @@
+class FeatureFlag
+  PERMANENT_SETTINGS = %i[
+    static_guidance_only
+  ].freeze
+
+  TEMPORARY_FEATURE_FLAGS = %i[
+
+  ].freeze
+
+  FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
+
+  def self.activate(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV["FEATURES[#{feature_name}]"] = 'active'
+  end
+
+  def self.deactivate(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV["FEATURES[#{feature_name}]"] = 'inactive'
+  end
+
+  def self.active?(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV["FEATURES[#{feature_name}]"] == 'active'
+  end
+end

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,19 +1,23 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-  <%- if @user && @user.is_dfe? %>
-
-  <%- elsif @user && @user.is_mno_user? %>
-    <%= nav_item( title: "Your requests", url: mno_recipients_path )  %>
-  <%- else %>
+  <%- if FeatureFlag.active?(:static_guidance_only) %>
     <%= nav_item( title: "Guidance", url: '/pages/guidance' )  %>
+  <%- else %>
+    <%- if @user && @user.is_dfe? %>
+
+    <%- elsif @user && @user.is_mno_user? %>
+      <%= nav_item( title: "Your requests", url: mno_recipients_path )  %>
+    <%- else %>
+      <%= nav_item( title: "Guidance", url: '/pages/guidance' )  %>
       <%= nav_item( title: "Tell us how many eligible young people you know about", url: new_allocation_request_form_path )  %>
       <%= nav_item( title: "Tell us about an eligible young person", url: new_application_form_path )  %>
-  <%- end %>
+    <%- end %>
 
-  <%- if session[:user_id].present? %>
-    <%- sign_out_link = link_to("Sign out", session_path(id: session.id), method: :delete, class: 'govuk-header__link' ) %>
-    <%- content = [ @user.email_address, sign_out_link].join(' | ') %>
-    <%= nav_item(url: session_path(id: session.id), content: content.html_safe) %>
-  <%- else %>
-      <%= nav_item( title: "Sign in", url: sign_in_path )  %>
+    <%- if session[:user_id].present? %>
+      <%- sign_out_link = link_to("Sign out", session_path(id: session.id), method: :delete, class: 'govuk-header__link' ) %>
+      <%- content = [ @user.email_address, sign_out_link].join(' | ') %>
+      <%= nav_item(url: session_path(id: session.id), content: content.html_safe) %>
+    <%- else %>
+        <%= nav_item( title: "Sign in", url: sign_in_path )  %>
+    <%- end %>
   <%- end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get '/pages/:guidance', to: 'pages#guidance'
+  get '/pages/guidance', to: 'pages#guidance', as: :guidance_page
 
   resources :application_forms do
     get 'success/:application_form_id', to: 'application_forms#success', as: :success

--- a/spec/features/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/static_guidance_only_feature_flag_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'Static Guidance Only feature flag', type: :feature do
+  context 'with the static_guidance_only feature flag set' do
+    before do
+      FeatureFlag.activate(:static_guidance_only)
+    end
+
+    scenario 'visiting the guidance page works' do
+      visit guidance_page_path
+      expect(page).to have_http_status(:ok)
+      expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+    end
+
+    scenario 'visiting any other page returns a 404' do
+      visit sign_in_path
+      expect(page).to have_http_status(:not_found)
+      expect(page).to have_selector 'h1', text: 'The page you were looking for doesn\'t exist'
+    end
+  end
+
+  context 'with the static_guidance_only feature flag NOT set' do
+    before do
+      FeatureFlag.deactivate(:static_guidance_only)
+    end
+
+    scenario 'visiting the guidance page works' do
+      visit guidance_page_path
+      expect(page).to have_http_status(:ok)
+      expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+    end
+
+    scenario 'visiting any other page works' do
+      visit sign_in_path
+      expect(page).to have_http_status(:ok)
+      expect(page).to have_selector 'h1', text: 'Sign in'
+    end
+  end
+end

--- a/spec/features/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/static_guidance_only_feature_flag_spec.rb
@@ -17,6 +17,11 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
       expect(page).to have_http_status(:not_found)
       expect(page).to have_selector 'h1', text: 'The page you were looking for doesn\'t exist'
     end
+
+    scenario 'Other nav links are not shown' do
+      visit guidance_page_path
+      expect(page).not_to have_text 'Sign in'
+    end
   end
 
   context 'with the static_guidance_only feature flag NOT set' do
@@ -34,6 +39,11 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
       visit sign_in_path
       expect(page).to have_http_status(:ok)
       expect(page).to have_selector 'h1', text: 'Sign in'
+    end
+
+    scenario 'Other nav links are shown' do
+      visit guidance_page_path
+      expect(page).to have_text 'Sign in'
     end
   end
 end


### PR DESCRIPTION
### Context

Since hitting the headlines last week & soft-launching a pilot, we are getting an increasing number of mails to support. We need to be able to launch some static guidance on a live URL ASAP, and that URL should not change later when the full app is launched. 

In order to minimize the risk of putting an application live that has not yet gone through the full governance cycle, we need to have a feature flag mechanism that allows us to ensure that only the static guidance page is reachable on prod.

### Changes proposed in this pull request

1. Add FeatureFlag service with an MVP backend based around environment variables
2. Add `static_guidance_only` feature flag that disables all URLs except the guidance page.
3. Add feature spec to make sure this behaviour works as intended

### Guidance to review

1. Start your local Rails server with the environment variable `FEATURES[static_guidance_only]=active`, e.g. `FEATURES[static_guidance_only]=active  bundle exec rails s -p (port)`
2. Visit '/'
You should only see the guidance page, with no other links in the navbar
3. Try hitting any other valid URL directly (e.g. /sign_in)
You should get a 404

Without the feature flag set:

<img width="978" alt="Screen Shot 2020-06-19 at 00 18 27" src="https://user-images.githubusercontent.com/134501/85080938-71d86400-b1c2-11ea-8649-966829921f4d.png">

With the feature flag set:

<img width="809" alt="Screen Shot 2020-06-19 at 00 19 50" src="https://user-images.githubusercontent.com/134501/85081032-bbc14a00-b1c2-11ea-8674-fef971c4b304.png">
