### PR TITLE
Use Timecop instead of sleep statement to test session timeout

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,0 @@
-session_ttl_seconds: 1

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -61,9 +61,10 @@ RSpec.feature 'Session behaviour', type: :feature do
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
 
-        sleep(2)
-        click_on 'Back'
-        expect(page).to have_text('Sign in')
+        Timecop.travel(Time.zone.now + Settings.session_ttl_seconds + 1) do
+          click_on 'Back'
+          expect(page).to have_text('Sign in')
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Sleep statements slow down the build and can cause flakiness.
It wasn't obvious how the test worked, because the session TTL was overridden somewhere else.

### Changes proposed in this pull request

* Use Timecop to travel forward in time when testing session expiry
* Having a mention of `Settings.session_ttl_seconds` should help explain the spec a bit better


