### PR TITLE
Store only active local authorities

### DIFF
--- a/app/models/local_authorities_in_england_register.rb
+++ b/app/models/local_authorities_in_england_register.rb
@@ -9,5 +9,6 @@ class LocalAuthoritiesInEnglandRegister
     local_authorities_register_results
       .values
       .map { |result| result['item'].first }
+      .reject { |result| result['end-date'].present? }
   end
 end

--- a/db/migrate/20200813205300_remove_closed_local_authorities.rb
+++ b/db/migrate/20200813205300_remove_closed_local_authorities.rb
@@ -1,0 +1,12 @@
+class RemoveClosedLocalAuthorities < ActiveRecord::Migration[6.0]
+  def up
+    closed_la_codes = %w[BKM AYL CHN SBU WYO WEY WDO PUR NDO EDO DOR CHC POL BMH SED FOR WSO TAU WAV SUF]
+    LocalAuthority
+      .where(local_authority_eng: closed_la_codes)
+      .delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_224858) do
+ActiveRecord::Schema.define(version: 2020_08_13_205300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/local_authorities_in_england_register_spec.rb
+++ b/spec/models/local_authorities_in_england_register_spec.rb
@@ -52,4 +52,27 @@ RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
       'name' => 'Teignbridge',
     })
   end
+
+  it 'filters out closed local authorities (those with an end-date)' do
+    stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
+      .to_return(body: '
+        {
+          "BKM": {
+            "index-entry-number": "392",
+            "entry-number": "392",
+            "entry-timestamp": "2020-02-29T11:57:30Z",
+            "key": "BKM",
+            "item": [{
+              "end-date": "2020-03-31",
+              "local-authority-type": "CTY",
+              "official-name": "Buckinghamshire County Council",
+              "local-authority-eng": "BKM",
+              "name": "Buckinghamshire",
+              "start-date": "1905-06-19"
+            }]
+          }
+        }')
+
+    expect(LocalAuthoritiesInEnglandRegister.entries).to be_empty
+  end
 end


### PR DESCRIPTION
### Context

The local authority importer was previously importing local authorities that were no longer existed. This led to two records called 'Buckinghamshire'.

### Changes proposed in this pull request

* Change the importer code to skip any LA register records that have an `end-date`
* Add a migration which deletes all the closed LAs from the data

