### PR TITLE
Add status to RB "Your requests" list

### DIFF
--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -19,13 +19,7 @@
     <%= l(extra_mobile_data_request.created_at, format: :short) %>
   </td>
   <td class="govuk-table__cell" class="request-status">
-    <span class="govuk-tag <%= extra_mobile_data_request_status_class(extra_mobile_data_request.status) %> request-status-<%= extra_mobile_data_request.status %>">
-      <%- if extra_mobile_data_request.queried? %>
-        <%= t( extra_mobile_data_request.problem, scope: %i[activerecord attributes extra_mobile_data_request problem_tags] ) %>
-      <%- else %>
-        <%= extra_mobile_data_request.translated_enum_value(:status) %>
-      <%- end %>
-    </span>
+    <%= render partial: 'shared/extra_mobile_data_request_status', locals: {extra_mobile_data_request: extra_mobile_data_request} %>
   </td>
   <td class="govuk-table__cell">
     <%- if extra_mobile_data_request.complete? || extra_mobile_data_request.cancelled? %>

--- a/app/views/responsible_body/extra_mobile_data_requests/index.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/index.html.erb
@@ -34,6 +34,7 @@
       <th class="govuk-table__header">Account holder</th>
       <th class="govuk-table__header">Mobile number</th>
       <th class="govuk-table__header">Mobile Network</th>
+      <th class="govuk-table__header">Status</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -42,6 +43,9 @@
         <td class="govuk-table__cell"><%= emd_request.account_holder_name %></td>
         <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
         <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
+        <td class="govuk-table__cell">
+          <%= render partial: 'shared/extra_mobile_data_request_status', locals: {extra_mobile_data_request: emd_request} %>
+        </td>
       </tr>
     <%- end %>
   </tbody>

--- a/app/views/shared/_extra_mobile_data_request_status.html.erb
+++ b/app/views/shared/_extra_mobile_data_request_status.html.erb
@@ -1,0 +1,7 @@
+<span class="govuk-tag <%= extra_mobile_data_request_status_class(extra_mobile_data_request.status) %> request-status-<%= extra_mobile_data_request.status %>">
+  <%- if extra_mobile_data_request.queried? %>
+    <%= t( extra_mobile_data_request.problem, scope: %i[activerecord attributes extra_mobile_data_request problem_tags] ) %>
+  <%- else %>
+    <%= extra_mobile_data_request.translated_enum_value(:status) %>
+  <%- end %>
+</span>


### PR DESCRIPTION
### Context

Brings it in line with the MNO "Your requests" list, enables the RB user to let families know what's happening

### Changes proposed in this pull request

Add a status column to the table of "Your requests" for an RB user

Screenshot:

![Screen Shot 2020-07-08 at 12 01 06](https://user-images.githubusercontent.com/134501/86911496-57cfd880-c113-11ea-9a5a-416c394ac226.png)


### Guidance to review

