### PR TITLE
Use the service name as a translation wherever possible

### DIFF
--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Increasing internet access for vulnerable and disadvantaged children
+      <%= t('service_name') %>
     </h1>
 
     <p class="govuk-body-l">

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting the static guidance pages works' do
       visit guidance_page_path
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
+      expect(page).to have_selector 'h1', text: I18n.t('service_name')
 
       visit '/bt-wifi/privacy-notice'
       expect(page).to have_http_status(:ok)
@@ -35,7 +35,7 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting the guidance page works' do
       visit guidance_page_path
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
+      expect(page).to have_selector 'h1', text: I18n.t('service_name')
     end
 
     scenario 'visiting any other page works' do

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     scenario 'it redirects to the guidance page' do
       visit(validate_token_url)
       expect(page).to have_current_path('/about-bt-wifi')
-      expect(page).to have_text 'Increasing internet access for vulnerable and disadvantaged children'
+      expect(page).to have_text I18n.t('service_name')
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       it 'redirects to the guidance page' do
         visit(validate_token_url)
         expect(page).to have_current_path('/about-bt-wifi')
-        expect(page).to have_text 'Increasing internet access for vulnerable and disadvantaged children'
+        expect(page).to have_text I18n.t('service_name')
       end
     end
   end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.feature 'View pages', type: :feature do
   scenario 'Root URL should be the guidance page' do
     visit '/'
-    expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
+    expect(page).to have_selector 'h1', text: I18n.t('service_name')
   end
 
   scenario 'Navigate to guidance page' do
     visit '/pages/guidance'
 
     expect(page).to have_http_status(:ok)
-    expect(page).to have_selector 'h1', text: 'Increasing internet access for vulnerable and disadvantaged children'
+    expect(page).to have_selector 'h1', text: I18n.t('service_name')
   end
 end


### PR DESCRIPTION
This makes it easier to change if we need to.