### PR TITLE
Correctly associate schools with trusts when present during import

### DIFF
--- a/app/models/school_data_file.rb
+++ b/app/models/school_data_file.rb
@@ -42,7 +42,7 @@ private
     {
       urn: row['URN'],
       name: row['EstablishmentName'],
-      responsible_body: row['LA (name)'],
+      responsible_body: find_responsible_body(row),
       address_1: row['Street'],
       address_2: row['Locality'],
       address_3: row['Address3'],
@@ -50,6 +50,16 @@ private
       county: row['County (name)'],
       postcode: row['Postcode'],
     }
+  end
+
+  def find_responsible_body(row)
+    # 3 - Multi-academy trust
+    # 5 - Single-academy trust
+    if row['TrustSchoolFlag (code)'].in? %w[3 5]
+      row['Trusts (name)']
+    else
+      row['LA (name)']
+    end
   end
 
   def skip_school?(row)

--- a/spec/models/school_data_file_spec.rb
+++ b/spec/models/school_data_file_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SchoolDataFile, type: :model do
           postcode: 'NW1 1AA',
           status: 'Open',
           type: 'Voluntary aided school',
+          trusts_flag: '0',
         }
       end
 
@@ -50,6 +51,7 @@ RSpec.describe SchoolDataFile, type: :model do
           postcode: 'NW1 1AA',
           status: 'Closed',
           type: 'Voluntary aided school',
+          trusts_flag: '0',
         }
       end
 
@@ -78,6 +80,7 @@ RSpec.describe SchoolDataFile, type: :model do
           postcode: 'NW1 1AA',
           status: 'Open',
           type: 'Other independent school',
+          trusts_flag: '0',
         }
       end
 
@@ -92,6 +95,80 @@ RSpec.describe SchoolDataFile, type: :model do
       it 'does not retrieve the school data' do
         schools = SchoolDataFile.new(filename).schools
         expect(schools).to be_empty
+      end
+    end
+
+    context 'when a school is managed by a Multi-Academy Trust' do
+      let(:attrs) do
+        {
+          urn: '100001',
+          name: 'Big School',
+          responsible_body: 'Camden',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          status: 'Open',
+          type: 'Academy sponsor led',
+          trusts_flag: '3',
+          trusts_name: 'The Multi-Trust Academy',
+        }
+      end
+
+      before do
+        create_school_csv_file(filename, [attrs])
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'retrieves the school data' do
+        schools = SchoolDataFile.new(filename).schools
+        expect(schools[0]).to include(
+          urn: '100001',
+          name: 'Big School',
+          responsible_body: 'The Multi-Trust Academy',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+        )
+      end
+    end
+
+    context 'when a school is managed by a Single-Academy Trust' do
+      let(:attrs) do
+        {
+          urn: '100001',
+          name: 'Big School',
+          responsible_body: 'Camden',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          status: 'Open',
+          type: 'Academy sponsor led',
+          trusts_flag: '5',
+          trusts_name: 'The Single-Trust Academy',
+        }
+      end
+
+      before do
+        create_school_csv_file(filename, [attrs])
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'retrieves the school data' do
+        schools = SchoolDataFile.new(filename).schools
+        expect(schools[0]).to include(
+          urn: '100001',
+          name: 'Big School',
+          responsible_body: 'The Single-Trust Academy',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+        )
       end
     end
   end

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -13,6 +13,8 @@ module CSVFileHelper
     postcode: 'Postcode',
     status: 'EstablishmentStatus (name)',
     type: 'TypeOfEstablishment (name)',
+    trusts_flag: 'TrustSchoolFlag (code)',
+    trusts_name: 'Trusts (name)',
   }.freeze
 
   def create_school_csv_file(filename, array_of_hashes)


### PR DESCRIPTION
### Context
Trusts were not getting associated with schools during the school import process, only LAs were being associated.

### Changes proposed in this pull request
Checks whether the school is a single or multi-academy trust establishment and then uses that trust name specified in the GIAS file as the responsible body.

### Guidance to review
Any schools already imported will need to be cleared down first. As there are references to school records you'll need to execute something like this `School.connection.execute('TRUNCATE schools RESTART IDENTITY CASCADE')` from the Rails console. **NOTE: this will remove any device allocations!!** - hopefully this isn't live yet 😬 
Once the schools have been cleared down, run `ImportSchoolsService.new.import_schools` from the Rails console to bring in the latest school data from GIAS. 