### PR TITLE
updated mobile phone number hint and error message

### DIFF
--- a/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
+++ b/app/views/responsible_body/extra_mobile_data_requests/new.html.erb
@@ -13,7 +13,7 @@
       <%= render partial: 'shared/use_the_mobile_guide' %>
 
       <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint_text: 'The account holder for a pay monthly contract must be over 18. There’s no minimum age for Pay-as-you-go customers.' %>
-      <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint_text: 'All UK mobile phone numbers start with 07' %>
+      <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint_text: 'This should start with 07 and have 11 digits' %>
 
       <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint_text: 'Only networks participating in the service are listed') do %>
         <%- for mobile_network in @participating_mobile_networks do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,8 +116,8 @@ en:
             account_holder_name:
               blank: Enter the full name of the account holder for the mobile device
             device_phone_number:
-              blank: Enter the phone number of the mobile device in the correct format
-              invalid: Enter the phone number of the mobile device in the correct format
+              blank: Enter a UK mobile number, like 07700 900999
+              invalid: Enter a UK mobile number, like 07700 900999
             mobile_network_id:
               blank: Select which mobile network the device is on
             agrees_with_privacy_statement:


### PR DESCRIPTION
### Context

As in the [Trello Card](https://trello.com/c/JISmia3v/248-review-mobile-phone-number-hint-error-message-wording), the wording around entering a mobile phone number could be better.

### Changes proposed in this pull request

Apply updates from content designer 

Before:

![Screen Shot 2020-07-22 at 14 23 06](https://user-images.githubusercontent.com/134501/88181530-e457bc00-cc26-11ea-88de-888ddf82da05.png)


After:

![Screen Shot 2020-07-22 at 14 16 56](https://user-images.githubusercontent.com/134501/88181485-d2761900-cc26-11ea-83d4-8fed238d991e.png)


### Guidance to review

