### PR TITLE
make status required on Recipient

### DIFF
--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,7 +1,8 @@
 class Recipient < ApplicationRecord
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network
-
+  validates :status, presence: true
+  
   enum status: {
     requested: 'requested',
     in_progress: 'in_progress',

--- a/db/migrate/20200701140641_disallow_null_recipient_status.rb
+++ b/db/migrate/20200701140641_disallow_null_recipient_status.rb
@@ -1,0 +1,6 @@
+class DisallowNullRecipientStatus < ActiveRecord::Migration[6.0]
+  def change
+    Recipient.where(status: nil).update_all(status: Recipient.statuses[:requested])
+    change_column :recipients, :status, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_132841) do
+ActiveRecord::Schema.define(version: 2020_07_01_140641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_132841) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "mobile_network_id"
-    t.string "status"
+    t.string "status", null: false
     t.integer "created_by_user_id"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_recipients_on_mobile_network_id_and_status_and_created_at"
     t.index ["status"], name: "index_recipients_on_status"

--- a/spec/controllers/mno/recipients_controller_spec.rb
+++ b/spec/controllers/mno/recipients_controller_spec.rb
@@ -84,5 +84,28 @@ describe Mno::RecipientsController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context 'when the given status is nil' do
+      let(:recipients) { [recipient_1_for_mno, recipient_2_for_mno] }
+      let(:params_with_invalid_status) do
+        {
+          mno_recipients_form: {
+            recipient_ids: recipients.pluck('id'),
+            status: nil,
+          },
+        }
+      end
+
+      it 'does not update the statusses' do
+        put :bulk_update, params: params_with_invalid_status
+        expect(recipient_1_for_mno.reload.status).not_to be_nil
+        expect(recipient_2_for_mno.reload.status).not_to be_nil
+      end
+
+      it 'responds with :unprocessable_entity' do
+        put :bulk_update, params: params_with_invalid_status
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Pentest issue - still possible to hack the body of a POST request and force a nil status, which then gets applied on a bulk_update and causes the recipients page to throw an error.

### Changes proposed in this pull request

Enforce presence of status on recipient
Add a spec for the particular scenario identified.

### Guidance to review

from the console:

```
[16] pry(main)> Recipient.last.valid?
  Recipient Load (0.5ms)  SELECT "recipients".* FROM "recipients" ORDER BY "recipients"."id" DESC LIMIT $1  [["LIMIT", 1]]
  MobileNetwork Load (0.2ms)  SELECT "mobile_networks".* FROM "mobile_networks" WHERE "mobile_networks"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
=> true

[17] pry(main)> r = Recipient.last; r.status = nil; r.valid?
  Recipient Load (0.4ms)  SELECT "recipients".* FROM "recipients" ORDER BY "recipients"."id" DESC LIMIT $1  [["LIMIT", 1]]
  MobileNetwork Load (0.3ms)  SELECT "mobile_networks".* FROM "mobile_networks" WHERE "mobile_networks"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
=> false

[18] pry(main)> r.errors.full_messages
=> ["'Status' can't be blank"]
```