### PR TITLE
move Host header poisoning prevention to Rack::Middleware

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,7 @@ class ApplicationController < ActionController::Base
                                 if: -> { FeatureFlag.active?(:http_basic_auth) }
 
   before_action :populate_user_from_session!,
-                :check_static_guidance_only_feature_flag!,
-                :protect_against_host_header_poisoning
+                :check_static_guidance_only_feature_flag!
 
   include Pagy::Backend
 
@@ -39,16 +38,6 @@ private
   def check_static_guidance_only_feature_flag!
     if FeatureFlag.active?(:static_guidance_only)
       render 'errors/not_found', status: :not_found unless %w[pages monitoring].include?(controller_name)
-    end
-  end
-
-  # Pentest issue: Host Header Poisoning vulnerability
-  def protect_against_host_header_poisoning
-    %w[HTTP_HOST HTTP_X_FORWARDED_HOST].each do |header|
-      if request.env[header] && \
-          (request.env[header] != Settings.hostname_for_urls)
-        request.env.delete(header)
-      end
     end
   end
 end

--- a/config/initializers/prevent_host_header_poisoning.rb
+++ b/config/initializers/prevent_host_header_poisoning.rb
@@ -1,0 +1,4 @@
+require 'middleware/prevent_host_header_poisoning'
+
+Rails.application.config.middleware.insert_before ActionDispatch::Executor,
+                                                  Middleware::PreventHostHeaderPoisoning

--- a/lib/middleware/prevent_host_header_poisoning.rb
+++ b/lib/middleware/prevent_host_header_poisoning.rb
@@ -1,0 +1,18 @@
+module Middleware
+  class PreventHostHeaderPoisoning
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      %w[HTTP_HOST HTTP_X_FORWARDED_HOST].each do |header|
+        if env[header] && \
+            !Settings.hostname_for_urls.include?(env[header])
+          env.delete(header)
+        end
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -108,38 +108,4 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
       end
     end
   end
-
-  context 'not signed in' do
-    describe 'GET #index' do
-      it 'redirects to sign_in' do
-        get :index
-        expect(response).to redirect_to(sign_in_path)
-      end
-
-      # Pentest issue: Host Header Poisoning vulnerability
-      it 'redirects to the host when Host header is Settings.hostname_for_urls' do
-        request.headers['HOST'] = Settings.hostname_for_urls
-        get :index
-        expect(response.headers['Location']).to include(Settings.hostname_for_urls)
-      end
-
-      it 'does not redirect to the malicious host when the Host header is not Settings.hostname_for_urls' do
-        request.headers['HOST'] = 'malicious.example.com'
-        get :index
-        expect(response.headers['Location']).not_to include('malicious.example.com')
-      end
-
-      it 'redirects to the X-Forwarded-Host when X-Forwarded-Host header is Settings.hostname_for_urls' do
-        request.headers['X-Forwarded-Host'] = Settings.hostname_for_urls
-        get :index
-        expect(response.headers['Location']).to include(Settings.hostname_for_urls)
-      end
-
-      it 'does not redirect to the malicious X-Forwarded-Host when X-Forwarded-Host header is not Settings.hostname_for_urls' do
-        request.headers['X-Forwarded-Host'] = 'malicious.example.com'
-        get :index
-        expect(response.headers['Location']).not_to include('malicious.example.com')
-      end
-    end
-  end
 end

--- a/spec/features/host_header_poisoning_prevention_spec.rb
+++ b/spec/features/host_header_poisoning_prevention_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'Host Header Poisoning Prevention', type: :feature do
+  context 'when Host header matches Settings.hostname_for_urls' do
+    before do
+      page.driver.header('Host', 'localhost:3000')
+    end
+
+    it 'redirects to the host' do
+      visit responsible_body_home_path
+      expect(page.current_url).to include(Settings.hostname_for_urls)
+    end
+  end
+
+  context 'when the Host header does not match Settings.hostname_for_urls' do
+    before do
+      page.driver.header('Host', 'malicious.example.com')
+    end
+
+    it 'does not redirect to the malicious host' do
+      visit responsible_body_home_path
+      expect(page.current_url).not_to include('malicious.example.com')
+    end
+  end
+
+  context 'when X-Forwarded-Host header matches Settings.hostname_for_urls' do
+    before do
+      page.driver.header('X-Forwarded-Host', 'localhost:3000')
+    end
+
+    it 'redirects to the host' do
+      visit responsible_body_home_path
+      expect(page.current_url).to include(Settings.hostname_for_urls)
+    end
+  end
+
+  context 'when the X-Forwarded-Host header does not match Settings.hostname_for_urls' do
+    before do
+      page.driver.header('X-Forwarded-Host', 'malicious.example.com')
+    end
+
+    it 'does not redirect to the malicious host' do
+      visit responsible_body_home_path
+      expect(page.current_url).not_to include('malicious.example.com')
+    end
+  end
+end


### PR DESCRIPTION
### Context

As requested by @benilovj on #85 
The middleware stack is a better place for this code

### Changes proposed in this pull request

Move the implementation to Rack::Middleware
Move the testing to a dedicated `feature` spec (as controller specs do not use Rack::Middleware)

### Guidance to review

