### PR TITLE
Add responsible bodies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ group :development, :test do
 
   # Testing framework
   gem 'rspec-rails', '~> 4.0.1'
+
+  # Stubbing web requests
+  gem 'webmock'
+
   # GOV.UK interpretation of rubocop for linting Ruby
   gem 'rubocop-govuk'
   gem 'scss_lint-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     database_cleaner (1.8.5)
     database_cleaner-active_record (1.8.0)
@@ -130,6 +132,7 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
+    hashdiff (1.0.1)
     highline (1.7.10)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
@@ -262,6 +265,7 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -318,6 +322,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -367,6 +375,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers (~> 4.3)
+  webmock
   webpacker
 
 RUBY VERSION

--- a/app/models/get_information_about_schools.rb
+++ b/app/models/get_information_about_schools.rb
@@ -1,0 +1,13 @@
+require 'open-uri'
+require 'csv'
+
+class GetInformationAboutSchools
+  URL = 'https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/allgroupsdata.csv'.freeze
+
+  def self.trusts_entries
+    gias_csv = URI.parse(URL).read.force_encoding(Encoding::ISO8859_1)
+    CSV.parse(gias_csv, headers: true).select { |row|
+      row['Group Type'].in? ['Single-academy trust', 'Multi-academy trust']
+    }.map(&:to_h)
+  end
+end

--- a/app/models/local_authorities_in_england_register.rb
+++ b/app/models/local_authorities_in_england_register.rb
@@ -1,0 +1,13 @@
+require 'open-uri'
+
+class LocalAuthoritiesInEnglandRegister
+  URL = 'https://local-authority-eng.register.gov.uk/records.json?page-size=5000'.freeze
+
+  def self.entries
+    local_authorities_register_results = JSON.parse(URI.open(URL).read)
+
+    local_authorities_register_results
+      .values
+      .map { |result| result['item'].first }
+  end
+end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,0 +1,2 @@
+class LocalAuthority < ResponsibleBody
+end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -1,0 +1,2 @@
+class ResponsibleBody < ApplicationRecord
+end

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -1,0 +1,2 @@
+class Trust < ResponsibleBody
+end

--- a/app/services/import_responsible_bodies_service.rb
+++ b/app/services/import_responsible_bodies_service.rb
@@ -1,0 +1,24 @@
+class ImportResponsibleBodiesService
+  def import_local_authorities
+    LocalAuthoritiesInEnglandRegister.entries.each do |entry|
+      LocalAuthority
+        .where(local_authority_eng: entry['local-authority-eng'])
+        .first_or_create!(
+          name: entry['name'],
+          organisation_type: entry['local-authority-type'],
+          local_authority_official_name: entry['official-name'],
+        )
+    end
+  end
+
+  def import_trusts
+    GetInformationAboutSchools.trusts_entries.each do |entry|
+      Trust
+        .where(companies_house_number: entry['Companies House Number'])
+        .first_or_create!(
+          name: entry['Group Name'],
+          organisation_type: entry['Group Type'],
+        )
+    end
+  end
+end

--- a/db/migrate/20200630142716_create_responsible_bodies.rb
+++ b/db/migrate/20200630142716_create_responsible_bodies.rb
@@ -1,0 +1,14 @@
+class CreateResponsibleBodies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :responsible_bodies do |t|
+      t.string :type, null: false
+      t.string :name, null: false
+      t.string :organisation_type, null: false
+      t.string :local_authority_official_name
+      t.string :local_authority_eng
+      t.string :companies_house_number
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_233926) do
+ActiveRecord::Schema.define(version: 2020_06_30_142716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,17 @@ ActiveRecord::Schema.define(version: 2020_06_24_233926) do
     t.integer "created_by_user_id"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_recipients_on_mobile_network_id_and_status_and_created_at"
     t.index ["status"], name: "index_recipients_on_status"
+  end
+
+  create_table "responsible_bodies", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "name", null: false
+    t.string "organisation_type", null: false
+    t.string "local_authority_official_name"
+    t.string "local_authority_eng"
+    t.string "companies_house_number"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "sessions", id: :string, force: :cascade do |t|

--- a/lib/tasks/import_responsible_bodies.rake
+++ b/lib/tasks/import_responsible_bodies.rake
@@ -11,4 +11,19 @@ namespace :import do
         )
     end
   end
+
+  desc 'Import single and multi-academy trusts'
+  task trusts: :environment do
+    GetInformationAboutSchools.trusts_entries.each do |entry|
+      Trust
+        .where(companies_house_number: entry['Companies House Number'])
+        .first_or_create!(
+          name: entry['Group Name'],
+          organisation_type: entry['Group Type'],
+        )
+    end
+  end
+
+  desc 'Populate the responsible body reference data table'
+  task responsible_bodies: %i[local_authorities_in_england trusts]
 end

--- a/lib/tasks/import_responsible_bodies.rake
+++ b/lib/tasks/import_responsible_bodies.rake
@@ -1,27 +1,12 @@
 namespace :import do
   desc 'Import local authorities in England'
   task local_authorities_in_england: :environment do
-    LocalAuthoritiesInEnglandRegister.entries.each do |entry|
-      LocalAuthority
-        .where(local_authority_eng: entry['local-authority-eng'])
-        .first_or_create!(
-          name: entry['name'],
-          organisation_type: entry['local-authority-type'],
-          local_authority_official_name: entry['official-name'],
-        )
-    end
+    ImportResponsibleBodiesService.new.import_local_authorities
   end
 
   desc 'Import single and multi-academy trusts'
   task trusts: :environment do
-    GetInformationAboutSchools.trusts_entries.each do |entry|
-      Trust
-        .where(companies_house_number: entry['Companies House Number'])
-        .first_or_create!(
-          name: entry['Group Name'],
-          organisation_type: entry['Group Type'],
-        )
-    end
+    ImportResponsibleBodiesService.new.import_trusts
   end
 
   desc 'Populate the responsible body reference data table'

--- a/lib/tasks/import_responsible_bodies.rake
+++ b/lib/tasks/import_responsible_bodies.rake
@@ -1,0 +1,14 @@
+namespace :import do
+  desc 'Import local authorities in England'
+  task local_authorities_in_england: :environment do
+    LocalAuthoritiesInEnglandRegister.entries.each do |entry|
+      LocalAuthority
+        .where(local_authority_eng: entry['local-authority-eng'])
+        .first_or_create!(
+          name: entry['name'],
+          organisation_type: entry['local-authority-type'],
+          local_authority_official_name: entry['official-name'],
+        )
+    end
+  end
+end

--- a/spec/models/get_information_about_schools_spec.rb
+++ b/spec/models/get_information_about_schools_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe GetInformationAboutSchools, type: :model do
+  it 'returns a filtered list of single- and multi-academy trusts' do
+    data = [
+      'Group Name,Companies House Number,Group Type',
+      'AAA,12345,Federation',
+      'AA TRUST,67890,Single-academy trust',
+      'ABC MAT,13579,Multi-academy trust',
+    ].join("\n")
+
+    stub_request(:get, GetInformationAboutSchools::URL)
+      .to_return(body: data)
+
+    entries = GetInformationAboutSchools.trusts_entries
+
+    expect(entries.size).to eq(2)
+    expect(entries.first).to eq({
+      'Group Name' => 'AA TRUST',
+      'Companies House Number' => '67890',
+      'Group Type' => 'Single-academy trust',
+    })
+    expect(entries.second).to eq({
+      'Group Name' => 'ABC MAT',
+      'Companies House Number' => '13579',
+      'Group Type' => 'Multi-academy trust',
+    })
+  end
+end

--- a/spec/models/local_authorities_in_england_register_spec.rb
+++ b/spec/models/local_authorities_in_england_register_spec.rb
@@ -3,7 +3,38 @@ require 'rails_helper'
 RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
   it 'returns a list of entries' do
     stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
-      .to_return(body: '{"BRD":{"index-entry-number":"11","entry-number":"11","entry-timestamp":"2016-10-21T16:11:20Z","key":"BRD","item":[{"local-authority-type":"MD","official-name":"City of Bradford Metropolitan District Council","local-authority-eng":"BRD","name":"Bradford","start-date":"1974-04-01"}]},"TEI":{"index-entry-number":"128","entry-number":"128","entry-timestamp":"2016-10-21T16:11:20Z","key":"TEI","item":[{"local-authority-type":"NMD","official-name":"Teignbridge District Council","local-authority-eng":"TEI","name":"Teignbridge"}]}}')
+      .to_return(body: '
+        {
+          "BRD": {
+            "index-entry-number": "11",
+            "entry-number": "11",
+            "entry-timestamp": "2016-10-21T16:11:20Z",
+            "key": "BRD",
+            "item": [
+              {
+                "local-authority-type": "MD",
+                "official-name": "City of Bradford Metropolitan District Council",
+                "local-authority-eng": "BRD",
+                "name": "Bradford",
+                "start-date": "1974-04-01"
+              }
+            ]
+          },
+          "TEI": {
+            "index-entry-number": "128",
+            "entry-number": "128",
+            "entry-timestamp": "2016-10-21T16:11:20Z",
+            "key": "TEI",
+            "item": [
+              {
+                "local-authority-type": "NMD",
+                "official-name": "Teignbridge District Council",
+                "local-authority-eng": "TEI",
+                "name": "Teignbridge"
+              }
+            ]
+          }
+        }')
 
     entries = LocalAuthoritiesInEnglandRegister.entries
 

--- a/spec/models/local_authorities_in_england_register_spec.rb
+++ b/spec/models/local_authorities_in_england_register_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
+  it 'returns a list of entries' do
+    stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
+      .to_return(body: '{"BRD":{"index-entry-number":"11","entry-number":"11","entry-timestamp":"2016-10-21T16:11:20Z","key":"BRD","item":[{"local-authority-type":"MD","official-name":"City of Bradford Metropolitan District Council","local-authority-eng":"BRD","name":"Bradford","start-date":"1974-04-01"}]},"TEI":{"index-entry-number":"128","entry-number":"128","entry-timestamp":"2016-10-21T16:11:20Z","key":"TEI","item":[{"local-authority-type":"NMD","official-name":"Teignbridge District Council","local-authority-eng":"TEI","name":"Teignbridge"}]}}')
+
+    entries = LocalAuthoritiesInEnglandRegister.entries
+
+    expect(entries.size).to eq(2)
+    expect(entries.first).to include({
+      'local-authority-type' => 'MD',
+      'official-name' => 'City of Bradford Metropolitan District Council',
+      'local-authority-eng' => 'BRD',
+      'name' => 'Bradford',
+    })
+    expect(entries.second).to include({
+      'local-authority-type' => 'NMD',
+      'official-name' => 'Teignbridge District Council',
+      'local-authority-eng' => 'TEI',
+      'name' => 'Teignbridge',
+    })
+  end
+end

--- a/spec/services/import_responsible_bodies_service_spec.rb
+++ b/spec/services/import_responsible_bodies_service_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe ImportResponsibleBodiesService, type: :model do
+  it 'imports each local authority only once' do
+    stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
+      .to_return(body: '
+        {
+          "BRD": {
+            "index-entry-number": "11",
+            "entry-number": "11",
+            "entry-timestamp": "2016-10-21T16:11:20Z",
+            "key": "BRD",
+            "item": [
+              {
+                "local-authority-type": "MD",
+                "official-name": "City of Bradford Metropolitan District Council",
+                "local-authority-eng": "BRD",
+                "name": "Bradford",
+                "start-date": "1974-04-01"
+              }
+            ]
+          },
+          "TEI": {
+            "index-entry-number": "128",
+            "entry-number": "128",
+            "entry-timestamp": "2016-10-21T16:11:20Z",
+            "key": "TEI",
+            "item": [
+              {
+                "local-authority-type": "NMD",
+                "official-name": "Teignbridge District Council",
+                "local-authority-eng": "TEI",
+                "name": "Teignbridge"
+              }
+            ]
+          }
+        }')
+
+    ImportResponsibleBodiesService.new.import_local_authorities
+
+    expect(LocalAuthority.count).to eq(2)
+
+    local_authorities = LocalAuthority.all.order("local_authority_eng asc")
+    expect(local_authorities.first.organisation_type).to eq('MD')
+    expect(local_authorities.first.local_authority_official_name).to eq('City of Bradford Metropolitan District Council')
+    expect(local_authorities.first.local_authority_eng).to eq('BRD')
+    expect(local_authorities.first.name).to eq('Bradford')
+
+    expect(local_authorities.second.organisation_type).to eq('NMD')
+    expect(local_authorities.second.local_authority_official_name).to eq('Teignbridge District Council')
+    expect(local_authorities.second.local_authority_eng).to eq('TEI')
+    expect(local_authorities.second.name).to eq('Teignbridge')
+
+    # re-run import again to check idempotence
+    ImportResponsibleBodiesService.new.import_local_authorities
+    expect(LocalAuthority.count).to eq(2)
+  end
+
+  it 'imports single- and multi-academy trusts only once' do
+    data = [
+      'Group Name,Companies House Number,Group Type',
+      'AAA,12345,Federation',
+      'AA TRUST,67890,Single-academy trust',
+      'ABC MAT,13579,Multi-academy trust',
+    ].join("\n")
+
+    stub_request(:get, GetInformationAboutSchools::URL)
+      .to_return(body: data)
+
+    ImportResponsibleBodiesService.new.import_trusts
+
+    expect(Trust.count).to eq(2)
+
+    trusts = Trust.all.order("name asc")
+    expect(trusts.first.name).to eq('AA TRUST')
+    expect(trusts.first.companies_house_number).to eq('67890')
+    expect(trusts.first.organisation_type).to eq('Single-academy trust')
+
+    expect(trusts.second.name).to eq('ABC MAT')
+    expect(trusts.second.companies_house_number).to eq('13579')
+    expect(trusts.second.organisation_type).to eq('Multi-academy trust')
+
+    # re-run import again to check idempotence
+    ImportResponsibleBodiesService.new.import_trusts
+    expect(Trust.count).to eq(2)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@
 require 'simplecov'
 SimpleCov.start
 
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
### Context

Responsible bodies (trusts and local authorities) will use the service.

### Changes proposed in this pull request

- create an STI `ResponsibleBody` model, with `LocalAuthority` and `Trust` subclasses
- add a Rake task to fetch local authority data from the [Local authorities in England register](https://www.registers.service.gov.uk/registers/local-authority-eng)
- add a Rake task to fetch trusts from the [Get information about schools service](https://get-information-schools.service.gov.uk/)

