### PR TITLE
Content tweaks following research

### DIFF
--- a/app/views/guide_to_collecting_mobile_information/privacy.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/privacy.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body">Those affected by the offer need to understand how we’ll use their personal information.</p>
 
-    <p class="govuk-body">Please read the following privacy statement to:</p>
+    <p class="govuk-body">Please read the following privacy statement out loud to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the adult account holder for the mobile device</li>

--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -12,7 +12,7 @@
 
       <%= render partial: 'shared/use_the_mobile_guide' %>
 
-      <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint_text: 'The account holder for a pay monthly contract must be over 18' %>
+      <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint_text: 'The account holder for a pay monthly contract must be over 18. There’s no minimum age for Pay-as-you-go customers.' %>
       <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint_text: 'All UK mobile phone numbers start with 07' %>
 
       <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint_text: 'Only networks participating in the service are listed') do %>


### PR DESCRIPTION
- Indicate PAYG can be under 18
- Highlight that the privacy statement should be read aloud