### PR TITLE
Convert remaining paths to use dashes, rather than underscores

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,19 +21,19 @@ Rails.application.routes.draw do
   get '/token/sent/:token', to: 'sign_in_tokens#sent', as: :sent_token
 
   namespace :mno do
-    resources :extra_mobile_data_requests, only: %i[index show edit update] do
-      put 'bulk_update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
-      get 'report_problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
+    resources :extra_mobile_data_requests, only: %i[index show edit update], path: '/extra-mobile-data-requests' do
+      put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
+      get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
     end
   end
 
-  namespace :responsible_body do
+  namespace :responsible_body, path: '/responsible-body' do
     get '/', to: 'home#show', as: :home
     get 'eligibility-and-hotspots', to: 'allocation_requests#new_or_edit', as: :allocation_request
     post 'eligibility-and-hotspots/check-answers', to: 'allocation_requests#check_your_answers', as: :check_your_allocation_request
     patch 'eligibility-and-hotspots/check-answers', to: 'allocation_requests#check_your_answers'
     post 'eligibility-and-hotspots', to: 'allocation_requests#create_or_update'
-    resources :extra_mobile_data_requests, only: %i[index new create]
+    resources :extra_mobile_data_requests, only: %i[index new create], path: '/extra-mobile-data-requests'
   end
 
   get '/healthcheck', to: 'monitoring#healthcheck', as: :healthcheck

--- a/spec/page_objects/responsible_body/allocation_request_form_page.rb
+++ b/spec/page_objects/responsible_body/allocation_request_form_page.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module ResponsibleBody
     class AllocationRequestFormPage < PageObjects::BasePage
-      set_url '/responsible_body/eligibility-and-hotspots'
+      set_url '/responsible-body/eligibility-and-hotspots'
 
       element :heading, 'h1'
 

--- a/spec/page_objects/responsible_body/home_page.rb
+++ b/spec/page_objects/responsible_body/home_page.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module ResponsibleBody
     class HomePage < PageObjects::BasePage
-      set_url '/responsible_body'
+      set_url '/responsible-body'
 
       elements :allocation_request_rows, '.govuk-summary-list__row'
       element :step_1_status, '#step-1-status'


### PR DESCRIPTION
This is in line with the GOV.UK style guide.