### PR TITLE
use zero-downtime deployment & multiple instances on prod, as per Gov.uk PaaS guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,8 @@ push: require_env_stub ## push the Docker image to Docker Hub
 	docker push $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)
 
 deploy: set_cf_target ## Deploy the docker image to gov.uk PaaS
-	(ls -l ./manifest.yml && rm ./manifest.yml) || true
-	ln -s ./config/manifests/$(env_stub)-manifest.yml ./manifest.yml
-	cf target -o $(PAAS_ORGANISATION) -s $(PAAS_SPACE)-$(env_stub)
-	cf push $(APP_NAME)-$(env_stub) --docker-image $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)
-	rm ./manifest.yml
+	cf v3-apply-manifest -f ./config/manifests/$(env_stub)-manifest.yml
+	cf v3-zdt-push $(APP_NAME)-$(env_stub) --docker-image $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub) --wait-for-deploy-complete
 
 release: require_env_stub
 	make ${env_stub} build push deploy
@@ -70,7 +67,7 @@ promote:
 
 ssh: set_cf_target
 	@echo "\n\nTo get a Rails console, run: \n./setup_env_for_rails_app \nbundle exec rails c\n\n" && \
-		cf ssh $(APP_NAME)-$(env_stub)
+		cf v3-ssh $(APP_NAME)-$(env_stub)
 
 logs: set_cf_target
 	cf logs $(APP_NAME)-$(env_stub)

--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: get-help-with-tech-dev
+  disk_quota: 2G
   services:
     - get-help-with-tech-dev-db

--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -1,5 +1,7 @@
 ---
 applications:
 - name: get-help-with-tech-prod
+  disk_quota: 2G
+  instances: 2
   services:
     - get-help-with-tech-prod-db

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: get-help-with-tech-staging
+  disk_quota: 2G
   services:
     - get-help-with-tech-staging-db


### PR DESCRIPTION
### Context

Gov.uk PaaS guidance on "Deploying an app to production" spells out that you should:
- use version 3 of the Cloud Foundry API to zero-downtime deploy your app
- run more than one instance of your app to make sure your app is always available

### Changes proposed in this pull request

- move to 2 instances on production
- use `cf v3 ...` commands for zero-downtime deploys

Also, consequent compatibility changes as per https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#-limitations:

- add explicit `v3-apply-manifest` call, as `v3-zdt-push` doesn't use the manifest (this also allows us to specify the manifest directly, so we can get rid of the transient manifest-symlinking on deploy)
- use `cf v3-ssh` to ssh onto containers, as moving to `v3-zdt-push` breaks existing `cf ssh` compatibility

### Guidance to review

`make (dev|staging|prod) release` should still work
`make (dev|staging|prod) ssh` should still work
