### PR TITLE
Run feature specs with sidekiq

### DIFF
--- a/spec/controllers/responsible_body/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/mobile/bulk_requests_controller_spec.rb
@@ -13,14 +13,9 @@ RSpec.describe ResponsibleBody::Mobile::BulkRequestsController, type: :controlle
       let(:request_data) { { bulk_upload_form: { upload: upload } } }
 
       before do
-        ActiveJob::Base.queue_adapter = :test
         ['EE', 'O2', 'Tesco Mobile', 'Virgin Mobile', 'Three'].each do |brand|
           create(:mobile_network, brand: brand)
         end
-      end
-
-      after do
-        ActiveJob::Base.queue_adapter = :inline
       end
 
       it 'sends an sms to the account holder of each valid request in the spreadsheet' do

--- a/spec/controllers/responsible_body/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/mobile/manual_requests_controller_spec.rb
@@ -13,15 +13,7 @@ RSpec.describe ResponsibleBody::Mobile::ManualRequestsController, type: :control
       let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
       let(:request_data) { { extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
 
-      before do
-        ActiveJob::Base.queue_adapter = :test
-      end
-
-      after do
-        ActiveJob::Base.queue_adapter = :inline
-      end
-
-      it 'sends an sms to the account holder of the request' do
+      it 'sends an SMS to the account holder of the request' do
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob).once

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -22,11 +22,8 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
       mobile_network
       sign_in_as user
       # prevent api call to Notify
-      ActiveJob::Base.queue_adapter = :test
-    end
-
-    after do
-      ActiveJob::Base.queue_adapter = :inline
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms')
+        .to_return(status: 201, body: '{}')
     end
 
     scenario 'Navigating to the form' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -65,14 +65,6 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
   describe '#notify_account_holder_later' do
     let(:request) { create(:extra_mobile_data_request) }
 
-    before do
-      ActiveJob::Base.queue_adapter = :test
-    end
-
-    after do
-      ActiveJob::Base.queue_adapter = :inline
-    end
-
     it 'enqueues a job to send the message' do
       expect {
         request.notify_account_holder_later

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'support/factory_bot'
 require 'support/controller_helper'
 require 'support/capybara_helper'
 require 'capybara/email/rspec'
+require 'support/sidekiq'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/services/extra_data_request_spreadsheet_importer_spec.rb
+++ b/spec/services/extra_data_request_spreadsheet_importer_spec.rb
@@ -6,14 +6,9 @@ RSpec.describe ExtraDataRequestSpreadsheetImporter, type: :model do
   let(:importer) { described_class.new }
 
   before do
-    ActiveJob::Base.queue_adapter = :test
     ['EE', 'O2', 'Tesco Mobile', 'Virgin Mobile', 'Three'].each do |brand|
       create(:mobile_network, brand: brand)
     end
-  end
-
-  after do
-    ActiveJob::Base.queue_adapter = :inline
   end
 
   it 'imports valid requests from a spreadsheet' do

--- a/spec/services/extra_mobile_data_request_account_holder_notification_spec.rb
+++ b/spec/services/extra_mobile_data_request_account_holder_notification_spec.rb
@@ -45,14 +45,6 @@ RSpec.describe ExtraMobileDataRequestAccountHolderNotification, type: :model do
   end
 
   describe '#deliver_later' do
-    before do
-      ActiveJob::Base.queue_adapter = :test
-    end
-
-    after do
-      ActiveJob::Base.queue_adapter = :inline
-    end
-
     it 'enqueues a job to deliver the message in the background' do
       expect {
         service.deliver_later

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,4 +1,21 @@
+require 'sidekiq/testing'
 ActiveJob::Base.queue_adapter = :test
 
-require 'sidekiq/testing'
-Sidekiq::Testing.inline!
+RSpec.configure do |config|
+  include ActiveJob::TestHelper
+
+  # Turn Sidekiq on automatically in feature specs. Use `sidekiq: false` in
+  # tests to avoid Sidekiq running.
+  config.define_derived_metadata(file_path: Regexp.new('/spec/features/')) do |metadata|
+    metadata[:sidekiq] = true unless metadata[:sidekiq] == false
+  end
+
+  # Use `sidekiq: true` to run jobs immediately
+  config.around sidekiq: true do |example|
+    perform_enqueued_jobs do
+      Sidekiq::Testing.inline! do
+        example.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Some of the current specs change the ActiveJob queue adapter before and after the spec. This makes the specs noisier than they need to be.

### Changes proposed in this pull request

Introduce suite-wide defaults about which ActiveJob queue adapter to use:

- feature specs use the real inline adapter by default
- all other specs use the test adapter by default

This can be overridden by setting `sidekiq: true|false` in the spec.

This change allows to remove some repeated setup/teardowns in some specs.

### Guidance to review

This was inspired by a similar setup in the [Apply for Teacher Training repo](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training).