### PR TITLE
Add content security policy

### DIFF
--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -7,7 +7,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  config.host = "www.education.gov.uk"
+  config.host = ENV['HOSTNAME_FOR_URLS'] || 'get-help-with-tech.education.gov.uk'
   config.port# = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
-  policy.script_src  :self, :https
+  policy.script_src  :self
   policy.style_src   :self, :https
   # If you are using webpack-dev-server then specify webpack-dev-server host
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?


### PR DESCRIPTION
### Context

We don't have a Content Security Policy header. We should - the pen testers reported this as an issue.

### Changes proposed in this pull request

Add a suitable CSP

### Guidance to review

Point this online checker at dev: https://csp-evaluator.withgoogle.com/

BEFORE:

<img width="922" alt="Screen Shot 2020-06-26 at 14 40 16" src="https://user-images.githubusercontent.com/134501/85865228-7b169180-b7bd-11ea-9a3a-6adfd32e9dd1.png">

AFTER:

<img width="933" alt="Screen Shot 2020-06-26 at 14 58 46" src="https://user-images.githubusercontent.com/134501/85865320-9c777d80-b7bd-11ea-9381-1b8e507f08be.png">

(note that the Rails DSL doesn't yet support the `require-trusted-types-for` flag. Not a biggie.)