### PR TITLE
Show all static pages when the 'static guidance only' feature flag is on

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ private
 
   def check_static_guidance_only_feature_flag!
     if FeatureFlag.active?(:static_guidance_only)
-      render 'errors/not_found', status: :not_found unless request.path == guidance_page_path
+      render 'errors/not_found', status: :not_found unless controller_name == "pages"
     end
   end
 end

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -6,10 +6,13 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
       FeatureFlag.activate(:static_guidance_only)
     end
 
-    scenario 'visiting the guidance page works' do
+    scenario 'visiting the static guidance pages works' do
       visit guidance_page_path
       expect(page).to have_http_status(:ok)
       expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
+
+      visit '/bt-wifi/privacy-notice'
+      expect(page).to have_http_status(:ok)
     end
 
     scenario 'visiting any other page returns a 404' do


### PR DESCRIPTION
### Context

The privacy notice page doesn't show when 'static guidance only' feature flag is enabled.

### Changes proposed in this pull request

Show all static guidance, not just one particular route.
