### PR TITLE
Make /healthcheck.json work when the static_guidance_only feature flag is set

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ private
 
   def check_static_guidance_only_feature_flag!
     if FeatureFlag.active?(:static_guidance_only)
-      render 'errors/not_found', status: :not_found unless controller_name == 'pages'
+      render 'errors/not_found', status: :not_found unless ['pages', 'monitoring'].include?(controller_name)
     end
   end
 end

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -15,6 +15,11 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
       expect(page).to have_http_status(:ok)
     end
 
+    scenario 'visiting the healthcheck works' do
+      visit '/healthcheck.json'
+      expect(page).to have_http_status(:ok)
+    end
+
     scenario 'visiting any other page returns a 404' do
       visit sign_in_path
       expect(page).to have_http_status(:not_found)


### PR DESCRIPTION
### Context

The static_guidance_only feature flag disables all controllers except `pages_controller` - including the healthcheck endpoint. We need the healthcheck endpoint to be working under all conditions.

### Changes proposed in this pull request

Make the static_guidance_only feature flag implementation allow `monitoring` as well as `pages` controllers

### Guidance to review

1. Enable the feature flag: `FEATURES_static_guidance_only=active bundle exec rails s`
2. Visit `/healthcheck.json` - it should work