### PR TITLE
Drop users.organisation column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,10 +15,6 @@ class User < ApplicationRecord
             uniqueness: { message: 'Email address has already been used' },
             length: { minimum: 2, maximum: 1024 }
 
-  validates :organisation,
-            presence: { message: 'Enter the name of the organisation you work for' },
-            length: { minimum: 2, maximum: 1024 }
-
   include SignInWithToken
 
   def is_mno_user?

--- a/app/views/shared/_user_form.html.erb
+++ b/app/views/shared/_user_form.html.erb
@@ -1,5 +1,0 @@
-<%= form.govuk_fieldset legend: { text: 'About you' } do %>
-  <%= form.govuk_text_field :user_name, required: true, label: { text: 'Your full name' } %>
-  <%= form.govuk_email_field :user_email, required: true, label: { text: 'Your email address' } %>
-  <%= form.govuk_text_field :user_organisation, required: true, label: { text: 'Name of the organisation you work for' } %>
-<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,7 +10,6 @@
 
       <%= f.govuk_text_field :full_name, required: true, label: { text: 'Your full name', size: 'm' } %>
       <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 'm' }, hint_text: 'Use your work address' %>
-      <%= f.govuk_text_field :organisation, required: true, label: { text: 'Organisation you work for', size: 'm' } %>
 
       <h2 class="govuk-heading-m">You won’t need a password to use this service</h2>
       <p class="govuk-body">

--- a/db/migrate/20200717224849_remove_organisation_from_user.rb
+++ b/db/migrate/20200717224849_remove_organisation_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationFromUser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :organisation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_171034) do
+ActiveRecord::Schema.define(version: 2020_07_17_224849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,6 @@ ActiveRecord::Schema.define(version: 2020_07_16_171034) do
   create_table "users", force: :cascade do |t|
     t.string "full_name"
     t.string "email_address"
-    t.string "organisation"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "sign_in_token"

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -4,7 +4,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
   let(:mno_user) { create(:mno_user) }
   let(:other_mno) { create(:mobile_network, brand: 'Other MNO') }
-  let(:user_from_other_mno) { create(:mno_user, name: 'Other MNO-User', organisation: 'Other MNO', mobile_network: other_mno) }
+  let(:user_from_other_mno) { create(:mno_user, name: 'Other MNO-User', mobile_network: other_mno) }
   let!(:extra_mobile_data_request_1_for_mno) { create(:extra_mobile_data_request, account_holder_name: 'mno extra_mobile_data_request', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
   let!(:extra_mobile_data_request_2_for_mno) { create(:extra_mobile_data_request, account_holder_name: 'mno extra_mobile_data_request', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
   let!(:extra_mobile_data_request_for_other_mno) { create(:extra_mobile_data_request, account_holder_name: 'other mno extra_mobile_data_request', mobile_network: other_mno, created_by_user: local_authority_user) }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
   factory :local_authority_user, class: 'User' do
     full_name                { 'Jane Doe' }
     sequence(:email_address) { |n| "jane.doe#{n}@somelocalauthority.gov.uk" }
-    organisation             { 'Some Local Authority' }
     association              :responsible_body, factory: :local_authority
     approved
   end
@@ -23,7 +22,6 @@ FactoryBot.define do
   factory :trust_user, class: 'User' do
     full_name                { 'Jane Doe' }
     sequence(:email_address) { |n| "jane.doe#{n}@somelocalauthority.gov.uk" }
-    organisation             { 'Some Trust' }
     association              :responsible_body, factory: :trust
     approved
   end
@@ -31,13 +29,11 @@ FactoryBot.define do
   factory :mno_user, class: 'User' do
     full_name     { 'Mike Mobile-Network' }
     email_address { 'mike.mobile-network@somemno.co.uk' }
-    organisation  { 'Participating Mobile Network' }
     association   :mobile_network
   end
 
   factory :dfe_user, class: 'User' do
     full_name     { 'Jane Doe' }
     email_address { 'jane.doe@digital.education.gov.uk' }
-    organisation  { 'DfE' }
   end
 end

--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'Creating an account', type: :feature do
 
       fill_in('Email address', with: new_user.email_address)
       fill_in('Your full name', with: new_user.full_name)
-      fill_in('Organisation you work for', with: new_user.organisation)
       click_on 'Create account'
       expect(page).to have_content 'Check your email'
     end

--- a/spec/features/feature_flags/public_account_creation_spec.rb
+++ b/spec/features/feature_flags/public_account_creation_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'Public account creation feature flag', type: :feature do
       it 'allows you to create an account' do
         fill_in 'Your full name', with: 'A Name'
         fill_in 'Email address', with: 'an.address@example.com'
-        fill_in 'Organisation you work for', with: 'Some LA'
         click_on 'Create account'
         expect(page).to have_content 'Check your email'
       end


### PR DESCRIPTION
It's superseded by `mobile_network_id` and `responsible_body_id`, and isn't needed for anything.