### PR TITLE
fix CSV code injection vulnerability

### DIFF
--- a/app/concerns/exportable_as_csv.rb
+++ b/app/concerns/exportable_as_csv.rb
@@ -17,9 +17,16 @@ module ExportableAsCsv
         csv << exportable_attributes.values
 
         all.each do |item|
-          csv << exportable_attributes.keys.map { |attr| item.send(attr) }
+          csv << exportable_attributes.keys.map do |attr|
+            safe_value = prevent_csv_code_injection(item.send(attr))
+            safe_value
+          end
         end
       end
+    end
+
+    def self.prevent_csv_code_injection(value)
+      value.to_s.starts_with?(/[\-+=@]/) ? value.gsub(/^([\-+=@].*)/, '.\1') : value
     end
   end
 end

--- a/app/concerns/exportable_as_csv.rb
+++ b/app/concerns/exportable_as_csv.rb
@@ -18,8 +18,7 @@ module ExportableAsCsv
 
         all.each do |item|
           csv << exportable_attributes.keys.map do |attr|
-            safe_value = prevent_csv_code_injection(item.send(attr))
-            safe_value
+            prevent_csv_code_injection(item.send(attr))
           end
         end
       end

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -1,5 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Recipient, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'to_csv' do
+    let(:recipients) { Recipient.all }
+
+    context 'when account_holder_name starts with a =' do
+      before { create(:recipient, account_holder_name: '=(1+2)') }
+
+      it 'prepends the = with a .' do
+        expect(recipients.to_csv).to include('.=(1+2)')
+      end
+    end
+
+    context 'when account_holder_name does not start with a =' do
+      before { create(:recipient, account_holder_name: 'Ben Benson') }
+
+      it 'does not prepend the account_holder_name with a .' do
+        expect(recipients.to_csv).to include('Ben Benson')
+        expect(recipients.to_csv).not_to include('.Ben Benson')
+      end
+    end
+
+    context 'when device_phone_number starts with a =' do
+      before { create(:recipient, device_phone_number: '=(1+2)') }
+
+      it 'prepends the = with a .' do
+        expect(recipients.to_csv).to include('.=(1+2)')
+      end
+    end
+
+    context 'when device_phone_number does not start with a =' do
+      before { create(:recipient, account_holder_name: '07123456789') }
+
+      it 'does not prepend the device_phone_number with a .' do
+        expect(recipients.to_csv).to include('07123456789')
+        expect(recipients.to_csv).not_to include('.07123456789')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

The pentest found it was possible to inject content into an exported CSV file via starting a user-inputted field with a =,+,-, or @ - the [CSV Injection vulnerability](https://owasp.org/www-community/attacks/CSV_Injection)

### Changes proposed in this pull request

Fix the issue by prepending a single '.' to any field in an exported CSV that starts with one of those characters

### Guidance to review

1. Sign in as an approved user
2. Submit a 'Tell us about an eligible person' form for a mobile network to which you have a login, and make the account holder name or device phone number something like `'=(1 + 2)'`
3. Sign in as the mobile network user, and download the CSV file
4. Open the CSV file in the spreadsheet program of your choice (Google spreadsheets, Open Office, Libre Office, Numbers, Excel)
5. Make sure that the field which had started with an equals sign ('=') :
  a. starts with a .
  b. is not interpreted as a formula (i.e. does not not contain '3')
