### PR TITLE
215 add docker image id to the healthcheck endpoint

### DIFF
--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -51,9 +51,8 @@ jobs:
         id: get_docker_image_id
         shell: bash
         run: |
-          # docker pull dfedigital/get-help-with-tech-dev
-          # echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
-          echo "::set-output name=docker_image_id::abc123"
+          docker pull dfedigital/get-help-with-tech-dev
+          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
   deploy-to-paas:
     needs: get-latest-docker-image-id
@@ -69,7 +68,7 @@ jobs:
         run: |
           curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
           # ...move it to /usr/local/bin or a location you know is in your $PATH
-          mv cf /usr/local/bin
+          sudo mv cf /usr/local/bin
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -57,18 +57,24 @@ jobs:
 
   deploy-to-paas:
     needs: get-latest-docker-image-id
-    runs-on: governmentpaas/cf-cli
+    runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
     steps:
-      # - name: checkout
-      #   uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install cf-cli
+        shell: bash
+        id: install-cf-cli
+        run: |
+          curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
+          # ...move it to /usr/local/bin or a location you know is in your $PATH
+          mv cf /usr/local/bin
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
         shell: bash
         run: |
-          echo DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }}
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
           DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -66,7 +66,8 @@ jobs:
         id: get_docker_image_id
         shell: bash
         run: |
-          echo "::set-output name=docker_image_id::$(docker pull dfedigital/get-help-with-tech-dev && docker image -q dfedigital/get-help-with-tech-dev)"
+          docker pull dfedigital/get-help-with-tech-dev
+          echo "::set-output name=docker_image_id::$(docker image -q dfedigital/get-help-with-tech-dev)"
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           docker pull dfedigital/get-help-with-tech-dev
-          echo "::set-output name=docker_image_id::$(docker image -q dfedigital/get-help-with-tech-dev)"
+          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-push-container:
     runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
-    if: github.event.pull_request.merged
+    # if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-container
     # Only run this when the PR has been merged -(i.e. not just closed)
-    if: github.event.pull_request.merged
+    # if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build-and-push-container:
+    outputs:
+      docker_image_id: ${{ steps.get_docker_image_id.outputs.docker_image_id }}
     runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
@@ -38,6 +40,12 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: dfedigital/get-help-with-tech-dev
           tags: latest
+      - name: Get new docker image id
+        id: get_docker_image_id
+        shell: bash
+        run: |
+          docker pull dfedigital/get-help-with-tech-dev
+          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
 
   deploy-to-paas:
@@ -48,26 +56,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      # - name: Install CloudFoundry CLI
-      #   shell: bash
-      #   run: |
-      #     # Install Cloud Foundry CLI
-      #     # ...or Linux 64-bit binary
-      #     # curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.2&source=github" | tar -zx
-      #     # ...move it to /usr/local/bin or a location you know is in your $PATH
-      #     # mv cf ~
-      #     wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-      #     echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-      #     sudo apt-get update
-      #     sudo apt-get install cf-cli
-      #     echo "$(cf --version)"
-
-      - name: Get new docker image id
-        id: get_docker_image_id
-        shell: bash
-        run: |
-          docker pull dfedigital/get-help-with-tech-dev
-          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
@@ -76,4 +64,4 @@ jobs:
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
-          DOCKER_IMAGE_ID=${{ steps.get_docker_image_id.outputs.docker_image_id }} make dev deploy
+          DOCKER_IMAGE_ID=${{ jobs.build-and-push-container.outputs.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -48,29 +48,30 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Install CloudFoundry CLI
-        shell: bash
-        run: |
-          # Install Cloud Foundry CLI
-          # ...or Linux 64-bit binary
-          # curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.2&source=github" | tar -zx
-          # ...move it to /usr/local/bin or a location you know is in your $PATH
-          # mv cf ~
-          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          sudo apt-get update
-          sudo apt-get install cf-cli
-          echo "$(cf --version)"
+      # - name: Install CloudFoundry CLI
+      #   shell: bash
+      #   run: |
+      #     # Install Cloud Foundry CLI
+      #     # ...or Linux 64-bit binary
+      #     # curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.47.2&source=github" | tar -zx
+      #     # ...move it to /usr/local/bin or a location you know is in your $PATH
+      #     # mv cf ~
+      #     wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+      #     echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+      #     sudo apt-get update
+      #     sudo apt-get install cf-cli
+      #     echo "$(cf --version)"
 
       - name: Get new docker image id
         id: get_docker_image_id
         shell: bash
         run: |
-          # docker pull dfedigital/get-help-with-tech-dev
+          docker pull dfedigital/get-help-with-tech-dev
           echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
+        runs-on: governmentpaas/cf-cli
         shell: bash
         run: |
           cf api https://api.london.cloud.service.gov.uk

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -2,9 +2,6 @@
 name: Build, push and deploy container
 
 on:
-  push:
-    branches:
-      - 215-add-docker-image-id-to-the-healthcheck-endpoint
   pull_request:
     types: [closed]
     branches:
@@ -40,11 +37,10 @@ jobs:
           tags: latest
 
   deploy-to-paas:
-    # Put this back once testing complete
-    # needs: build-and-push-container
+    needs: build-and-push-container
     runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
-    # if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -74,6 +74,7 @@ jobs:
         id: deploy-to-paas
         shell: bash
         run: |
+          echo "DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }}"
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
           DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -66,7 +66,7 @@ jobs:
         id: get_docker_image_id
         shell: bash
         run: |
-          docker pull dfedigital/get-help-with-tech-dev
+          # docker pull dfedigital/get-help-with-tech-dev
           echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
       - name: Deploy to Gov.uk PaaS

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -49,8 +49,8 @@ jobs:
 
 
   deploy-to-paas:
-    runs-on: ubuntu-latest
     needs: build-and-push-container
+    runs-on: governmentpaas/cf-cli
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
     steps:
@@ -59,7 +59,6 @@ jobs:
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
-        runs-on: governmentpaas/cf-cli
         shell: bash
         run: |
           cf api https://api.london.cloud.service.gov.uk

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -63,4 +63,4 @@ jobs:
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
-          DOCKER_IMAGE_ID=${{ jobs.build-and-push-container.outputs.get_docker_image_id.outputs.docker_image_id }} make dev deploy
+          DOCKER_IMAGE_ID=${{ needs.build-and-push-container.outputs.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           echo "##[set-output name=branch;]$(git rev-parse --abbrev-ref HEAD)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=docker_image_id::$(docker pull dfedigital/get-help-with-tech-dev && docker image -q dfedigital/get-help-with-tech-dev)"
 
       # We can't use the `make build push` task for this,
       # due to limitations in the way docker login works (or not) in non-TTY
@@ -39,6 +38,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: dfedigital/get-help-with-tech-dev
           tags: latest
+
+
   deploy-to-paas:
     runs-on: ubuntu-latest
     needs: build-and-push-container
@@ -60,10 +61,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install cf-cli
           echo "$(cf --version)"
+
+      - name: Get new docker image id
+        id: get_docker_image_id
+        shell: bash
+        run: |
+          echo "::set-output name=docker_image_id::$(docker pull dfedigital/get-help-with-tech-dev && docker image -q dfedigital/get-help-with-tech-dev)"
+
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
         shell: bash
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
-          make dev deploy
+          DOCKER_IMAGE_ID=${{ steps.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -37,19 +37,18 @@ jobs:
           tags: latest
 
   deploy-to-paas:
-    needs: build-and-push-container
     runs-on: ubuntu-latest
+    needs: build-and-push-container
     # Only run this when the PR has been merged -(i.e. not just closed)
     if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: install cf-cli
+      - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli
         run: |
           curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
-          # ...move it to /usr/local/bin or a location you know is in your $PATH
           sudo mv cf /usr/local/bin
 
       - name: Deploy to Gov.uk PaaS

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           echo "##[set-output name=branch;]$(git rev-parse --abbrev-ref HEAD)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=docker_image_id::$(docker pull dfedigital/get-help-with-tech-dev && docker image -q dfedigital/get-help-with-tech-dev)"
 
       # We can't use the `make build push` task for this,
       # due to limitations in the way docker login works (or not) in non-TTY

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   build-and-push-container:
-    outputs:
-      docker_image_id: ${{ steps.get_docker_image_id.outputs.docker_image_id }}
     runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
-    # if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -40,16 +38,24 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: dfedigital/get-help-with-tech-dev
           tags: latest
-      - name: Get new docker image id
+
+  get-latest-docker-image-id:
+    outputs:
+      docker_image_id: ${{ steps.get_docker_image_id.outputs.docker_image_id }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get latest docker image id
         id: get_docker_image_id
         shell: bash
         run: |
           docker pull dfedigital/get-help-with-tech-dev
           echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
 
-
   deploy-to-paas:
-    needs: build-and-push-container
+    needs: get-latest-docker-image-id
     runs-on: governmentpaas/cf-cli
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
@@ -61,6 +67,7 @@ jobs:
         id: deploy-to-paas
         shell: bash
         run: |
+          echo DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }}
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
-          DOCKER_IMAGE_ID=${{ needs.build-and-push-container.outputs.get_docker_image_id.outputs.docker_image_id }} make dev deploy
+          DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }} make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -51,8 +51,9 @@ jobs:
         id: get_docker_image_id
         shell: bash
         run: |
-          docker pull dfedigital/get-help-with-tech-dev
-          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
+          # docker pull dfedigital/get-help-with-tech-dev
+          # echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
+          echo "::set-output name=docker_image_id::abc123"
 
   deploy-to-paas:
     needs: get-latest-docker-image-id
@@ -60,8 +61,8 @@ jobs:
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      # - name: checkout
+      #   uses: actions/checkout@v2
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -39,23 +39,9 @@ jobs:
           repository: dfedigital/get-help-with-tech-dev
           tags: latest
 
-  get-latest-docker-image-id:
-    outputs:
-      docker_image_id: ${{ steps.get_docker_image_id.outputs.docker_image_id }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Get latest docker image id
-        id: get_docker_image_id
-        shell: bash
-        run: |
-          docker pull dfedigital/get-help-with-tech-dev
-          echo "::set-output name=docker_image_id::$(docker images -q dfedigital/get-help-with-tech-dev:latest)"
-
   deploy-to-paas:
-    needs: get-latest-docker-image-id
+    # Put this back once testing complete
+    # needs: build-and-push-container
     runs-on: ubuntu-latest
     # Only run this when the PR has been merged -(i.e. not just closed)
     # if: github.event.pull_request.merged
@@ -74,7 +60,6 @@ jobs:
         id: deploy-to-paas
         shell: bash
         run: |
-          echo "DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }}"
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
-          DOCKER_IMAGE_ID=${{ needs.get-latest-docker-image-id.get_docker_image_id.outputs.docker_image_id }} make dev deploy
+          make dev deploy

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -2,6 +2,9 @@
 name: Build, push and deploy container
 
 on:
+  push:
+    branches:
+      - 215-add-docker-image-id-to-the-healthcheck-endpoint
   pull_request:
     types: [closed]
     branches:

--- a/app/services/healthcheck_service.rb
+++ b/app/services/healthcheck_service.rb
@@ -8,7 +8,14 @@ class HealthcheckService
       services: all_services_status,
       info: {
         git: git_info,
+        docker: docker_info
       },
+    }
+  end
+
+  def self.docker_info
+    {
+      image_id: ENV['DOCKER_IMAGE_ID']
     }
   end
 

--- a/app/services/healthcheck_service.rb
+++ b/app/services/healthcheck_service.rb
@@ -8,14 +8,14 @@ class HealthcheckService
       services: all_services_status,
       info: {
         git: git_info,
-        docker: docker_info
+        docker: docker_info,
       },
     }
   end
 
   def self.docker_info
     {
-      image_id: ENV['DOCKER_IMAGE_ID']
+      image_id: ENV['DOCKER_IMAGE_ID'],
     }
   end
 

--- a/spec/controllers/monitoring_controller_spec.rb
+++ b/spec/controllers/monitoring_controller_spec.rb
@@ -76,5 +76,29 @@ RSpec.describe MonitoringController, type: :controller do
         expect(json['info']['git']['commit_sha']).to eq(nil)
       end
     end
+
+    context 'when DOCKER_IMAGE_ID is present in the ENV' do
+      before do
+        ENV['DOCKER_IMAGE_ID'] = 'abc123'
+      end
+
+      it 'reports DOCKER_IMAGE_ID in the info/docker/image_id key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['docker']['image_id']).to eq('abc123')
+      end
+    end
+
+    context 'when DOCKER_IMAGE_ID is not present in the ENV' do
+      before do
+        ENV['DOCKER_IMAGE_ID'] = nil
+      end
+
+      it 'reports null in the info/docker/image_id key' do
+        get :healthcheck, format: :json
+
+        expect(json['info']['docker']['image_id']).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

The healthcheck endpoint allows us to see what Git SHA was used to build the app, but not the actual image id of the Docker container. Adding this allows us to diagnose any issues more quickly by isolating exactly which version is where.

### Changes proposed in this pull request

In the Makefile, extend the `deploy` task to add an extra post-push step for setting the DOCKER_IMAGE_ID as an env var. We must do this _after_ a successful push, not before.

In the github action, install `cf-cli` from a binary distribution rather than apt-get - cuts down execution time by about 45s

Add docker -> image_id to the info element in the `/healthcheck.json` endpoint

### Guidance to review

`make dev deploy` - then hit `/healthcheck.json`
