### PR TITLE
Small UI fixes

### DIFF
--- a/app/views/responsible_body/extra_mobile_data_requests/index.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/index.html.erb
@@ -16,12 +16,13 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.request_extra_mobile_data') %>
     </h1>
-    <%= render partial: 'shared/pilot_mno_offer_eligibility' %>
+
+    <% unless @extra_mobile_data_requests.any? %>
+      <%= render partial: 'shared/use_the_mobile_guide' %>
+    <% end %>
+
     <p class="govuk-body">
-      <%= govuk_link_to 'Read our guide on collecting mobile information', '/guide-to-collecting-mobile-information' %>
-    </p>
-    <p class="govuk-body">
-      <%= govuk_button_link_to 'Request data for someone', new_responsible_body_extra_mobile_data_request_path, class: 'govuk-!-margin-top-5' %>
+      <%= govuk_button_link_to 'Request data for someone', new_responsible_body_extra_mobile_data_request_path %>
     </p>
   </div>
 </div>

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -2,21 +2,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.who_needs_the_data') %>
-    </h1>
-
-    <div class="govuk-inset-text govuk-!-margin-bottom-8">
-      <p class="govuk-body">
-        Use the guide to tell people what’s available and collect the information you&nbsp;need:
-      </p>
-      <p class="govuk-body">
-        <%= govuk_link_to 'Guide to collecting mobile information', guide_to_collecting_mobile_information_path %>
-      </p>
-    </div>
-
     <%= form_for @extra_mobile_data_request, url: responsible_body_extra_mobile_data_requests_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.who_needs_the_data') %>
+      </h1>
+
+      <div class="govuk-inset-text govuk-!-margin-bottom-8">
+        <p class="govuk-body">
+          Use the guide to tell people what’s available and collect the information you&nbsp;need:
+        </p>
+        <p class="govuk-body">
+          <%= govuk_link_to 'Guide to collecting mobile information', guide_to_collecting_mobile_information_path %>
+        </p>
+      </div>
 
       <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint_text: 'The account holder for a pay monthly contract must be over 18' %>
       <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint_text: 'All UK mobile phone numbers start with 07' %>

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -28,7 +28,7 @@
         <%= f.hidden_field :agrees_with_privacy_statement, value: false %>
         <%= f.govuk_check_box :agrees_with_privacy_statement, true, multiple: false, link_errors: true, label: { text: 'Yes, the privacy statement has been shared' } %>
 
-        <p class="govuk-hint" style="margin-top: -20px">
+        <p class="govuk-hint">
           <%= govuk_link_to 'Guidance for sharing the privacy statement', guide_to_collecting_mobile_information_privacy_path %>
         </p>
       <%- end %>

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -10,14 +10,7 @@
         <%= t('page_titles.who_needs_the_data') %>
       </h1>
 
-      <div class="govuk-inset-text govuk-!-margin-bottom-8">
-        <p class="govuk-body">
-          Use the guide to tell people what’s available and collect the information you&nbsp;need:
-        </p>
-        <p class="govuk-body">
-          <%= govuk_link_to 'Guide to collecting mobile information', guide_to_collecting_mobile_information_path %>
-        </p>
-      </div>
+      <%= render partial: 'shared/use_the_mobile_guide' %>
 
       <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint_text: 'The account holder for a pay monthly contract must be over 18' %>
       <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint_text: 'All UK mobile phone numbers start with 07' %>

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -1,4 +1,5 @@
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_link_to('Back', responsible_body_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.who_needs_the_data'), @extra_mobile_data_request.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -5,10 +5,16 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.who_needs_the_data') %>
     </h1>
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-inset-text govuk-!-margin-bottom-8">
+      <p class="govuk-body">
+        Use the guide to tell people what’s available and collect the information you&nbsp;need:
+      </p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Guide to collecting mobile information', guide_to_collecting_mobile_information_path %>
+      </p>
+    </div>
+
     <%= form_for @extra_mobile_data_request, url: responsible_body_extra_mobile_data_requests_path do |f| %>
       <%= f.govuk_error_summary %>
 
@@ -35,17 +41,5 @@
       <%= f.govuk_submit %>
 
     <%- end %>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <aside class="app-related" role="complementary">
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="-title">Guidance</h2>
-      <div class="app-related__body">
-        <%= govuk_link_to 'Read our guide on collecting mobile information', guide_to_collecting_mobile_information_path %>
-      </div>
-      <nav role="navigation" aria-labelledby="-title">
-        <ul class="app-related__list">
-        </ul>
-    </nav>
-    </aside>
   </div>
 </div>

--- a/app/views/shared/_use_the_mobile_guide.html.erb
+++ b/app/views/shared/_use_the_mobile_guide.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-inset-text">
+  <p class="govuk-body">
+    Use the guide to tell people what’s available and collect the information you&nbsp;need:
+  </p>
+  <p class="govuk-body">
+    <%= govuk_link_to 'Guide to collecting mobile information', guide_to_collecting_mobile_information_path %>
+  </p>
+</div>


### PR DESCRIPTION
### Context

- Move error summary on mobile data request above title
- Move guidance link from right column to be inline
- Hide guidance on requests index once a request is made
- Add a missing page title
- Remove an inline style to fix a CSP warning


### Guidance on requests index

![Screen Shot 2020-07-20 at 10 57 06](https://user-images.githubusercontent.com/319055/87926746-0cee8300-ca7a-11ea-84bd-60e20c2422d4.png)

![Screen Shot 2020-07-20 at 10 57 17](https://user-images.githubusercontent.com/319055/87926744-0c55ec80-ca7a-11ea-8598-dc9b6accf27e.png)

### Guidance on form

![Screen Shot 2020-07-20 at 10 45 44](https://user-images.githubusercontent.com/319055/87926793-1e378f80-ca7a-11ea-854c-4dfcdb006b34.png)
