### PR TITLE
Fake data service should generate consistent data for queried requests

### DIFF
--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -11,6 +11,7 @@ class FakeDataService
         created_by_user_id: created_by_user_id,
       )
       r.update(created_at: Time.now.utc - rand(500_000).seconds)
+      r.update(problem: ExtraMobileDataRequest.problems.values.sample) if r.queried?
       Rails.logger.info "created #{r.id} - #{r.account_holder_name}"
     end
   end


### PR DESCRIPTION
### Context

The fake data service generates extra mobile data requests in queried status that don't have a `problem` set.

### Changes proposed in this pull request

Fix the data inconsistency.
