### PR TITLE
Make sign_in_tokens expire after 30 mins by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,13 @@ bundle exec brakeman
 3. Run `make (dev|staging|prod) build push deploy` to build, push and deploy the Docker image to Gov.uk PaaS
 
 The app should be available at https://get-help-with-tech-(dev|staging|prod).london.cloudapps.digital
+
+## Environment variables
+
+Some values are configurable with environment variables:
+
+Name|Description|Default
+----|-----------|-------
+SIGN_IN_TOKEN_TTL_SECONDS|Sign-in tokens will expire after this many seconds|600
+HTTP_BASIC_AUTH_USERNAME|Username for HTTP Basic authentication - only has an effect if the `http_basic_auth` FeatureFlag is set|(nil)
+HTTP_BASIC_AUTH_PASSWORD|Password for HTTP Basic authentication - only has an effect if the `http_basic_auth` FeatureFlag is set|(nil)

--- a/app/concerns/sign_in_with_token.rb
+++ b/app/concerns/sign_in_with_token.rb
@@ -5,7 +5,7 @@ module SignInWithToken
     validates :sign_in_token, uniqueness: true, allow_nil: true
 
     def generate_token!(ttl: nil)
-      ttl ||= (ENV['SIGN_IN_TOKEN_TTL_SECONDS'] || 600)
+      ttl ||= (ENV['SIGN_IN_TOKEN_TTL_SECONDS'] || 1800)
 
       update!(
         sign_in_token: SecureRandom.uuid,

--- a/app/concerns/sign_in_with_token.rb
+++ b/app/concerns/sign_in_with_token.rb
@@ -4,13 +4,26 @@ module SignInWithToken
   included do
     validates :sign_in_token, uniqueness: true, allow_nil: true
 
-    def generate_token!
-      update!(sign_in_token: SecureRandom.uuid)
+    def generate_token!(ttl: nil)
+      ttl ||= (ENV['SIGN_IN_TOKEN_TTL_SECONDS'] || 600)
+
+      update!(
+        sign_in_token: SecureRandom.uuid,
+        sign_in_token_expires_at: Time.now.utc + ttl.seconds,
+      )
       sign_in_token
     end
 
+    def token_is_valid?(token:, identifier:)
+      [
+        token == sign_in_token,
+        (sign_in_token_expires_at.present? && sign_in_token_expires_at >= Time.now.utc),
+        identifier == sign_in_identifier(token),
+      ].all?
+    end
+
     def clear_token!
-      update!(sign_in_token: nil)
+      update!(sign_in_token: nil, sign_in_token_expires_at: nil)
     end
 
     def sign_in_identifier(token)

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -14,7 +14,7 @@ class SessionService
 
   def self.validate_token!(token:, identifier:)
     user = User.where(sign_in_token: token).first
-    if user && user.sign_in_identifier(token) == identifier
+    if user && user.token_is_valid?(token: token, identifier: identifier)
       user.clear_token!
       user
     else

--- a/db/migrate/20200620124213_add_sign_in_token_expires_at_to_user.rb
+++ b/db/migrate/20200620124213_add_sign_in_token_expires_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddSignInTokenExpiresAtToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :sign_in_token_expires_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_114104) do
+ActiveRecord::Schema.define(version: 2020_06_20_124213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2020_06_16_114104) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "sign_in_token"
     t.integer "mobile_network_id"
+    t.datetime "sign_in_token_expires_at"
     t.index ["dfe_sign_in_id"], name: "index_users_on_dfe_sign_in_id"
     t.index ["email_address"], name: "index_users_on_email_address"
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -2,25 +2,40 @@ require 'rails_helper'
 
 RSpec.feature 'Sign-in token behaviour', type: :feature do
   let(:user) { create(:local_authority_user) }
-  let(:token) { user.generate_token! }
+  let(:ttl) { nil }
+  let(:token) { user.generate_token!(ttl: ttl) }
   let(:identifier) { user.sign_in_identifier(token) }
 
   context 'with a valid sign_in_token link' do
     let(:validate_token_url) { validate_sign_in_token_url(token: token, identifier: identifier) }
 
-    scenario 'Visiting a valid sign_in_token link signs the user in' do
-      visit validate_token_url
-      expect(page).to have_text(user.email_address)
-      expect(page).to have_text('Sign out')
+    context 'that has not expired' do
+      let(:ttl) { 3600 }
+
+      scenario 'Visiting a valid sign_in_token link signs the user in' do
+        visit validate_token_url
+        expect(page).to have_text(user.email_address)
+        expect(page).to have_text('Sign out')
+      end
+
+      scenario 'Visiting a sign_in_token link twice does not work the second time' do
+        visit validate_token_url
+        click_on 'Sign out'
+
+        visit validate_token_url
+        expect(page).to have_http_status(:bad_request)
+        expect(page).not_to have_text('Sign out')
+      end
     end
 
-    scenario 'Visiting a sign_in_token link twice does not work the second time' do
-      visit validate_token_url
-      click_on 'Sign out'
+    context 'that has expired' do
+      let(:ttl) { -1 }
 
-      visit validate_token_url
-      expect(page).to have_http_status(:bad_request)
-      expect(page).not_to have_text('Sign out')
+      scenario 'Visiting a valid sign_in_token link after it expires does not sign the user in' do
+        visit validate_token_url
+        expect(page).to have_http_status(:bad_request)
+        expect(page).not_to have_text('Sign out')
+      end
     end
   end
 


### PR DESCRIPTION
### Context

See [Trello card](https://trello.com/c/3tRtyZrZ/121-make-signintokens-time-limited)

### Changes proposed in this pull request

Make sign_in_tokens expire after 10 mins by default. 
Add option to set a different expiry period via env var
Add spec for expiry/non-expiry behaviour

### Guidance to review

1. Generate a sign-in token by clicking 'Sign in' and entering your email address. Copy the sign-in URL from the footer
2. From the console, check that `sign_in_token_expires_at` is set correctly (`User.where(email_address: '...').sign_in_token_expires_at`)
3. Wait until that expires (or update it from the console), and then try and use the sign-in token URL - it should not work


4.
