### PR TITLE
fix for pentest issue - user can view success pages for submissions from other users

### DIFF
--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -16,12 +16,10 @@ class AllocationRequestFormsController < ApplicationController
   end
 
   def success
-    @allocation_request = AllocationRequest.where(id: params[:allocation_request_id], created_by_user_id: @user.id).first
-    if @allocation_request
-      @allocation_request_form = AllocationRequestForm.new(allocation_request: @allocation_request)
-    else
-      render template: 'errors/not_found', status: :not_found
-    end
+    @allocation_request = @user.allocation_requests.find(params[:allocation_request_id])
+    @allocation_request_form = AllocationRequestForm.new(allocation_request: @allocation_request)
+  rescue ActiveRecord::RecordNotFound
+    render template: 'errors/not_found', status: :not_found
   end
 
 private

--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -9,16 +9,19 @@ class AllocationRequestFormsController < ApplicationController
     @allocation_request_form = AllocationRequestForm.new(allocation_request_form_params.merge(created_by_user: @user))
     begin
       @allocation_request_form.save!
-      redirect_to allocation_request_form_success_path(@allocation_request_form.allocation_request.id)
+      redirect_to success_allocation_request_forms_path(@allocation_request_form.allocation_request.id)
     rescue ActiveModel::ValidationError
       render :new, status: :bad_request
     end
   end
 
   def success
-    # NOTE: restful route expects :application_form_id, we're actually using it
-    # to retrieve the recipient. Not good, need to refactor
-    @allocation_request_form = AllocationRequestForm.new(allocation_request: AllocationRequest.find(params[:allocation_request_form_id]))
+    @allocation_request = AllocationRequest.where(id: params[:allocation_request_id], created_by_user_id: @user.id).first
+    if @allocation_request
+      @allocation_request_form = AllocationRequestForm.new(allocation_request: @allocation_request)
+    else
+      render template: 'errors/not_found', status: :not_found
+    end
   end
 
 private

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -10,7 +10,7 @@ class ApplicationFormsController < ApplicationController
     @application_form = ApplicationForm.new(application_form_params.merge(created_by_user: @user))
     begin
       @application_form.save!
-      redirect_to application_form_success_path(@application_form.recipient.id)
+      redirect_to success_application_forms_path(recipient_id: @application_form.recipient.id)
     rescue ActiveModel::ValidationError
       @mobile_networks = MobileNetwork.order('LOWER(brand)')
       render :new, status: :bad_request
@@ -18,9 +18,12 @@ class ApplicationFormsController < ApplicationController
   end
 
   def success
-    # NOTE: restful route expects :application_form_id, we're actually using it
-    # to retrieve the recipient. Not good, need to refactor
-    @application_form = ApplicationForm.new(recipient: Recipient.find(params[:application_form_id]))
+    @recipient = Recipient.where(id: params[:recipient_id], created_by_user_id: @user.id).first
+    if @recipient
+      @application_form = ApplicationForm.new(recipient: @recipient)
+    else
+      render template: 'errors/not_found', status: :not_found
+    end
   end
 
 private

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -18,12 +18,10 @@ class ApplicationFormsController < ApplicationController
   end
 
   def success
-    @recipient = Recipient.where(id: params[:recipient_id], created_by_user_id: @user.id).first
-    if @recipient
-      @application_form = ApplicationForm.new(recipient: @recipient)
-    else
-      render template: 'errors/not_found', status: :not_found
-    end
+    @recipient = @user.recipients.find(params[:recipient_id])
+    @application_form = ApplicationForm.new(recipient: @recipient)
+  rescue ActiveRecord::RecordNotFound
+    render template: 'errors/not_found', status: :not_found
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :allocation_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
+  has_many :recipients, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
+
   belongs_to :mobile_network, optional: true
 
   validates :full_name,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,10 @@ Rails.application.routes.draw do
   get '/pages/guidance', to: redirect('/about-bt-wifi')
 
   resources :application_forms do
-    get 'success/:application_form_id', to: 'application_forms#success', as: :success
+    get 'success/:recipient_id', on: :collection, to: 'application_forms#success', as: :success
   end
   resources :allocation_request_forms do
-    get 'success', to: 'allocation_request_forms#success'
+    get 'success/:allocation_request_id', on: :collection, to: 'allocation_request_forms#success', as: :success
   end
 
   resources :sessions, only: %i[create destroy]

--- a/spec/controllers/allocation_request_forms_controller_spec.rb
+++ b/spec/controllers/allocation_request_forms_controller_spec.rb
@@ -79,4 +79,31 @@ describe AllocationRequestFormsController, type: :controller do
       end
     end
   end
+
+  describe 'success' do
+    let(:user) { create(:local_authority_user) }
+    let(:other_user) { create(:local_authority_user, email_address: 'other user') }
+
+    before do
+      sign_in_as user
+    end
+
+    context 'given the id of an allocation_request created_by the current user' do
+      let(:allocation_request) { create(:allocation_request, created_by_user: user) }
+
+      it 'responds with 200' do
+        get :success, params: { allocation_request_id: allocation_request.id }
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'given the id of an allocation_request not created_by the current user' do
+      let(:allocation_request) { create(:allocation_request, created_by_user: other_user) }
+
+      it 'responds with 404' do
+        get :success, params: { allocation_request_id: allocation_request.id }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/spec/controllers/application_forms_controller_spec.rb
+++ b/spec/controllers/application_forms_controller_spec.rb
@@ -71,6 +71,11 @@ describe ApplicationFormsController, type: :controller do
         the_request
         expect(created_recipient.created_by_user_id).to eq(session[:user_id])
       end
+
+      it 'redirects to :success' do
+        the_request
+        expect(response).to redirect_to(success_application_forms_path(created_recipient.id))
+      end
     end
 
     context 'with invalid params and an existing user in session' do
@@ -89,6 +94,33 @@ describe ApplicationFormsController, type: :controller do
       it 'responds with a 400 status code' do
         post :create, params: params
         expect(response.status).to eq(400)
+      end
+    end
+  end
+
+  describe 'success' do
+    let(:user) { create(:local_authority_user) }
+    let(:other_user) { create(:local_authority_user, email_address: 'other user') }
+
+    before do
+      sign_in_as user
+    end
+
+    context 'given the id of a recipient created_by the current user' do
+      let(:recipient) { create(:recipient, created_by_user: user) }
+
+      it 'responds with 200' do
+        get :success, params: { recipient_id: recipient.id }
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'given the id of a recipient not created_by the current user' do
+      let(:recipient) { create(:recipient, created_by_user: other_user) }
+
+      it 'responds with 404' do
+        get :success, params: { recipient_id: recipient.id }
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/factories/allocation_requests.rb
+++ b/spec/factories/allocation_requests.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :allocation_request, class: 'AllocationRequest' do
+    number_eligible                     { Faker::Number.between(from: 0, to: 100) }
+    number_eligible_with_hotspot_access { Faker::Number.between(from: 0, to: number_eligible) }
+    association :created_by_user, factory: :local_authority_user
+  end
+end


### PR DESCRIPTION
### Context

The pentest found that if a user could guess the ID of another users' form submission, they could see the success page for it, which exposed the submitting users' email address (details in the [Trello card](https://trello.com/c/HROXHQ6u/205-username-email-enumeration-issue) )

### Changes proposed in this pull request

Fix the issue by including created_by_user_id criteria in the success page query
Tidy up "TODO" issue with correct parameter names
Add specs

### Guidance to review

1. Sign-in as a regular user
2. Submit one of each kind of form. Copy the URL of the success page (e.g. `/allocation_request_forms/2/success`)
3. Sign-in as a different user
4. Enter the URL of the previous user's success page into your browser's address bar
5. Before, you would be able to see that users' email address. Now, you should only see a 404
