### PR TITLE
Remove "children's" from heading

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,7 +16,7 @@
       <%= govuk_link_to 'More about free access to BT wifi hotspots', about_bt_wifi_path %>
     </p>
 
-    <h2 class="govuk-heading-l" id="were-increasing-data-allowances-on-childrens-mobile-devices">We’re increasing data allowances on children’s mobile devices</h2>
+    <h2 class="govuk-heading-l" id="were-increasing-data-allowances-on-childrens-mobile-devices">We’re increasing data allowances on mobile devices</h2>
 
     <p class="govuk-body">We’re also running a pilot scheme to temporarily increase data allowances on certain mobile devices. This is so disadvantaged children and young people can continue their remote education and maintain contact with social care services without incurring extra data charges.</p>
 


### PR DESCRIPTION
It's not just children's devices

