### PR TITLE
fix "No such file or directory" error on first setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore all logfiles and tempfiles.
-/log/*
+/log/*.log
 /tmp/*
 /coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore all logfiles and tempfiles.
-/log/*.log
+*.log
 /tmp/*
 /coverage
 
@@ -35,7 +35,6 @@ manifest.yml
 .env
 .env.*
 *.env
-*.log
 
 config/settings.local.yml
 config/settings/*.local.yml


### PR DESCRIPTION
### Context

There was no `log/` directory in the repo, which meant running `rake db:setup` on a fresh install failed with an error `Errno::ENOENT: No such file or directory @ rb_sysopen - log/mail.log`.

### Changes proposed in this pull request

Make the .gitignore directive more specific and add an empty `log/placeholder.txt` file, to make the repo contain a `log/` dir

### Guidance to review

