### PR TITLE
Add a static Markdown page for the accessibility statement

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  layout 'single_page', only: :accessibility
+
   def guidance; end
 
   def bt_wifi_privacy_notice; end
@@ -10,4 +12,6 @@ class PagesController < ApplicationController
   def start; end
 
   def about_increasing_mobile_data; end
+
+  def accessibility; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,6 +91,11 @@
             <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="<%= accessibility_path %>">
+                  Accessibility
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="<%= bt_wifi_privacy_notice_path %>">
                   Privacy notice for wifi hotspot scheme
                 </a>

--- a/app/views/layouts/single_page.html.erb
+++ b/app/views/layouts/single_page.html.erb
@@ -1,0 +1,14 @@
+<% page_title = I18n.t!("page_titles.#{action_name}") %>
+<%= content_for :title, page_title %>
+
+<% content_for :content do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= page_title %></h1>
+
+      <%= yield %>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/app/views/pages/accessibility.md
+++ b/app/views/pages/accessibility.md
@@ -1,0 +1,35 @@
+Increasing internet access for disadvantaged children is a pilot service from the Department for Education.
+
+To make this service accessible we designed it using [GOV.UK accessible design principles](https://design-system.service.gov.uk/accessibility/).
+
+Throughout most of the service, users should be able to:
+
+* change colours, contrast levels and fonts
+* zoom in up to 300% without the text spilling off the screen
+* navigate using just a keyboard
+* navigate using speech recognition software
+* listen to the content using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)
+
+## What to do if you cannot access parts of this service
+
+If you need information in a different format, such as an accessible PDF, large print, easy read or an audio recording or braille, email <COVID.TECHNOLOGY@education.gov.uk> and we’ll respond to you within 5 days.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability. They also have a free helpline: 0800 048 7642 and you can also email <enquiries@abilitynet.org.uk>.
+
+## Reporting accessibility problems
+
+If you want to tell us about problems you’ve had using this service, or to give us feedback, email  <COVID.TECHNOLOGY@education.gov.uk> and put ‘Accessibility problem’ in your subject line.
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+If you’re not happy with how we respond to your complaint, you can [contact the quality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this web applications accessibility
+
+The Department for Education is committed to making web services accessible in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+This website is compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21) AA standard.
+
+## We’ll continue to improve accessibility
+
+This statement was prepared on 28 July 2020. We’ll continue to test the accessibility of this pilot service as it develops over the summer.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
     download_bt_hotspots: Download your BT hotspot log-ins
     you_are_signed_in: You’re signed in
     service_performance: Service performance
+    accessibility: Accessibility statement
   devices_guidance:
     about_the_offer:
       title: About the offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/bt-wifi/privacy-notice', to: 'pages#bt_wifi_privacy_notice'
   get '/bt-wifi/suggested-email-to-schools', to: 'pages#suggested_email_to_schools'
   get '/increasing-mobile-data/privacy-notice', to: 'pages#increasing_mobile_data_privacy_notice'
+  get '/accessibility', to: 'pages#accessibility'
   get '/mobile-privacy', to: redirect('/increasing-mobile-data/privacy-notice')
   get '/pages/guidance', to: redirect('/')
 


### PR DESCRIPTION
### Context

The service needs an accessibility statement.

### Changes proposed in this pull request

- add a static markdown-powered accessibility statement
- link to it from the footer

### Guidance to review

![screencapture-localhost-3000-accessibility-2020-07-28-14_21_06](https://user-images.githubusercontent.com/23801/88674090-4ad65180-d0e1-11ea-99b6-7fa50309b32f.png)

Adding static guidance using Markdown is nice...