### PR TITLE
bump serialize-javascript to >=3.1.0 as per security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "core-js": ">=3",
     "govuk-frontend": ">=3.6.0",
     "jquery": "3.5.1",
-    "serialize-javascript": ">=3.0.0",
+    "serialize-javascript": ">=3.1.0",
     "set-value": ">=3.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6398,7 +6398,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@>=3.0.0:
+serialize-javascript@>=3.1.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==


### PR DESCRIPTION
### Context

We got a security alert from Github Dependabot, telling us to bump `serialize-javascript` to 3.1.0 or later, due to [CVE-2020-7660](https://github.com/advisories/GHSA-hxcc-f52p-wc94)

### Changes proposed in this pull request

Bump `serialize-javascript` to 3.1.0 or later

### Guidance to review

