### PR TITLE
add router_response_time_sec to Logstash filter & Makefile task to setup Logit

### DIFF
--- a/etc/logstash-filter.conf
+++ b/etc/logstash-filter.conf
@@ -39,6 +39,17 @@ filter {
             value_split => ":"
             remove_field => "router_keys"
         }
+        # we're going to copy the {router: {response_time}} nested string field
+        # to a top-level field called "response_time_seconds", and convert it to
+        # a float
+        mutate
+        {
+           copy => { "[router][response_time]" => "router_response_time_sec" }
+        }
+        mutate
+        {
+           convert => [ "router_response_time_sec", "float" ]
+        }
     }
 
     # Application logs


### PR DESCRIPTION
### Context

see [Trello card 267](https://trello.com/c/vOQREk0V/267-make-the-logit-stack-more-comprehensible)

### Changes proposed in this pull request

Update the Logstash filter to copy the `router.response_time` field to `router_response_time_sec` and convert it to a float. This is now present in the '*-*' index pattern.

Add a makefile task to setup the logit log-shipping

### Guidance to review

Have a look at the [GHWT Prod Dashboard in Logit](https://kibana.logit.io/app/kibana#/dashboard/8ba14770-c27b-11ea-831c-410f90b17e14)

We also have staging shipping logs to the same stack - you can filter on `cf.app` to choose which environment, or  use the saved query "Prod-only, no static assets" (click the disk icon next to the query box)

screenshot:
<img width="1126" alt="Screen Shot 2020-07-27 at 11 42 28" src="https://user-images.githubusercontent.com/134501/88533652-8cda9700-cffe-11ea-9d2e-c6fb7f52a08a.png">


