### PR TITLE
Remove extra .csv extension from MNO csv download link

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -4,7 +4,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
 
     respond_to do |format|
       format.csv do
-        render csv: @extra_mobile_data_requests, filename: "requests-mno-#{@mobile_network.id}-#{Time.now.iso8601}.csv"
+        render csv: @extra_mobile_data_requests, filename: "requests-mno-#{@mobile_network.id}-#{Time.now.iso8601}"
       end
       # capybara sends through NullType sometimes
       format.any do


### PR DESCRIPTION
Otherwise the downloaded file is called `.csv.csv`
