### PR TITLE
408 add computacenter namespace

### DIFF
--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -10,6 +10,5 @@
       <li>download a CSV file of users who have permission to place orders on TechSource</li>
     </ul>
 
-    <hr class="govuk-section-break govuk-section-break--l">
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     service_performance: Service performance
     accessibility: Accessibility statement
     support_responsible_bodies: On-boarded responsible bodies
-    computacenter_home: Increase children’s internet access
+    computacenter_home: Users with permission to place orders and receive support through Computacenter
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:


### PR DESCRIPTION
### Context

First part of [Trello card 408](https://trello.com/c/fsNGK22g/408-spin-up-first-api-end-point-to-share) - spin up a first draft API endpoint for Computacenter to notify us of orders placed

### Changes proposed in this pull request

* Add `/computacenter` namespaced `base_` and `home_` controllers
* Add distinguishing of computacenter users based on their email address
* Add basic placeholder computacenter homepage
* Restrict computacenter-namespaced controllers to computacenter users

### Guidance to review

