### PR TITLE
262 optimise docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@
 ./log/*
 ./coverage
 ./public/packs
+.byebug_history
+.git


### PR DESCRIPTION
### Context

As in [Trello card 262](https://trello.com/c/tFpiRTPK/262-optimise-docker-build) - there's a lot of stuff in the docker image that doesn't _need_ to be there. A smaller build context & docker image speeds up the build, push and deploy tasks, and saves disk space on our laptops & servers.

### Changes proposed in this pull request

Tell Docker to ignore lots of local-only directories (./tmp, ./git. ./coverage) as well as public/packs (which gets re-built as part of the docker build in asset precompilation anyway)

### Guidance to review

`make (dev|staging|prod) release` should still work, and should be faster

Before:

```
# build context BEFORE
$ make dev build push deploy
docker build -t get-help-with-tech-dev --build-arg GIT_COMMIT_SHA=35f9bdb --build-arg GIT_BRANCH=HEAD .
Sending build context to Docker daemon    357MB
(...)

# build context AFTER
$ make dev build
docker build -t get-help-with-tech-dev --build-arg GIT_COMMIT_SHA=346703c --build-arg GIT_BRANCH=262-optimise-docker-build .
Sending build context to Docker daemon   90.7MB

# deployable docker image is ~300MB SMALLER:
$ docker images | grep dev
get-help-with-tech-dev                         latest              a176a2e39caa        19 minutes ago      1.5GB
dfedigital/get-help-with-tech-dev              <none>              e59535200dc2        2 hours ago         1.81GB

```
