### PR TITLE
add rake task for importing schools, for consistency

### DIFF
--- a/lib/tasks/import_schools.rake
+++ b/lib/tasks/import_schools.rake
@@ -1,0 +1,6 @@
+namespace :import do
+  desc 'Import schools from GIAS'
+  task schools: :environment do
+    ImportSchoolsService.new.import_schools
+  end
+end


### PR DESCRIPTION
### Context

We have a set of existing tasks in the `import` namespace for importing responsible bodies, each of which calls a method on the `ImportResponsibleBodiesService`.
We have a `ImportSchoolsService` with a method to import_schools - but no rake wrapper

### Changes proposed in this pull request

Add a simple one-liner rake task for importing schools, so that it's consistent

### Guidance to review

```bash
$ rake --tasks import
rake bt_wifi:import_voucher_allocations[csv_url]  # Import BT Wifi voucher allocations
rake bt_wifi:import_vouchers[csv_url]             # Import BT Wifi vouchers
rake import:dfe_as_a_responsible_body             # Import DfE as a responsible body for direct connectivity distribution
rake import:local_authorities_in_england          # Import local authorities in England
rake import:responsible_bodies                    # Populate the responsible body reference data table
rake import:schools                               # Import schools from GIAS
rake import:trusts                                # Import single and multi-academy trusts
```

you can then run the rake task as:

```bash
rake import:schools
```

