### PR TITLE
Interstitial for magic links

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -18,7 +18,6 @@ class SignInTokensController < ApplicationController
   rescue SessionService::TokenValidButExpired
     render :token_is_valid_but_expired, status: :bad_request
   rescue SessionService::TokenNotRecognised, SessionService::InvalidTokenAndIdentifierCombination
-    @sign_in_token_form = SignInTokenForm.new(token: params[:token], identifier: params[:identifier])
     render :token_not_recognised, status: :bad_request
   end
 

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -12,7 +12,6 @@ class SignInTokensController < ApplicationController
     unless SessionService.is_signed_in?(session)
       @user = SessionService.validate_token!(token: params[:token], identifier: params[:identifier])
       save_user_to_session!
-      flash.notice = "Welcome, #{@user.full_name}"
     end
     redirect_to root_url_for(@user)
   rescue SessionService::TokenValidButExpired

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -15,14 +15,11 @@ class SignInTokensController < ApplicationController
       flash.notice = "Welcome, #{@user.full_name}"
     end
     redirect_to root_url_for(@user)
-  rescue ArgumentError
-    user = User.find_by(sign_in_token: params[:token])
-    if user&.token_is_valid_but_expired?(token: params[:token], identifier: params[:identifier])
-      render :token_is_valid_but_expired, status: :bad_request
-    else
-      @sign_in_token_form = SignInTokenForm.new(token: params[:token], identifier: params[:identifier])
-      render :token_not_recognised, status: :bad_request
-    end
+  rescue SessionService::TokenValidButExpired
+    render :token_is_valid_but_expired, status: :bad_request
+  rescue SessionService::TokenNotRecognised, SessionService::InvalidTokenAndIdentifierCombination
+    @sign_in_token_form = SignInTokenForm.new(token: params[:token], identifier: params[:identifier])
+    render :token_not_recognised, status: :bad_request
   end
 
   def validate_manual

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -24,7 +24,6 @@ class SessionService
     raise TokenNotRecognised if user.blank?
 
     if user.token_is_valid?(token: token, identifier: identifier)
-      user.clear_token!
       user
     elsif user.token_is_valid_but_expired?(token: token, identifier: identifier)
       raise TokenValidButExpired

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -1,4 +1,8 @@
 class SessionService
+  class TokenValidButExpired < StandardError; end
+  class TokenNotRecognised < StandardError; end
+  class InvalidTokenAndIdentifierCombination < StandardError; end
+
   def self.send_magic_link_email!(email_address)
     if (user = find_user_by_email(email_address))
       user.generate_token!
@@ -16,12 +20,16 @@ class SessionService
   end
 
   def self.validate_token!(token:, identifier:)
-    user = User.where(sign_in_token: token).first
-    if user && user.token_is_valid?(token: token, identifier: identifier)
+    user = User.find_by(sign_in_token: token)
+    raise TokenNotRecognised if user.blank?
+
+    if user.token_is_valid?(token: token, identifier: identifier)
       user.clear_token!
       user
+    elsif user.token_is_valid_but_expired?(token: token, identifier: identifier)
+      raise TokenValidButExpired
     else
-      raise ArgumentError, 'token & id combination not recognised'
+      raise InvalidTokenAndIdentifierCombination
     end
   end
 

--- a/app/views/sign_in_tokens/you_are_signed_in.html.erb
+++ b/app/views/sign_in_tokens/you_are_signed_in.html.erb
@@ -1,0 +1,14 @@
+<%- content_for :title, t('page_titles.you_are_signed_in') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.you_are_signed_in') %>
+    </h1>
+    <p class="govuk-body">
+      <%= form_with url: destroy_sign_in_token_path, method: 'post' do |f| %>
+        <%= f.govuk_submit 'Continue' %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
     report_a_problem: Report a problem
     devices_guidance_index: "Get help with technology: devices"
     download_bt_hotspots: Download your BT hotspot log-ins
+    you_are_signed_in: You’re signed in
   devices_guidance:
     about_the_offer:
       title: About the offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
 
   get '/token/validate', to: 'sign_in_tokens#validate', as: :validate_sign_in_token
+  post '/token/validate', to: 'sign_in_tokens#destroy', as: :destroy_sign_in_token
   get '/token/validate-manual', to: 'sign_in_tokens#validate_manual', as: :validate_manually_entered_sign_in_token
   get '/token/sent/:token', to: 'sign_in_tokens#sent', as: :sent_token
   get '/token/email-not-recognised', to: 'sign_in_tokens#email_not_recognised', as: :email_not_recognised

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe SignInTokensController, type: :controller do
+  let(:user) { create(:local_authority_user, :who_has_requested_a_magic_link) }
+
+  describe 'destroy' do
+    it 'clears the token when the user is signed in' do
+      sign_in_as user
+
+      post :destroy
+
+      expect(user.reload.sign_in_token).to be_nil
+    end
+
+    it 'redirects to the sign-in path if the user is not signed in' do
+      post :destroy
+
+      expect(user.reload.sign_in_token).not_to be_nil
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
     last_signed_in_at { nil }
   end
 
+  trait :who_has_requested_a_magic_link do
+    sign_in_token            { SecureRandom.uuid }
+    sign_in_token_expires_at { 30.minutes.from_now }
+  end
+
   factory :local_authority_user, class: 'User' do
     full_name                { 'Jane Doe' }
     sequence(:email_address) { |n| "jane.doe#{n}@somelocalauthority.gov.uk" }

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -80,6 +80,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 're-using the same magic-link redirects to the home page for user' do
       visit validate_token_url
+      click_on 'Continue'
       expect(page).to have_current_path(responsible_body_home_path)
     end
 

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
 
     scenario 'it redirects to the responsible_body_home page' do
-      visit(validate_token_url)
+      sign_in_as user
       expect(page).to have_current_path(responsible_body_home_path)
       expect(page).to have_text 'Increase children’s internet access'
     end
@@ -69,7 +69,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       end
 
       it 'redirects to the guidance page' do
-        visit(validate_token_url)
+        sign_in_as user
         expect(page).to have_current_path(guidance_page_path)
         expect(page).to have_text I18n.t('service_name')
       end
@@ -85,7 +85,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       end
 
       scenario 'it redirects to Your Requests' do
-        visit(validate_token_url)
+        sign_in_as user
         expect(page).to have_current_path(mno_extra_mobile_data_requests_path)
         expect(page).to have_text 'Your requests'
       end
@@ -97,7 +97,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       end
 
       it 'redirects to the guidance page' do
-        visit(validate_token_url)
+        sign_in_as user
         expect(page).to have_current_path(guidance_page_path)
         expect(page).to have_text I18n.t('service_name')
       end

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -6,6 +6,7 @@ module CapybaraHelper
 
   def sign_in_as(user)
     visit validate_token_url_for(user)
+    click_on 'Continue'
   end
 
   def validate_token_url_for(user)


### PR DESCRIPTION
### Context

Some responsible bodies appear to have link checkers that follow email links. This causes a problem for the single-use magic links that we use to authenticate the users of our service, because:

1. The link checker follows the link, thus invalidating the token
2. When the user tries to follow the magic link for real, they're told that their token is not recognised and they need a new magic link.
3. Rinse and repeat.

Part of the problem comes from having a destructive operation (token invalidation) happen on a GET.

### Changes proposed in this pull request

Change the sign-in flow so that:

- The magic link takes users to an interstitial page:

![screencapture-localhost-3000-token-validate-2020-07-23-16_26_41](https://user-images.githubusercontent.com/23801/88305770-ca3edc00-cd01-11ea-9094-09585fdaa5c7.png)

- At this point, the user is signed-in but the token is still valid (as discussed on Slack)
- As soon as the user clicks 'Continue', their token is invalidated. We are assuming that link checker bots won't be hitting the button.

### Guidance to review

- I've done some clean-up of the `SignInTokensController`, to move more logic into `SessionService`.
- Added a controller spec to cover an edge case that is too granular for a feature spec