### PR TITLE
allow generated fake recipients to have a created_by_user_id

### DIFF
--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -1,5 +1,5 @@
 class FakeDataService
-  def self.generate!(recipients: 10, mobile_network_id:)
+  def self.generate!(recipients: 10, mobile_network_id:, created_by_user_id: nil)
     recipients.times do
       name = Faker::Name.name
       r = Recipient.create!(
@@ -11,6 +11,7 @@ class FakeDataService
         understands_how_pii_will_be_used: true,
         mobile_network_id: mobile_network_id,
         status: Recipient.statuses.values.sample,
+        created_by_user_id: created_by_user_id,
       )
       r.update(created_at: Time.now.utc - rand(500_000).seconds)
       puts "created #{r.id} - #{r.account_holder_name}"


### PR DESCRIPTION
### Context

Since #24 Recipients will not be seen by MNOs until the user who created them is approved.
So we need the ability to specify the user when generating fake data.

### Changes proposed in this pull request

Add `created_by_user_id:` keyword arg to `FakeDataService.generate!`

### Guidance to review

From the console:

`FakeDataService.generate!(recipients: 5, created_by_user_id: ... )
Recipient.last(5).pluck(:created_by_user_id)`

The 5 created_by_user_id's should be exactly the value you gave.