### PR TITLE
Change 'destroy token' route to be a DELETE

### DIFF
--- a/app/views/sign_in_tokens/you_are_signed_in.html.erb
+++ b/app/views/sign_in_tokens/you_are_signed_in.html.erb
@@ -6,7 +6,7 @@
       <%= t('page_titles.you_are_signed_in') %>
     </h1>
     <p class="govuk-body">
-      <%= form_with url: destroy_sign_in_token_path, method: 'post' do |f| %>
+      <%= form_with url: destroy_sign_in_token_path, method: 'delete' do |f| %>
         <%= f.govuk_submit 'Continue' %>
       <% end %>
     </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
 
   get '/token/validate', to: 'sign_in_tokens#validate', as: :validate_sign_in_token
-  post '/token/validate', to: 'sign_in_tokens#destroy', as: :destroy_sign_in_token
+  delete '/token/validate', to: 'sign_in_tokens#destroy', as: :destroy_sign_in_token
   get '/token/validate-manual', to: 'sign_in_tokens#validate_manual', as: :validate_manually_entered_sign_in_token
   get '/token/sent/:token', to: 'sign_in_tokens#sent', as: :sent_token
   get '/token/email-not-recognised', to: 'sign_in_tokens#email_not_recognised', as: :email_not_recognised


### PR DESCRIPTION
### Context

Follow-on from #149.

### Changes proposed in this pull request

Change 'destroy token' route to be a DELETE, so the routes are more RESTful.


