### PR TITLE
Service performance tweaks part i

### DIFF
--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -15,7 +15,7 @@
       <span class="app-card__secondary-count">
         <%= @stats.extra_mobile_data_requests_by_status['requested'] || 0 %>
       </span>
-      requested
+      new
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -29,9 +29,9 @@
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card app-card--red">
       <span class="app-card__secondary-count">
-        <%= @stats.extra_mobile_data_requests_by_status['queried'] || 0 %>
+        <%= (@stats.extra_mobile_data_requests_by_status['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status['cancelled'] || 0) %>
       </span>
-      not valid
+      not valid or cancelled
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -33,6 +33,10 @@ RSpec.feature 'Viewing service performance', type: :feature do
                 status: :complete,
                 mobile_network: create(:mobile_network, brand: 'Three'),
                 created_by_user: create(:user, responsible_body: local_authority))
+    create_list(:extra_mobile_data_request, 1,
+                status: :cancelled,
+                mobile_network: create(:mobile_network, brand: 'Virgin'),
+                created_by_user: create(:user, responsible_body: local_authority))
   end
 
   def when_i_sign_in_as_a_dfe_user
@@ -50,10 +54,12 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   def and_i_see_stats_about_extra_mobile_data_requests
-    expect(page).to have_text('8 requests')
+    expect(page).to have_text('9 requests')
     expect(page).to have_text('3 in progress')
+    expect(page).to have_text('1 not valid or cancelled')
     expect(page).to have_text('5 completed')
     expect(page).to have_text('EE 3')
     expect(page).to have_text('Three 5')
+    expect(page).to have_text('Virgin 1')
   end
 end

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -25,18 +25,27 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   def and_some_extra_mobile_data_requests_have_been_made
+    ee = create(:mobile_network, brand: 'EE')
+    three = create(:mobile_network, brand: 'Three')
+    virgin = create(:mobile_network, brand: 'Virgin')
+    requester = create(:user, responsible_body: local_authority)
+
+    create_list(:extra_mobile_data_request, 1,
+                status: :requested,
+                mobile_network: virgin,
+                created_by_user: requester)
     create_list(:extra_mobile_data_request, 3,
                 status: :in_progress,
-                mobile_network: create(:mobile_network, brand: 'EE'),
-                created_by_user: create(:user, responsible_body: local_authority))
+                mobile_network: ee,
+                created_by_user: requester)
     create_list(:extra_mobile_data_request, 5,
                 status: :complete,
-                mobile_network: create(:mobile_network, brand: 'Three'),
+                mobile_network: three,
                 created_by_user: create(:user, responsible_body: local_authority))
     create_list(:extra_mobile_data_request, 1,
                 status: :cancelled,
-                mobile_network: create(:mobile_network, brand: 'Virgin'),
-                created_by_user: create(:user, responsible_body: local_authority))
+                mobile_network: virgin,
+                created_by_user: requester)
   end
 
   def when_i_sign_in_as_a_dfe_user
@@ -54,12 +63,13 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   def and_i_see_stats_about_extra_mobile_data_requests
-    expect(page).to have_text('9 requests')
+    expect(page).to have_text('10 requests')
+    expect(page).to have_text('1 new')
     expect(page).to have_text('3 in progress')
     expect(page).to have_text('1 not valid or cancelled')
     expect(page).to have_text('5 completed')
     expect(page).to have_text('EE 3')
     expect(page).to have_text('Three 5')
-    expect(page).to have_text('Virgin 1')
+    expect(page).to have_text('Virgin 2')
   end
 end


### PR DESCRIPTION
### Context

#156 introduced the service performance dashboard. Some issues with it only became apparent when it was used with live data.

### Changes proposed in this pull request

- include cancelled MNO requests in the stats
- show MNO requests in "requested" as "new"

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/89229948-568eb000-d5da-11ea-9189-5849b8857888.png)

More tweaks that will follow in subsequent PRs.