### PR TITLE
Connect extra mobile data requests to responsible body

### DIFF
--- a/db/migrate/20200716172037_associate_extra_mobile_data_requests_with_responsible_body.rb
+++ b/db/migrate/20200716172037_associate_extra_mobile_data_requests_with_responsible_body.rb
@@ -1,0 +1,5 @@
+class AssociateExtraMobileDataRequestsWithResponsibleBody < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :extra_mobile_data_requests, :responsible_body, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,9 @@ ActiveRecord::Schema.define(version: 2020_07_17_224849) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
+    t.bigint "responsible_body_id"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
+    t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"
     t.index ["status"], name: "index_extra_mobile_data_requests_on_status"
   end
 
@@ -93,4 +95,5 @@ ActiveRecord::Schema.define(version: 2020_07_17_224849) do
 
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
+  add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
 end


### PR DESCRIPTION
~(depends on #128)~ Ready for review.

### Context

Currently, extra mobile data requests are tied to the RB user that raised them. That means that if another user from the same RB logs in, they can't see already raised requests.

### Changes proposed in this pull request

This is the first part of associating extra mobile data requests with responsible bodies. This just adds the column. Code changes and data migrations will happen in a subsequent pull request.
