### PR TITLE
Fix for pentest issue - Host/X-Forwarded-Host header poisoning vulnerability

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ private
   def protect_against_host_header_poisoning
     %w[HTTP_HOST HTTP_X_FORWARDED_HOST].each do |header|
       if request.env[header] && \
-        (request.env[header] != Settings.hostname_for_urls)
+          (request.env[header] != Settings.hostname_for_urls)
         request.env.delete(header)
       end
     end

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -9,7 +9,6 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
   let!(:extra_mobile_data_request_2_for_mno) { create(:extra_mobile_data_request, account_holder_name: 'mno extra_mobile_data_request', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
   let!(:extra_mobile_data_request_for_other_mno) { create(:extra_mobile_data_request, account_holder_name: 'other mno extra_mobile_data_request', mobile_network: other_mno, created_by_user: local_authority_user) }
 
-
   describe 'PUT /bulk_update' do
     before do
       sign_in_as mno_user
@@ -118,36 +117,28 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
       end
 
       # Pentest issue: Host Header Poisoning vulnerability
-      context 'with a Host header that is Settings.hostname_for_urls' do
-        it 'redirects to the host' do
-          request.headers['HOST'] = Settings.hostname_for_urls
-          get :index
-          expect(response.headers['Location']).to include(Settings.hostname_for_urls)
-        end
+      it 'redirects to the host when Host header is Settings.hostname_for_urls' do
+        request.headers['HOST'] = Settings.hostname_for_urls
+        get :index
+        expect(response.headers['Location']).to include(Settings.hostname_for_urls)
       end
 
-      context 'with a Host header that is not Settings.hostname_for_urls' do
-        it 'does not redirect to the malicious host' do
-          request.headers['HOST'] = 'malicious.example.com'
-          get :index
-          expect(response.headers['Location']).not_to include('malicious.example.com')
-        end
+      it 'does not redirect to the malicious host when the Host header is not Settings.hostname_for_urls' do
+        request.headers['HOST'] = 'malicious.example.com'
+        get :index
+        expect(response.headers['Location']).not_to include('malicious.example.com')
       end
 
-      context 'with a X-Forwarded-Host header that is Settings.hostname_for_urls' do
-        it 'redirects to the X-Forwarded-Host' do
-          request.headers['X-Forwarded-Host'] = Settings.hostname_for_urls
-          get :index
-          expect(response.headers['Location']).to include(Settings.hostname_for_urls)
-        end
+      it 'redirects to the X-Forwarded-Host when X-Forwarded-Host header is Settings.hostname_for_urls' do
+        request.headers['X-Forwarded-Host'] = Settings.hostname_for_urls
+        get :index
+        expect(response.headers['Location']).to include(Settings.hostname_for_urls)
       end
 
-      context 'with a X-Forwarded-Host header that is not Settings.hostname_for_urls' do
-        it 'does not redirect to the malicious X-Forwarded-Host' do
-          request.headers['X-Forwarded-Host'] = 'malicious.example.com'
-          get :index
-          expect(response.headers['Location']).not_to include('malicious.example.com')
-        end
+      it 'does not redirect to the malicious X-Forwarded-Host when X-Forwarded-Host header is not Settings.hostname_for_urls' do
+        request.headers['X-Forwarded-Host'] = 'malicious.example.com'
+        get :index
+        expect(response.headers['Location']).not_to include('malicious.example.com')
       end
     end
   end


### PR DESCRIPTION
### Context

The pentest identified that the Host & X-Forwarded-Host headers are always trusted & used when generating URLs for redirecting users (for instance, when signing in). This could theoretically be used to dupe the user into visiting a malicious site. 

### Changes proposed in this pull request

Drop Host & X-Forwarded-Host headers if they don't match the hostname_for_urls setting

### Guidance to review

Try removing / commenting-out the contents of `ApplicationController.protect_against_host_header_poisoning`, and running the spec `spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb'

You should see two errors, mentioning `...does not redirect to the malicious...`

Un-comment the code, and re-run the spec - all should pass.
