### PR TITLE
Updated default settings to 4 requests per second

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,9 +40,9 @@ throttling:
     post: 4
     put: 4
     /token:
-      get: 1
+      get: 4
     /sign_in_tokens:
-      get: 1
+      get: 4
 
 logstash:
   host: # Fill in with logstash host, leave blank to disable


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/XiwnxBea/327-increase-default-rate-limit-to-4-per-ip-per-second-for-all-gets)
Update the default number of requests per second permitted to 4 for all cases.  Currently token related endpoints are set to 1 request per second.

### Changes proposed in this pull request
Update `config/settings.yml` to change the default values.

### Guidance to review

