### PR TITLE
add Makefile task to setup the cdn-route to forward all headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ setup_paas_db: set_cf_target
 setup_paas_app: set_cf_target
 	cf scale $(APP_NAME)-$(env_stub) -k 2G
 
+setup_cdn_route: set_cf_target
+	# tell it to forward all headers from Cloudfront, otherwise we only get Host
+	cf update-service $(APP_NAME)-$(env_stub)-cdn-route -c '{"headers": ["*"]}'
+
 set_cf_target: require_env_stub
 	cf target -o $(PAAS_ORGANISATION) -s $(PAAS_SPACE)-$(env_stub)
 


### PR DESCRIPTION
### Context

See [Trello card 338](https://trello.com/c/q52ePQep/338-we-are-not-seeing-valid-user-agent-strings-in-logit) - while investigating issues with sign-in tokens, we found that all user-agent fields in Logit were empty. Turns out the default set up for the  cdn-route  service (which is how you get custom domains to work in Gov.UK PaaS) is to only forward the Host header to your app: https://docs.cloud.service.gov.uk/deploying_services/use_a_custom_domain/#forwarding-headers

### Changes proposed in this pull request

Add a Makefile task to tell the cdn-route service to forward all headers.

### Guidance to review

The change is already made on prod, this is more just a record of what I did, so that it can be done again in future if needed
