### PR TITLE
Added notifying extra mobile data account holder by sms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ gem 'config'
 # Semantic Logger makes logs pretty, also needed for logit integration
 gem 'rails_semantic_logger'
 
+# GOV.UK Notify client
+gem 'notifications-ruby-client'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.3)
   logstash-logger (~> 0.26.1)
   mail-notify
+  notifications-ruby-client
   pagy
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/controllers/responsible_body/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/responsible_body/extra_mobile_data_requests_controller.rb
@@ -25,7 +25,8 @@ class ResponsibleBody::ExtraMobileDataRequestsController < ResponsibleBody::Base
         session.delete(:extra_mobile_data_request_params)
         @extra_mobile_data_request.save!
 
-        NotifyExtraMobileDataAccountHolderService.call(@extra_mobile_data_request)
+        sms_service.deliver!(@extra_mobile_data_request)
+        # NotifyExtraMobileDataAccountHolderService.call(@extra_mobile_data_request)
 
         flash[:success] = I18n.t('responsible_body.extra_mobile_data_requests.create.success')
         redirect_to responsible_body_extra_mobile_data_requests_path
@@ -59,5 +60,9 @@ private
       mobile_network_id
       confirm
     ])
+  end
+
+  def sms_service
+    @sms_service ||= NotifyExtraMobileDataAccountHolderService.new
   end
 end

--- a/app/controllers/responsible_body/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/responsible_body/extra_mobile_data_requests_controller.rb
@@ -24,6 +24,9 @@ class ResponsibleBody::ExtraMobileDataRequestsController < ResponsibleBody::Base
         # clear the stashed params once the user has confirmed them
         session.delete(:extra_mobile_data_request_params)
         @extra_mobile_data_request.save!
+
+        NotifyExtraMobileDataAccountHolderService.call(@extra_mobile_data_request)
+
         flash[:success] = I18n.t('responsible_body.extra_mobile_data_requests.create.success')
         redirect_to responsible_body_extra_mobile_data_requests_path
       else

--- a/app/services/notify_extra_mobile_data_account_holder_service.rb
+++ b/app/services/notify_extra_mobile_data_account_holder_service.rb
@@ -1,0 +1,56 @@
+class NotifyExtraMobileDataAccountHolderService
+  class NotifySmsError < StandardError; end
+
+  def self.call(extra_mobile_data_request)
+    new(extra_mobile_data_request).call
+  end
+
+  def initialize(extra_mobile_data_request)
+    @extra_mobile_data_request = extra_mobile_data_request
+  end
+
+  def call
+    @response = sms_client.send_sms(
+      phone_number: telephone,
+      template_id: template_id,
+      personalisation: {
+        mno: mno_name,
+      },
+    )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.message)
+    raise NotifySmsError, e
+  end
+
+private
+
+  def sms_client
+    @sms_client ||= Notifications::Client.new(api_key)
+  end
+
+  def api_key
+    Settings.govuk_notify.api_key
+  end
+
+  def telephone
+    @extra_mobile_data_request.device_phone_number
+  end
+
+  def mno_name
+    @extra_mobile_data_request.mobile_network.brand
+  end
+
+  def mno_participating_in_scheme?
+    @extra_mobile_data_request.mobile_network.participating?
+  end
+
+  def template_id
+    templates = Settings.govuk_notify.templates.extra_mobile_data_requests
+
+    if mno_participating_in_scheme?
+      templates.mno_in_scheme_sms
+    else
+      templates.mno_not_in_scheme_sms
+    end
+  end
+end

--- a/app/services/notify_extra_mobile_data_account_holder_service.rb
+++ b/app/services/notify_extra_mobile_data_account_holder_service.rb
@@ -1,15 +1,17 @@
 class NotifyExtraMobileDataAccountHolderService
   class NotifySmsError < StandardError; end
 
-  def self.call(extra_mobile_data_request)
-    new(extra_mobile_data_request).call
-  end
+  # def self.call(extra_mobile_data_request)
+  #   new(extra_mobile_data_request).call
+  # end
 
-  def initialize(extra_mobile_data_request)
+  # def initialize(extra_mobile_data_request)
+  #   @extra_mobile_data_request = extra_mobile_data_request
+  # end
+
+  def deliver!(extra_mobile_data_request)
     @extra_mobile_data_request = extra_mobile_data_request
-  end
 
-  def call
     @response = sms_client.send_sms(
       phone_number: telephone,
       template_id: template_id,

--- a/app/services/notify_extra_mobile_data_account_holder_service.rb
+++ b/app/services/notify_extra_mobile_data_account_holder_service.rb
@@ -1,14 +1,6 @@
 class NotifyExtraMobileDataAccountHolderService
   class NotifySmsError < StandardError; end
 
-  # def self.call(extra_mobile_data_request)
-  #   new(extra_mobile_data_request).call
-  # end
-
-  # def initialize(extra_mobile_data_request)
-  #   @extra_mobile_data_request = extra_mobile_data_request
-  # end
-
   def deliver!(extra_mobile_data_request)
     @extra_mobile_data_request = extra_mobile_data_request
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/bt-wifi/privacy-notice', to: 'pages#bt_wifi_privacy_notice'
   get '/bt-wifi/suggested-email-to-schools', to: 'pages#suggested_email_to_schools'
   get '/increasing-mobile-data/privacy-notice', to: 'pages#increasing_mobile_data_privacy_notice'
+  get '/mobile-privacy', to: redirect('/increasing-mobile-data/privacy-notice')
   get '/pages/guidance', to: redirect('/')
 
   get '/guide-to-collecting-mobile-information', to: 'guide_to_collecting_mobile_information#index'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,9 @@ govuk_notify:
   templates:
     # ID of the template in GOV.UK Notify used for mailing sign-in tokens
     sign_in_token_mail: '89b4abbb-0f01-4546-bf30-f88db5e0ae3c'
+    extra_mobile_data_requests:
+      mno_in_scheme_sms: 'a3610e88-4852-4acc-b22c-767899d2d4c7'
+      mno_not_in_scheme_sms: '401aed7e-83ac-4e90-abac-3e2f9bc45a95'
 
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,4 @@
+govuk_notify:
+  # API key for the GOV.UK Notify service, used for sending emails
+  api_key: 'test-key'
+

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 govuk_notify:
   # API key for the GOV.UK Notify service, used for sending emails
-  api_key: 'test-key'
+  api_key: 'dummy_testing-5147bd8e-e622-4ae2-b004-f93ff2f1a109-d0af2215-e1e9-421f-a92a-a4049d614f9e'
 

--- a/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
@@ -11,20 +11,19 @@ RSpec.describe ResponsibleBody::ExtraMobileDataRequestsController, type: :contro
     end
 
     describe 'create' do
-      let(:sms_client) { mock_notify_sms_client }
+      let(:sms_client) { instance_double('Notifications::Client') }
       let(:mno) { create(:mobile_network) }
       let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
+      let(:request_data) { { extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
+      let(:service) { NotifyExtraMobileDataAccountHolderService.new }
 
       before do
         allow(sms_client).to receive(:send_sms)
+        allow(service).to receive(:sms_client) { sms_client }
+        controller.send(:instance_variable_set, '@sms_service', service)
       end
 
       it 'sends an sms to the account holder of the request' do
-        request_data = {
-          extra_mobile_data_request: form_attrs,
-          confirm: 'confirm',
-        }
-
         post :create, params: request_data
 
         expect(sms_client).to have_received(:send_sms).with(

--- a/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe ResponsibleBody::ExtraMobileDataRequestsController, type: :contro
     end
 
     describe 'create' do
-      let(:sms_client) { double('sms_client') }
+      let(:sms_client) { mock_notify_sms_client }
       let(:mno) { create(:mobile_network) }
       let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
 
       before do
-        allow_any_instance_of(NotifyExtraMobileDataAccountHolderService).to receive(:sms_client).and_return(sms_client)
+        allow(sms_client).to receive(:send_sms)
       end
 
       it 'sends an sms to the account holder of the request' do
@@ -25,7 +25,9 @@ RSpec.describe ResponsibleBody::ExtraMobileDataRequestsController, type: :contro
           confirm: 'confirm',
         }
 
-        expect(sms_client).to receive(:send_sms).with(
+        post :create, params: request_data
+
+        expect(sms_client).to have_received(:send_sms).with(
           {
             phone_number: form_attrs[:device_phone_number],
             template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_in_scheme_sms,
@@ -34,7 +36,6 @@ RSpec.describe ResponsibleBody::ExtraMobileDataRequestsController, type: :contro
             },
           },
         )
-        post :create, params: request_data
       end
     end
   end

--- a/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/extra_mobile_data_requests_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::ExtraMobileDataRequestsController, type: :controller do
+  let(:local_authority_user) { create(:local_authority_user) }
+
+  context 'when authenticated' do
+    before do
+      sign_in_as local_authority_user
+
+      @vouchers = create_list(:bt_wifi_voucher, 2, responsible_body: local_authority_user.responsible_body)
+    end
+
+    describe 'create' do
+      let(:sms_client) { double('sms_client') }
+      let(:mno) { create(:mobile_network) }
+      let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
+
+      before do
+        allow_any_instance_of(NotifyExtraMobileDataAccountHolderService).to receive(:sms_client).and_return(sms_client)
+      end
+
+      it 'sends an sms to the account holder of the request' do
+        request_data = {
+          extra_mobile_data_request: form_attrs,
+          confirm: 'confirm',
+        }
+
+        expect(sms_client).to receive(:send_sms).with(
+          {
+            phone_number: form_attrs[:device_phone_number],
+            template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_in_scheme_sms,
+            personalisation: {
+              mno: mno.brand,
+            },
+          },
+        )
+        post :create, params: request_data
+      end
+    end
+  end
+end

--- a/spec/factories/extra_mobile_data_requests.rb
+++ b/spec/factories/extra_mobile_data_requests.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
       status  { :queried }
       problem { ExtraMobileDataRequest.problems.keys.sample }
     end
+
+    trait :mno_not_participating do
+      association :mobile_network, factory: %i[mobile_network maybe_participating_in_pilot]
+    end
   end
 end

--- a/spec/features/mobile_privacy_notice_spec.rb
+++ b/spec/features/mobile_privacy_notice_spec.rb
@@ -11,4 +11,3 @@ RSpec.feature 'Display the mobile data privacy notice page', type: :feature do
     expect(page).to have_selector 'h1', text: I18n.t('page_titles.increasing_mobile_data_privacy_notice')
   end
 end
-

--- a/spec/features/mobile_privacy_notice_spec.rb
+++ b/spec/features/mobile_privacy_notice_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature 'Display the mobile data privacy notice page', type: :feature do
+  scenario 'Privacy notice is available via original location' do
+    visit '/increasing-mobile-data/privacy-notice'
+    expect(page).to have_selector 'h1', text: I18n.t('page_titles.increasing_mobile_data_privacy_notice')
+  end
+
+  scenario 'New shorter privacy url displays privacy notice' do
+    visit '/mobile-privacy'
+    expect(page).to have_selector 'h1', text: I18n.t('page_titles.increasing_mobile_data_privacy_notice')
+  end
+end
+

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
 
     before do
       mobile_network
+      stub_notify_sms
       sign_in_as user
     end
 

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
 
     before do
       mobile_network
-      stub_notify_sms
       sign_in_as user
     end
 
@@ -72,10 +71,13 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
       expect(page.status_code).to eq(200)
       expect(page).to have_text('Check your answers')
 
-      click_on 'Confirm request'
+      stub_notify_request
 
+      click_on 'Confirm request'
       expect(page).to have_text('Your request has been received')
       expect(page).to have_text('My confirmed account holder name')
+
+      WebMock.reset!
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 require 'support/factory_bot'
 require 'support/controller_helper'
 require 'support/capybara_helper'
+require 'support/notify_helper'
 require 'capybara/email/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -112,5 +113,6 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace('gem name')
 
   config.include CapybaraHelper, type: :feature
+  config.include NotifyHelper
   config.include ControllerHelper, type: :controller
 end

--- a/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
+++ b/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
   context 'for a mno that is providing extra data' do
     let(:request) { create(:extra_mobile_data_request) }
     let(:sms_client) { instance_double('Notifications::Client') }
-    let(:service) { described_class.new(request) }
+    let(:service) { described_class.new }
 
     before do
       allow(service).to receive(:sms_client) { sms_client }
@@ -12,7 +12,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
     end
 
     it 'sends the extra data offer sms message' do
-      service.call
+      service.deliver!(request)
       expect(sms_client).to have_received(:send_sms).with(
         {
           phone_number: request.device_phone_number,
@@ -27,7 +27,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
 
   context 'for a mno that has not signed up' do
     let(:request) { create(:extra_mobile_data_request, :mno_not_participating) }
-    let(:service) { described_class.new(request) }
+    let(:service) { described_class.new }
     let(:sms_client) { instance_double('Notifications::Client') }
 
     before do
@@ -36,7 +36,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
     end
 
     it 'sends the mno not providing data sms message' do
-      service.call
+      service.deliver!(request)
       expect(sms_client).to have_received(:send_sms).with(
         {
           phone_number: request.device_phone_number,
@@ -51,7 +51,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
 
   context 'when the Notify client raises an error' do
     let(:request) { create(:extra_mobile_data_request) }
-    let(:service) { described_class.new(request) }
+    let(:service) { described_class.new }
     let(:sms_client) { instance_double('Notifications::Client') }
 
     before do
@@ -64,7 +64,7 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
     end
 
     it 'catches the error and raises a NotifySmsError' do
-      expect { service.call }.to raise_error(NotifyExtraMobileDataAccountHolderService::NotifySmsError)
+      expect { service.deliver!(request) }.to raise_error(NotifyExtraMobileDataAccountHolderService::NotifySmsError)
     end
   end
 end

--- a/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
+++ b/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
+  context 'for a mno that is providing extra data' do
+    let(:request) { create(:extra_mobile_data_request) }
+    let(:sms_client) { double('sms_client') }
+
+    subject { described_class.new(request) }
+
+    before do
+      allow(subject).to receive(:sms_client) { sms_client }
+    end
+
+    it 'sends the extra data offer sms message' do
+      expect(sms_client).to receive(:send_sms).with(
+        {
+          phone_number: request.device_phone_number,
+          template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_in_scheme_sms,
+          personalisation: {
+            mno: request.mobile_network.brand,
+          },
+        },
+      )
+      subject.call
+    end
+  end
+
+  context 'for a mno that has not signed up' do
+    let(:request) { create(:extra_mobile_data_request, :mno_not_participating) }
+    let(:sms_client) { double('sms_client') }
+
+    subject { described_class.new(request) }
+
+    before do
+      allow(subject).to receive(:sms_client) { sms_client }
+    end
+
+    it 'sends the mno not providing data sms message' do
+      expect(sms_client).to receive(:send_sms).with(
+        {
+          phone_number: request.device_phone_number,
+          template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_not_in_scheme_sms,
+          personalisation: {
+            mno: request.mobile_network.brand,
+          },
+        },
+      )
+      subject.call
+    end
+  end
+
+  context 'an error with Notify' do
+    let(:request) { create(:extra_mobile_data_request) }
+    let(:sms_client) { double('sms_client') }
+
+    subject { described_class.new(request) }
+
+    before do
+      err = double('error')
+      allow(err).to receive(:code).and_return(400)
+      allow(err).to receive(:body).and_return('boom')
+
+      allow(subject).to receive(:sms_client) { sms_client }
+      allow(sms_client).to receive(:send_sms).and_raise(Notifications::Client::RequestError, err)
+    end
+
+    it 'catches the error and raises a NotifySmsError' do
+      expect { subject.call }.to raise_error(NotifyExtraMobileDataAccountHolderService::NotifySmsError)
+    end
+  end
+end

--- a/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
+++ b/spec/services/notify_extra_mobile_data_account_holder_service_spec.rb
@@ -3,16 +3,17 @@ require 'rails_helper'
 RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
   context 'for a mno that is providing extra data' do
     let(:request) { create(:extra_mobile_data_request) }
-    let(:sms_client) { double('sms_client') }
-
-    subject { described_class.new(request) }
+    let(:sms_client) { instance_double('Notifications::Client') }
+    let(:service) { described_class.new(request) }
 
     before do
-      allow(subject).to receive(:sms_client) { sms_client }
+      allow(service).to receive(:sms_client) { sms_client }
+      allow(sms_client).to receive(:send_sms)
     end
 
     it 'sends the extra data offer sms message' do
-      expect(sms_client).to receive(:send_sms).with(
+      service.call
+      expect(sms_client).to have_received(:send_sms).with(
         {
           phone_number: request.device_phone_number,
           template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_in_scheme_sms,
@@ -21,22 +22,22 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
           },
         },
       )
-      subject.call
     end
   end
 
   context 'for a mno that has not signed up' do
     let(:request) { create(:extra_mobile_data_request, :mno_not_participating) }
-    let(:sms_client) { double('sms_client') }
-
-    subject { described_class.new(request) }
+    let(:service) { described_class.new(request) }
+    let(:sms_client) { instance_double('Notifications::Client') }
 
     before do
-      allow(subject).to receive(:sms_client) { sms_client }
+      allow(service).to receive(:sms_client) { sms_client }
+      allow(sms_client).to receive(:send_sms)
     end
 
     it 'sends the mno not providing data sms message' do
-      expect(sms_client).to receive(:send_sms).with(
+      service.call
+      expect(sms_client).to have_received(:send_sms).with(
         {
           phone_number: request.device_phone_number,
           template_id: Settings.govuk_notify.templates.extra_mobile_data_requests.mno_not_in_scheme_sms,
@@ -45,27 +46,25 @@ RSpec.describe NotifyExtraMobileDataAccountHolderService, type: :model do
           },
         },
       )
-      subject.call
     end
   end
 
-  context 'an error with Notify' do
+  context 'when the Notify client raises an error' do
     let(:request) { create(:extra_mobile_data_request) }
-    let(:sms_client) { double('sms_client') }
-
-    subject { described_class.new(request) }
+    let(:service) { described_class.new(request) }
+    let(:sms_client) { instance_double('Notifications::Client') }
 
     before do
-      err = double('error')
+      err = instance_double('Net::HTTPClientError')
       allow(err).to receive(:code).and_return(400)
       allow(err).to receive(:body).and_return('boom')
 
-      allow(subject).to receive(:sms_client) { sms_client }
+      allow(service).to receive(:sms_client) { sms_client }
       allow(sms_client).to receive(:send_sms).and_raise(Notifications::Client::RequestError, err)
     end
 
     it 'catches the error and raises a NotifySmsError' do
-      expect { subject.call }.to raise_error(NotifyExtraMobileDataAccountHolderService::NotifySmsError)
+      expect { service.call }.to raise_error(NotifyExtraMobileDataAccountHolderService::NotifySmsError)
     end
   end
 end

--- a/spec/support/data/notify_success_body.json
+++ b/spec/support/data/notify_success_body.json
@@ -1,0 +1,16 @@
+{
+  "content":{
+    "body":"We've received your name and mobile number and passed them on to Participating mobile network 1 to request more data. You should hear from them within 14 days.\n\nSee https://get-help-with-tech.education.gov.uk/increasing-mobile-data/privacy-notice for details about how we use your personal information.",
+    "from_number":"GOVUK"
+  },
+  "id":"69618e64-b739-49ef-8382-b66f6bba8dc4",
+  "reference":null,
+  "scheduled_for":null,
+  "template":{
+    "id":"a3610e88-4852-4acc-b22c-767899d2d4c7",
+    "uri":"https://api.notifications.service.gov.uk/services/71eea423-f9c5-4b7f-aac9-c88a4ca4dea2/templates/a3610e88-4852-4acc-b22c-767899d2d4c7",
+    "version":3
+  },
+  "uri":"https://api.notifications.service.gov.uk/v2/notifications/69618e64-b739-49ef-8382-b66f6bba8dc4"
+}
+

--- a/spec/support/notify_helper.rb
+++ b/spec/support/notify_helper.rb
@@ -1,13 +1,13 @@
 module NotifyHelper
-  def mock_notify_sms_client
-    sms_client = instance_double('Notifications::Client')
-    allow_any_instance_of(NotifyExtraMobileDataAccountHolderService).to receive(:sms_client).and_return(sms_client)
-    sms_client
+  def stub_notify_request
+    WebMock.stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms').to_return(
+      status: 201,
+      body: success_response_body,
+      headers: { content_type: 'application/json' },
+    )
   end
 
-  def stub_notify_sms
-    sms_client = mock_notify_sms_client
-    allow(sms_client).to receive(:send_sms)
-    sms_client
+  def success_response_body
+    File.new(Rails.root.join('spec/support/data/notify_success_body.json'))
   end
 end

--- a/spec/support/notify_helper.rb
+++ b/spec/support/notify_helper.rb
@@ -1,0 +1,13 @@
+module NotifyHelper
+  def mock_notify_sms_client
+    sms_client = instance_double('Notifications::Client')
+    allow_any_instance_of(NotifyExtraMobileDataAccountHolderService).to receive(:sms_client).and_return(sms_client)
+    sms_client
+  end
+
+  def stub_notify_sms
+    sms_client = mock_notify_sms_client
+    allow(sms_client).to receive(:send_sms)
+    sms_client
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/nNKhfK4c/305-text-message-for-all-mno-extra-mobile-data-requests)

### Changes proposed in this pull request
Addition of sending an sms message to an account holder on creation of a extra mobile data request via GOV.UK Notify service.  One of two messages can be sent, depending on whether the chosen mno is participating in the data scheme or not.

### Guidance to review
Happy path only. Currently not persisting the response Id from Notify and no implementation of a background process to verify success or failure of delivery.