### PR TITLE
prevent echo statements in Makefile being outputted as well as their own output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ prod:
 				logs logs-recent
 
 require_env_stub:
-	test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
+	@test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)
 
 get_git_status:
 	$(eval export git_commit_sha=$(shell git rev-parse --short HEAD))
@@ -63,13 +63,13 @@ release: require_env_stub
 	make ${env_stub} build push deploy
 
 promote:
-	test ${FROM} || (echo ">> FROM is not set (${FROM})- please use make promote FROM=(dev|staging|prod)"; exit 1)
+	@test ${FROM} || (echo ">> FROM is not set (${FROM})- please use make promote FROM=(dev|staging|prod)"; exit 1)
 	docker pull $(REMOTE_DOCKER_IMAGE_NAME)-$(FROM)
 	docker tag $(REMOTE_DOCKER_IMAGE_NAME)-$(FROM) $(APP_NAME)-$(env_stub)
 	make $(env_stub) push deploy
 
 ssh: set_cf_target
-	echo "\n\nTo get a Rails console, run: \n./setup_env_for_rails_app \nbundle exec rails c\n\n" && \
+	@echo "\n\nTo get a Rails console, run: \n./setup_env_for_rails_app \nbundle exec rails c\n\n" && \
 		cf ssh $(APP_NAME)-$(env_stub)
 
 logs: set_cf_target


### PR DESCRIPTION
### Context

Several of our make tasks have lines like `test (condition) || echo (error if condition fails) && exit 1` or `echo (informational message)`. The default make behaviour is to echo out each command before executing, so you get redundant and/or misleading lines outputted to your console while building.

### Changes proposed in this pull request

Suppress the echo-ing of each line containing an `echo` statement - if it needs to tell you something, it will do, no need to have the test / echo statement as well.

### Guidance to review

Before:
```
$ make require_env_stub
test  || (echo ">> env_stub is not set ()- please use make dev|staging|prod (task)"; exit 1)
>> env_stub is not set ()- please use make dev|staging|prod (task)
make: *** [require_env_stub] Error 1

```

After:
```
$ make require_env_stub
>> env_stub is not set ()- please use make dev|staging|prod (task)
make: *** [require_env_stub] Error 1
```