### PR TITLE
Expire sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,6 @@ private
     if SessionService.is_signed_in?(session)
       @user = User.find(session[:user_id])
       SessionService.update_session!(session[:session_id])
-    else
-      byebug
     end
     @user ||= User.new
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,8 @@ private
     if SessionService.is_signed_in?(session)
       @user = User.find(session[:user_id])
       SessionService.update_session!(session[:session_id])
+    else
+      byebug
     end
     @user ||= User.new
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,22 +13,20 @@ class ApplicationController < ActionController::Base
 private
 
   def populate_user_from_session!
-    @user = User.find(session[:user_id]) if is_signed_in?
+    if SessionService.is_signed_in?(session)
+      @user = User.find(session[:user_id])
+      SessionService.update_session!(session[:session_id])
+    end
     @user ||= User.new
   end
 
   def save_user_to_session!(user = @user)
-    session[:user_id] ||= user.id if user.present?
-  end
-
-  def is_signed_in?
-    session[:user_id].present?
+    session[:user_id] ||= user.id
+    SessionService.create_session!(session[:session_id])
   end
 
   def require_sign_in!
-    unless is_signed_in?
-      redirect_to_sign_in
-    end
+    redirect_to_sign_in unless SessionService.is_signed_in?(session)
   end
 
   def redirect_to_sign_in

--- a/app/controllers/mno/base_controller.rb
+++ b/app/controllers/mno/base_controller.rb
@@ -4,7 +4,7 @@ class Mno::BaseController < ApplicationController
 private
 
   def require_mno_user!
-    if is_signed_in?
+    if SessionService.is_signed_in?(session)
       render 'errors/forbidden', status: :forbidden unless @user.is_mno_user?
     else
       redirect_to_sign_in

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   def destroy
+    SessionService.destroy_session!(session[:session_id])
     reset_session
     request.env['HTTP_COOKIE'] = nil
     flash.notice = 'You have signed out succesfully'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 module ApplicationHelper
   include Pagy::Frontend
 
+  delegate :is_signed_in?, to: :controller
+
   def browser_title
     page_browser_title = content_for(:browser_title).presence || content_for(:title)
     [page_browser_title, t('service_name'), 'GOV.UK'].select(&:present?).join(' - ')

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,13 @@
+class Session < ApplicationRecord
+  DEFAULT_SESSION_TTL_SECONDS = 3600
+
+  def expired?
+    updated_at.nil? \
+    || (updated_at.utc + ttl.seconds) < Time.now.utc
+  end
+
+  def ttl
+    (ENV['SESSION_TTL_SECONDS'] || \
+      DEFAULT_SESSION_TTL_SECONDS).to_i
+  end
+end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -37,7 +37,16 @@ class SessionService
 
   def self.validate_session!(session_id)
     db_session = Session.where(id: session_id).first
-    db_session && !db_session.expired?
+    if db_session
+      if db_session.expired?
+        destroy_session!(session_id)
+        false
+      else
+        true
+      end
+    else
+      false
+    end
   end
 
   def self.create_session!(session_id)

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -30,4 +30,25 @@ class SessionService
   def self.find_user_by_email(email_address)
     User.where(email_address: email_address).first
   end
+
+  def self.is_signed_in?(session)
+    session[:user_id].present? && validate_session!(session[:session_id])
+  end
+
+  def self.validate_session!(session_id)
+    db_session = Session.where(id: session_id).first
+    db_session && !db_session.expired?
+  end
+
+  def self.create_session!(session_id)
+    Session.create!(id: session_id)
+  end
+
+  def self.update_session!(session_id)
+    Session.where(id: session_id).update_all(updated_at: Time.now.utc)
+  end
+
+  def self.destroy_session!(session_id)
+    Session.where(id: session_id).destroy_all
+  end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,8 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<% content_for :title, 'Sorry, there is a problem with the service' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Try again later.</p>
   </div>
-</main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,9 +1,13 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
-      <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<% content_for :title, 'Page not found' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Page not found</h1>
+    <p class="govuk-body">
+      If you typed the web address, check it is correct.
+    </p>
+    <p class="govuk-body">
+      If you pasted the web address, check you copied the entire address.
+    </p>
   </div>
-</main>
+</div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -12,8 +12,8 @@
       <%= nav_item( title: "Tell us about an eligible young person", url: new_application_form_path )  %>
     <%- end %>
 
-    <%- if session[:user_id].present? %>
-      <%- sign_out_link = link_to("Sign out", session_path(id: session.id), method: :delete, class: 'govuk-header__link' ) %>
+    <%- if SessionService.is_signed_in?(session) %>
+      <%- sign_out_link = link_to("Sign out", session_path(id: session[:session_id]), method: :delete, class: 'govuk-header__link' ) %>
       <%- content = [ @user.email_address, sign_out_link].join(' | ') %>
       <%= nav_item(url: session_path(id: session.id), content: content.html_safe) %>
     <%- else %>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,34 +1,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Increasing children’s internet&nbsp;access
+      Increasing internet access for vulnerable and disadvantaged children
     </h1>
 
     <p class="govuk-body-l">
-      We know internet access supports remote education, as well as virtual meetings between children and their social workers. That’s why we’re providing laptops, tablets and 4G wireless routers to disadvantaged families. (There’s more about this on <%= govuk_link_to 'GOV.UK', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.)
+      Internet access supports remote education, as well as virtual contact between children, their social workers and other services.
     </p>
     <p class="govuk-body-l">
-      We also know some children don’t have reliable internet access. That’s why we’re now acting to change this.
+      We know that many children don’t have reliable internet access, and we’re acting to change this.
     </p>
     <h2 class="govuk-heading-l">
-      How we’re improving children’s internet access
+      We’re giving children free access to wifi hotspots
     </h2>
     <p class="govuk-body">
-      The Department for Education has teamed up with BT and mobile network operators to improve children’s internet access in two different ways:
+      The Department for Education has teamed up with BT to give children and young people free access to BT wifi hotspots. If they live in range of a BT hotspot, their school will give them log-in details to access the network.
     </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        We’re giving them free access to BT wifi hotspots. BT will create a set of profiles that young people can activate through name/password combinations.
-      </li>
-      <li>
-        For anyone who can’t connect to a BT hotspot, we plan to boost data allowances on their mobile devices so they can access the internet without incurring data charges.
-      </li>
-    </ul>
     <h2 class="govuk-heading-l">
       Who can get help
     </h2>
     <p class="govuk-body">
-      Increased internet access is available to children from early years up to 16, and care leavers up to 25 if they:
+      Increased internet access is available to families with children from early years up to 16, and care leavers up to 25 if they:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
@@ -39,34 +31,65 @@
       </li>
     </ul>
     <h2 class="govuk-heading-l">
-      Accessing BT hotspots
+      How the scheme works
     </h2>
     <p class="govuk-body">
-      The Department for Education has allocated a number of BT hotspot profiles to trusts and local authorities.
+      At the moment, we’re trialling the scheme. We’ve asked a small number of local authorities and academy trusts to let us know who needs connectivity support and who can access a BT wifi hotspot.
     </p>
     <p class="govuk-body">
-      Once trusts and local authorities confirm they want these, they’ll receive profile details which they can pass on to schools to distribute.
+      Once we get this information, we’ll allocate a suitable number of hotspot accounts for local authorities and academy trusts to distribute to schools and families.
     </p>
     <p class="govuk-body">
-      Schools should only distribute the profiles to eligible young people who have access to BT hotspots.
-    </p>
-    <p class="govuk-body">
-      If trusts and local authorities think their initial allocation isn’t sufficient, they can request more.
+      We hope to make this scheme available to more families across England in the coming months.
     </p>
     <h2 class="govuk-heading-l">
-      There’s technical support
+      How schools, local authorities and trusts can get involved
     </h2>
     <p class="govuk-body">
-      BT are offering technical support to young people using the hotspots.
+      We know this support is needed urgently, and we plan to make it available to everyone as soon as we can. We’ll be in touch when we’re ready to bring you on board.
     </p>
     <p class="govuk-body">
-      Their free help desk is open from 8am until 8pm on 0800 587 9983.
+      In the meantime, you can prepare by:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        identifying who needs help
+      </li>
+      <li>
+        finding out if those who need help can access a BT hotspot
+      </li>
+    </ul>
+    <p class="govuk-body">
+      You can see hotspot coverage by:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        doing a postcode check on <%= govuk_link_to 'https://www.btwifi.com/find/', 'https://www.btwifi.com/find/' %>, or
+      </li>
+      <li>
+        checking whether BT wifi is an available network at home (this will appear as BTWi-fi when you look at available networks on your device)
+      </li>
+    </ul>
+    <h2 class="govuk-heading-l">
+      How individuals can get involved
+    </h2>
+    <p class="govuk-body">
+      If you don’t have access to a fixed line broadband connection at home and you need help to access remote education or social care, please find out what support is currently available.
+    </p>
+    <p class="govuk-body">
+      If you’re at school, talk to your school. If you have a social worker, talk to your social care team.
     </p>
     <h2 class="govuk-heading-l">
-      For young people who can’t connect to BT hotspots
+      There’s also support for those who can’t access hotspots
     </h2>
     <p class="govuk-body">
-      We want to support young people who can’t connect to a BT hotspot. One possible solution is increasing data allowances on young people’s mobile devices so they can access the internet without incurring data charges. There will be more information about this once we confirm our plans.
+      Hotspot coverage varies across the country, so we’re also working with telecommunications companies to explore how to increase internet access for children and young people who rely on mobile data to connect to the internet at home.
+    </p>
+    <h2 class="govuk-heading-l">
+      If you have questions
+    </h2>
+    <p class="govuk-body">
+      If you have any questions, email <%= govuk_link_to 'COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk?subject=Increasing%20internet%20access' %> using the subject line ‘Increasing internet access’.
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  service_name: Increasing children’s internet access
+  service_name: Increasing internet access for vulnerable and disadvantaged children
   page_titles:
     sign_in: Sign in
     check_your_email: Check your email

--- a/db/migrate/20200622133205_create_sessions.rb
+++ b/db/migrate/20200622133205_create_sessions.rb
@@ -1,0 +1,8 @@
+class CreateSessions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sessions, id: false do |t|
+      t.string :id, unique: true, primary_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_20_124213) do
+ActiveRecord::Schema.define(version: 2020_06_22_133205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,11 @@ ActiveRecord::Schema.define(version: 2020_06_20_124213) do
     t.string "status"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_recipients_on_mobile_network_id_and_status_and_created_at"
     t.index ["status"], name: "index_recipients_on_status"
+  end
+
+  create_table "sessions", id: :string, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/allocation_request_forms_controller_spec.rb
+++ b/spec/controllers/allocation_request_forms_controller_spec.rb
@@ -27,6 +27,8 @@ describe AllocationRequestFormsController, type: :controller do
     context 'with valid params and no existing user in session' do
       before do
         session.delete(:user)
+        # TestSession doesn't create this automatically like a real session
+        session[:session_id] = SecureRandom.uuid
       end
 
       it 'creates a user' do

--- a/spec/features/feature_flags/http_basic_auth_spec.rb
+++ b/spec/features/feature_flags/http_basic_auth_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'HTTP Basic Auth feature flag', type: :feature do
     scenario 'visiting the root url requires basic auth' do
       visit '/'
       expect(page).to have_http_status(:unauthorized)
-      expect(page).not_to have_selector 'h1', text: 'Increasing children’s internet access'
+      expect(page).not_to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.feature 'HTTP Basic Auth feature flag', type: :feature do
     scenario 'visiting the root url does not require basic auth' do
       visit '/'
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+      expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
     end
   end
 end

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting any other page returns a 404' do
       visit sign_in_path
       expect(page).to have_http_status(:not_found)
-      expect(page).to have_selector 'h1', text: 'The page you were looking for doesn\'t exist'
+      expect(page).to have_selector 'h1', text: 'Page not found'
     end
 
     scenario 'Other nav links are not shown' do

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting the guidance page works' do
       visit guidance_page_path
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+      expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
     end
 
     scenario 'visiting any other page returns a 404' do
@@ -32,7 +32,7 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting the guidance page works' do
       visit guidance_page_path
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+      expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
     end
 
     scenario 'visiting any other page works' do

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -35,6 +35,22 @@ RSpec.feature 'Session behaviour', type: :feature do
       expect(page).to have_text('Sign out')
     end
 
+    context 'when the session expires between requests' do
+      before do
+        ENV['SESSION_TTL_SECONDS'] = '1'
+      end
+
+      scenario 'visiting with a valid but expired session logs the user out' do
+        visit new_application_form_path
+        fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
+        click_on 'Continue'
+
+        sleep(2)
+        click_on 'Tell us about another child or young person'
+        expect(page).to have_text('Sign in')
+      end
+    end
+
     scenario 'clicking "Sign out" signs the user out' do
       visit new_application_form_path
       fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     scenario 'it redirects to the guidance page' do
       visit(validate_token_url)
       expect(page).to have_current_path('/pages/guidance')
-      expect(page).to have_text 'Increasing children’s internet access'
+      expect(page).to have_text 'Increasing internet access for vulnerable and disadvantaged children'
     end
   end
 

--- a/spec/features/submitting_an_allocation_request_form_spec.rb
+++ b/spec/features/submitting_an_allocation_request_form_spec.rb
@@ -27,5 +27,6 @@ RSpec.feature 'Submitting an allocation_request_form', type: :feature do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_text('Thank you')
+    expect(page).to have_text('Sign out')
   end
 end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.feature 'View pages', type: :feature do
   scenario 'Root URL should be the guidance page' do
     visit '/'
-    expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+    expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
   end
 
   scenario 'Navigate to guidance page' do
     visit '/pages/guidance'
 
     expect(page).to have_http_status(:ok)
-    expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
+    expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
   end
 end


### PR DESCRIPTION
### Context

Currently browser-cookie-based sessions will expire when and only when the user closes their browser window. This means a session could potentially last forever.

We should expire sessions when the user has not visited a page after a certain time - say, 1hr by default. This should also be configurable by env var.

### Changes proposed in this pull request

Create a session record in the DB so that we can track last visit time reliably on the server
Refactor the SessionService to take more of the management of sessions out of the controllers
Add specs for desired behaviour

### Guidance to review

1. Start the server with an env var `SESSION_TTL_SECONDS` set to a short value - say, 5 (for example, `SESSION_TTL_SECONDS=5 FEATURES_show_debug_info=active bundle exec rails server`)

2. Sign in the usual way (magic link in footer)

3. Wait at least (SESSION_TTL_SECONDS) seconds, then refresh the page

4. You should no longer be signed in
