### PR TITLE
make controller spec use delete method too

### DIFF
--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe SignInTokensController, type: :controller do
     it 'clears the token when the user is signed in' do
       sign_in_as user
 
-      post :destroy
+      delete :destroy
 
       expect(user.reload.sign_in_token).to be_nil
     end
 
     it 'redirects to the sign-in path if the user is not signed in' do
-      post :destroy
+      delete :destroy
 
       expect(user.reload.sign_in_token).not_to be_nil
       expect(response).to redirect_to(sign_in_path)


### PR DESCRIPTION
### Context

#152 changed the method of the destroy token action to `:delete` - but not the controller spec.

### Changes proposed in this pull request

Make the controller spec use :delete too

### Guidance to review

