### PR TITLE
Use a nonce to make inline script secure

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,9 @@
   </head>
 
   <body class="govuk-template__body ">
-    <script>
+    <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end -%>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,6 +24,8 @@ end
 # Set the nonce only to specific directives
 # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
 
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only


### PR DESCRIPTION
Our js enabled or not enabled script isn't running because we don't allow unsafe inline scripts to execute. This means Accordions don't work correctly.

Add a secure `nonce` attribute which we generate on each request

Followed guide here:
https://edgeguides.rubyonrails.org/security.html