### PR TITLE
Remove Rails UJS since we don't use it

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -13,9 +13,9 @@
   <%- end %>
 
   <%- if SessionService.is_signed_in?(session) %>
-    <%- sign_out_link = link_to("Sign out", session_path(id: session[:session_id]), method: :delete, class: 'govuk-header__link' ) %>
+    <%- sign_out_link = link_to("Sign out", session_sign_out_path(session_id: session[:session_id]), class: 'govuk-header__link' ) %>
     <%- content = [ @user.email_address, sign_out_link].join(' | ') %>
-    <%= nav_item(url: session_path(id: session.id), content: content.html_safe) %>
+    <%= nav_item(url: sessions_path(id: session.id), content: content.html_safe) %>
   <%- else %>
       <%= nav_item( title: "Sign in", url: sign_in_path )  %>
   <%- end %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,10 +1,8 @@
 require.context('govuk-frontend/govuk/assets');
 
 import '../styles/application.scss';
-import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
-Rails.start();
 initAll();
 
 require('jquery')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
   get '/devices', to: 'devices_guidance#index', as: :devices_guidance_index
   get '/devices/:subpage_slug', to: 'devices_guidance#subpage', as: :devices_guidance_subpage
 
-  resources :sessions, only: %i[create destroy]
+  resources :sessions, only: %i[create] do
+    get '/sign-out', to: 'sessions#destroy', as: :sign_out
+  end
   resources :users, only: %i[new create]
 
   get '/token/validate', to: 'sign_in_tokens#validate', as: :validate_sign_in_token

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "core-js": ">=3",
     "govuk-frontend": ">=3.6.0",
     "jquery": "3.5.1",
-    "rails-ujs": ">=5.2.4",
     "serialize-javascript": ">=3.0.0",
     "set-value": ">=3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5967,11 +5967,6 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-rails-ujs@>=5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.4.tgz#31056ccd62d868f7d044395f31d77a4440550ceb"
-  integrity sha512-Mzu6bnTBKn4IuJvP7BDJRy4lzvR1zMWVDeTdPwDubXBfxpFEKqwOi5Nb6tfE2SYtTd+bb3PRETf40I94jgKw3w==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
### Context

We don't need/want to use Rails UJS, and its magic has bitten me once already during development.

### Changes proposed in this pull request

- Remove Rails UJS.
- Change the sign out link to use GET instead of DELETE.