### PR TITLE
add Sentry for error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'rack-throttle'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 6.0.3.1'
 
+# Error emails via Sentry
+gem 'sentry-raven'
+
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,8 @@ GEM
     semantic_logger (4.7.1)
       concurrent-ruby (~> 1.0)
     semantic_range (2.3.0)
+    sentry-raven (2.13.0)
+      faraday (>= 0.7.6, < 1.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -444,6 +446,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   rubocop-govuk
   scss_lint-govuk
+  sentry-raven
   simplecov
   site_prism
   spring

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ GHWT__STATIC_FILE_CACHE_TTL                      |how long CDNs and browsers sho
 GHWT__THROTTLE__*                                |Request throttling limits, see [settings.yaml](config/settings.yml) for more info                                                           |_(see settings)_
 GHWT__LOGSTASH__HOST                             | Hostname for where logstash should send logs                                                           | (nil)
 GHWT__LOGSTASH__PORT                             | Port for where logstash should send logs                                                               | (nil)
+GHWT__SENTRY__DSN                                | DSN (Client key) for Sentry.io error reporting | (nil)
 
 See the [settings.yaml file](config/settings.yml) for full details on configurable options.
 

--- a/config/initializers/sentry_raven.rb
+++ b/config/initializers/sentry_raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.dsn = Settings.sentry.dsn
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,9 @@ http_basic_auth:
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000
 
+sentry:
+  dsn:
+    
 session_ttl_seconds: 3600
 
 # Sign-in tokens will expire after this many seconds


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Provide default sentry setup. 
All errors will go to my email address at the moment, until we get the organisation & team members set up - waiting on #digital-tools-support for that 

### Guidance to review

