### PR TITLE
add school device allocations model, migration and factory

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -1,0 +1,10 @@
+class SchoolDeviceAllocation < ApplicationRecord
+  belongs_to  :school
+  belongs_to  :created_by_user, class_name: 'User'
+  belongs_to  :last_updated_by_user, class_name: 'User'
+
+  enum device_type: {
+    'coms_device': 'coms_device',
+    'std_device': 'std_device',
+  }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,10 @@ en:
           participating: 'Offers data now'
           not_participating: 'Not participating'
           maybe_participating: 'May offer data when the service launches'
+      school_device_allocation:
+        device_type:
+          std_device: 'Standard device (laptop etc)'
+          coms_device: 'Communication device (router etc)'
     errors:
       models:
         extra_mobile_data_request:

--- a/db/migrate/20200812155338_add_school_device_allocation.rb
+++ b/db/migrate/20200812155338_add_school_device_allocation.rb
@@ -1,0 +1,13 @@
+class AddSchoolDeviceAllocation < ActiveRecord::Migration[6.0]
+  def change
+    create_table :school_device_allocations do |t|
+      t.references  :schools, foreign_key: true
+      t.string      :device_type, null: false
+      t.integer     :allocation, default: 0
+      t.integer     :devices_ordered, default: 0
+      t.bigint      :created_by_user_id, null: true, foreign_key: true
+      t.bigint      :last_updated_by_user_id, null: true, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200812155338_add_school_device_allocation.rb
+++ b/db/migrate/20200812155338_add_school_device_allocation.rb
@@ -1,7 +1,7 @@
 class AddSchoolDeviceAllocation < ActiveRecord::Migration[6.0]
   def change
     create_table :school_device_allocations do |t|
-      t.references  :schools, foreign_key: true
+      t.references  :school, foreign_key: true
       t.string      :device_type, null: false
       t.integer     :allocation, default: 0
       t.integer     :devices_ordered, default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_140013) do
+ActiveRecord::Schema.define(version: 2020_08_12_155338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,18 @@ ActiveRecord::Schema.define(version: 2020_08_12_140013) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "school_device_allocations", force: :cascade do |t|
+    t.bigint "schools_id"
+    t.string "device_type", null: false
+    t.integer "allocation", default: 0
+    t.integer "devices_ordered", default: 0
+    t.bigint "created_by_user_id"
+    t.bigint "last_updated_by_user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["schools_id"], name: "index_school_device_allocations_on_schools_id"
+  end
+
   create_table "schools", force: :cascade do |t|
     t.integer "urn", null: false
     t.string "name", null: false
@@ -109,5 +121,6 @@ ActiveRecord::Schema.define(version: 2020_08_12_140013) do
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
   add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
+  add_foreign_key "school_device_allocations", "schools", column: "schools_id"
   add_foreign_key "schools", "responsible_bodies"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 2020_08_12_155338) do
   end
 
   create_table "school_device_allocations", force: :cascade do |t|
-    t.bigint "schools_id"
+    t.bigint "school_id"
     t.string "device_type", null: false
     t.integer "allocation", default: 0
     t.integer "devices_ordered", default: 0
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 2020_08_12_155338) do
     t.bigint "last_updated_by_user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["schools_id"], name: "index_school_device_allocations_on_schools_id"
+    t.index ["school_id"], name: "index_school_device_allocations_on_school_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -121,6 +121,6 @@ ActiveRecord::Schema.define(version: 2020_08_12_155338) do
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
   add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
-  add_foreign_key "school_device_allocations", "schools", column: "schools_id"
+  add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "schools", "responsible_bodies"
 end

--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :school_device_allocation do
+    association :school
+    association :created_by_user, factory: :dfe_user
+    association :last_updated_by_user, factory: :dfe_user
+    device_type { SchoolDeviceAllocation.device_types.keys.sample }
+  end
+end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SchoolDeviceAllocation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Context

We need to add a model for allocations of devices to schools, so that we can build a provisional API endpoint for computacenter to hit when an order is placed

### Changes proposed in this pull request

### Guidance to review

