### PR TITLE
Extra mobile data request improvements

### DIFF
--- a/app/controllers/responsible_body/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/mobile/manual_requests_controller.rb
@@ -20,9 +20,7 @@ class ResponsibleBody::Mobile::ManualRequestsController < ResponsibleBody::BaseC
       if params[:confirm]
         # clear the stashed params once the user has confirmed them
         session.delete(:extra_mobile_data_request_params)
-        @extra_mobile_data_request.save!
-
-        @extra_mobile_data_request.notify_account_holder_later
+        @extra_mobile_data_request.save_and_notify_account_holder!
 
         flash[:success] = I18n.t('responsible_body.extra_mobile_data_requests.create.success')
         redirect_to responsible_body_mobile_extra_data_requests_path

--- a/app/controllers/responsible_body/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/mobile/manual_requests_controller.rb
@@ -13,10 +13,7 @@ class ResponsibleBody::Mobile::ManualRequestsController < ResponsibleBody::BaseC
 
   def create
     @extra_mobile_data_request = ExtraMobileDataRequest.new(
-      extra_mobile_data_request_params.merge(
-        created_by_user: @user,
-        status: :requested,
-      ),
+      extra_mobile_data_request_params.merge(created_by_user: @user),
     )
 
     if @extra_mobile_data_request.valid?

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -1,4 +1,6 @@
 class ExtraMobileDataRequest < ApplicationRecord
+  after_initialize :set_defaults
+
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network
 
@@ -78,5 +80,9 @@ private
 
   def notification
     @notification ||= ExtraMobileDataRequestAccountHolderNotification.new(self)
+  end
+
+  def set_defaults
+    self.status ||= :requested if new_record?
   end
 end

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -72,7 +72,8 @@ class ExtraMobileDataRequest < ApplicationRecord
     notification.deliver_now
   end
 
-  def notify_account_holder_later
+  def save_and_notify_account_holder!
+    save!
     notification.deliver_later
   end
 

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -77,6 +77,14 @@ class ExtraMobileDataRequest < ApplicationRecord
     notification.deliver_later
   end
 
+  def has_already_been_made?
+    self.class.exists?(
+      account_holder_name: account_holder_name,
+      device_phone_number: device_phone_number,
+      mobile_network_id: mobile_network_id,
+    )
+  end
+
 private
 
   def notification

--- a/app/models/extra_mobile_data_request_spreadsheet.rb
+++ b/app/models/extra_mobile_data_request_spreadsheet.rb
@@ -1,0 +1,34 @@
+class ExtraMobileDataRequestSpreadsheet
+  def initialize(spreadsheet_path)
+    @spreadsheet_path = spreadsheet_path
+  end
+
+  def requests
+    workbook = RubyXL::Parser.parse(@spreadsheet_path)
+    worksheet = workbook['Extra mobile data requests']
+
+    worksheet.map.with_index { |row, n|
+      next if n.zero? || row.nil? # skip the header row
+
+      request_attrs = fetch_request_attrs(row)
+
+      ExtraMobileDataRequest.new(request_attrs) if request_attrs
+    }.compact
+  end
+
+private
+
+  def fetch_request_attrs(row)
+    attrs = {
+      account_holder_name: row[0]&.value,
+      device_phone_number: row[1]&.value,
+      mobile_network: lookup_network(row[2]&.value),
+      agrees_with_privacy_statement: row[4]&.value,
+    }
+    return attrs unless attrs.values.all?(&:nil?)
+  end
+
+  def lookup_network(network_name)
+    MobileNetwork.find_by(brand: network_name)
+  end
+end

--- a/app/services/extra_data_request_spreadsheet_importer.rb
+++ b/app/services/extra_data_request_spreadsheet_importer.rb
@@ -50,10 +50,7 @@ private
 
   def create_request(request_attrs, user)
     ExtraMobileDataRequest.new(
-      request_attrs.merge({
-        created_by_user: user,
-        status: :requested,
-      }),
+      request_attrs.merge(created_by_user: user),
     )
   end
 

--- a/app/services/extra_data_request_spreadsheet_importer.rb
+++ b/app/services/extra_data_request_spreadsheet_importer.rb
@@ -6,51 +6,20 @@ class ExtraDataRequestSpreadsheetImporter
   end
 
   def import!(spreadsheet_path, user)
-    workbook = RubyXL::Parser.parse(spreadsheet_path)
-    worksheet = workbook['Extra mobile data requests']
+    spreadsheet = ExtraMobileDataRequestSpreadsheet.new(spreadsheet_path)
 
-    worksheet.each_with_index do |row, n|
-      next if n.zero? || row.nil? # skip the header row
+    spreadsheet.requests.each do |extra_mobile_data_request|
+      extra_mobile_data_request.created_by_user = user
 
-      request_attrs = fetch_request_attrs(row)
-
-      next unless request_attrs
-
-      extra_mobile_data_request = create_request(request_attrs, user)
-
-      if extra_mobile_data_request.valid?
-        if extra_mobile_data_request.has_already_been_made?
-          summary.add_existing_record(extra_mobile_data_request)
-        else
-          extra_mobile_data_request.save_and_notify_account_holder!
-          summary.add_successful_record(extra_mobile_data_request)
-        end
-      else
+      if extra_mobile_data_request.invalid?
         summary.add_error_record(extra_mobile_data_request)
+      elsif extra_mobile_data_request.has_already_been_made?
+        summary.add_existing_record(extra_mobile_data_request)
+      else
+        extra_mobile_data_request.save_and_notify_account_holder!
+        summary.add_successful_record(extra_mobile_data_request)
       end
     end
     summary
-  end
-
-private
-
-  def fetch_request_attrs(row)
-    attrs = {
-      account_holder_name: row[0]&.value,
-      device_phone_number: row[1]&.value,
-      mobile_network_id: lookup_network_id(row[2]&.value),
-      agrees_with_privacy_statement: row[4]&.value,
-    }
-    return attrs unless attrs.values.all?(&:nil?)
-  end
-
-  def lookup_network_id(network_name)
-    MobileNetwork.find_by(brand: network_name)&.id
-  end
-
-  def create_request(request_attrs, user)
-    ExtraMobileDataRequest.new(
-      request_attrs.merge(created_by_user: user),
-    )
   end
 end

--- a/app/services/extra_data_request_spreadsheet_importer.rb
+++ b/app/services/extra_data_request_spreadsheet_importer.rb
@@ -19,7 +19,7 @@ class ExtraDataRequestSpreadsheetImporter
       extra_mobile_data_request = create_request(request_attrs, user)
 
       if extra_mobile_data_request.valid?
-        if request_already_exists?(extra_mobile_data_request)
+        if extra_mobile_data_request.has_already_been_made?
           summary.add_existing_record(extra_mobile_data_request)
         else
           extra_mobile_data_request.save_and_notify_account_holder!
@@ -51,14 +51,6 @@ private
   def create_request(request_attrs, user)
     ExtraMobileDataRequest.new(
       request_attrs.merge(created_by_user: user),
-    )
-  end
-
-  def request_already_exists?(request)
-    ExtraMobileDataRequest.exists?(
-      account_holder_name: request.account_holder_name,
-      device_phone_number: request.device_phone_number,
-      mobile_network_id: request.mobile_network_id,
     )
   end
 end

--- a/app/services/extra_data_request_spreadsheet_importer.rb
+++ b/app/services/extra_data_request_spreadsheet_importer.rb
@@ -22,7 +22,7 @@ class ExtraDataRequestSpreadsheetImporter
         if request_already_exists?(extra_mobile_data_request)
           summary.add_existing_record(extra_mobile_data_request)
         else
-          save_and_notify!(extra_mobile_data_request)
+          extra_mobile_data_request.save_and_notify_account_holder!
           summary.add_successful_record(extra_mobile_data_request)
         end
       else
@@ -60,10 +60,5 @@ private
       device_phone_number: request.device_phone_number,
       mobile_network_id: request.mobile_network_id,
     )
-  end
-
-  def save_and_notify!(request)
-    request.save!
-    request.notify_account_holder_later
   end
 end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
   end
 
-  describe '#notify_account_holder_later' do
-    let(:request) { create(:extra_mobile_data_request) }
+  describe '#save_and_notify_account_holder!' do
+    let(:request) { build(:extra_mobile_data_request, mobile_network: create(:mobile_network)) }
 
     before do
       ActiveJob::Base.queue_adapter = :test
@@ -75,8 +75,9 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
     it 'enqueues a job to send the message' do
       expect {
-        request.notify_account_holder_later
+        request.save_and_notify_account_holder!
       }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob)
+      expect(request).to be_persisted
     end
   end
 

--- a/spec/models/extra_mobile_data_request_spreadsheet_spec.rb
+++ b/spec/models/extra_mobile_data_request_spreadsheet_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ExtraMobileDataRequestSpreadsheet, type: :model do
+  let(:file_path) { file_fixture('extra-mobile-data-requests.xlsx') }
+
+  subject(:spreadsheet) { described_class.new(file_path) }
+
+  before do
+    ['EE', 'O2', 'Tesco Mobile', 'Virgin Mobile', 'Three'].each do |brand|
+      create(:mobile_network, brand: brand)
+    end
+  end
+
+  it 'imports reads requests from a spreadsheet' do
+    requests = spreadsheet.requests
+
+    expect(requests.size).to eq(5)
+
+    expect(requests[0]).to have_attributes(
+      account_holder_name: 'Jane Smith',
+      device_phone_number: '07123456789',
+      mobile_network: MobileNetwork.find_by(brand: 'Virgin Mobile'),
+      agrees_with_privacy_statement: true,
+    )
+    expect(requests[1]).to have_attributes(
+      account_holder_name: 'Bill Jones',
+      device_phone_number: '07000222222',
+      mobile_network: MobileNetwork.find_by(brand: 'O2'),
+      agrees_with_privacy_statement: true,
+    )
+    expect(requests[2]).to have_attributes(
+      account_holder_name: 'Mary West',
+      device_phone_number: '07111456789',
+      mobile_network: MobileNetwork.find_by(brand: 'Tesco Mobile'),
+      agrees_with_privacy_statement: true,
+    )
+    expect(requests[3]).to have_attributes(
+      account_holder_name: 'Arthur Radish',
+      device_phone_number: '07722123123',
+      mobile_network: MobileNetwork.find_by(brand: 'Virgin Mobile'),
+      agrees_with_privacy_statement: true,
+    )
+    expect(requests[4]).to have_attributes(
+      account_holder_name: 'Felicity Hamburger',
+      device_phone_number: '07001234567',
+      mobile_network: MobileNetwork.find_by(brand: 'Three'),
+      agrees_with_privacy_statement: false,
+    )
+  end
+end


### PR DESCRIPTION
### Context

We now have 2 routes for creating extra mobile data requests (one-at-a-time via a form or bulk upload via a spreadsheet). This has surfaced some logic that ended up duplicated across controllers and services that probably should sit in models.

The aim here is to keep services and controllers focussed, and try to better stick to the single responsibility principle.

### Changes proposed in this pull request

- push some logic out of controllers and services into models
- split a new `ExtraMobileDataRequestSpreadsheet ` model out of the `ExtraDataRequestSpreadsheetImporter`, which only deals with reading from the spreadsheet.

