### PR TITLE
Fix the header toggle

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
         <% else %>
           <div class="govuk-header__content">
             <%= link_to t('service_name'), "/", class: "govuk-header__link govuk-header__link--service-name" %>
-            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
             <nav>
               <%= render partial: 'layouts/nav' %>
             </nav>

--- a/public/429.html
+++ b/public/429.html
@@ -44,7 +44,7 @@
 </a>        </div>
           <div class="govuk-header__content">
             <a class="govuk-header__link govuk-header__link--service-name" href="/">Increasing internet access for vulnerable and disadvantaged children</a>
-            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
             <nav>
               <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
     <li class="govuk-header__navigation-item"><a class="govuk-header__link" href="/">Guidance</a></li>


### PR DESCRIPTION
### Context

The header toggle is broken and nothing happens when you click on the "Menu" link/mobile hamburger button. It's likely never worked in this repo because it was [already broken (and now fixed)](https://github.com/DFE-Digital/govuk-rails-boilerplate/pull/286) in the [`govuk-boiler-template`](https://github.com/DFE-Digital/govuk-rails-boilerplate) repository.

The issue related to a CSS class rename in v3.0.0 of govuk-frontend:

https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#update-css-class-names

### Changes proposed in this pull request

Bring the class name in the layout in line with `govuk-frontend` v3.0.0 and later.
