### PR TITLE
407 provide bulk schools upload file initial to cc

### DIFF
--- a/app/services/responsible_body_exporter.rb
+++ b/app/services/responsible_body_exporter.rb
@@ -22,7 +22,7 @@ class ResponsibleBodyExporter
         csv << EXPORT_ATTRS.map do |attr|
           if attr == :type && rb.type == 'LocalAuthority'
             'Local Authority'
-          else 
+          else
             rb.send(attr)
           end
         end

--- a/app/services/responsible_body_exporter.rb
+++ b/app/services/responsible_body_exporter.rb
@@ -1,0 +1,43 @@
+require 'csv'
+
+class ResponsibleBodyExporter
+  attr_reader :filename
+
+  EXPORT_ATTRS = %i[
+    name
+    type
+    local_authority_official_name
+    local_authority_eng
+    companies_house_number
+  ].freeze
+
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def export_responsible_bodies
+    CSV.open(filename, 'w') do |csv|
+      csv << headings
+      responsible_bodies.each do |rb|
+        csv << EXPORT_ATTRS.map do |attr|
+          if attr == :type && rb.type == 'LocalAuthority'
+            'Local Authority'
+          else 
+            rb.send(attr)
+          end
+        end
+      end
+    end
+    nil
+  end
+
+private
+
+  def headings
+    EXPORT_ATTRS.map { |s| s.to_s.humanize.titlecase }
+  end
+
+  def responsible_bodies
+    ResponsibleBody.where.not(name: 'Department for Education').order(type: :asc, name: :asc)
+  end
+end

--- a/app/services/school_data_exporter.rb
+++ b/app/services/school_data_exporter.rb
@@ -1,0 +1,51 @@
+require 'csv'
+
+class SchoolDataExporter
+  attr_reader :filename
+
+  EXPORT_ATTRS = %i[
+    urn
+    name
+    address_1
+    address_2
+    address_3
+    town
+    county
+    postcode
+    responsible_body_name
+  ].freeze
+
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def export_schools
+    CSV.open(filename, 'w') do |csv|
+      csv << headings
+      schools.each do |school|
+        csv << EXPORT_ATTRS.map do |attr|
+          if attr == :responsible_body_name
+            if school.responsible_body.type == 'LocalAuthority'
+              school.responsible_body.local_authority_official_name
+            else
+              school.responsible_body.name
+            end
+          else
+            school.send(attr)
+          end
+        end
+      end
+    end
+    nil
+  end
+
+private
+
+  def headings
+    EXPORT_ATTRS.map { |s| s.to_s.humanize.titlecase }
+  end
+
+  def schools
+    School.all.includes(:responsible_body).order(urn: :asc)
+  end
+end

--- a/lib/tasks/export_data.rake
+++ b/lib/tasks/export_data.rake
@@ -1,0 +1,13 @@
+namespace :export do
+  desc 'Export responsible bodies to CSV'
+  task :responsible_bodies, [:filename] => :environment do |_t, args|
+    filename = args[:filename] || 'responsible_bodies.csv'
+    ResponsibleBodyExporter.new(filename).export_responsible_bodies
+  end
+
+  desc 'Export school data to CSV'
+  task :schools, [:filename] => :environment do |_t, args|
+    filename = args[:filename] || 'schools.csv'
+    SchoolDataExporter.new(filename).export_schools
+  end
+end

--- a/spec/services/responsible_body_exporter_spec.rb
+++ b/spec/services/responsible_body_exporter_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBodyExporter, type: :model do
+  let(:responsible_body) { create(:trust) }
+  let(:filename) { Rails.root.join('tmp/responsible_bodies_test_data.csv') }
+  let(:exporter) { described_class.new(filename) }
+
+  context 'when exporting responsible_body data' do
+    before do
+      exporter.export_responsible_bodies
+    end
+
+    after do
+      remove_file(filename)
+    end
+
+    it 'creates a CSV file' do
+      expect(File.exist?(filename)).to be true
+    end
+
+    it 'includes a heading row and all of the responsible bodies in the CSV file' do
+      line_count = `wc -l "#{filename}"`.split.first.to_i
+      expect(line_count).to eq(ResponsibleBody.count + 1)
+    end
+  end
+end

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SchoolDataExporter, type: :model do
+  let(:school) { create(:school) }
+  let(:filename) { Rails.root.join('tmp/school_test_data.csv') }
+  let(:exporter) { described_class.new(filename) }
+
+  context 'when exporting school data' do
+    before do
+      exporter.export_schools
+    end
+
+    after do
+      remove_file(filename)
+    end
+
+    it 'creates a CSV file' do
+      expect(File.exist?(filename)).to be true
+    end
+
+    it 'includes a heading row and all of the Schools in the CSV file' do
+      line_count = `wc -l "#{filename}"`.split.first.to_i
+      expect(line_count).to eq(School.count + 1)
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/Hz5xNtqi/407-provide-bulk-schools-upload-file-initial-to-cc) - Provide CSV export files for Responsible Bodies and Schools, primarily for CC.

### Changes proposed in this pull request
Add exporters to create CSV files.

### Guidance to review
Data can be exported via console or rake task `bundle exec rails export:responsible_bodies` and `bundle exec rails export:schools` will generate csv files in the current directory.
