### PR TITLE
add promote Makefile task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ prod:
 	$(eval export db_plan=small-ha-11)
 	@true
 
-.PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app
+.PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app promote
 
 require_env_stub:
 	test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
@@ -60,3 +60,9 @@ deploy: set_cf_target ## Deploy the docker image to gov.uk PaaS
 
 release: require_env_stub
 	make ${env_stub} build push deploy
+
+promote:
+	test ${FROM} || (echo ">> FROM is not set (${FROM})- please use make promote FROM=(dev|staging|prod)"; exit 1)
+	docker pull $(REMOTE_DOCKER_IMAGE_NAME)-$(FROM)
+	docker tag $(REMOTE_DOCKER_IMAGE_NAME)-$(FROM) $(APP_NAME)-$(env_stub)
+	make $(env_stub) push deploy

--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@ bundle exec brakeman
 2. Run `docker login` to log in to Docker Hub
 3. Run `make dev build push deploy` to build, push and deploy the Docker image to GOV.UK PaaS development instance
 4. Test on https://get-help-with-tech-dev.london.cloudapps.digital
-5. Run `docker tag dfedigital/get-help-with-tech-dev:latest get-help-with-tech-staging` to promote the Docker image to staging
-6. Run `make staging push deploy` to deploy to staging
+5. Run `make staging promote FROM=dev` to deploy the -dev image to staging
 7. Test on https://get-help-with-tech-staging.london.cloudapps.digital
-8. Run `docker tag dfedigital/get-help-with-tech-dev:latest get-help-with-tech-prod` to promote the Docker image to prod
-9. Run `make prod push deploy` to deploy to production
+8. Run `make prod promote FROM=staging` to deploy to production
 10. Test on https://get-help-with-tech-prod.london.cloudapps.digital
 
 The app should be available at https://get-help-with-tech-(dev|staging|prod).london.cloudapps.digital


### PR DESCRIPTION
### Context

Making different docker images for dev, staging and prod can be useful when you want to deploy different versions - but not when you want to promote a particular image between environments. You don't get the comfort of knowing that it's the _exact same_ image.

### Changes proposed in this pull request

Add a `make (target env) promote FROM=(source env)` task, and update the README.

This task pulls the (source env) image from dockerhub, tags it for the target-env, and then calls `make (target env) push deploy` as normal

### Guidance to review

Try deploying a new dev image (`make dev build push deploy`), then promoting it to staging with `make staging promote FROM=dev`
If you then hit compare the dev and staging healthcheck endpoints (https://get-help-with-tech-dev.london.cloudapps.digital/healthcheck.json and https://get-help-with-tech-staging.london.cloudapps.digital/healthcheck.json) you should see that the git_commit_sha and git_branch attributes are exactly the same.

_caveat: yes, this is comparing the git commit rather than the docker image id - but there doesn't seem to be a way of introspecting the image id from within PaaS, and you can't bake an image id into an image that's still being built, so this will have to do for now at least_