### PR TITLE
Trusts: only import open ones from GIAS

### DIFF
--- a/app/models/get_information_about_schools.rb
+++ b/app/models/get_information_about_schools.rb
@@ -7,7 +7,7 @@ class GetInformationAboutSchools
   def self.trusts_entries
     gias_csv = URI.parse(URL).read.force_encoding(Encoding::ISO8859_1)
     CSV.parse(gias_csv, headers: true).select { |row|
-      row['Group Type'].in? ['Single-academy trust', 'Multi-academy trust']
+      row['Group Type'].in?(['Single-academy trust', 'Multi-academy trust']) && row['Group Status'] == 'Open'
     }.map(&:to_h)
   end
 end

--- a/spec/models/get_information_about_schools_spec.rb
+++ b/spec/models/get_information_about_schools_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe GetInformationAboutSchools, type: :model do
-  it 'returns a filtered list of single- and multi-academy trusts' do
+  it 'returns a filtered list of open single- and multi-academy trusts' do
     data = [
-      'Group Name,Companies House Number,Group Type',
-      'AAA,12345,Federation',
-      'AA TRUST,67890,Single-academy trust',
-      'ABC MAT,13579,Multi-academy trust',
+      'Group Name,Companies House Number,Group Type,Group Status',
+      'AAA,12345,Federation,Open',
+      'AA TRUST,67890,Single-academy trust,Open',
+      'ABC MAT,13579,Multi-academy trust,Open',
+      'ZZZ MAT,14725,Multi-academy trust,Closed',
     ].join("\n")
 
     stub_request(:get, GetInformationAboutSchools::URL)
@@ -19,11 +20,13 @@ RSpec.describe GetInformationAboutSchools, type: :model do
       'Group Name' => 'AA TRUST',
       'Companies House Number' => '67890',
       'Group Type' => 'Single-academy trust',
+      'Group Status' => 'Open',
     })
     expect(entries.second).to eq({
       'Group Name' => 'ABC MAT',
       'Companies House Number' => '13579',
       'Group Type' => 'Multi-academy trust',
+      'Group Status' => 'Open',
     })
   end
 end

--- a/spec/services/import_responsible_bodies_service_spec.rb
+++ b/spec/services/import_responsible_bodies_service_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe ImportResponsibleBodiesService, type: :model do
 
   it 'imports single- and multi-academy trusts only once' do
     data = [
-      'Group Name,Companies House Number,Group Type',
-      'AAA,12345,Federation',
-      'AA TRUST,67890,Single-academy trust',
-      'ABC MAT,13579,Multi-academy trust',
+      'Group Name,Companies House Number,Group Type,Group Status',
+      'AAA,12345,Federation,Open',
+      'AA TRUST,67890,Single-academy trust,Open',
+      'ABC MAT,13579,Multi-academy trust,Open',
     ].join("\n")
 
     stub_request(:get, GetInformationAboutSchools::URL)


### PR DESCRIPTION
### Context

As of August 2020, the Get Information About Schools (GIAS) service includes both open and closed trusts in its data export. We don't need the closed ones in our DB.

Similar to #228.

### Changes proposed in this pull request

* Only import open trusts from GIAS

### Guidance to review

We don't appear to have the closed trusts on production, which suggests that the closed ones were added some time after we did our initial import 🤷 . Consequently, this PR doesn't include any clean-up migration.