### PR TITLE
add make task to view logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ prod:
 	$(eval export db_plan=small-ha-11)
 	@true
 
-.PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app promote ssh
+.PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app promote ssh \
+				logs logs-recent
 
 require_env_stub:
 	test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
@@ -70,3 +71,9 @@ promote:
 ssh: set_cf_target
 	echo "\n\nTo get a Rails console, run: \n./setup_env_for_rails_app \nbundle exec rails c\n\n" && \
 		cf ssh $(APP_NAME)-$(env_stub)
+
+logs: set_cf_target
+	cf logs $(APP_NAME)-$(env_stub)
+
+logs-recent: set_cf_target
+	cf logs --recent $(APP_NAME)-$(env_stub)

--- a/README.md
+++ b/README.md
@@ -133,3 +133,18 @@ In this subshell, you can then launch the console in the normal way:
 ```
 bundle exec rails c
 ```
+
+### Viewing Logs
+
+Tail the logs for a given env:
+
+```sh
+make (env) logs
+```
+
+View recent logs for a given env:
+
+```sh
+make (env) logs-recent
+```
+


### PR DESCRIPTION
### Context

Had to dive into the Makefile to figure out how to view logs, figured I'd add this little ditty while there.

### Changes proposed in this pull request

Add convenience task to view logs, similar to other tasks like `ssh`:

```sh
# Tail the logs:
make dev logs

# View recent logs:
make dev logs-recent
```

### Guidance to review

