### PR TITLE
Add public_account_creation feature flag, to align sign-in with the prototype

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -1,6 +1,11 @@
 class SignInTokensController < ApplicationController
   def new
     @sign_in_token_form = SignInTokenForm.new
+    if FeatureFlag.active?(:public_account_creation)
+      render :sign_in_or_create_account
+    else
+      render :sign_in_only
+    end
   end
 
   def validate
@@ -19,7 +24,10 @@ class SignInTokensController < ApplicationController
 
   def create
     @sign_in_token_form = SignInTokenForm.new(sign_in_token_form_params)
-    redirect_to new_user_path and return if @sign_in_token_form.already_have_account == 'no'
+    if FeatureFlag.active?(:public_account_creation) && \
+        @sign_in_token_form.already_have_account == 'no'
+      redirect_to new_user_path and return
+    end
 
     if @sign_in_token_form.valid?
       token = if @sign_in_token_form.email_is_user?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :check_public_account_creation_feature_flag!
+
   def new
     @user = User.new
   end
@@ -30,5 +32,11 @@ private
       :email_address,
       :organisation,
     )
+  end
+
+  def check_public_account_creation_feature_flag!
+    if FeatureFlag.inactive?(:public_account_creation)
+      render 'errors/not_found', status: :not_found
+    end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     show_debug_info
     dfe_admin_ui
     rate_limiting
+    public_account_creation
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[
@@ -28,5 +29,9 @@ class FeatureFlag
     raise unless feature_name.in?(FEATURES)
 
     ENV["FEATURES_#{feature_name}"] == 'active'
+  end
+
+  def self.inactive?(feature_name)
+    !active?(feature_name)
   end
 end

--- a/app/views/sign_in_tokens/sign_in_only.html.erb
+++ b/app/views/sign_in_tokens/sign_in_only.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, t('page_titles.sign_in') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.sign_in') %>
+    </h1>
+    <%= form_for @sign_in_token_form, url: sign_in_tokens_path, method: :POST do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 's' }, hint_text: 'Enter your email address, and we’ll send you a link to sign in.' %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sign_in_tokens/sign_in_or_create_account.html.erb
+++ b/app/views/sign_in_tokens/sign_in_or_create_account.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, t('page_titles.sign_in') %>
+<% content_for :title, t('page_titles.sign_in_or_create_account') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.sign_in') %>
+      <%= t('page_titles.sign_in_or_create_account') %>
     </h1>
     <%= form_for @sign_in_token_form, url: sign_in_tokens_path, method: :POST do |f| %>
       <%= f.govuk_error_summary %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,8 @@ en:
   page_titles:
     about_bt_wifi: Increasing children’s internet access through free BT hotspots
     about_increasing_mobile_data: Increasing data allowances on children’s mobile devices
-    sign_in: Create an account or sign in
+    sign_in_or_create_account: Create an account or sign in
+    sign_in: Sign in
     check_your_email: Check your email
     eligible_people: Tell us how many eligible young people you know about
     eligible_person: Tell us about an eligible young person

--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -4,21 +4,27 @@ RSpec.feature 'Creating an account', type: :feature do
   let(:user) { create(:local_authority_user) }
   let(:new_user) { build(:local_authority_user) }
 
-  scenario 'clicking sign in shows option to create an account' do
-    visit sign_in_path
-    expect(page).to have_content('Do you already have an account?')
-    expect(page).to have_content('No, I need to create an account')
-  end
+  context 'with public_account_creation FeatureFlag active' do
+    before do
+      FeatureFlag.activate(:public_account_creation)
+    end
 
-  scenario 'supplying valid info sends a token via email' do
-    visit sign_in_path
-    find('#sign-in-token-form-already-have-account-no-field').choose
-    click_on('Continue')
+    scenario 'clicking sign in shows option to create an account' do
+      visit sign_in_path
+      expect(page).to have_content('Do you already have an account?')
+      expect(page).to have_content('No, I need to create an account')
+    end
 
-    fill_in('Email address', with: new_user.email_address)
-    fill_in('Your full name', with: new_user.full_name)
-    fill_in('Organisation you work for', with: new_user.organisation)
-    click_on 'Create account'
-    expect(page).to have_content 'Check your email'
+    scenario 'supplying valid info sends a token via email' do
+      visit sign_in_path
+      find('#sign-in-token-form-already-have-account-no-field').choose
+      click_on('Continue')
+
+      fill_in('Email address', with: new_user.email_address)
+      fill_in('Your full name', with: new_user.full_name)
+      fill_in('Organisation you work for', with: new_user.organisation)
+      click_on 'Create account'
+      expect(page).to have_content 'Check your email'
+    end
   end
 end

--- a/spec/features/feature_flags/public_account_creation_spec.rb
+++ b/spec/features/feature_flags/public_account_creation_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature 'Public account creation feature flag', type: :feature do
+  context 'with the public_account_creation feature flag active' do
+    before do
+      FeatureFlag.activate(:public_account_creation)
+    end
+
+    context 'visiting the sign_in_path' do
+      before do
+        visit sign_in_path
+      end
+
+      it 'shows an option to create an account' do
+        expect(page).to have_content 'Create an account'
+      end
+    end
+
+    context 'visiting the new user page' do
+      before do
+        visit new_user_path
+      end
+
+      it 'allows you to create an account' do
+        fill_in 'Your full name', with: 'A Name'
+        fill_in 'Email address', with: 'an.address@example.com'
+        fill_in 'Organisation you work for', with: 'Some LA'
+        click_on 'Create account'
+        expect(page).to have_content 'Check your email'
+      end
+    end
+  end
+
+  context 'with the public_account_creation feature flag inactive' do
+    before do
+      FeatureFlag.deactivate(:public_account_creation)
+    end
+
+    context 'visiting the sign_in_path' do
+      before do
+        visit sign_in_path
+      end
+
+      it 'does not show an option to create an account' do
+        expect(page).not_to have_content 'Create an account'
+      end
+    end
+
+    context 'visiting the new user page' do
+      before do
+        visit new_user_path
+      end
+
+      it 'returns a 404' do
+        expect(page).to have_http_status :not_found
+      end
+    end
+  end
+end

--- a/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
+++ b/spec/features/feature_flags/static_guidance_only_feature_flag_spec.rb
@@ -46,7 +46,6 @@ RSpec.feature 'Static Guidance Only feature flag', type: :feature do
     scenario 'visiting any other page works' do
       visit sign_in_path
       expect(page).to have_http_status(:ok)
-      expect(page).to have_selector 'h1', text: 'Create an account or sign in'
     end
 
     scenario 'Other nav links are shown' do

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -8,15 +8,34 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
 
   scenario 'clicking sign in shows option to sign in' do
     visit sign_in_path
-    expect(page).to have_content('Do you already have an account?')
+    expect(page).to have_content('Sign in')
   end
 
-  scenario 'supplying a valid email sends a token' do
-    visit sign_in_path
-    find('#sign-in-token-form-already-have-account-yes-field').choose
-    fill_in('Email address', with: user.email_address)
-    click_on 'Continue'
-    expect(page).to have_content 'Check your email'
+  context 'with the public_account_creation FeatureFlag active' do
+    before do
+      FeatureFlag.activate(:public_account_creation)
+    end
+
+    scenario 'supplying a valid email sends a token' do
+      visit sign_in_path
+      find('#sign-in-token-form-already-have-account-yes-field').choose
+      fill_in('Email address', with: user.email_address)
+      click_on 'Continue'
+      expect(page).to have_content 'Check your email'
+    end
+  end
+
+  context 'with the public_account_creation FeatureFlag inactive' do
+    before do
+      FeatureFlag.deactivate(:public_account_creation)
+    end
+
+    scenario 'supplying a valid email sends a token' do
+      visit sign_in_path
+      fill_in('Email address', with: user.email_address)
+      click_on 'Continue'
+      expect(page).to have_content 'Check your email'
+    end
   end
 
   context 'as a user who is not dfe or mno' do


### PR DESCRIPTION
### Context

For launch, we will disable public account creation - so only pre-created users can sign in .

### Changes proposed in this pull request

Put a FeatureFlag around all account creation code, views, and specs

### Guidance to review

With public_account_creation feature flag active:

<img width="709" alt="Screen Shot 2020-07-02 at 13 24 47" src="https://user-images.githubusercontent.com/134501/86358526-84917500-bc67-11ea-8f3b-f6b69cb0b8c5.png">

With public_account_creation feature flag INactive:

<img width="732" alt="Screen Shot 2020-07-02 at 13 24 29" src="https://user-images.githubusercontent.com/134501/86358564-9410be00-bc67-11ea-901e-7705deda5793.png">
