### PR TITLE
Responsible bodies in support

### DIFF
--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -1,0 +1,5 @@
+class Support::ResponsibleBodiesController < Support::BaseController
+  def index
+    @responsible_bodies = ResponsibleBody.joins(:users).distinct.order('name asc')
+  end
+end

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -1,5 +1,9 @@
 class Support::ResponsibleBodiesController < Support::BaseController
   def index
-    @responsible_bodies = ResponsibleBody.joins(:users).distinct.order('type asc, name asc')
+    @responsible_bodies = ResponsibleBody
+      .includes(:bt_wifi_voucher_allocation)
+      .joins(:users)
+      .distinct
+      .order('type asc, name asc')
   end
 end

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -1,5 +1,5 @@
 class Support::ResponsibleBodiesController < Support::BaseController
   def index
-    @responsible_bodies = ResponsibleBody.joins(:users).distinct.order('name asc')
+    @responsible_bodies = ResponsibleBody.joins(:users).distinct.order('type asc, name asc')
   end
 end

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -1,7 +1,7 @@
 class Support::ResponsibleBodiesController < Support::BaseController
   def index
     @responsible_bodies = ResponsibleBody
-      .includes(:bt_wifi_voucher_allocation)
+      .includes(:bt_wifi_voucher_allocation, :bt_wifi_vouchers)
       .joins(:users)
       .distinct
       .order('type asc, name asc')

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,6 +1,7 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <%- if @user&.is_dfe? %>
     <%= nav_item( title: "Service performance", url: support_service_performance_path )  %>
+    <%= nav_item( title: "Responsible bodies", url: support_responsible_bodies_path )  %>
     <%= nav_item( title: "Background jobs", url: support_sidekiq_admin_path, html_options: {target: '_blank'} )  %>
   <%- elsif @user&.is_mno_user? %>
     <%= nav_item( title: "Your requests", url: mno_extra_mobile_data_requests_path )  %>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -9,12 +9,14 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">User count</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <% @responsible_bodies.each do |responsible_body| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= responsible_body.name %></td>
+        <td class="govuk-table__cell"><%= pluralize(responsible_body.users.size, "user") %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -13,6 +13,7 @@
       <th scope="col" class="govuk-table__header">User count</th>
       <th scope="col" class="govuk-table__header">Users signed in at least once</th>
       <th scope="col" class="govuk-table__header">BT hotspot allocations</th>
+      <th scope="col" class="govuk-table__header">Downloaded vouchers?</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -25,6 +26,9 @@
           <%= pluralize(responsible_body.users.select { |u| u.sign_in_count > 0 }.size, "user") %> signed in
         </td>
         <td class="govuk-table__cell"><%= responsible_body&.bt_wifi_voucher_allocation&.amount %></td>
+        <td class="govuk-table__cell">
+          <%= responsible_body.bt_wifi_vouchers.map(&:distributed_at).compact.present? ? 'Yes' : 'No' %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -12,6 +12,7 @@
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">User count</th>
       <th scope="col" class="govuk-table__header">Users signed in at least once</th>
+      <th scope="col" class="govuk-table__header">BT hotspot allocations</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -23,6 +24,7 @@
         <td class="govuk-table__cell">
           <%= pluralize(responsible_body.users.select { |u| u.sign_in_count > 0 }.size, "user") %> signed in
         </td>
+        <td class="govuk-table__cell"><%= responsible_body&.bt_wifi_voucher_allocation&.amount %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, t('page_titles.support_responsible_bodies') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.support_responsible_bodies') %>
+</h1>
+
+<table id="responsible-bodies" class="govuk-table">
+  <caption class="govuk-table__caption">Responsible bodies with at least one user</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @responsible_bodies.each do |responsible_body| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= responsible_body.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -8,6 +8,7 @@
   <caption class="govuk-table__caption">Responsible bodies with at least one user</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Type</th>
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">User count</th>
     </tr>
@@ -15,6 +16,7 @@
   <tbody class="govuk-table__body">
     <% @responsible_bodies.each do |responsible_body| %>
       <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= responsible_body.type.underscore.humanize %></td>
         <td class="govuk-table__cell"><%= responsible_body.name %></td>
         <td class="govuk-table__cell"><%= pluralize(responsible_body.users.size, "user") %></td>
       </tr>

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -11,6 +11,7 @@
       <th scope="col" class="govuk-table__header">Type</th>
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">User count</th>
+      <th scope="col" class="govuk-table__header">Users signed in at least once</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -19,6 +20,9 @@
         <td class="govuk-table__cell"><%= responsible_body.type.underscore.humanize %></td>
         <td class="govuk-table__cell"><%= responsible_body.name %></td>
         <td class="govuk-table__cell"><%= pluralize(responsible_body.users.size, "user") %></td>
+        <td class="govuk-table__cell">
+          <%= pluralize(responsible_body.users.select { |u| u.sign_in_count > 0 }.size, "user") %> signed in
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
     you_are_signed_in: You’re signed in
     service_performance: Service performance
     accessibility: Accessibility statement
+    support_responsible_bodies: On-boarded responsible bodies
   devices_guidance:
     about_the_offer:
       title: About the offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
 
   namespace :support do
     get '/', to: 'service_performance#index', as: :service_performance
+    resources :responsible_bodies, only: %i[index], path: '/responsible-bodies'
 
     mount Sidekiq::Web => '/sidekiq', constraints: RequireDFEUserConstraint.new, as: :sidekiq_admin
   end

--- a/spec/factories/bt_wifi_vouchers.rb
+++ b/spec/factories/bt_wifi_vouchers.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     trait :unassigned do
       responsible_body { nil }
     end
+
+    trait :downloaded do
+      distributed_at { Time.now.utc - rand(500_000).seconds }
+    end
   end
 end

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -37,11 +37,16 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
 
   def then_i_can_see_the_responsible_bodies_with_users
     expect(responsible_bodies_page.responsible_body_rows.size).to eq(2)
-    expect(responsible_bodies_page.responsible_body_rows[0]).to have_text('AWESOME TRUST')
-    expect(responsible_bodies_page.responsible_body_rows[0]).to have_text('1 user')
 
-    expect(responsible_bodies_page.responsible_body_rows[1]).to have_text('Coventry')
-    expect(responsible_bodies_page.responsible_body_rows[1]).to have_text('2 users')
+    first_row = responsible_bodies_page.responsible_body_rows[0]
+    expect(first_row).to have_text('Coventry')
+    expect(first_row).to have_text('2 users')
+    expect(first_row).to have_text('Local authority')
+
+    second_row = responsible_bodies_page.responsible_body_rows[1]
+    expect(second_row).to have_text('AWESOME TRUST')
+    expect(second_row).to have_text('1 user')
+    expect(second_row).to have_text('Trust')
   end
 
   def and_i_cannot_see_the_responsible_bodies_without_users

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -19,10 +19,12 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     create(:user, responsible_body: la, sign_in_count: 0)
     create(:user, responsible_body: la, sign_in_count: 2)
     create(:bt_wifi_voucher_allocation, amount: 123, responsible_body: la)
+    create_list(:bt_wifi_voucher, 123, :downloaded, responsible_body: la)
 
     trust = create(:trust, name: 'AWESOME TRUST')
     create(:user, responsible_body: trust, sign_in_count: 0)
     create(:bt_wifi_voucher_allocation, amount: 456, responsible_body: trust)
+    create_list(:bt_wifi_voucher, 456, responsible_body: trust)
   end
 
   def and_given_there_are_responsible_bodies_that_do_not_have_any_users
@@ -47,6 +49,7 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     expect(first_row).to have_text('1 user signed in')
     expect(first_row).to have_text('Local authority')
     expect(first_row).to have_text('123')
+    expect(first_row).to have_text('Yes') # hotspots downloaded?
 
     second_row = responsible_bodies_page.responsible_body_rows[1]
     expect(second_row).to have_text('AWESOME TRUST')
@@ -54,6 +57,7 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     expect(second_row).to have_text('0 users signed in')
     expect(second_row).to have_text('Trust')
     expect(second_row).to have_text('456')
+    expect(second_row).to have_text('No') # hotspots downloaded?
   end
 
   def and_i_cannot_see_the_responsible_bodies_without_users

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type: :feature do
+  let(:responsible_bodies_page) { PageObjects::Support::ResponsibleBodiesPage.new }
+
+  scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
+    given_there_are_responsible_bodies_that_have_users
+    and_given_there_are_responsible_bodies_that_do_not_have_any_users
+
+    when_i_sign_in_as_a_dfe_user
+    and_i_visit_the_support_responsible_bodies_page
+
+    then_i_can_see_the_responsible_bodies_with_users
+    and_i_cannot_see_the_responsible_bodies_without_users
+  end
+
+  def given_there_are_responsible_bodies_that_have_users
+    la = create(:local_authority, name: 'Coventry')
+    create_list(:user, 2, responsible_body: la)
+
+    trust = create(:trust, name: 'AWESOME TRUST')
+    create(:user, responsible_body: trust)
+  end
+
+  def and_given_there_are_responsible_bodies_that_do_not_have_any_users
+    create(:local_authority, name: 'Wandsworth')
+    create(:trust, name: 'ANOTHER TRUST')
+  end
+
+  def when_i_sign_in_as_a_dfe_user
+    sign_in_as create(:dfe_user)
+  end
+
+  def and_i_visit_the_support_responsible_bodies_page
+    responsible_bodies_page.load
+  end
+
+  def then_i_can_see_the_responsible_bodies_with_users
+    expect(responsible_bodies_page.responsible_body_rows.size).to eq(2)
+    expect(responsible_bodies_page.responsible_body_rows[0]).to have_text('AWESOME TRUST')
+    expect(responsible_bodies_page.responsible_body_rows[1]).to have_text('Coventry')
+  end
+
+  def and_i_cannot_see_the_responsible_bodies_without_users
+    expect(page).not_to have_text('Wandsworth')
+    expect(page).not_to have_text('ANOTHER TRUST')
+  end
+end

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -18,9 +18,11 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     la = create(:local_authority, name: 'Coventry')
     create(:user, responsible_body: la, sign_in_count: 0)
     create(:user, responsible_body: la, sign_in_count: 2)
+    create(:bt_wifi_voucher_allocation, amount: 123, responsible_body: la)
 
     trust = create(:trust, name: 'AWESOME TRUST')
     create(:user, responsible_body: trust, sign_in_count: 0)
+    create(:bt_wifi_voucher_allocation, amount: 456, responsible_body: trust)
   end
 
   def and_given_there_are_responsible_bodies_that_do_not_have_any_users
@@ -44,12 +46,14 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     expect(first_row).to have_text('2 users')
     expect(first_row).to have_text('1 user signed in')
     expect(first_row).to have_text('Local authority')
+    expect(first_row).to have_text('123')
 
     second_row = responsible_bodies_page.responsible_body_rows[1]
     expect(second_row).to have_text('AWESOME TRUST')
     expect(second_row).to have_text('1 user')
     expect(second_row).to have_text('0 users signed in')
     expect(second_row).to have_text('Trust')
+    expect(second_row).to have_text('456')
   end
 
   def and_i_cannot_see_the_responsible_bodies_without_users

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -16,10 +16,11 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
 
   def given_there_are_responsible_bodies_that_have_users
     la = create(:local_authority, name: 'Coventry')
-    create_list(:user, 2, responsible_body: la)
+    create(:user, responsible_body: la, sign_in_count: 0)
+    create(:user, responsible_body: la, sign_in_count: 2)
 
     trust = create(:trust, name: 'AWESOME TRUST')
-    create(:user, responsible_body: trust)
+    create(:user, responsible_body: trust, sign_in_count: 0)
   end
 
   def and_given_there_are_responsible_bodies_that_do_not_have_any_users
@@ -41,11 +42,13 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     first_row = responsible_bodies_page.responsible_body_rows[0]
     expect(first_row).to have_text('Coventry')
     expect(first_row).to have_text('2 users')
+    expect(first_row).to have_text('1 user signed in')
     expect(first_row).to have_text('Local authority')
 
     second_row = responsible_bodies_page.responsible_body_rows[1]
     expect(second_row).to have_text('AWESOME TRUST')
     expect(second_row).to have_text('1 user')
+    expect(second_row).to have_text('0 users signed in')
     expect(second_row).to have_text('Trust')
   end
 

--- a/spec/features/support/viewing_onboarded_responsible_bodies.rb
+++ b/spec/features/support/viewing_onboarded_responsible_bodies.rb
@@ -38,7 +38,10 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
   def then_i_can_see_the_responsible_bodies_with_users
     expect(responsible_bodies_page.responsible_body_rows.size).to eq(2)
     expect(responsible_bodies_page.responsible_body_rows[0]).to have_text('AWESOME TRUST')
+    expect(responsible_bodies_page.responsible_body_rows[0]).to have_text('1 user')
+
     expect(responsible_bodies_page.responsible_body_rows[1]).to have_text('Coventry')
+    expect(responsible_bodies_page.responsible_body_rows[1]).to have_text('2 users')
   end
 
   def and_i_cannot_see_the_responsible_bodies_without_users

--- a/spec/page_objects/support/responsible_bodies_page.rb
+++ b/spec/page_objects/support/responsible_bodies_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Support
+    class ResponsibleBodiesPage < PageObjects::BasePage
+      set_url '/support/responsible-bodies'
+
+      elements :responsible_body_rows, '#responsible-bodies tbody tr'
+    end
+  end
+end


### PR DESCRIPTION
### Context

It's useful to see a list of responsible bodies in the support area of the service, so that:

- DfE ops users can see engagement stats around both pilots
- There is a jump-off points for further operations on the responsible bodies (e.g. managing users)

### Changes proposed in this pull request

- Add a list of responsible bodies in the support area, only accessible to DfE staff
- Display some basic engagement stats per responsible body

### Guidance to review

Is the table layout appropriate?

* pros: can be copied directly into Excel for further manipulation
* cons: not very compact or scannable

![image](https://user-images.githubusercontent.com/23801/89468891-51636980-d770-11ea-9be7-366cd98176af.png)

Does the microcopy make sense?

(I intend to add the extra mobile data requests later when the data model has been improved for reporting.)