### PR TITLE
333 support cf cli v7 as well as v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ PAAS_SPACE=get-help-with-tech
 # support CF CLI 6 as well as 7, until we're confident that everyone can run v7
 $(eval export cf_major_version=$(shell cf version | grep -o -E '[0-9]+' | head -n 1))
 ifeq "$(cf_major_version)" "6"
-	cf_v3_prefix:=v3-
+	CF_V3_PREFIX:=v3-
 else
-	cf_v3_prefix:=
+	CF_V3_PREFIX:=
 endif
 
 .PHONY: dev staging prod
@@ -63,8 +63,8 @@ push: require_env_stub ## push the Docker image to Docker Hub
 	docker push $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub)
 
 deploy: set_cf_target ## Deploy the docker image to gov.uk PaaS
-	cf $(cf_v3_prefix)apply-manifest -f ./config/manifests/$(env_stub)-manifest.yml
-	cf $(cf_v3_prefix)zdt-push $(APP_NAME)-$(env_stub) --docker-image $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub) --wait-for-deploy-complete
+	cf $(CF_V3_PREFIX)apply-manifest -f ./config/manifests/$(env_stub)-manifest.yml
+	cf $(CF_V3_PREFIX)zdt-push $(APP_NAME)-$(env_stub) --docker-image $(REMOTE_DOCKER_IMAGE_NAME)-$(env_stub) --wait-for-deploy-complete
 
 release: require_env_stub
 	make ${env_stub} build push deploy
@@ -77,7 +77,7 @@ promote:
 
 ssh: set_cf_target
 	@echo "\n\nTo get a Rails console, run: \n./setup_env_for_rails_app \nbundle exec rails c\n\n" && \
-		cf $(cf_v3_prefix)ssh $(APP_NAME)-$(env_stub)
+		cf $(CF_V3_PREFIX)ssh $(APP_NAME)-$(env_stub)
 
 logs: set_cf_target
 	cf logs $(APP_NAME)-$(env_stub)


### PR DESCRIPTION
### Context

See [Trello card 333](https://trello.com/c/EKp7m63i/333-support-cf-cli-v7-as-well-as-v6) - Tony was not able to do a release as he has installed CF V7, which has just recently been made Generally Available.

### Changes proposed in this pull request

Add a few lines to the `Makefile` which conditionally add the required 'v3-' prefix to some commands if the user is running CF V6. 

### Guidance to review

Please check that you are able to run `make dev ssh` and `make dev deploy`. 

You *don't* need to see the deploy right through to the end, if it's going to fail it will fail within a few seconds with:
```
'(something)-apply-manifest' is not a registered command. See 'cf help -a'
make: *** [deploy] Error 1
```
As long as you see a line starting with `Applying manifest`, you can CTRL+C it to quit, and that counts as a success.

Please confirm with a comment, and add the output of running `cf version`