### PR TITLE
Markdown rendering improvements

### DIFF
--- a/app/webpacker/styles/_styled-content.scss
+++ b/app/webpacker/styles/_styled-content.scss
@@ -1,59 +1,14 @@
-.app-styled-content {
-  h2 {
-    @extend %govuk-heading-l;
-  }
+.govuk-grid-column-two-thirds img {
+  max-width: 100%;
+  border: 2px solid $govuk-border-colour;
 
-  h3 {
-    @extend %govuk-heading-m;
+  // Cover both columns in a two-thirds/one-third layout
+  @include govuk-media-query($from: tablet) {
+    max-width: 150%;
   }
+}
 
-  h4 {
-    @extend %govuk-heading-s;
-  }
-
-  h5 {
-    @extend %govuk-heading-s;
-    font-size: 0.99em;
-  }
-
-  p,
-  dl {
-    @extend %govuk-body-m;
-  }
-
-  ol {
-    @extend %govuk-list;
-    @extend %govuk-list--number;
-  }
-
-  ul {
-    @extend %govuk-list;
-    @extend %govuk-list--bullet;
-  }
-
-  strong,
-  b,
-  dt {
-    @include govuk-typography-weight-bold;
-  }
-
-  a {
-    @extend %govuk-link;
-  }
-
-  hr {
-    @extend %govuk-section-break;
-    @extend %govuk-section-break--visible;
-    @extend %govuk-section-break--xl;
-  }
-
-  .govuk-grid-column-two-thirds & img {
-    max-width: 100%;
-    border: 2px solid $govuk-border-colour;
-
-    // Cover both columns in a two-thirds/one-third layout
-    @include govuk-media-query($from: tablet) {
-      max-width: 150%;
-    }
-  }
+.app-table-of-contents ul {
+  @extend %govuk-list;
+  @extend %govuk-list--bullet;
 }

--- a/lib/action_view/template/handlers/markdown.rb
+++ b/lib/action_view/template/handlers/markdown.rb
@@ -1,3 +1,5 @@
+require 'govuk/markdown_renderer'
+
 module ActionView
   module Template::Handlers
     class Markdown
@@ -6,17 +8,15 @@ module ActionView
 
         <<~CODE
           content_for :html_list_of_headings_links do
-            ('<div class="app-styled-content">' +
+            ('<div class="app-table-of-contents">' +
               #{rendered_table_of_contents_for(compiled_source).inspect} +
             '</div>').html_safe
           end
-          '<div class="app-styled-content">' +
             Redcarpet::Markdown.new(
-              Redcarpet::Render::HTML.new(with_toc_data: true)
+              Govuk::MarkdownRenderer.new(with_toc_data: true)
             ).render(
               begin;#{compiled_source};end
-            ).html_safe +
-          '</div>'
+            ).html_safe
         CODE
       end
 

--- a/lib/action_view/template/handlers/markdown.rb
+++ b/lib/action_view/template/handlers/markdown.rb
@@ -1,28 +1,38 @@
 module ActionView
   module Template::Handlers
     class Markdown
-      def call(_template, source)
-        @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(with_toc_data: true))
-        "
-        content_for :html_list_of_headings_links do
-          #{wrap_in_a_div(rendered_table_of_contents_for(source)).inspect}.html_safe
-        end
-        #{wrap_in_a_div(@markdown.render(source)).inspect}.html_safe
-        "
+      def call(template, source)
+        compiled_source = erb.call(template, source)
+
+        <<~CODE
+          content_for :html_list_of_headings_links do
+            ('<div class="app-styled-content">' +
+              #{rendered_table_of_contents_for(compiled_source).inspect} +
+            '</div>').html_safe
+          end
+          '<div class="app-styled-content">' +
+            Redcarpet::Markdown.new(
+              Redcarpet::Render::HTML.new(with_toc_data: true)
+            ).render(
+              begin;#{compiled_source};end
+            ).html_safe +
+          '</div>'
+        CODE
       end
 
     private
 
-      def rendered_table_of_contents_for(source)
-        @table_of_contents = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC.new(nesting_level: 2))
-        @table_of_contents
-          .render(source)
-          .html_safe
+      def erb
+        @erb ||= ActionView::Template.registered_template_handler(:erb)
       end
 
-      # this makes it easier to target the generated code with CSS
-      def wrap_in_a_div(source)
-        "<div class=\"app-styled-content\">#{source}</div>"
+      def rendered_table_of_contents_for(compiled_source)
+        @output_buffer = ActionView::OutputBuffer.new # needed for the eval
+        erb_output = instance_eval(compiled_source)
+
+        Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC.new(nesting_level: 2))
+          .render(erb_output)
+          .html_safe
       end
     end
   end

--- a/lib/govuk/markdown_renderer.rb
+++ b/lib/govuk/markdown_renderer.rb
@@ -1,0 +1,54 @@
+module Govuk
+  class MarkdownRenderer < ::Redcarpet::Render::HTML
+    def header(text, header_level)
+      heading_size = case header_level
+                     when 1 then 'xl'
+                     when 2 then 'l'
+                     when 3 then 'm'
+                     else 's' end
+
+      id_attribute = @options[:with_toc_data] ? " id=\"#{text.parameterize}\"" : ''
+
+      <<~HTML
+        <h#{header_level}#{id_attribute} class="govuk-heading-#{heading_size}">#{text}</h#{header_level}>
+      HTML
+    end
+
+    def paragraph(text)
+      <<~HTML
+        <p class="govuk-body-m">#{text}</p>
+      HTML
+    end
+
+    def list(contents, list_type)
+      if list_type == :unordered
+        <<~HTML
+          <ul class="govuk-list govuk-list--bullet">
+            #{contents}
+          </ul>
+        HTML
+      elsif list_type == :ordered
+        <<~HTML
+          <ol class="govuk-list govuk-list--number">
+            #{contents}
+          </ol>
+        HTML
+      else
+        raise "Unexpected type #{list_type.inspect}"
+      end
+    end
+
+    def link(link, title, content)
+      title_attribute = title.present? ? " title=\"#{title}\"" : ''
+      <<~HTML
+        <a href="#{link}" class="govuk-link"#{title_attribute}>#{content}</a>
+      HTML
+    end
+
+    def hrule
+      <<~HTML
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+      HTML
+    end
+  end
+end

--- a/spec/lib/action_view/template/handlers/markdown_spec.rb
+++ b/spec/lib/action_view/template/handlers/markdown_spec.rb
@@ -36,20 +36,16 @@ RSpec.describe ActionView::Template::Handlers::Markdown, type: :model do
   let(:result) { test_view.instance_eval subject.call(ActionView::Template::Text.new(''), example_markdown) }
 
   it 'generates ruby code that renders markdown as HTML' do
-    expect(result).to include('<p>Some text</p>')
-    expect(result).to include('<p>More text</p>')
-    expect(result).to include('<p>Even more text</p>')
+    expect(result).to include('<p class="govuk-body-m">Some text</p>')
+    expect(result).to include('<p class="govuk-body-m">More text</p>')
+    expect(result).to include('<p class="govuk-body-m">Even more text</p>')
   end
 
   it 'generates ruby code that renders markdown with headings as HTML headings with ids' do
-    expect(result).to include('<h1 id="my-page">My page</h1>')
-    expect(result).to include('<h2 id="heading-a">Heading A</h2>')
-    expect(result).to include('<h3 id="subheading-i">Subheading i</h3>')
-    expect(result).to include('<h2 id="heading-b">Heading B</h2>')
-  end
-
-  it 'generates ruby code that wraps the generated markdown in a div that can be targetted by CSS' do
-    expect(result).to match(/<div class="app-styled-content">.*<\/div>/m)
+    expect(result).to include('<h1 id="my-page" class="govuk-heading-xl">My page</h1>')
+    expect(result).to include('<h2 id="heading-a" class="govuk-heading-l">Heading A</h2>')
+    expect(result).to include('<h3 id="subheading-i" class="govuk-heading-m">Subheading i</h3>')
+    expect(result).to include('<h2 id="heading-b" class="govuk-heading-l">Heading B</h2>')
   end
 
   it 'generates ruby code that sets the content_for block with a div-wrapped HTML list of links to the H1s and H2s' do
@@ -57,7 +53,7 @@ RSpec.describe ActionView::Template::Handlers::Markdown, type: :model do
 
     headings_links = test_view.content_for(:html_list_of_headings_links)
 
-    expect(headings_links).to match(/<div class="app-styled-content">.*<\/div>/m)
+    expect(headings_links).to match(/<div class="app-table-of-contents">.*<\/div>/m)
     expect(headings_links).to include('<a href="#my-page">My page</a>')
     expect(headings_links).to include('<a href="#heading-a">Heading A</a>')
     expect(headings_links).to include('<a href="#heading-b">Heading B</a>')
@@ -74,9 +70,9 @@ RSpec.describe ActionView::Template::Handlers::Markdown, type: :model do
     end
 
     it 'generates ruby code that evaluates ERB expressions in the markdown' do
-      expect(result).to include('<h1 id="my-page">My page</h1>')
-      expect(result).to include('<h2 id="heading-a">Heading A</h2>')
-      expect(result).to include('<p>Even more text 3</p>')
+      expect(result).to include('<h1 id="my-page" class="govuk-heading-xl">My page</h1>')
+      expect(result).to include('<h2 id="heading-a" class="govuk-heading-l">Heading A</h2>')
+      expect(result).to include('<p class="govuk-body-m">Even more text 3</p>')
     end
 
     it 'generates ruby code that sets the content_for block with a div-wrapped HTML list of links to the H1s and H2s' do
@@ -84,7 +80,7 @@ RSpec.describe ActionView::Template::Handlers::Markdown, type: :model do
 
       headings_links = test_view.content_for(:html_list_of_headings_links)
 
-      expect(headings_links).to match(/<div class="app-styled-content">.*<\/div>/m)
+      expect(headings_links).to match(/<div class="app-table-of-contents">.*<\/div>/m)
       expect(headings_links).to include('<a href="#my-page">My page</a>')
       expect(headings_links).to include('<a href="#heading-a">Heading A</a>')
     end

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe Govuk::MarkdownRenderer, type: :model do
+  subject(:renderer) { Govuk::MarkdownRenderer.new(with_toc_data: true) }
+
+  def render(content)
+    Redcarpet::Markdown.new(renderer).render(content).strip
+  end
+
+  it 'renders H1s with ids and GOV.UK classes' do
+    expect(render('# My title')).to eq('<h1 id="my-title" class="govuk-heading-xl">My title</h1>')
+  end
+
+  it 'renders H2s with ids and GOV.UK classes' do
+    expect(render('## Top heading')).to eq('<h2 id="top-heading" class="govuk-heading-l">Top heading</h2>')
+  end
+
+  it 'renders H3s with ids and GOV.UK classes' do
+    expect(render('### A heading')).to eq('<h3 id="a-heading" class="govuk-heading-m">A heading</h3>')
+  end
+
+  it 'renders H4s with ids and GOV.UK classes' do
+    expect(render('#### A heading')).to eq('<h4 id="a-heading" class="govuk-heading-s">A heading</h4>')
+  end
+
+  it 'renders H5s with ids and GOV.UK classes' do
+    expect(render('##### A heading')).to eq('<h5 id="a-heading" class="govuk-heading-s">A heading</h5>')
+  end
+
+  it 'renders H6s with ids and GOV.UK classes' do
+    expect(render('###### A heading')).to eq('<h6 id="a-heading" class="govuk-heading-s">A heading</h6>')
+  end
+
+  it 'renders paragraphs with GOV.UK classes' do
+    expect(render('abc')).to eq('<p class="govuk-body-m">abc</p>')
+  end
+
+  it 'renders unordered lists with GOV.UK classes' do
+    input = <<~MARKDOWN
+      * abc def
+      * xyz
+    MARKDOWN
+    expected = <<~HTML
+      <ul class="govuk-list govuk-list--bullet">
+        <li>abc def</li>
+      <li>xyz</li>
+
+      </ul>
+    HTML
+    expect(render(input)).to eq(expected.strip)
+  end
+
+  it 'renders ordered lists with GOV.UK classes' do
+    input = <<~MARKDOWN
+      1. abc def
+      2. xyz
+    MARKDOWN
+    expected = <<~HTML
+      <ol class="govuk-list govuk-list--number">
+        <li>abc def</li>
+      <li>xyz</li>
+
+      </ol>
+    HTML
+    expect(render(input)).to eq(expected.strip)
+  end
+
+  it 'renders links without titles with GOV.UK classes' do
+    expect(render('[GOV.UK homepage](https://www.gov.uk)')).to eq(
+      '<p class="govuk-body-m"><a href="https://www.gov.uk" class="govuk-link">GOV.UK homepage</a>
+</p>',
+    )
+  end
+
+  it 'renders links with titles with GOV.UK classes' do
+    expect(render('[GOV.UK homepage](https://www.gov.uk "My title")')).to eq(
+      '<p class="govuk-body-m"><a href="https://www.gov.uk" class="govuk-link" title="My title">GOV.UK homepage</a>
+</p>',
+    )
+  end
+
+  it 'renders hrules with GOV.UK classes' do
+    expect(render('---')).to eq('<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">')
+  end
+end


### PR DESCRIPTION
### Context

This service contains a lot of guidance, and has a few content designers who are (or will be) working on it.

Some of the pages are already authored using Markdown, e.g. the devices guidance. However, the current approach is limited by inability to use Rails partials (e.g. for shared snippets) or do any kind of Ruby interpolation (e.g. to avoid hard-coding URLs all over the place).

### Changes proposed in this pull request

1. Allow using ERB interpolation within Markdown documents. For example, this becomes possible now:

```markdown
### Eligibility

<%= render partial: 'shared/bt_wifi_eligibility' %>

### Who can help
...
```

2. Reduce the need for custom CSS by introducing a custom Markdown renderer that spits out GOV.UK-flavoured HTML. This means that the produced HTML is compatible with the GOV.UK Design System and uses its styles by default.

### Guidance to review

There are still a couple of bespoke styles relating to Markdown content:

* for images, which is a deliberate app-specific design choice
* for the table of contents – the entire `HTML_TOC` renderer would have needed to be re-implemented from scratch (in order to add the GOV.UK element classes in the right place), which felt like a lot of extra code to maintain for fairly minimal benefit.

Also worth noting: the custom GOV.UK renderer does not re-implement every possible element, but the most common ones that need extra classes that one comes across in Markdown. We should watch for missing styling when converting pages to Markdown, in case something has been missed.

The `ActionView::Template::Handlers::Markdown` class is still a bit horrible and brittle. Some of this is necessary complexity owing to how Rails template handlers work, but I'm open to suggestions on how to improve it. I tried to maintain good spec coverage, to prevent regressions for anyone brave enough to try to change that code at a later date 🤣 .