### PR TITLE
Move MNO requests to be at responsible body-level, not at user level

### DIFF
--- a/app/controllers/responsible_body/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/mobile/extra_data_requests_controller.rb
@@ -1,6 +1,6 @@
 class ResponsibleBody::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
   def index
-    @extra_mobile_data_requests = @user.extra_mobile_data_requests
+    @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests
   end
 
   def new

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -3,6 +3,7 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network
+  belongs_to :responsible_body, optional: true
 
   validates :status, presence: true
   validates :account_holder_name, presence: true
@@ -92,6 +93,11 @@ class ExtraMobileDataRequest < ApplicationRecord
       device_phone_number: device_phone_number,
       mobile_network_id: mobile_network_id,
     )
+  end
+
+  def created_by_user=(new_user)
+    super
+    self.responsible_body = new_user.responsible_body if new_user
   end
 
 private

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -2,4 +2,5 @@ class ResponsibleBody < ApplicationRecord
   has_one :bt_wifi_voucher_allocation
   has_many :bt_wifi_vouchers
   has_many :users
+  has_many :extra_mobile_data_requests
 end

--- a/db/migrate/20200809151453_backfill_responsible_body_on_extra_mobile_data_requests.rb
+++ b/db/migrate/20200809151453_backfill_responsible_body_on_extra_mobile_data_requests.rb
@@ -1,0 +1,19 @@
+class BackfillResponsibleBodyOnExtraMobileDataRequests < ActiveRecord::Migration[6.0]
+  def up
+    execute '
+      UPDATE
+          extra_mobile_data_requests r
+      SET
+          responsible_body_id = u.responsible_body_id
+      FROM
+          users u
+      WHERE
+          r.created_by_user_id = u.id
+          AND r.responsible_body_id IS NULL
+      '
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -32,6 +32,8 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
   end
 
   context 'when the user has already submitted requests' do
+    let(:another_user_from_the_same_rb) { create(:user, responsible_body: rb_user.responsible_body) }
+
     before do
       @requests = create_list(:extra_mobile_data_request, 5, status: 'requested', created_by_user: rb_user)
       @requests.last.unavailable!
@@ -48,6 +50,18 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
       end
       expect(page).to have_text('Requested').exactly(4).times
       expect(page).to have_text('Unavailable').once
+    end
+
+    scenario 'another user from the same responsible body can also see the raised requests' do
+      sign_out
+      sign_in_as another_user_from_the_same_rb
+
+      visit responsible_body_mobile_extra_data_requests_path
+
+      @requests.each do |request|
+        expect(page).to have_content(request.device_phone_number)
+        expect(page).to have_content(request.account_holder_name)
+      end
     end
   end
 end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -160,4 +160,16 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
       end
     end
   end
+
+  describe 'setting created_by_user' do
+    let(:request) { build(:extra_mobile_data_request, created_by_user: nil, responsible_body: nil) }
+    let(:user) { create(:trust_user) }
+
+    it 'sets the responsible body at the same time' do
+      request.created_by_user = user
+
+      expect(request.created_by_user).to eq(user)
+      expect(request.responsible_body).to eq(user.responsible_body)
+    end
+  end
 end

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -9,6 +9,10 @@ module CapybaraHelper
     click_on 'Continue'
   end
 
+  def sign_out
+    click_on 'Sign out'
+  end
+
   def validate_token_url_for(user)
     token = user.generate_token!
     identifier = user.sign_in_identifier(token)


### PR DESCRIPTION
### Context

Currently, when a responsible body user creates an extra mobile data request (MNO request), other users within the RB don't see the request. However we think of MNO requests as being on RB level, and they should really work like that.

On the data level, `extra_mobile_data_requests.responsible_body_id` isn't being set when a request is created, making it harder to query total MNO requests per RB.

### Changes proposed in this pull request

- populate `extra_mobile_data_requests.responsible_body_id` when an MNO request is created, taking the RB from the user who made the request
- on the RB side, change MNO request visibility from user- to RB-level
- add a database migration which back-fills `extra_mobile_data_requests.responsible_body_id` for existing MNO requests

### Guidance to review

After this change is rolled out, it will be possible to make `extra_mobile_data_requests.responsible_body_id` not null on the DB level, which will help with data integrity.