### PR TITLE
Make the Too Many Requests error be a statically-pre-rendered page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 /public/assets
 .byebug_history
+.DS_Store
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, 'Too many requests' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Too many requests</h1>
+    <p class="govuk-body">
+      Please try again in a few seconds.
+    </p>
+  </div>
+</div>

--- a/config/initializers/rack_throttle.rb
+++ b/config/initializers/rack_throttle.rb
@@ -22,6 +22,6 @@ if FeatureFlag.active?(:rate_limiting)
                                           rules: RackThrottleConfig::RULES,
                                           default: RackThrottleConfig::DEFAULT,
                                           code: 429,
-                                          message: File.read(File.join(Rails.root, 'public', '429.html')),
+                                          message: File.read(Rails.root.join('public/429.html')),
                                           type: 'text/html; charset=utf-8'
 end

--- a/config/initializers/rack_throttle.rb
+++ b/config/initializers/rack_throttle.rb
@@ -21,5 +21,7 @@ if FeatureFlag.active?(:rate_limiting)
   Rails.application.config.middleware.use Rack::Throttle::Rules,
                                           rules: RackThrottleConfig::RULES,
                                           default: RackThrottleConfig::DEFAULT,
-                                          code: 429
+                                          code: 429,
+                                          message: File.read(File.join(Rails.root, 'public', '429.html')),
+                                          type: 'text/html; charset=utf-8'
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,0 +1,15 @@
+namespace :release do
+  desc 'Render 429.html error page to the public folder'
+  task :render_429_to_file do
+    Rails.application.initialize!
+    renderer = ApplicationController.renderer.new(
+      http_host: Settings.hostname_for_urls,
+    )
+    content = renderer.render(template: 'errors/too_many_requests')
+    path = File.join(Rails.root, 'public', '429.html')
+    File.open(path, 'w+') do |f|
+      f << content
+    end
+    puts ['Rendered ', content.length, 'bytes to ', path].join(' ')
+  end
+end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -10,6 +10,6 @@ namespace :release do
     File.open(path, 'w+') do |f|
       f << content
     end
-    puts ['Rendered ', content.length, 'bytes to ', path].join(' ')
+    puts "Rendered #{content.length} bytes to #{path}"
   end
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -6,7 +6,7 @@ namespace :release do
       http_host: Settings.hostname_for_urls,
     )
     content = renderer.render(template: 'errors/too_many_requests')
-    path = File.join(Rails.root, 'public', '429.html')
+    path = Rails.root.join('public/429.html')
     File.open(path, 'w+') do |f|
       f << content
     end

--- a/public/429.html
+++ b/public/429.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+  <head>
+    <title>Too many requests - Increasing internet access for vulnerable and disadvantaged children - GOV.UK</title>
+    <meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="BP6TnGf+/Qh38eBoqdNaSIDMvA7aabw0ZIbezbyb4R0lssM3bZOTBnNop47aWH0fpEK5CVemOWFfrh+FzAYeoQ==" />
+    
+    <meta property="og:url" content="https://get-help-with-tech.education.gov.uk:80" /><link href="https://get-help-with-tech.education.gov.uk:80" rel="canonical" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta property="og:image" content="/packs/media/images/govuk-opengraph-image-b0487e2f.png" />
+    <meta name="theme-color" content="#0b0c0c" />
+    <link rel="shortcut icon" type="image/x-icon" href="/packs/media/images/favicon-b5bada83.ico" />
+    <link rel="mask-icon" type="image/svg" href="/packs/media/images/govuk-mask-icon-b3c94baf.svg" color="#0b0c0c" />
+    <link rel="apple-touch-icon" type="image/png" href="/packs/media/images/govuk-apple-touch-icon-7e22b25b.png" />
+    <link rel="apple-touch-icon" type="image/png" href="/packs/media/images/govuk-apple-touch-icon-152x152-a030b91c.png" size="152x152" />
+    <link rel="apple-touch-icon" type="image/png" href="/packs/media/images/govuk-apple-touch-icon-167x167-64c971c1.png" size="167x167" />
+    <link rel="apple-touch-icon" type="image/png" href="/packs/media/images/govuk-apple-touch-icon-180x180-f9fe1555.png" size="180x180" />
+    <link rel="stylesheet" media="all" href="/packs/css/application-973e4c2e.css" />
+    <script src="/packs/js/application-ef7e0ea14034e4c99aec.js" defer="defer"></script>
+  </head>
+
+  <body class="govuk-template__body ">
+    <script>
+//<![CDATA[
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+
+//]]>
+</script>
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a class="govuk-header__link govuk-header__link--homepage" href="/">
+            <span class="govuk-header__logotype">
+              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/packs/media/images/govuk-logotype-crown-5c77cb65.png" class="govuk-header__logotype-crown-fallback-image"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+</a>        </div>
+          <div class="govuk-header__content">
+            <a class="govuk-header__link govuk-header__link--service-name" href="/">Increasing internet access for vulnerable and disadvantaged children</a>
+            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+            <nav>
+              <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+    <li class="govuk-header__navigation-item"><a class="govuk-header__link" href="/">Guidance</a></li>
+
+      <li class="govuk-header__navigation-item"><a class="govuk-header__link" href="/sign-in">Sign in</a></li>
+</ul>
+
+            </nav>
+          </div>
+      </div>
+    </header>
+    <div class="govuk-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            alpha
+          </strong>
+          <span class="govuk-phase-banner__text">
+            This is a new service – your <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk?subject=Feedback">feedback</a> will help us to improve it.
+          </span>
+        </p>
+      </div>
+      
+      <main class="govuk-main-wrapper " id="main-content" role="main">
+        
+        
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Too many requests</h1>
+    <p class="govuk-body">
+      Please try again in a few seconds.
+    </p>
+  </div>
+</div>
+
+      </main>
+    </div>
+
+    <footer class="govuk-footer " role="contentinfo">
+      <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+            <h2 class="govuk-heading-m">Need help?</h2>
+            <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+              <li>Email: <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a></li>
+              <li>Monday to Friday (except public holidays)</li>
+              <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+            </ul>
+
+            <h2 class="govuk-visually-hidden">Support links</h2>
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/bt-wifi/privacy-notice">
+                  Privacy notice for wifi hotspot scheme
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/increasing-mobile-data/privacy-notice">
+                  Privacy notice for increasing mobile data scheme
+                </a>
+              </li>
+            </ul>
+
+            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+              />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+            </span>
+          </div>
+          <div class="govuk-footer__meta-item">
+            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
### Context

As the rate-limiting is done in Rack middleware, it does not have access to the regular Rails rendering pipeline - so when the rate limit is hit the default behaviour is to just return the string 'Too many requests' as `text/plain` content. 

User testing showed that when this limit was hit, the raw nature of the error was jarring and confusing. The user did not know what to do and said they would contact support. A consistently-branded error message would help reassure the user that they just needed to wait a few seconds and try again.

### Changes proposed in this pull request

* add a rake task to pre-render a govuk-styled 'Too many requests' error page into the `public/` folder
* call the rake task as part of the Docker build
* add `Rack::Throttle` config to read that file on startup, pass the contents to the middleware as `:message`, and serve it as `text/html`

### Guidance to review

Run the rake task with `rake release:render_429_to_file`
With the `rate_limiting` feature flag active (e.g. `FEATURES_rate_limiting=active bundle exec rails s`) , click `sign in`
Once you've entered your email address and got the 'Check your email' page, refresh it at least 4 times in quick succession.
You should see a page like this:
<img width="985" alt="Screen Shot 2020-07-21 at 13 25 43" src="https://user-images.githubusercontent.com/134501/88054719-b8203a80-cb55-11ea-9be6-ba9887be71ec.png">
