### PR TITLE
Move user validation messages to i18n file

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,12 @@ class User < ApplicationRecord
   scope :approved, -> { where.not(approved_at: nil) }
 
   validates :full_name,
-            presence: { message: 'Enter your full name' },
+            presence: true,
             length: { minimum: 2, maximum: 1024 }
 
   validates :email_address,
-            presence: { message: 'Enter an email address in the correct format, like name@example.com' },
-            uniqueness: { message: 'Email address has already been used' },
+            presence: true,
+            uniqueness: true,
             length: { minimum: 2, maximum: 1024 }
 
   include SignInWithToken

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,13 @@ en:
               blank: Select which mobile network the device is on
             agrees_with_privacy_statement:
               inclusion: The privacy statement must be shared with the account holder
+        user:
+          attributes:
+            full_name:
+              blank: Enter your full name
+            email_address:
+              blank: Enter an email address in the correct format, like name@example.com
+              taken: Email address has already been used
   time:
     formats:
       time_only: "%l:%M%P"


### PR DESCRIPTION
~Depends on #130. Rebase after that one's merged.~ Ready for review.

### Context

For all other models apart from `User`, their bespoke error messages have been moved into `en.yml`.

### Changes proposed in this pull request

Move `User` model error messages into `en.yml` for consistency.
