### PR TITLE
Fix error when signing-in with an invalid email

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -1,6 +1,6 @@
 class SignInTokensController < ApplicationController
   def new
-    @sign_in_token_form = SignInTokenForm.new
+    @sign_in_token_form ||= SignInTokenForm.new
     if FeatureFlag.active?(:public_account_creation)
       render :sign_in_or_create_account
     else
@@ -34,7 +34,7 @@ class SignInTokensController < ApplicationController
       redirect_to new_user_path and return
     end
 
-    render :new and return unless @sign_in_token_form.valid?
+    new and return unless @sign_in_token_form.valid?
 
     if @sign_in_token_form.email_is_user?
       token = SessionService.send_magic_link_email!(@sign_in_token_form.email_address)

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -136,6 +136,20 @@ RSpec.feature 'Session behaviour', type: :feature do
 
         expect(page).to have_text('We didn’t recognise that email address')
       end
+
+      scenario 'Entering an invalid email sends the user back to the sign-in page' do
+        visit '/'
+        click_on 'Sign in'
+        expect(page).to have_text('Email address')
+
+        clear_emails
+        expect(current_email).to be_nil
+        fill_in 'Email address', with: 'ab.c'
+        click_on 'Continue'
+
+        expect(page).to have_text('Sign in')
+        expect(page).to have_text('Enter an email address in the correct format')
+      end
     end
   end
 end


### PR DESCRIPTION
There's no :new template for SignInTokensController.
Also added spec coverage to cover this case.

Before:

500

After:

![image](https://user-images.githubusercontent.com/23801/87151965-b8dee400-c2ac-11ea-958d-8b5514496ffe.png)
