### PR TITLE
Re-align Gemfile.lock with Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,8 +216,6 @@ GEM
     msgpack (1.3.3)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
     net-http-pipeline (1.0.1)
@@ -246,8 +244,6 @@ GEM
       json
       websocket (~> 1.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -336,7 +332,6 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -364,11 +359,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    sinatra (2.0.8.1)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
-      tilt (~> 2.0)
     site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
@@ -471,7 +461,6 @@ DEPENDENCIES
   sentry-raven
   sidekiq
   simplecov
-  sinatra
   site_prism
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
### Context

Running `bundler` on the main branch yields changes in `Gemfile.lock` – I'm guessing there was a mismatch between `Gemfile` and `Gemfile.lock` in #165.

### Changes proposed in this pull request

* Re-align Gemfile.lock with Gemfile
