### PR TITLE
Fix unstyled 500 error when the current user is deleted

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -6,12 +6,12 @@
     <%= nav_item( title: "Your requests", url: mno_extra_mobile_data_requests_path )  %>
   <%- else %>
     <%= nav_item( title: "Guidance", url: guidance_page_path )  %>
-    <%- if SessionService.is_signed_in?(session) && @user.is_responsible_body_user? %>
+    <%- if @user&.is_responsible_body_user? %>
       <%= nav_item( title: "Tell us who needs more data", url: responsible_body_extra_mobile_data_requests_path )  %>
     <%- end %>
   <%- end %>
 
-  <%- if SessionService.is_signed_in?(session) %>
+  <%- if SessionService.is_signed_in?(session) && @user %>
     <%- sign_out_link = button_to("Sign out", session_path(id: session[:session_id]), method: :delete, class: 'nav-button-as-link govuk-link govuk-header__link', form_class: 'form-inline' ) %>
     <%- content = [ @user.email_address, sign_out_link].join(' | ') %>
     <%= nav_item(url: sessions_path(id: session.id), content: content.html_safe) %>


### PR DESCRIPTION
### Context

If the nicely-styled 500 error page throws an error, Rails detects this and renders a plain-text 500 fallback message. In this case, it was due to `SessionService.is_signed_in?` checking `session[:user_id]`, but code in that `if...` block assuming that means that `@user` is present. For the vast majority of cases that will be true, but in this particular case it is not, and the nav on the error page throws an error.

### Changes proposed in this pull request

Add an explicit test for @user to the `is_signed_in?` clause in the nav

### Guidance to review

see steps to reproduce in the [Trello card](https://trello.com/c/5RxQPFRH/335-users-seeing-unstyled-500-page-when-an-error-occurs) - you might also want to set `config.consider_all_requests_local = false` so that the error page shows locally. 