### PR TITLE
Make new users pending

### DIFF
--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -8,7 +8,7 @@ class AllocationRequestFormsController < ApplicationController
     begin
       @allocation_request_form.save!
       @user = @allocation_request_form.user
-      save_user_to_session!
+      save_user_to_session! unless SessionService.is_signed_in?(session)
       redirect_to allocation_request_form_success_path(@allocation_request_form.allocation_request.id)
     rescue ActiveModel::ValidationError
       render :new, status: :bad_request

--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -18,7 +18,7 @@ class AllocationRequestFormsController < ApplicationController
   def success
     # NOTE: restful route expects :application_form_id, we're actually using it
     # to retrieve the recipient. Not good, need to refactor
-    @allocation_request_form = AllocationRequestForm.new(user: @user, allocation_request: AllocationRequest.find(params[:allocation_request_form_id]))
+    @allocation_request_form = AllocationRequestForm.new(allocation_request: AllocationRequest.find(params[:allocation_request_form_id]))
   end
 
 private

--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -1,14 +1,14 @@
 class AllocationRequestFormsController < ApplicationController
+  before_action :require_sign_in!
+
   def new
-    @allocation_request_form = AllocationRequestForm.new(user: @user)
+    @allocation_request_form = AllocationRequestForm.new
   end
 
   def create
-    @allocation_request_form = AllocationRequestForm.new(user: @user, params: allocation_request_form_params)
+    @allocation_request_form = AllocationRequestForm.new(allocation_request_form_params.merge(created_by_user: @user))
     begin
       @allocation_request_form.save!
-      @user = @allocation_request_form.user
-      save_user_to_session! unless SessionService.is_signed_in?(session)
       redirect_to allocation_request_form_success_path(@allocation_request_form.allocation_request.id)
     rescue ActiveModel::ValidationError
       render :new, status: :bad_request
@@ -25,9 +25,6 @@ private
 
   def allocation_request_form_params
     params.require(:allocation_request_form).permit(
-      :user_name,
-      :user_email,
-      :user_organisation,
       :number_eligible,
       :number_eligible_with_hotspot_access,
     )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ private
   def redirect_to_sign_in
     session[:return_url] = request.url
     flash[:error] = 'You must sign in to access that page'
-    redirect_to new_sign_in_token_path
+    redirect_to sign_in_path
   end
 
   def check_static_guidance_only_feature_flag!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ private
 
   def check_static_guidance_only_feature_flag!
     if FeatureFlag.active?(:static_guidance_only)
-      render 'errors/not_found', status: :not_found unless controller_name == "pages"
+      render 'errors/not_found', status: :not_found unless controller_name == 'pages'
     end
   end
 end

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -1,17 +1,15 @@
 class ApplicationFormsController < ApplicationController
   before_action :require_sign_in!
-  
+
   def new
-    @application_form = ApplicationForm.new(user: @user)
+    @application_form = ApplicationForm.new
     @mobile_networks = MobileNetwork.order('LOWER(brand)')
   end
 
   def create
-    @application_form = ApplicationForm.new(user: @user, params: application_form_params)
+    @application_form = ApplicationForm.new(application_form_params.merge(created_by_user: @user))
     begin
       @application_form.save!
-      @user = @application_form.user
-      save_user_to_session! unless SessionService.is_signed_in?(session)
       redirect_to application_form_success_path(@application_form.recipient.id)
     rescue ActiveModel::ValidationError
       @mobile_networks = MobileNetwork.order('LOWER(brand)')
@@ -22,21 +20,14 @@ class ApplicationFormsController < ApplicationController
   def success
     # NOTE: restful route expects :application_form_id, we're actually using it
     # to retrieve the recipient. Not good, need to refactor
-    @application_form = ApplicationForm.new(user: @user, recipient: Recipient.find(params[:application_form_id]))
+    @application_form = ApplicationForm.new(recipient: Recipient.find(params[:application_form_id]))
   end
 
 private
 
   def application_form_params
     params.require(:application_form).permit(
-      :user_name,
-      :user_email,
-      :user_organisation,
-      :full_name,
-      :address,
-      :postcode,
       :can_access_hotspot,
-      :is_account_holder,
       :account_holder_name,
       :device_phone_number,
       :mobile_network_id,

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -9,7 +9,7 @@ class ApplicationFormsController < ApplicationController
     begin
       @application_form.save!
       @user = @application_form.user
-      save_user_to_session!
+      save_user_to_session! unless SessionService.is_signed_in?(session)
       redirect_to application_form_success_path(@application_form.recipient.id)
     rescue ActiveModel::ValidationError
       @mobile_networks = MobileNetwork.order('LOWER(brand)')

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationFormsController < ApplicationController
+  before_action :require_sign_in!
+  
   def new
     @application_form = ApplicationForm.new(user: @user)
     @mobile_networks = MobileNetwork.order('LOWER(brand)')

--- a/app/controllers/mno/recipients_controller.rb
+++ b/app/controllers/mno/recipients_controller.rb
@@ -1,6 +1,7 @@
 class Mno::RecipientsController < Mno::BaseController
   def index
-    @recipients = Recipient.where(mobile_network_id: @mobile_network.id)
+    @recipients = Recipient.from_approved_users
+                           .where(mobile_network_id: @mobile_network.id)
                            .order(safe_order)
 
     respond_to do |format|

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -61,7 +61,7 @@ private
   def root_url_for(user)
     if user.is_mno_user?
       mno_recipients_path
-    elsif user.is_dfe?
+    elsif user.is_dfe? && FeatureFlag.active?(:dfe_admin_ui)
       admin_path
     else
       '/'

--- a/app/form_objects/allocation_request_form.rb
+++ b/app/form_objects/allocation_request_form.rb
@@ -1,33 +1,25 @@
 class AllocationRequestForm
   include ActiveModel::Model
-  include InlineUser
 
-  attr_accessor :full_name,
-                :address,
-                :postcode,
-                :number_eligible,
+  attr_accessor :number_eligible,
                 :number_eligible_with_hotspot_access,
-                :allocation_request,
-                :user
+                :allocation_request
 
   validates :number_eligible, numericality: { only_integer: true, minimum: 0, maximum: 10_000, message: 'Please tell us how many young people are eligible, for example 27' }
   validates :number_eligible_with_hotspot_access, numericality: { only_integer: true, minimum: 0, maximum: 10_000, message: 'Please tell us how many eligible young people can access a BT hotspot, for example 12' }
   validate  :number_eligible_with_hotspot_access_is_not_more_than_number_eligible
 
-  def initialize(user: nil, allocation_request: nil, params: {})
-    @user = user
-    @allocation_request = allocation_request
+  def initialize(opts = {})
+    @allocation_request = opts[:allocation_request] || AllocationRequest.new(opts)
+    @number_eligible = opts[:number_eligible] || @allocation_request.number_eligible
+    @number_eligible_with_hotspot_access = opts[:number_eligible_with_hotspot_access] || @allocation_request.number_eligible_with_hotspot_access
 
-    populate_from_user! if user
     populate_from_allocation_request! if allocation_request
-    populate_from_params!(params) unless params.empty?
   end
 
   def save!
-    @user ||= construct_user
     @allocation_request ||= construct_allocation_request
     validate!
-    @user.save!
     @allocation_request.save!
   end
 
@@ -42,26 +34,14 @@ private
 
   def construct_allocation_request
     AllocationRequest.new(
-      created_by_user: @user,
+      created_by_user: @created_by_user,
       number_eligible: @number_eligible,
       number_eligible_with_hotspot_access: @number_eligible_with_hotspot_access,
     )
   end
 
-  def populate_from_params!(params = {})
-    @user ||= User.new
-    params.each do |key, value|
-      send("#{key}=", value)
-    end
-    @user.full_name = params[:user_name]
-    @user.email_address = params[:user_email]
-    @user.organisation = params[:user_organisation]
-
-    @number_eligible = params[:number_eligible]
-    @number_eligible_with_hotspot_access = params[:number_eligible_with_hotspot_access]
-  end
-
   def populate_from_allocation_request!
+    @created_by_user = @allocation_request.created_by_user
     @number_eligible = @allocation_request.number_eligible
     @number_eligible_with_hotspot_access = @allocation_request.number_eligible_with_hotspot_access
   end

--- a/app/form_objects/allocation_request_form.rb
+++ b/app/form_objects/allocation_request_form.rb
@@ -13,8 +13,6 @@ class AllocationRequestForm
     @allocation_request = opts[:allocation_request] || AllocationRequest.new(opts)
     @number_eligible = opts[:number_eligible] || @allocation_request.number_eligible
     @number_eligible_with_hotspot_access = opts[:number_eligible_with_hotspot_access] || @allocation_request.number_eligible_with_hotspot_access
-
-    populate_from_allocation_request! if allocation_request
   end
 
   def save!
@@ -34,15 +32,8 @@ private
 
   def construct_allocation_request
     AllocationRequest.new(
-      created_by_user: @created_by_user,
       number_eligible: @number_eligible,
       number_eligible_with_hotspot_access: @number_eligible_with_hotspot_access,
     )
-  end
-
-  def populate_from_allocation_request!
-    @created_by_user = @allocation_request.created_by_user
-    @number_eligible = @allocation_request.number_eligible
-    @number_eligible_with_hotspot_access = @allocation_request.number_eligible_with_hotspot_access
   end
 end

--- a/app/form_objects/application_form.rb
+++ b/app/form_objects/application_form.rb
@@ -30,6 +30,7 @@ class ApplicationForm
   def save!
     @recipient ||= construct_recipient
     validate!
+    @recipient.status ||= Recipient.statuses[:requested]
     @recipient.save!
   end
 

--- a/app/form_objects/application_form.rb
+++ b/app/form_objects/application_form.rb
@@ -1,52 +1,36 @@
 class ApplicationForm
   include ActiveModel::Model
-  include InlineUser
 
-  attr_accessor :full_name,
-                :address,
-                :postcode,
+  attr_accessor :account_holder_name,
                 :can_access_hotspot,
-                :is_account_holder,
-                :account_holder_name,
                 :device_phone_number,
                 :mobile_network_id,
-                :phone_network_name,
                 :privacy_statement_sent_to_family,
                 :understands_how_pii_will_be_used,
-                :recipient,
-                :user
+                :recipient
 
-  validates :full_name, presence: { message: "Tell us the recipient's full name, like John Smith" }
-  validates :address, presence: { message: "Tell us the recipient's address, not including the postcode" }
-  validates :postcode, presence: { message: 'Enter a postcode, like AA1 1AA' }
   validates :can_access_hotspot, presence: { message: 'Tell us whether this young person can access a BT hotspot' }
-  validates :is_account_holder, presence: { message: 'Tell us whether this young person is the account holder for the mobile device' }
-  validates :account_holder_name, presence: { message: 'Tell us the full name of the account holder for the mobile device' }, if: :not_account_holder?
+  validates :account_holder_name, presence: { message: 'Tell us the full name of the account holder for the mobile device' }
   validates :device_phone_number, presence: { message: 'Tell us the phone number of the mobile device' }
   validate  :mobile_network_exists
   validates :privacy_statement_sent_to_family, presence: { message: 'Please confirm whether this family have received the privacy statement' }
   validates :understands_how_pii_will_be_used, presence: { message: 'Please confirm whether this family understand how their personally-identifying information will be used' }
 
-  def initialize(user: nil, recipient: nil, params: {})
-    @user = user
-    @recipient = recipient
-    populate_from_user! if user
-    populate_from_recipient! if recipient
-    populate_from_params!(params) unless params.empty?
+  def initialize(opts = {})
+    @recipient = opts[:recipient] || Recipient.new(opts)
+
+    @can_access_hotspot = opts[:can_access_hotspot] || @recipient.can_access_hotspot
+    @account_holder_name = opts[:account_holder_name] || @recipient.account_holder_name
+    @device_phone_number = opts[:device_phone_number] || @recipient.device_phone_number
+    @mobile_network_id = opts[:mobile_network_id] || @recipient.mobile_network_id
+    @privacy_statement_sent_to_family = opts[:privacy_statement_sent_to_family] || @recipient.privacy_statement_sent_to_family
+    @understands_how_pii_will_be_used = opts[:understands_how_pii_will_be_used] || @recipient.understands_how_pii_will_be_used
   end
 
   def save!
-    unless @user.try(:persisted?)
-      @user = retrieve_user_by_email(@user.email_address) || construct_user
-    end
     @recipient ||= construct_recipient
     validate!
-    @user.save!
     @recipient.save!
-  end
-
-  def not_account_holder?
-    is_account_holder == false
   end
 
 private
@@ -57,10 +41,6 @@ private
 
   def construct_recipient
     Recipient.new(
-      created_by_user: @user,
-      full_name: @full_name,
-      address: @address,
-      postcode: @postcode,
       can_access_hotspot: @can_access_hotspot,
       is_account_holder: @is_account_holder,
       account_holder_name: @account_holder_name,
@@ -70,47 +50,5 @@ private
       privacy_statement_sent_to_family: @privacy_statement_sent_to_family,
       understands_how_pii_will_be_used: @understands_how_pii_will_be_used,
     )
-  end
-
-  def populate_from_params!(params = {})
-    @user ||= User.new
-    params.each do |key, value|
-      send("#{key}=", value)
-    end
-    @user.full_name = params[:user_name]
-    @user.email_address = params[:user_email]
-    @user.organisation = params[:user_organisation]
-
-    @full_name = params[:full_name]
-    @address = params[:address]
-    @postcode = params[:postcode]
-    @can_access_hotspot = params[:can_access_hotspot]
-    @is_account_holder = params[:is_account_holder]
-    @account_holder_name = params[:account_holder_name]
-    if @account_holder_name.blank? && @is_account_holder
-      @account_holder_name = @full_name
-    end
-    @device_phone_number = params[:device_phone_number]
-    @mobile_network_id = params[:mobile_network_id]
-    @phone_network_name = params[:phone_network_name]
-    @privacy_statement_sent_to_family = params[:privacy_statement_sent_to_family]
-    @understands_how_pii_will_be_used = params[:understands_how_pii_will_be_used]
-  end
-
-  def populate_from_recipient!
-    @full_name = @recipient.full_name
-    @address = @recipient.address
-    @postcode = @recipient.postcode
-    @can_access_hotspot = @recipient.can_access_hotspot
-    @is_account_holder = @recipient.is_account_holder
-    @account_holder_name = @recipient.account_holder_name
-    if @account_holder_name.blank? && @recipient.is_account_holder?
-      @account_holder_name = @recipient.full_name
-    end
-    @device_phone_number = @recipient.device_phone_number
-    @mobile_network_id = @recipient.mobile_network_id
-    @phone_network_name = @recipient.phone_network_name
-    @privacy_statement_sent_to_family = @recipient.privacy_statement_sent_to_family
-    @understands_how_pii_will_be_used = @recipient.understands_how_pii_will_be_used
   end
 end

--- a/app/mailers/sign_in_token_mailer.rb
+++ b/app/mailers/sign_in_token_mailer.rb
@@ -8,7 +8,6 @@ class SignInTokenMailer < ApplicationMailer
     personalisation = {
       to: @user.email_address,
       token_url: url(:validate_sign_in_token_url, token: @user.sign_in_token, identifier: identifier),
-      token_expires_at: I18n.l(@user.sign_in_token_expires_at, format: :time_only),
       sign_in_link: url(:sign_in_url),
     }
 

--- a/app/models/allocation_request.rb
+++ b/app/models/allocation_request.rb
@@ -1,6 +1,4 @@
 class AllocationRequest < ApplicationRecord
-  # NOTE the `optional: true` is so that the form object can save the user
-  # before allocation_request.
   belongs_to :created_by_user, class_name: 'User', optional: true
   validates :number_eligible, numericality: { only_integer: true, greater_than: -1, less_than: 10_000 }
   validates :number_eligible_with_hotspot_access, numericality: { only_integer: true, greater_than: -1, less_than: 10_000 }

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,4 +1,5 @@
 class Recipient < ApplicationRecord
+  belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network
 
   enum status: {

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -23,4 +23,8 @@ class Recipient < ApplicationRecord
       status: 'Status',
     }
   end
+
+  def self.from_approved_users
+    joins(:created_by_user).where.not(users: { approved_at: nil })
+  end
 end

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -13,7 +13,7 @@ class FakeDataService
         status: Recipient.statuses.values.sample,
       )
       r.update(created_at: Time.now.utc - rand(500_000).seconds)
-      puts "created #{r.id} - #{r.full_name}"
+      puts "created #{r.id} - #{r.account_holder_name}"
     end
   end
 end

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -3,10 +3,7 @@ class FakeDataService
     recipients.times do
       name = Faker::Name.name
       r = Recipient.create!(
-        full_name: name,
         device_phone_number: Faker::PhoneNumber.cell_phone,
-        address: [Faker::Address.street_address, Faker::Address.city].join("\n"),
-        postcode: Faker::Address.postcode,
         can_access_hotspot: true,
         is_account_holder: true,
         account_holder_name: name,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -2,6 +2,7 @@ class FeatureFlag
   PERMANENT_SETTINGS = %i[
     http_basic_auth
     show_debug_info
+    dfe_admin_ui
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/views/allocation_request_forms/new.html.erb
+++ b/app/views/allocation_request_forms/new.html.erb
@@ -10,9 +10,6 @@
     </p>
     <%= form_for @allocation_request_form do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.fields_for :user do |user_form| %>
-        <%= render partial: 'shared/user_form', locals: { form: f } %>
-      <% end %>
       <%= f.govuk_fieldset legend: { text: 'About the eligible young people' } do %>
         <%= f.govuk_number_field :number_eligible,
                                   required: true,

--- a/app/views/allocation_request_forms/success.html.erb
+++ b/app/views/allocation_request_forms/success.html.erb
@@ -14,9 +14,8 @@
       What happens next
     </h2>
     <p class="govuk-body">
-      We will contact you on the email address you provided (
-      <%= @allocation_request_form.user.email_address %>
-      ) soon.
+      We will contact you by email soon, on
+      <%= @allocation_request_form.allocation_request.created_by_user.email_address %>
     </p>
   </div>
 </div>

--- a/app/views/application_forms/new.html.erb
+++ b/app/views/application_forms/new.html.erb
@@ -13,7 +13,6 @@
     <%= form_for @application_form do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_fieldset legend: { text: 'About the recipient' } do %>
       <%= f.govuk_text_field :account_holder_name, label: { size: 'm', text: 'Account holder name' }, hint_text: 'An account holder must be over 16. Do not enter a child\'s name.' %>
       <%= f.govuk_phone_field :device_phone_number, required: true, label: { size: 'm', text: 'Mobile phone number' }, hint_text: 'All UK mobile phone numbers start with 07' %>
       <%= f.govuk_collection_radio_buttons :can_access_hotspot,
@@ -24,28 +23,27 @@
                                           hint_text: 'There’s guidance available on <a class="govuk-link" href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
                                           legend: { text: 'Can the child or young person access a BT hotspot?' }  %>
 
+      <%= f.govuk_collection_select :mobile_network_id,
+                                  @mobile_networks,
+                                  :id,
+                                  :brand,
+                                  label: { size: 'm', text: 'Mobile network' }  %>
 
-        <%= f.govuk_collection_select :mobile_network_id,
-                                    @mobile_networks,
-                                    :id,
-                                    :brand,
-                                    label: { size: 'm', text: 'Mobile network' }  %>
-
-        <%= f.govuk_collection_radio_buttons :privacy_statement_sent_to_family,
-                                          yes_no_options,
-                                          :id,
-                                          :name,
-                                          inline: true,
-                                          legend: { text: 'Has the privacy statement been sent to the family?' } %>
+      <%= f.govuk_collection_radio_buttons :privacy_statement_sent_to_family,
+                                        yes_no_options,
+                                        :id,
+                                        :name,
+                                        inline: true,
+                                        legend: { text: 'Has the privacy statement been sent to the family?' } %>
 
 
-        <%= f.govuk_collection_radio_buttons :understands_how_pii_will_be_used,
-                                          yes_no_options,
-                                          :id,
-                                          :name,
-                                          inline: true,
-                                          legend: { text: 'Does the child/family understand how their personal information will be used?' } %>
-      <%- end %>
+      <%= f.govuk_collection_radio_buttons :understands_how_pii_will_be_used,
+                                        yes_no_options,
+                                        :id,
+                                        :name,
+                                        inline: true,
+                                        legend: { text: 'Does the child/family understand how their personal information will be used?' } %>
+
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">
           !

--- a/app/views/application_forms/new.html.erb
+++ b/app/views/application_forms/new.html.erb
@@ -13,13 +13,10 @@
     <%= form_for @application_form do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= render partial: 'shared/user_form', locals: { form: f } %>
-
       <%= f.govuk_fieldset legend: { text: 'About the recipient' } do %>
-        <%= f.govuk_text_field :full_name, required: true, label: { text: 'Name of the eligible child or young person' } %>
-        <%= f.govuk_text_area  :address, required: true, rows: 3, label: { text: 'Address of the child or young person' } %>
-        <%= f.govuk_text_field :postcode, required: true, width: 'one-quarter', label: { text: 'Postcode of the child or young person' } %>
-        <%= f.govuk_collection_radio_buttons :can_access_hotspot,
+      <%= f.govuk_text_field :account_holder_name, label: { size: 'm', text: 'Account holder name' }, hint_text: 'An account holder must be over 16. Do not enter a child\'s name.' %>
+      <%= f.govuk_phone_field :device_phone_number, required: true, label: { size: 'm', text: 'Mobile phone number' }, hint_text: 'All UK mobile phone numbers start with 07' %>
+      <%= f.govuk_collection_radio_buttons :can_access_hotspot,
                                           yes_no_options,
                                           :id,
                                           :name,
@@ -27,19 +24,12 @@
                                           hint_text: 'There’s guidance available on <a class="govuk-link" href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
                                           legend: { text: 'Can the child or young person access a BT hotspot?' }  %>
 
-        <%= f.govuk_radio_buttons_fieldset :is_account_holder, legend: { text: 'Who is the account holder for the mobile device?' } do %>
-          <%= f.govuk_radio_button :is_account_holder, 'yes', label: { text: 'Child/young person' } %>
-          <%= f.govuk_radio_button :is_account_holder, 'no', label: { text: 'Parent/guardian' } do %>
-            <%= f.govuk_text_field :account_holder_name, label: { text: 'Please give the name of the account holder ' } %>
-          <%- end %>
-        <%- end %>
-        <%= f.govuk_phone_field :device_phone_number, required: true, label: { text: 'Phone number of device' } %>
 
         <%= f.govuk_collection_select :mobile_network_id,
                                     @mobile_networks,
                                     :id,
                                     :brand,
-                                    label: { text: 'Name of phone network' }  %>
+                                    label: { size: 'm', text: 'Mobile network' }  %>
 
         <%= f.govuk_collection_radio_buttons :privacy_statement_sent_to_family,
                                           yes_no_options,

--- a/app/views/application_forms/success.html.erb
+++ b/app/views/application_forms/success.html.erb
@@ -14,9 +14,8 @@
       What happens next
     </h2>
     <p class="govuk-body">
-      We will contact you on the email address you provided (
-      <%= @application_form.user.email_address %>
-      ) soon.
+      We will contact you by email soon, on
+      <%= @application_form.recipient.created_by_user.email_address %>
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'Tell us about another child or young person', new_application_form_path %>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -8,8 +8,10 @@
       <%= nav_item( title: "Your requests", url: mno_recipients_path )  %>
     <%- else %>
       <%= nav_item( title: "Guidance", url: guidance_page_path )  %>
-      <%= nav_item( title: "Tell us how many eligible young people you know about", url: new_allocation_request_form_path )  %>
-      <%= nav_item( title: "Tell us about an eligible young person", url: new_application_form_path )  %>
+      <%- if SessionService.is_signed_in?(session) %>
+        <%= nav_item( title: "Tell us how many young people are eligible", url: new_allocation_request_form_path )  %>
+        <%= nav_item( title: "Tell us who needs more data", url: new_application_form_path )  %>
+      <%- end %>
     <%- end %>
 
     <%- if SessionService.is_signed_in?(session) %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,8 @@ Rails.application.configure do
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY', nil)
   }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch('HOSTNAME_FOR_URLS', 'http://localhost:3000')
+    host: ENV.fetch('HOSTNAME_FOR_URLS', 'http://localhost:3000'),
+    protocol: 'https'
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/db/migrate/20200624224602_add_created_by_user_to_recipient.rb
+++ b/db/migrate/20200624224602_add_created_by_user_to_recipient.rb
@@ -1,0 +1,6 @@
+class AddCreatedByUserToRecipient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :recipients, :created_by_user_id, :integer, references: :users, foreign_key: true, null: true
+
+  end
+end

--- a/db/migrate/20200624224602_add_created_by_user_to_recipient.rb
+++ b/db/migrate/20200624224602_add_created_by_user_to_recipient.rb
@@ -1,6 +1,5 @@
 class AddCreatedByUserToRecipient < ActiveRecord::Migration[6.0]
   def change
     add_column :recipients, :created_by_user_id, :integer, references: :users, foreign_key: true, null: true
-
   end
 end

--- a/db/migrate/20200624232421_remove_name_and_address_from_recipient.rb
+++ b/db/migrate/20200624232421_remove_name_and_address_from_recipient.rb
@@ -1,0 +1,7 @@
+class RemoveNameAndAddressFromRecipient < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :recipients, :full_name
+    remove_column :recipients, :address
+    remove_column :recipients, :postcode
+  end
+end

--- a/db/migrate/20200624232421_remove_name_and_address_from_recipient.rb
+++ b/db/migrate/20200624232421_remove_name_and_address_from_recipient.rb
@@ -1,7 +1,7 @@
 class RemoveNameAndAddressFromRecipient < ActiveRecord::Migration[6.0]
   def change
-    remove_column :recipients, :full_name
-    remove_column :recipients, :address
-    remove_column :recipients, :postcode
+    remove_column :recipients, :full_name, :string
+    remove_column :recipients, :address, :string
+    remove_column :recipients, :postcode, :string
   end
 end

--- a/db/migrate/20200624233926_add_user_approved_at.rb
+++ b/db/migrate/20200624233926_add_user_approved_at.rb
@@ -1,0 +1,7 @@
+class AddUserApprovedAt < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :approved_at, :datetime, null: true
+
+    add_index :users, :approved_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_153248) do
+ActiveRecord::Schema.define(version: 2020_06_24_224602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_153248) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "mobile_network_id"
     t.string "status"
+    t.integer "created_by_user_id"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_recipients_on_mobile_network_id_and_status_and_created_at"
     t.index ["status"], name: "index_recipients_on_status"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_224602) do
+ActiveRecord::Schema.define(version: 2020_06_24_233926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,9 +35,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_224602) do
   end
 
   create_table "recipients", force: :cascade do |t|
-    t.string "full_name"
-    t.string "address"
-    t.string "postcode"
     t.boolean "can_access_hotspot"
     t.boolean "is_account_holder"
     t.string "account_holder_name"
@@ -70,6 +67,8 @@ ActiveRecord::Schema.define(version: 2020_06_24_224602) do
     t.string "sign_in_token"
     t.integer "mobile_network_id"
     t.datetime "sign_in_token_expires_at"
+    t.datetime "approved_at"
+    t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["dfe_sign_in_id"], name: "index_users_on_dfe_sign_in_id"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"

--- a/spec/controllers/allocation_request_forms_controller_spec.rb
+++ b/spec/controllers/allocation_request_forms_controller_spec.rb
@@ -47,6 +47,7 @@ describe AllocationRequestFormsController, type: :controller do
 
     context 'with valid params and an existing user in session' do
       let(:user) { create(:local_authority_user) }
+
       before do
         sign_in_as user
       end
@@ -69,6 +70,7 @@ describe AllocationRequestFormsController, type: :controller do
       let(:user) { create(:local_authority_user) }
       let(:params) { { allocation_request_form: invalid_params } }
       let(:the_request) { post :create, params: params }
+
       before do
         sign_in_as user
       end

--- a/spec/controllers/application_forms_controller_spec.rb
+++ b/spec/controllers/application_forms_controller_spec.rb
@@ -52,6 +52,7 @@ describe ApplicationFormsController, type: :controller do
 
     context 'with valid params and an existing user in session' do
       let(:user) { create(:local_authority_user) }
+
       before do
         sign_in_as user
       end
@@ -62,6 +63,7 @@ describe ApplicationFormsController, type: :controller do
           account_holder_name: 'Anne Account-Holder',
           device_phone_number: '01234 567890',
           mobile_network_id: mobile_network.id,
+          status: Recipient.statuses[:requested],
         )
       end
 
@@ -75,6 +77,7 @@ describe ApplicationFormsController, type: :controller do
       let(:user) { create(:local_authority_user) }
       let(:params) { { application_form: invalid_params } }
       let(:the_request) { post :create, params: params }
+
       before do
         sign_in_as user
       end

--- a/spec/controllers/application_forms_controller_spec.rb
+++ b/spec/controllers/application_forms_controller_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe ApplicationFormsController, type: :controller do
+  def sign_in_as(user)
+    # TestSession doesn't do this automatically like a real session
+    session[:session_id] = SecureRandom.uuid
+    controller.send(:save_user_to_session!, user)
+  end
+
+  describe '#create' do
+    let(:mobile_network) { create(:mobile_network) }
+    let(:invalid_params) do
+      {
+        account_holder_name: '.',
+      }
+    end
+    let(:valid_params) do
+      {
+        account_holder_name: 'Anne Account-Holder',
+        device_phone_number: '01234 567890',
+        mobile_network_id: mobile_network.id,
+        can_access_hotspot: true,
+        privacy_statement_sent_to_family: true,
+        understands_how_pii_will_be_used: true,
+      }
+    end
+    let(:params) { { application_form: valid_params } }
+    let(:created_recipient) { Recipient.last }
+    let(:the_request) { post :create, params: params }
+
+    context 'with valid params and no existing user in session' do
+      before do
+        session.delete(:user)
+        # TestSession doesn't create this automatically like a real session
+        session[:session_id] = SecureRandom.uuid
+      end
+
+      it 'redirects to sign_in' do
+        the_request
+        expect(response).to redirect_to(sign_in_path)
+      end
+
+      it 'does not change the user_id in session' do
+        expect { the_request }.not_to(change { session[:user_id] })
+        expect(session[:user_id]).to be_nil
+      end
+
+      it 'does not create a Recipient' do
+        expect { the_request }.not_to change(Recipient, :count)
+      end
+    end
+
+    context 'with valid params and an existing user in session' do
+      let(:user) { create(:local_authority_user) }
+      before do
+        sign_in_as user
+      end
+
+      it 'creates a Recipient with the right attributes' do
+        the_request
+        expect(created_recipient).to have_attributes(
+          account_holder_name: 'Anne Account-Holder',
+          device_phone_number: '01234 567890',
+          mobile_network_id: mobile_network.id,
+        )
+      end
+
+      it 'creates a Recipient associated with the sessions user' do
+        the_request
+        expect(created_recipient.created_by_user_id).to eq(session[:user_id])
+      end
+    end
+
+    context 'with invalid params and an existing user in session' do
+      let(:user) { create(:local_authority_user) }
+      let(:params) { { application_form: invalid_params } }
+      let(:the_request) { post :create, params: params }
+      before do
+        sign_in_as user
+      end
+
+      it 'does not create a Recipient' do
+        expect { post :create, params: params }.not_to change(Recipient, :count)
+      end
+
+      it 'responds with a 400 status code' do
+        post :create, params: params
+        expect(response.status).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/factories/recipients.rb
+++ b/spec/factories/recipients.rb
@@ -1,15 +1,13 @@
 FactoryBot.define do
   factory :recipient, class: 'Recipient' do
-    full_name                         { Faker::Name.name }
-    address                           { '22 Acacia Avenue\r\nSometown' }
-    postcode                          { 'SOM3 T0WN' }
     can_access_hotspot                { true }
     is_account_holder                 { true }
-    account_holder_name               { full_name }
+    account_holder_name               { Faker::Name.name }
     device_phone_number               { '07123 456789' }
     privacy_statement_sent_to_family  { true }
     understands_how_pii_will_be_used  { true }
     status                            { :requested }
     association :mobile_network
+    association :created_by_user, factory: :local_authority_user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,4 +12,10 @@ FactoryBot.define do
     organisation  { 'Participating Mobile Network' }
     association   :mobile_network
   end
+
+  factory :dfe_user, class: 'User' do
+    full_name     { 'Jane Doe' }
+    email_address { 'jane.doe@digital.education.gov.uk' }
+    organisation  { 'DfE' }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     full_name     { 'Jane Doe' }
     email_address { 'jane.doe@somelocalauthority.gov.uk' }
     organisation  { 'Some Local Authority' }
+    approved_at   { Time.now.utc - 3.days }
   end
 
   factory :mno_user, class: 'User' do

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -30,7 +30,27 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   end
 
   context 'as a dfe user' do
-    pending
+    let(:user) { create(:dfe_user) }
+
+    context 'with the FeatureFlag active' do
+      before do
+        FeatureFlag.activate(:dfe_admin_ui)
+      end
+
+      pending
+    end
+
+    context 'with the FeatureFlag inactive' do
+      before do
+        FeatureFlag.deactivate(:dfe_admin_ui)
+      end
+
+      it 'redirects to the guidance page' do
+        visit(validate_token_url)
+        expect(page).to have_current_path('/about-bt-wifi')
+        expect(page).to have_text 'Increasing internet access for vulnerable and disadvantaged children'
+      end
+    end
   end
 
   context 'as a mobile network operator' do

--- a/spec/features/submitting_an_allocation_request_form_spec.rb
+++ b/spec/features/submitting_an_allocation_request_form_spec.rb
@@ -1,32 +1,49 @@
 require 'rails_helper'
+require 'support/sign_in_as'
 
 RSpec.feature 'Submitting an allocation_request_form', type: :feature do
-  scenario 'Navigating to the form' do
-    visit '/'
-    click_on('Tell us how many eligible young people you know about')
-    expect(page).to have_current_path(new_allocation_request_form_path)
+  context 'not signed in' do
+    it 'does not show the link in the nav' do
+      visit '/'
+      expect(page).not_to have_text('Tell us how many young people are eligible')
+    end
+
+    scenario 'visiting the form directly should redirect to sign_in' do
+      visit new_allocation_request_form_path
+      expect(current_path).to eq(sign_in_path)
+    end
   end
 
-  scenario 'submitting the form with invalid params' do
-    visit new_allocation_request_form_path
-    fill_in 'Your full name', with: 'Bob'
-    fill_in 'Your email address', with: 'no-one@anywhere'
-    click_on 'Continue'
-    expect(page.status_code).not_to eq(200)
-    expect(page).to have_text('There is a problem')
-  end
+  context 'signed in' do
+    let(:user) { create(:local_authority_user) }
 
-  scenario 'submitting the form with valid params' do
-    visit new_allocation_request_form_path
-    fill_in 'Your full name', with: 'Bob Boberts'
-    fill_in 'Your email address', with: 'validmail@localauthority.gov.uk'
-    fill_in 'Name of the organisation you work for', with: 'A Local Authority'
-    fill_in 'Total number of children and young people eligible for increased internet access', with: 2
-    fill_in 'Total number of eligible children and young people who can access a BT hotspot', with: 1
-    click_on 'Continue'
+    before do
+      sign_in_as user
+    end
 
-    expect(page.status_code).to eq(200)
-    expect(page).to have_text('Thank you')
-    expect(page).to have_text('Sign out')
+    scenario 'Navigating to the form' do
+      visit '/'
+      click_on('Tell us how many young people are eligible')
+      expect(page).to have_text('Total number of children and young people eligible for increased internet access')
+    end
+
+    scenario 'submitting the form with invalid params shows errors' do
+      visit new_allocation_request_form_path
+      fill_in 'Total number of children and young people eligible for increased internet access', with: '-1'
+      click_on 'Continue'
+      expect(page.status_code).not_to eq(200)
+      expect(page).to have_text('There is a problem')
+    end
+
+    scenario 'submitting the form with valid params works' do
+      visit new_allocation_request_form_path
+      fill_in 'Total number of children and young people eligible for increased internet access', with: 2
+      fill_in 'Total number of eligible children and young people who can access a BT hotspot', with: 1
+      click_on 'Continue'
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_text('Thank you')
+      expect(page).to have_text('Sign out')
+    end
   end
 end

--- a/spec/features/submitting_an_allocation_request_form_spec.rb
+++ b/spec/features/submitting_an_allocation_request_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Submitting an allocation_request_form', type: :feature do
 
     scenario 'visiting the form directly should redirect to sign_in' do
       visit new_allocation_request_form_path
-      expect(current_path).to eq(sign_in_path)
+      expect(page).to have_current_path(sign_in_path)
     end
   end
 

--- a/spec/features/submitting_an_application_form_spec.rb
+++ b/spec/features/submitting_an_application_form_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+require 'support/sign_in_as'
+require 'shared/filling_in_forms'
+
+RSpec.feature 'Submitting an application_form', type: :feature do
+  context 'not signed in' do
+    it 'does not show the link in the nav' do
+      visit '/'
+      expect(page).not_to have_text('Tell us how many young people are eligible')
+    end
+
+    scenario 'visiting the form directly should redirect to sign_in' do
+      visit new_application_form_path
+      expect(current_path).to eq(sign_in_path)
+    end
+  end
+
+  context 'signed in' do
+    let(:user) { create(:local_authority_user) }
+    let(:mobile_network) { create(:mobile_network) }
+
+    before do
+      mobile_network
+      sign_in_as user
+    end
+
+    scenario 'Navigating to the form' do
+      visit '/'
+      click_on('Tell us who needs more data')
+      expect(page).to have_text('Mobile phone number')
+    end
+
+    scenario 'submitting the form with invalid params shows errors' do
+      visit new_application_form_path
+      fill_in 'Mobile phone number', with: '-1'
+      click_on 'Continue'
+      expect(page.status_code).not_to eq(200)
+      expect(page).to have_text('There is a problem')
+    end
+
+    scenario 'submitting the form with valid params works' do
+      visit new_application_form_path
+      fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
+      click_on 'Continue'
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_text('Thank you')
+      expect(page).to have_text('Sign out')
+    end
+  end
+end

--- a/spec/features/submitting_an_application_form_spec.rb
+++ b/spec/features/submitting_an_application_form_spec.rb
@@ -47,5 +47,21 @@ RSpec.feature 'Submitting an application_form', type: :feature do
       expect(page).to have_text('Thank you')
       expect(page).to have_text('Sign out')
     end
+
+    scenario 'submitting multiple forms in the same sesssion works' do
+      visit new_application_form_path
+      fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
+      click_on 'Continue'
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_text('Thank you')
+
+      click_on 'Tell us about another child or young person'
+      fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
+      click_on 'Continue'
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_text('Thank you')
+    end
   end
 end

--- a/spec/features/submitting_an_application_form_spec.rb
+++ b/spec/features/submitting_an_application_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Submitting an application_form', type: :feature do
 
     scenario 'visiting the form directly should redirect to sign_in' do
       visit new_application_form_path
-      expect(current_path).to eq(sign_in_path)
+      expect(page).to have_current_path(sign_in_path)
     end
   end
 

--- a/spec/form_objects/allocation_request_form_spec.rb
+++ b/spec/form_objects/allocation_request_form_spec.rb
@@ -2,20 +2,6 @@ require 'rails_helper'
 
 describe AllocationRequestForm do
   describe 'valid?' do
-    let(:valid_user_params) do
-      {
-        full_name: 'John Smith',
-        email_address: 'some@localauthority.gov.uk',
-        organisation: 'some LA',
-      }
-    end
-    let(:invalid_user_params) do
-      {
-        full_name: '',
-        email_address: '2',
-        organisation: '',
-      }
-    end
     let(:valid_allocation_request_params) do
       {
         number_eligible: 20,
@@ -29,13 +15,9 @@ describe AllocationRequestForm do
       }
     end
 
-    context 'with a valid user and a valid allocation_request' do
-      let(:args) { { user: User.new(valid_user_params), params: {} } }
-      let(:form) { AllocationRequestForm.new(user: args[:user], allocation_request: args[:allocation_request], params: args[:params]) }
-
-      before do
-        args[:allocation_request] = AllocationRequest.new(valid_allocation_request_params)
-      end
+    context 'with a valid allocation_request' do
+      let(:allocation_request) { AllocationRequest.new(valid_allocation_request_params) }
+      let(:form) { AllocationRequestForm.new(allocation_request: allocation_request) }
 
       it 'is true' do
         expect(form.valid?).to be true
@@ -47,8 +29,7 @@ describe AllocationRequestForm do
       end
     end
 
-    context 'with a valid user and an invalid allocation_request' do
-      let(:args) { { user: User.new(valid_user_params), params: {} } }
+    context 'with an invalid allocation_request' do
       let(:form) { AllocationRequestForm.new(allocation_request: AllocationRequest.new(invalid_allocation_request_params)) }
 
       it 'is false' do
@@ -61,32 +42,16 @@ describe AllocationRequestForm do
       end
     end
 
-    context 'with an invalid user' do
-      let(:args) { { user: User.new(invalid_user_params), params: {} } }
-      let(:form) { AllocationRequestForm.new(user: args[:user], allocation_request: args[:allocation_request], params: args[:params]) }
-
-      it 'is false' do
-        expect(form.valid?).to be false
-      end
-
-      it 'sets an error' do
-        form.valid?
-        expect(form.errors).not_to be_empty
-      end
-    end
 
     context 'with valid params' do
       let(:params) do
         {
-          user_name: 'jane doe',
-          user_email: 'jane@example.com',
-          user_organisation: 'some org',
           number_eligible: 20,
           number_eligible_with_hotspot_access: 12,
         }
       end
 
-      let(:form) { AllocationRequestForm.new(params: params) }
+      let(:form) { AllocationRequestForm.new(params) }
 
       it 'is valid' do
         expect(form).to be_valid
@@ -98,7 +63,7 @@ describe AllocationRequestForm do
     end
 
     context 'with number_eligible < number_eligible_with_hotspot_access' do
-      let(:form) { AllocationRequestForm.new(params: { number_eligible: 12, number_eligible_with_hotspot_access: 20 }) }
+      let(:form) { AllocationRequestForm.new( number_eligible: 12, number_eligible_with_hotspot_access: 20 ) }
 
       it 'is not valid' do
         expect(form).not_to be_valid

--- a/spec/form_objects/allocation_request_form_spec.rb
+++ b/spec/form_objects/allocation_request_form_spec.rb
@@ -42,7 +42,6 @@ describe AllocationRequestForm do
       end
     end
 
-
     context 'with valid params' do
       let(:params) do
         {
@@ -50,7 +49,6 @@ describe AllocationRequestForm do
           number_eligible_with_hotspot_access: 12,
         }
       end
-
       let(:form) { AllocationRequestForm.new(params) }
 
       it 'is valid' do
@@ -63,7 +61,7 @@ describe AllocationRequestForm do
     end
 
     context 'with number_eligible < number_eligible_with_hotspot_access' do
-      let(:form) { AllocationRequestForm.new( number_eligible: 12, number_eligible_with_hotspot_access: 20 ) }
+      let(:form) { AllocationRequestForm.new(number_eligible: 12, number_eligible_with_hotspot_access: 20) }
 
       it 'is not valid' do
         expect(form).not_to be_valid

--- a/spec/shared/filling_in_forms.rb
+++ b/spec/shared/filling_in_forms.rb
@@ -1,13 +1,10 @@
 def fill_in_valid_application_form(mobile_network_name: 'Participating mobile network')
-  fill_in 'Name of the eligible child or young person', with: 'young person'
-  fill_in 'Address of the child or young person', with: '1 some street\nsome town'
-  fill_in 'Postcode of the child or young person', with: 'AB128TH'
-
   find('#application-form-can-access-hotspot-yes-field').choose
-  find('#application-form-is-account-holder-yes-field').choose
-  fill_in 'Phone number of device', with: '0123456789'
 
-  select mobile_network_name, from: 'Name of phone network'
+  fill_in 'Account holder name', with: 'Anne Account-Holder'
+  fill_in 'Mobile phone number', with: '07123456789'
+
+  select mobile_network_name, from: 'Mobile network'
   find('#application-form-privacy-statement-sent-to-family-yes-field').choose
   find('#application-form-understands-how-pii-will-be-used-yes-field').choose
 end

--- a/spec/shared/filling_in_forms.rb
+++ b/spec/shared/filling_in_forms.rb
@@ -1,8 +1,4 @@
-def fill_in_valid_application_form(user_email: 'validmail@localauthority.gov.uk', mobile_network_name: 'Participating mobile network')
-  fill_in 'Your full name', with: 'Bob Boberts'
-  fill_in 'Your email address', with: user_email
-  fill_in 'Name of the organisation you work for', with: 'A Local Authority'
-
+def fill_in_valid_application_form(mobile_network_name: 'Participating mobile network')
   fill_in 'Name of the eligible child or young person', with: 'young person'
   fill_in 'Address of the child or young person', with: '1 some street\nsome town'
   fill_in 'Postcode of the child or young person', with: 'AB128TH'


### PR DESCRIPTION
### Context

Anyone can create an account and submit data, so long as they can validate their email with a token link.
We agreed in this morning's prioritisation session that to prevent abuse, we'll :
1. mark new users as pending
2. have a manual approval process for users
3. hide any requests submitted by unapproved users from the MNO interface
4. hide & disable form submission by users who have not signed in

### Changes proposed in this pull request

All the above, plus removal of a lot of now-redundant cruft & complexity from the forms, views & controllers
Also removed the critical PII (name, address, postcode of young person) which we don't actually need

### Guidance to review

1. Visit a page without being signed in - you should only see the 'Guidance' & 'Sign in' links in the nav
2. Create an account - you should be able to see the 'Tell us...' links once you're signed in
3. Submit a 'eligible young person' form for a participating mobile network with which you have a user account (or create a user with `mobile_network_id` set from the console) - you should be able to submit data with no problems
4. Sign out, and sign in as the MNO user - you should not see the request you just submitted in 'Your requests'
5. From the console, set `approved_at` to a valid datetime on the user who submitted the data, and save that user
6. Reload the MNO 'Your requests' page - you should now be able to see the request


Simpler form UI, more inline with design prototype:

![Screen Shot 2020-06-25 at 01 26 21](https://user-images.githubusercontent.com/134501/85640149-e90a6e00-b682-11ea-88eb-75f4a03629e8.png)

