### PR TITLE
Add healthcheck.json endpoint to report health, backing service health, and git commit/branch info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/source
 
 RUN apt-get update && apt-get install -y nodejs postgresql-contrib libpq-dev yarn
 
-
 ENV RAILS_ROOT /var/www/${APPNAME}
 RUN mkdir -p $RAILS_ROOT
 WORKDIR $RAILS_ROOT
@@ -25,17 +24,13 @@ RUN gem install bundler
 RUN chown -R deploy:deploy /usr/local/bundle/
 USER 1001
 
-
 # install all gems
 COPY --chown=deploy:deploy Gemfile Gemfile.lock .ruby-version ./
 ARG BUNDLE_FLAGS="--jobs 2 --no-cache --without development test"
 RUN bundle install ${BUNDLE_FLAGS}
 RUN bundle package --all
 
-
 COPY --chown=deploy:deploy . .
-
-
 
 # allow access to port 3000
 ENV APP_PORT 3000
@@ -45,6 +40,13 @@ EXPOSE $APP_PORT
 RUN yarn
 ARG RAILS_ENV=production
 RUN RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE=$(bin/rake secret) bundle exec rails webpacker:compile
+
+# Cache the git commit sha & branch
+ARG GIT_COMMIT_SHA=""
+ARG GIT_BRANCH=""
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+RUN echo "[{'commit_sha': '${GIT_COMMIT_SHA}', 'branch': '${GIT_BRANCH}'}]" > ./.gitinfo.json
 
 # run the rails server
 ARG RAILS_ENV=production

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,15 @@ prod:
 	$(eval export db_plan=small-ha-11)
 	@true
 
-.PHONY: require_env_stub build push deploy setup_paas_env
+.PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app
+
 require_env_stub:
 	test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
+
+get_git_status:
+	$(eval export git_commit_sha=$(shell git rev-parse HEAD))
+	$(eval export git_branch=$(shell git rev-parse --abbrev-ref HEAD))
+	@true
 
 setup_paas_db: set_cf_target
 	cf create-service postgres $(db_plan) $(APP_NAME)-$(env_stub)-db
@@ -38,8 +44,8 @@ setup_paas_env: set_cf_target
 	bin/rails secret | xargs cf set-env $(APP_NAME)-$(env_stub) SECRET_KEY_BASE
 	cf restage $(APP_NAME)-$(env_stub)
 
-build: require_env_stub ## Create & tag a new docker image
-	docker build -t $(APP_NAME)-$(env_stub) .
+build: require_env_stub get_git_status ## Create & tag a new docker image
+	docker build -t $(APP_NAME)-$(env_stub) --build-arg GIT_COMMIT_SHA=$(git_commit_sha) --build-arg GIT_BRANCH=$(git_branch) .
 
 push: require_env_stub ## push the Docker image to Docker Hub
 	docker tag $(APP_NAME)-$(env_stub) $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ require_env_stub:
 	test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
 
 get_git_status:
-	$(eval export git_commit_sha=$(shell git rev-parse HEAD))
+	$(eval export git_commit_sha=$(shell git rev-parse --short HEAD))
 	$(eval export git_branch=$(shell git rev-parse --abbrev-ref HEAD))
 	@true
 

--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -1,0 +1,11 @@
+class MonitoringController < ApplicationController
+  def healthcheck
+    @healthcheck = HealthcheckService.run
+    @status = (@healthcheck[:status] == 'UP' ? :ok : :internal_server_error)
+    respond_to do |format|
+      format.json do
+        render json: @healthcheck.to_json, status: @status
+      end
+    end
+  end
+end

--- a/app/services/healthcheck_service.rb
+++ b/app/services/healthcheck_service.rb
@@ -1,0 +1,44 @@
+class HealthcheckService
+  SERVICES = %i[db].freeze
+
+  def self.run
+    all_services_status = services_status
+    {
+      status: (all_services_status.values.all?('UP') ? 'UP' : 'DOWN'),
+      services: all_services_status,
+      info: {
+        git: git_info,
+      },
+    }
+  end
+
+  def self.git_info
+    {
+      commit_sha: ENV['GIT_COMMIT_SHA'],
+      branch: ENV['GIT_BRANCH'],
+    }
+  end
+
+  def self.services_status
+    status = {}
+    SERVICES.each do |service|
+      status[service] = status_of(service)
+    end
+    status
+  end
+
+  # TODO: refactor when we have more than one service
+  # Maybe have separate XYZHealthcheck classes?
+  def self.status_of(service)
+    case service
+    when :db then db_status
+    end
+  rescue StandardError
+    'DOWN'
+  end
+
+  def self.db_status
+    Recipient.maximum(:created_at)
+    'UP'
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ Bundler.require(*Rails.groups)
 module GovukRailsBoilerplate
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/healthcheck', to: 'monitoring#healthcheck', as: :healthcheck
+
   get '/sign_in', to: 'sign_in_tokens#new', as: :sign_in
 
   get '/403', to: 'errors#forbidden', via: :all

--- a/spec/controllers/monitoring_controller_spec.rb
+++ b/spec/controllers/monitoring_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe MonitoringController, type: :controller do
+  describe 'healthcheck.json' do
+    let(:json) do
+      JSON.parse(response.body)
+    end
+
+    it 'returns json' do
+      get :healthcheck, format: :json
+      expect(response.media_type).to eq('application/json')
+    end
+
+    context 'when everything is OK' do
+      it 'has status ok' do
+        get :healthcheck, format: :json
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when not everything is OK' do
+      before do
+        allow(HealthcheckService).to receive(:db_status).and_return('DOWN')
+      end
+
+      it 'has status internal_server_error' do
+        get :healthcheck, format: :json
+        expect(response.status).to eq(500)
+      end
+    end
+
+    context 'when GIT_BRANCH is present in the ENV' do
+      before do
+        ENV['GIT_BRANCH'] = 'my-branch-name'
+      end
+
+      it 'reports GIT_BRANCH in the info/git/branch key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['git']['branch']).to eq('my-branch-name')
+      end
+    end
+
+    context 'when GIT_BRANCH is not present in the ENV' do
+      before do
+        ENV['GIT_BRANCH'] = nil
+      end
+
+      it 'reports null in the info/git/branch key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['git']['branch']).to eq(nil)
+      end
+    end
+
+    context 'when GIT_COMMIT_SHA is present in the ENV' do
+      before do
+        ENV['GIT_COMMIT_SHA'] = 'my-commit-sha'
+      end
+
+      it 'reports GIT_COMMIT_SHA in the info/git/commit_sha key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['git']['commit_sha']).to eq('my-commit-sha')
+      end
+    end
+
+    context 'when GIT_COMMIT_SHA is not present in the ENV' do
+      before do
+        ENV['GIT_COMMIT_SHA'] = nil
+      end
+
+      it 'reports null in the info/git/commit_sha key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['git']['commit_sha']).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

It will be very helpful to be able to see which version is running on which environment ([Trello card](https://trello.com/c/GO9yEnZz/188-add-a-healthcheckjson-endpoint-that-includes-the-git-sha))

### Changes proposed in this pull request

Bake git commit / branch into the Docker container as env vars
Add healthcheck.json endpoint which reports them alongside overall status and status of backing services

### Guidance to review

Check out the endpoint on dev: 
<img width="1170" alt="Screen Shot 2020-06-26 at 13 42 44" src="https://user-images.githubusercontent.com/134501/85858414-81a00b80-b7b3-11ea-8530-6f2570e25a21.png">

To test locally, provide `GIT_COMMIT_SHA` and `GIT_BRANCH` as env vars to the rails server (for instance `GIT_COMMIT_SHA=abc123 GIT_BRANCH=my-branch bundle exec rails s`) and then hit /healthcheck.json
