### PR TITLE
Updated github deployment workflow to run on pushes to main branch

### DIFF
--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -2,16 +2,13 @@
 name: Build, push and deploy container
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
 jobs:
   build-and-push-container:
     runs-on: ubuntu-latest
-    # Only run this when the PR has been merged -(i.e. not just closed)
-    if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -39,8 +36,6 @@ jobs:
   deploy-to-paas:
     runs-on: ubuntu-latest
     needs: build-and-push-container
-    # Only run this when the PR has been merged -(i.e. not just closed)
-    if: github.event.pull_request.merged
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Context
[Trello Card](https://trello.com/c/B8gTg0RU/369-update-the-automatic-govuk-push-to-run-off-the-main-branch)

### Changes proposed in this pull request
Change the GitHub automated workflow so that the `main` branch is used for deployment to GOV.UK PaaS.
As `main` is protected, we can use the `push` trigger on the `main` branch instead of the `pull_request` trigger.
This will then act on the `main` branch.

### Guidance to review

I have a simple test repo that I used to check the behaviour: [Test repo](https://github.com/tonyheadford/actions-test)