### PR TITLE
330 add unavailable status

### DIFF
--- a/app/controllers/responsible_body/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/mobile/manual_requests_controller.rb
@@ -23,16 +23,16 @@ class ResponsibleBody::Mobile::ManualRequestsController < ResponsibleBody::BaseC
       if params[:confirm]
         # clear the stashed params once the user has confirmed them
         session.delete(:extra_mobile_data_request_params)
-        @extra_mobile_data_request.save!
 
-        @extra_mobile_data_request.notify_account_holder_later
+        @extra_mobile_data_request.save_and_notify_account_holder!
 
-        flash[:success] = I18n.t('responsible_body.extra_mobile_data_requests.create.success')
+        flash[:success] = build_success_message(@extra_mobile_data_request.mobile_network.participating?)
         redirect_to responsible_body_mobile_extra_data_requests_path
       else
         # store given params in session,so that we don't have to pass them back in the URL
         # if the user clicks 'Change' on the confirmation page
         session[:extra_mobile_data_request_params] = extra_mobile_data_request_params
+        @extra_mobile_data_request = presenter(@extra_mobile_data_request)
         render :confirm
       end
     else
@@ -59,5 +59,17 @@ private
       mobile_network_id
       confirm
     ])
+  end
+
+  def build_success_message(mno_is_participating)
+    if mno_is_participating
+      I18n.t('responsible_body.extra_mobile_data_requests.create.success')
+    else
+      I18n.t('responsible_body.extra_mobile_data_requests.create.success_saved')
+    end
+  end
+
+  def presenter(extra_mobile_data_request)
+    ExtraMobileDataRequestPresenter.new(extra_mobile_data_request)
   end
 end

--- a/app/controllers/responsible_body/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/mobile/manual_requests_controller.rb
@@ -63,9 +63,9 @@ private
 
   def build_success_message(mno_is_participating)
     if mno_is_participating
-      I18n.t('responsible_body.extra_mobile_data_requests.create.success')
+      I18n.t('responsible_body.extra_mobile_data_requests.create.success.participating_mno')
     else
-      I18n.t('responsible_body.extra_mobile_data_requests.create.success_saved')
+      I18n.t('responsible_body.extra_mobile_data_requests.create.success.non_participating_mno')
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,7 @@ module ApplicationHelper
       complete: 'govuk-tag--green',
       queried: 'govuk-tag--red',
       cancelled: 'govuk-tag--grey',
+      unavailable: 'govuk-tag--grey',
     }[status.to_sym]
   end
 end

--- a/app/presenters/extra_mobile_data_request_presenter.rb
+++ b/app/presenters/extra_mobile_data_request_presenter.rb
@@ -3,6 +3,20 @@ class ExtraMobileDataRequestPresenter < SimpleDelegator
     mobile_network.brand if mobile_network.present?
   end
 
+  def network_name_with_participation_status
+    name = network_name
+    return name if mobile_network.participating?
+    I18n.t(:mobile_network_not_on_service_yet, scope: i18n_scope, mno: name) 
+  end
+
+  def passing_data_to_provider_message
+    if mobile_network.participating?
+      I18n.t(:details_passed_to_provider, scope: i18n_scope, mno: network_name)
+    else
+      I18n.t(:details_passed_to_provider_only_if_they_join, scope: i18n_scope, mno: network_name)
+    end
+  end
+
   def error_message
     return unless errors.any?
 
@@ -30,5 +44,9 @@ private
 
   def extra_mobile_data_request
     __getobj__
+  end
+
+  def i18n_scope
+    'responsible_body.extra_mobile_data_requests'
   end
 end

--- a/app/presenters/extra_mobile_data_request_presenter.rb
+++ b/app/presenters/extra_mobile_data_request_presenter.rb
@@ -6,7 +6,8 @@ class ExtraMobileDataRequestPresenter < SimpleDelegator
   def network_name_with_participation_status
     name = network_name
     return name if mobile_network.participating?
-    I18n.t(:mobile_network_not_on_service_yet, scope: i18n_scope, mno: name) 
+
+    I18n.t(:mobile_network_not_on_service_yet, scope: i18n_scope, mno: name)
   end
 
   def passing_data_to_provider_message

--- a/app/services/extra_data_request_spreadsheet_importer.rb
+++ b/app/services/extra_data_request_spreadsheet_importer.rb
@@ -16,13 +16,13 @@ class ExtraDataRequestSpreadsheetImporter
 
       next unless request_attrs
 
-      extra_mobile_data_request = create_request(request_attrs, user)
+      extra_mobile_data_request = build_request(request_attrs, user)
 
       if extra_mobile_data_request.valid?
         if request_already_exists?(extra_mobile_data_request)
           summary.add_existing_record(extra_mobile_data_request)
         else
-          save_and_notify!(extra_mobile_data_request)
+          extra_mobile_data_request.save_and_notify_account_holder!
           summary.add_successful_record(extra_mobile_data_request)
         end
       else
@@ -48,7 +48,7 @@ private
     MobileNetwork.find_by(brand: network_name)&.id
   end
 
-  def create_request(request_attrs, user)
+  def build_request(request_attrs, user)
     ExtraMobileDataRequest.new(
       request_attrs.merge({
         created_by_user: user,
@@ -63,10 +63,5 @@ private
       device_phone_number: request.device_phone_number,
       mobile_network_id: request.mobile_network_id,
     )
-  end
-
-  def save_and_notify!(request)
-    request.save!
-    request.notify_account_holder_later
   end
 end

--- a/app/views/responsible_body/mobile/manual_requests/confirm.html.erb
+++ b/app/views/responsible_body/mobile/manual_requests/confirm.html.erb
@@ -39,7 +39,7 @@
           Mobile network
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @extra_mobile_data_request.mobile_network.brand %>
+          <%= @extra_mobile_data_request.network_name_with_participation_status %>
         </dd>
         <dd class="govuk-summary-list__actions">
           <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path(anchor: "extra-mobile-data-request-mobile-network-id-#{@extra_mobile_data_request.mobile_network_id}-field") ) do %>
@@ -62,7 +62,7 @@
         </dd>
       </div>
     </dl>
-    <p class="govuk-body">These details will be passed to <%= @extra_mobile_data_request.mobile_network.brand %></p>
+    <p class="govuk-body"><%= @extra_mobile_data_request.passing_data_to_provider_message %></p>
 
     <%= form_for @extra_mobile_data_request, url: responsible_body_mobile_manual_requests_path do |f| %>
       <%= f.hidden_field :account_holder_name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,8 +179,9 @@ en:
         manual_submission: Manually (entering details one at a time)
         bulk_submission: Using a spreadsheet
       create:
-        success: Your request has been received
-        success_saved: Your request has been saved
+        success:
+          participating_mno: Your request has been received
+          non_particpating_mno: Your request has been saved
       mobile_network_not_on_service_yet: "%{mno} (not on service yet)"
       details_passed_to_provider: "These details will be passed to %{mno}"
       details_passed_to_provider_only_if_they_join: "These details will be passed to %{mno} only if they join the service"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
           queried: Queried
           complete: Complete
           cancelled: Cancelled
+          unavailable: Unavailable
       mobile_network:
         participation_in_pilots:
           participating: 'Offers data now'
@@ -179,3 +180,7 @@ en:
         bulk_submission: Using a spreadsheet
       create:
         success: Your request has been received
+        success_saved: Your request has been saved
+      mobile_network_not_on_service_yet: "%{mno} (not on service yet)"
+      details_passed_to_provider: "These details will be passed to %{mno}"
+      details_passed_to_provider_only_if_they_join: "These details will be passed to %{mno} only if they join the service"

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
   context 'when the user has already submitted requests' do
     before do
       @requests = create_list(:extra_mobile_data_request, 5, status: 'requested', created_by_user: rb_user)
+      @requests.last.unavailable!
     end
 
     scenario 'the user can see their previous requests' do
@@ -45,6 +46,8 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
         expect(page).to have_content(request.device_phone_number)
         expect(page).to have_content(request.account_holder_name)
       end
+      expect(page).to have_text('Requested').exactly(4).times
+      expect(page).to have_text('Unavailable').once
     end
   end
 end

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -22,11 +22,8 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
       mobile_network
       sign_in_as user
       # prevent api call to Notify
-      ActiveJob::Base.queue_adapter = :test
-    end
-
-    after do
-      ActiveJob::Base.queue_adapter = :inline
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms')
+        .to_return(status: 201, body: '{}')
     end
 
     scenario 'Navigating to the form' do

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'shared/filling_in_forms'
+
+RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature do
+  context 'not signed in' do
+    it 'does not show the link in the nav' do
+      visit '/'
+      expect(page).not_to have_text('Tell us who needs more data')
+    end
+
+    scenario 'visiting the form directly should redirect to sign_in' do
+      visit new_responsible_body_mobile_bulk_request_path
+      expect(page).to have_current_path(sign_in_path)
+    end
+  end
+
+  context 'signed in' do
+    let(:user) { create(:local_authority_user) }
+    let(:mobile_network) { create(:mobile_network) }
+
+    before do
+      mobile_network
+      sign_in_as user
+      # prevent api call to Notify
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    after do
+      ActiveJob::Base.queue_adapter = :inline
+    end
+
+    scenario 'Navigating to the form' do
+      visit responsible_body_mobile_extra_data_requests_path
+      click_on('New request')
+      expect(page).to have_text('How would you like to submit information?')
+      choose('Using a spreadsheet')
+      click_on('Continue')
+      expect(page).to have_text('Pick a spreadsheet file')
+    end
+
+    scenario 'submitting the form without making a choice shows errors' do
+      visit new_responsible_body_mobile_bulk_request_path
+      click_on 'Upload requests'
+      expect(page.status_code).not_to eq(200)
+      expect(page).to have_text('There is a problem')
+    end
+
+    scenario 'submitting the form with a valid file shows a summary page' do
+      visit new_responsible_body_mobile_bulk_request_path
+      attach_file('Pick a spreadsheet file', file_fixture('extra-mobile-data-requests.xlsx'))
+      click_on 'Upload requests'
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_text('We’ve processed your spreadsheet')
+    end
+  end
+end

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -43,13 +43,31 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
       expect(page).to have_text('There is a problem')
     end
 
-    scenario 'submitting the form with valid params goes to confirmation page' do
-      visit new_responsible_body_mobile_manual_request_path
-      fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
-      click_on 'Continue'
+    context 'when the mno is participating' do
+      scenario 'submitting the form with valid params goes to confirmation page' do
+        visit new_responsible_body_mobile_manual_request_path
+        fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
+        click_on 'Continue'
 
-      expect(page.status_code).to eq(200)
-      expect(page).to have_text('Check your answers')
+        expect(page.status_code).to eq(200)
+        expect(page).to have_text('Check your answers')
+        expect(page).to have_text("These details will be passed to #{mobile_network.brand}")
+      end
+    end
+
+    context 'when the mno is not particpating' do
+      let(:mobile_network) { create(:mobile_network, :maybe_participating_in_pilot) }
+
+      scenario 'submitting the form with valid params goes to confirmation page with extra messaging' do
+        visit new_responsible_body_mobile_manual_request_path
+        fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
+        click_on 'Continue'
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_text('Check your answers')
+        expect(page).to have_text("#{mobile_network.brand} (not on service yet)")
+        expect(page).to have_text("These details will be passed to #{mobile_network.brand} only if they join the service")
+      end
     end
 
     scenario 'clicking Change on the confirmation page populates the form again' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -90,14 +90,6 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
   end
 
   describe '#save_and_notify_account_holder!' do
-    before do
-      ActiveJob::Base.queue_adapter = :test
-    end
-
-    after do
-      ActiveJob::Base.queue_adapter = :inline
-    end
-
     context 'when mno is participating' do
       let(:request) { create(:extra_mobile_data_request) }
 

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -88,4 +88,57 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
       end
     end
   end
+
+  describe '#save_and_notify_account_holder!' do
+    before do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    after do
+      ActiveJob::Base.queue_adapter = :inline
+    end
+
+    context 'when mno is participating' do
+      let(:request) { create(:extra_mobile_data_request) }
+
+      it 'saves the request' do
+        expect {
+          request.save_and_notify_account_holder!
+        }.to change { ExtraMobileDataRequest.count }.by(1)
+      end
+
+      it 'does not change the status from requested' do
+        request.save_and_notify_account_holder!
+        expect(request.requested?).to be true
+      end
+
+      it 'enqueues a job to message the account holder' do
+        expect {
+          request.save_and_notify_account_holder!
+        }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob)
+      end
+    end
+
+    context 'when mno is not participating' do
+      let(:network) { create(:mobile_network, :maybe_participating_in_pilot) }
+      let(:request) { create(:extra_mobile_data_request, mobile_network_id: network.id) }
+
+      it 'saves the request' do
+        expect {
+          request.save_and_notify_account_holder!
+        }.to change { ExtraMobileDataRequest.count }.by(1)
+      end
+
+      it 'changes the status to unavailable' do
+        request.save_and_notify_account_holder!
+        expect(request.unavailable?).to be true
+      end
+
+      it 'enqueues a job to message the account holder' do
+        expect {
+          request.save_and_notify_account_holder!
+        }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/Tx9RTGFF/330-add-unavailable-status)
### Changes proposed in this pull request
This change adds `unavailable` to the status enum for the `ExtraMobileDataRequest` model. The status should be set to `unavailable` if the mobile network is not yet participating.  This status should be displayed in the list of requests for the user.
There is also altered messaging during submission to indicate that the network is not yet in the service and that the request has been saved rather than submitted.

### Guidance to review

