### PR TITLE
Add "Change email address" to sign in

### DIFF
--- a/app/views/sign_in_tokens/sign_in_only.html.erb
+++ b/app/views/sign_in_tokens/sign_in_only.html.erb
@@ -10,6 +10,17 @@
 
       <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 's' }, hint_text: 'Enter your email address, and we’ll send you a link to sign in.' %>
 
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Change email address
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>Contact <%= ghwt_contact_mailto(subject: 'Request%access%20for%20another%20email%20address') %> to request access for a different email address.</p>
+        </div>
+      </details>
+
       <%= f.govuk_submit %>
     <% end %>
   </div>


### PR DESCRIPTION
Add details element to cover the case when the account we've set up for someone wasn't set up for the right person.