### PR TITLE
Fix the fake data service

### DIFF
--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -4,11 +4,8 @@ class FakeDataService
       name = Faker::Name.name
       r = ExtraMobileDataRequest.create!(
         device_phone_number: Faker::PhoneNumber.cell_phone,
-        can_access_hotspot: true,
-        is_account_holder: true,
         account_holder_name: name,
-        privacy_statement_sent_to_family: true,
-        understands_how_pii_will_be_used: true,
+        agrees_with_privacy_statement: true,
         mobile_network_id: mobile_network_id,
         status: ExtraMobileDataRequest.statuses.values.sample,
         created_by_user_id: created_by_user_id,

--- a/spec/services/fake_data_service_spec.rb
+++ b/spec/services/fake_data_service_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe FakeDataService, type: :model do
+  let(:mobile_network) { create(:mobile_network) }
+
+  let(:fake_data_call) { FakeDataService.generate!(extra_mobile_data_requests: 3, mobile_network_id: mobile_network.id) }
+
+  it 'creates the requested number of extra mobile data requests' do
+    expect { fake_data_call }.to change { ExtraMobileDataRequest.count }.from(0).to(3)
+  end
+
+  it 'creates all requests against the passed network ID' do
+    fake_data_call
+
+    expect(ExtraMobileDataRequest.distinct.pluck(:mobile_network_id)).to eq([mobile_network.id])
+  end
+end


### PR DESCRIPTION
### Context

The fake data service can be useful during development, in order to have some extra mobile data requests locally. However it was broken by some past data migrations.

### Changes proposed in this pull request

- fix the `FakeDataService` by removing obsolete attributes from it
- add a spec to prevent future regressions
