### PR TITLE
add Cache-Control header in production if env var set 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ HTTP_BASIC_AUTH_PASSWORD|Password for HTTP Basic authentication - only has an ef
 GOVUK_NOTIFY_API_KEY|API key for the GOV.UK Notify service, used for sending emails|REQUIRED
 HOSTNAME_FOR_URLS|Hostname used for generating URLs in emails|http://localhost:3000/
 SIGN_IN_TOKEN_MAIL_NOTIFY_TEMPLATE_ID|ID of the template in GOV.UK Notify used for mailing sign-in tokens|'89b4abbb-0f01-4546-bf30-f88db5e0ae3c'
+STATIC_FILE_CACHE_TTL|how long CDNs and browsers should cache static assets for in production, in seconds.|(nil)
 
 ### Feature Flags
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,12 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # tell CDNs (and browsers) to cache static assets for 1hr by default
+  if ENV['STATIC_FILE_CACHE_TTL'].present?
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=' + ENV['STATIC_FILE_CACHE_TTL']
+    }
+  end
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
### Context

Currently the Rails app in prod is serving all static assets, every request.
This makes the logs tricky to navigate

### Changes proposed in this pull request

Add the `Cache-Control` header in production (i.e. all deployed envs) if the `STATIC_FILE_CACHE_TTL` env var is set.

### Guidance to review

