### PR TITLE
Hide nav menu on you're signed in and check your email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
+  def hide_nav_menu?
+    false
+  end
+
 private
 
   def populate_user_from_session!

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -68,6 +68,10 @@ class SignInTokensController < ApplicationController
     end
   end
 
+  def hide_nav_menu?
+    action_name == 'validate' || action_name == 'sent'
+  end
+
 private
 
   def sign_in_token_form_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,10 @@ module ApplicationHelper
     ]
   end
 
+  def hide_nav_menu?
+    controller_name == 'sign_in_tokens' && (%w[validate sent].include? action_name)
+  end
+
   def nav_item(title: nil, url: nil, content: nil, html_options: {})
     class_name = 'govuk-header__navigation-item'
     class_name = [class_name, 'govuk-header__navigation-item--active'].join(' ') if request.path == url

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,10 +16,6 @@ module ApplicationHelper
     ]
   end
 
-  def hide_nav_menu?
-    controller_name == 'sign_in_tokens' && (%w[validate sent].include? action_name)
-  end
-
   def nav_item(title: nil, url: nil, content: nil, html_options: {})
     class_name = 'govuk-header__navigation-item'
     class_name = [class_name, 'govuk-header__navigation-item--active'].join(' ') if request.path == url

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,8 @@
         <% else %>
           <div class="govuk-header__content">
             <%= link_to t('service_name'), "/", class: "govuk-header__link govuk-header__link--service-name" %>
-            <% unless hide_nav_menu? %>
+
+            <% unless controller.hide_nav_menu? %>
               <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
               <nav>
                 <%= render partial: 'layouts/nav' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,10 +55,12 @@
         <% else %>
           <div class="govuk-header__content">
             <%= link_to t('service_name'), "/", class: "govuk-header__link govuk-header__link--service-name" %>
-            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-            <nav>
-              <%= render partial: 'layouts/nav' %>
-            </nav>
+            <% unless hide_nav_menu? %>
+              <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+              <nav>
+                <%= render partial: 'layouts/nav' %>
+              </nav>
+            <%- end %>
           </div>
         <% end %>
       </div>

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -93,6 +93,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 'using a magic link from a different user signs in as the different user' do
       visit other_user_magic_link
+      click_on 'Continue'
       expect(page).to have_content(other_user.email_address)
     end
   end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -14,8 +14,10 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
 
       scenario 'Visiting a valid sign_in_token link signs the user in' do
         visit validate_token_url
-        expect(page).to have_text(user.email_address)
-        expect(page).to have_button('Sign out')
+        expect(page).not_to have_text(user.email_address)
+        expect(page).not_to have_button('Sign out')
+        expect(page).to have_text('You’re signed in')
+        expect(page).to have_button('Continue')
       end
 
       scenario 'Visiting the valid sign_in_token link increments sign-in count and timestamp' do
@@ -40,7 +42,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
 
       scenario 'Visiting a sign_in_token link twice does not work the second time if the user did not continue through the interstitial page' do
         visit validate_token_url
-        click_on 'Sign out'
+        expect(page).to have_text(I18n.t('page_titles.you_are_signed_in'))
 
         visit validate_token_url
         expect(page).to have_http_status(:ok)

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       fill_in('Email address', with: user.email_address)
       click_on 'Continue'
       expect(page).to have_content 'Check your email'
+      expect(page).not_to have_content('Sign out')
     end
   end
 
@@ -39,6 +40,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       fill_in('Email address', with: user.email_address)
       click_on 'Continue'
       expect(page).to have_content 'Check your email'
+      expect(page).not_to have_content('Sign out')
     end
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/ylCz6nEW/360-dont-show-nav-links-on-the-interstitial-youre-signed-in-and-check-your-email-pages) - hide nav menus from users on the 'You're signed in' and 'Check your email' pages during sign-in process

### Changes proposed in this pull request
Make rendering of nav (and mobile menu link) conditional based on `controller_name` and `action_name` to prevent rendering where not required.
 
### Guidance to review
Nav menu should not be visible on the 'You're signed in' and 'Check your email' pages but visible as expected elsewhere.
