### PR TITLE
Add a rake task for creating new responsible body users

### DIFF
--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -1,0 +1,11 @@
+class CreateUserService
+  def call(full_name:, email_address:, responsible_body_name:)
+    responsible_body = ResponsibleBody.find_by!(name: responsible_body_name)
+    User.create!(
+      full_name: full_name,
+      email_address: email_address,
+      responsible_body: responsible_body,
+      approved_at: Time.zone.now,
+    )
+  end
+end

--- a/lib/tasks/create_user.rake
+++ b/lib/tasks/create_user.rake
@@ -1,0 +1,8 @@
+desc 'Create a new user in an existing responsible body'
+task :create_rb_user, %i[full_name email_address responsible_body_name] => :environment do |_t, args|
+  CreateUserService.new.call(
+    full_name: args[:full_name].strip,
+    email_address: args[:email_address].strip,
+    responsible_body_name: args[:responsible_body_name].strip,
+  )
+end

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe CreateUserService, type: :model do
+  let(:trust) { create(:trust) }
+
+  subject(:service) { described_class.new }
+
+  context 'for an existing responsible body' do
+    before do
+      Timecop.freeze(Date.new(2020, 7, 1)) do
+        service.call(full_name: 'A B', email_address: 'ab@example.com', responsible_body_name: trust.name)
+      end
+    end
+
+    it 'creates a new user attached to the responsible body' do
+      expect(User.count).to eq(1)
+    end
+
+    it 'creates a user with the passed attributes' do
+      user = User.first
+      expect(user.full_name).to eq('A B')
+      expect(user.email_address).to eq('ab@example.com')
+      expect(user.responsible_body).to eq(trust)
+    end
+
+    it 'creates an approved user' do
+      expect(User.first.approved_at).to eq(Date.new(2020, 7, 1))
+    end
+  end
+
+  context 'for a non-existent responsible body' do
+    it 'throws an error' do
+      expect {
+        service.call(responsible_body_name: 'made up', full_name: 'A B', email_address: 'ab@example.com')
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'when there is an issue with the user attributes' do
+    it 'throws an error' do
+      expect {
+        service.call(email_address: 'a', full_name: 'A B', responsible_body_name: trust.name)
+      }.to raise_error(ActiveRecord::RecordInvalid, /'Email address' is too short/)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We're getting support requests from responsible bodies to authorise access for additional people. Currently these are being done via the Rails console 😬 .

### Changes proposed in this pull request

Add a rake task as a stepping stone to adding this functionality to the support interface.
It's more convenient that running the commands on the Rails console.
