### PR TITLE
Fix ability to modify bulk_update params & update recipients from other MNOs

### DIFF
--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -27,4 +27,8 @@ class Recipient < ApplicationRecord
   def self.from_approved_users
     joins(:created_by_user).where.not(users: { approved_at: nil })
   end
+
+  def self.visible_to_user(user)
+    from_approved_users.where(mobile_network_id: user.mobile_network_id)
+  end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src  :self
   policy.style_src   :self, :https
   # If you are using webpack-dev-server then specify webpack-dev-server host
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+  policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035' if Rails.env.development?
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"

--- a/spec/controllers/allocation_request_forms_controller_spec.rb
+++ b/spec/controllers/allocation_request_forms_controller_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 describe AllocationRequestFormsController, type: :controller do
-  def sign_in_as(user)
-    # TestSession doesn't do this automatically like a real session
-    session[:session_id] = SecureRandom.uuid
-    controller.send(:save_user_to_session!, user)
-  end
-
   describe '#create' do
     let(:invalid_params) do
       {

--- a/spec/controllers/mno/recipients_controller_spec.rb
+++ b/spec/controllers/mno/recipients_controller_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe Mno::RecipientsController, type: :controller do
+  let(:local_authority_user) { create(:local_authority_user) }
+  let(:mno_user) { create(:mno_user) }
+  let(:other_mno) { create(:mobile_network, brand: 'Other MNO') }
+  let(:user_from_other_mno) { create(:mno_user, name: 'Other MNO-User', organisation: 'Other MNO', mobile_network: other_mno) }
+  let!(:recipient_1_for_mno) { create(:recipient, account_holder_name: 'mno recipient', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
+  let!(:recipient_2_for_mno) { create(:recipient, account_holder_name: 'mno recipient', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
+  let!(:recipient_for_other_mno) { create(:recipient, account_holder_name: 'other mno recipient', mobile_network: other_mno, created_by_user: local_authority_user) }
+
+  before do
+    sign_in_as mno_user
+  end
+
+  describe 'PUT /bulk_update' do
+    let(:valid_params) do
+      {
+        mno_recipients_form: {
+          recipient_ids: recipients.pluck('id'),
+          status: 'cancelled',
+        },
+      }
+    end
+    let(:recipient_statusses) { recipients.map { |r| r.reload.status } }
+
+    context 'with recipient_ids from the same MNO as the user' do
+      let(:recipients) { [recipient_1_for_mno, recipient_2_for_mno] }
+
+      it 'updates all the recipients' do
+        put :bulk_update, params: valid_params
+
+        expect(recipient_1_for_mno.reload.status).to eq('cancelled')
+        expect(recipient_2_for_mno.reload.status).to eq('cancelled')
+      end
+
+      it 'redirects_to recipients index' do
+        put :bulk_update, params: valid_params
+        expect(response).to redirect_to(mno_recipients_path)
+      end
+    end
+
+    # Pentest issue, Trello card #202
+    context 'with some recipient_ids from another MNO' do
+      let(:recipients) { [recipient_1_for_mno, recipient_for_other_mno] }
+
+      it 'updates the recipients from the same MNO as the user' do
+        put :bulk_update, params: valid_params
+
+        expect(recipient_1_for_mno.reload.status).to eq('cancelled')
+      end
+
+      it 'does not update the recipient from the other MNO' do
+        put :bulk_update, params: valid_params
+
+        expect(recipient_for_other_mno.reload.status).not_to eq('cancelled')
+      end
+
+      it 'redirects_to recipients index' do
+        put :bulk_update, params: valid_params
+        expect(response).to redirect_to(mno_recipients_path)
+      end
+    end
+
+    context 'when the given status is not valid' do
+      let(:recipients) { [recipient_1_for_mno, recipient_2_for_mno] }
+      let(:params_with_invalid_status) do
+        {
+          mno_recipients_form: {
+            recipient_ids: recipients.pluck('id'),
+            status: 'not_a_real_status',
+          },
+        }
+      end
+
+      it 'does not update the statusses' do
+        put :bulk_update, params: params_with_invalid_status
+        expect(recipient_1_for_mno.reload.status).not_to eq('not_a_real_status')
+        expect(recipient_2_for_mno.reload.status).not_to eq('not_a_real_status')
+      end
+
+      it 'responds with :unprocessable_entity' do
+        put :bulk_update, params: params_with_invalid_status
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/features/mno/recipients_spec.rb
+++ b/spec/features/mno/recipients_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/sign_in_as'
 require 'shared/expect_download'
 
 RSpec.feature 'MNO Requests view', type: :feature do

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'shared/filling_in_forms'
-require 'support/sign_in_as'
 
 RSpec.feature 'Session behaviour', type: :feature do
   scenario 'new visitor has sign in link' do

--- a/spec/features/submitting_an_allocation_request_form_spec.rb
+++ b/spec/features/submitting_an_allocation_request_form_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/sign_in_as'
 
 RSpec.feature 'Submitting an allocation_request_form', type: :feature do
   context 'not signed in' do

--- a/spec/features/submitting_an_application_form_spec.rb
+++ b/spec/features/submitting_an_application_form_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/sign_in_as'
 require 'shared/filling_in_forms'
 
 RSpec.feature 'Submitting an application_form', type: :feature do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/factory_bot'
+require 'support/controller_helper'
 require 'support/capybara_helper'
 require 'capybara/email/rspec'
 
@@ -105,5 +106,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace('gem name')
 
-  config.include CapybaraHelper
+  config.include CapybaraHelper, type: :feature
+  config.include ControllerHelper, type: :controller
 end

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -3,4 +3,12 @@ module CapybaraHelper
     encoded_login = ["#{username}:#{password}"].pack('m*')
     page.driver.header 'Authorization', "Basic #{encoded_login}"
   end
+
+  def sign_in_as(user)
+    token = user.generate_token!
+    identifier = user.sign_in_identifier(token)
+    validate_token_url = validate_sign_in_token_url(token: token, identifier: identifier)
+
+    visit validate_token_url
+  end
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,0 +1,7 @@
+module ControllerHelper
+  def sign_in_as(user)
+    # TestSession doesn't do this automatically like a real session
+    session[:session_id] = SecureRandom.uuid
+    controller.send(:save_user_to_session!, user)
+  end
+end

--- a/spec/support/sign_in_as.rb
+++ b/spec/support/sign_in_as.rb
@@ -1,7 +1,0 @@
-def sign_in_as(user)
-  token = user.generate_token!
-  identifier = user.sign_in_identifier(token)
-  validate_token_url = validate_sign_in_token_url(token: token, identifier: identifier)
-
-  visit validate_token_url
-end


### PR DESCRIPTION
### Context

The pentest identified that a malicious user could modify the `recipient_ids` parameter in a bulk_update and modify the status of recipients for other MNOs

### Changes proposed in this pull request

Fix the loophole that allowed users to do that.
Add tests for this scenario

### Guidance to review

From the root directory in a shell, `rspec spec/controllers/mno/recipients_controller_spec.rb --format doc`
You should see output similar to this:

```
Mno::RecipientsController
  PUT /bulk_update
    with recipient_ids from the same MNO as the user
      updates all the recipients
      redirects_to recipients index
    with some recipient_ids from another MNO
      updates the recipients from the same MNO as the user
      does not update the recipient from the other MNO
      redirects_to recipients index
    when the given status is not valid
      does not update the statusses
      responds with :unprocessable_entity

Finished in 0.46959 seconds (files took 3.1 seconds to load)
7 examples, 0 failures
```


