### PR TITLE
Email authentication should be case-insensitive

### DIFF
--- a/app/form_objects/sign_in_token_form.rb
+++ b/app/form_objects/sign_in_token_form.rb
@@ -9,6 +9,6 @@ class SignInTokenForm
             format: { with: URI::MailTo::EMAIL_REGEXP, message: 'Enter an email address in the correct format, like name@example.com' }
 
   def email_is_user?
-    User.where(email_address: @email_address).exists?
+    SessionService.find_user_by_email(email_address).present?
   end
 end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -31,7 +31,7 @@ class SessionService
 
   # Will expand to cover MNO / MVNO and DfE users too
   def self.find_user_by_email(email_address)
-    User.where(email_address: email_address).first
+    User.where('lower(email_address) = ?', email_address.downcase).first
   end
 
   def self.is_signed_in?(session)

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -93,6 +93,24 @@ RSpec.feature 'Session behaviour', type: :feature do
         expect(page).to have_text('Check your email')
       end
 
+      scenario "Signing in as a recognised user still works even when the email address case doesn't exactly match" do
+        valid_user.update(email_address: 'Jane.Smith@example.com')
+
+        visit '/'
+        click_on 'Sign in'
+        find('#sign-in-token-form-already-have-account-yes-field').choose if FeatureFlag.active?(:public_account_creation)
+        expect(page).to have_text('Email address')
+
+        clear_emails
+        expect(current_email).to be_nil
+        fill_in 'Email address', with: 'jane.smith@example.com'
+        click_on 'Continue'
+        open_email(valid_user.email_address)
+
+        expect(current_email).not_to be_nil
+        expect(page).to have_text('Check your email')
+      end
+
       scenario 'Entering an unrecognised email address shows an informative message' do
         visit '/'
         click_on 'Sign in'


### PR DESCRIPTION
If my email is jsmith@example.com, I should still be able to log-in with JSmith@example.com
