### PR TITLE
port SHOW_DEBUG_INFO behaviour to use a FeatureFlag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,31 @@ bundle exec brakeman
 3. Run `make (dev|staging|prod) build push deploy` to build, push and deploy the Docker image to Gov.uk PaaS
 
 The app should be available at https://get-help-with-tech-(dev|staging|prod).london.cloudapps.digital
+
+## Feature Flags
+
+Certain aspects of app behaviour are governed by a minimal implementation of Feature Flags.
+These are activated by having an environment variable FEATURES_(flag name) set to 'active', for example:
+
+```
+# start the rails server with debug info rendered into the footer
+FEATURES_show_debug_info=active bundle exec rails s
+```
+
+The available flags are listed in `app/services/feature_flag.rb`, and available in the constant `FeatureFlag::FEATURES`. Each one is tested with a dedicated spec in `spec/features/feature_flags/`.
+
+To set / unset environment variables on Gov.uk PaaS, use the commands:
+
+```
+# set an env var
+cf set-env (app name) (environment variable name) (value)
+
+# For example:
+cf set-env get-help-with-tech-prod FEATURES_show_debug_info active
+
+# To unset the var:
+cf unset-env (app name) (environment variable name)
+
+# For example:
+cf unset-env get-help-with-tech-prod FEATURES_show_debug_info
+```

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,7 @@
 class FeatureFlag
   PERMANENT_SETTINGS = %i[
     http_basic_auth
+    show_debug_info
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <%- if ENV['SHOW_DEBUG_INFO'] %>
+            <%- if FeatureFlag.active?(:show_debug_info) %>
               <%= render partial: 'layouts/debug' %>
             <%- end %>
 

--- a/spec/features/feature_flags/show_debug_info_spec.rb
+++ b/spec/features/feature_flags/show_debug_info_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Show debug info feature flag', type: :feature do
+  context 'with the show_debug_info feature flag active' do
+    before do
+      FeatureFlag.activate(:show_debug_info)
+      visit '/'
+    end
+
+    it 'renders the session into the footer' do
+      within('footer') { expect(page).to have_content 'Session' }
+    end
+  end
+
+  context 'with the show_debug_info feature flag inactive' do
+    before do
+      FeatureFlag.deactivate(:show_debug_info)
+      visit '/'
+    end
+
+    it 'does not render the session into the footer' do
+      within('footer') { expect(page).not_to have_content 'Session' }
+    end
+  end
+end


### PR DESCRIPTION
### Context

We've been using an env var SHOW_DEBUG_INFO as a temporary way to render the session & sign-in links into the footer during development. Now we have an actual FeatureFlag implementation, it should use that.

### Changes proposed in this pull request

1. replace the SHOW_DEBUG_INFO with a show_debug_info FeatureFlag
2. add feature_flag spec for the behaviour
3. add a section to the README about FeatureFlags and how to set them locally and on PaaS

### Guidance to review

