### PR TITLE
[371] Allow signing in as a different user when already signed in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ private
   def save_user_to_session!(user = @user)
     # prevent duplicate key errors if they're already signed_in
     SessionService.destroy_session!(session[:session_id]) if session[:session_id]
-    session[:user_id] ||= user.id
+    session[:user_id] = user.id
     SessionService.create_session!(session_id: session[:session_id], user: user)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,8 @@ private
   end
 
   def save_user_to_session!(user = @user)
+    # prevent duplicate key errors if they're already signed_in
+    SessionService.destroy_session!(session[:session_id]) if session[:session_id]
     session[:user_id] ||= user.id
     SessionService.create_session!(session_id: session[:session_id], user: user)
   end

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -72,6 +72,9 @@ RSpec.feature 'Session behaviour', type: :feature do
     let(:user) { create(:local_authority_user) }
     let(:validate_token_url) { validate_token_url_for(user) }
 
+    let(:other_user) { create(:mno_user) }
+    let(:other_user_magic_link) { validate_token_url_for(other_user) }
+
     before do
       visit validate_token_url
     end
@@ -85,6 +88,11 @@ RSpec.feature 'Session behaviour', type: :feature do
     scenario 'using a new magic link redirects to the home page for user' do
       sign_in_as(user)
       expect(page).to have_current_path(responsible_body_home_path)
+    end
+
+    scenario 'using a magic link from a different user signs in as the different user' do
+      visit other_user_magic_link
+      expect(page).to have_content(other_user.email_address)
     end
   end
 


### PR DESCRIPTION
### Context

When we're testing the system, it's quite common for us to sign in as one person (say, a responsible body user), do something (like submit a request), then sign in as someone else (say, an MNO user, to see that the request has come through). Since #144 this hasn't worked - the new session is ignored (see [Trello card](https://trello.com/c/FipwUPrE/371-signing-in-as-a-new-user-when-already-signed-in-doesnt-sign-you-in) )

### Changes proposed in this pull request

Restore this behaviour

### Guidance to review

