### PR TITLE
move existing RB user mobile/BT interface code under a new internet namespace

### DIFF
--- a/app/controllers/responsible_body/internet/bt_wifi_vouchers_controller.rb
+++ b/app/controllers/responsible_body/internet/bt_wifi_vouchers_controller.rb
@@ -1,4 +1,4 @@
-class ResponsibleBody::BTWifiVouchersController < ResponsibleBody::BaseController
+class ResponsibleBody::Internet::BTWifiVouchersController < ResponsibleBody::BaseController
   def index
     vouchers = @responsible_body.bt_wifi_vouchers.order('username asc')
     respond_to do |format|

--- a/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
@@ -1,4 +1,4 @@
-class ResponsibleBody::Mobile::BulkRequestsController < ResponsibleBody::BaseController
+class ResponsibleBody::Internet::Mobile::BulkRequestsController < ResponsibleBody::BaseController
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -1,4 +1,4 @@
-class ResponsibleBody::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
+class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
   def index
     @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests
   end
@@ -9,9 +9,9 @@ class ResponsibleBody::Mobile::ExtraDataRequestsController < ResponsibleBody::Ba
 
       if @submission_type.valid?
         if @submission_type.manual?
-          redirect_to new_responsible_body_mobile_manual_request_path
+          redirect_to new_responsible_body_internet_mobile_manual_request_path
         else
-          redirect_to new_responsible_body_mobile_bulk_request_path
+          redirect_to new_responsible_body_internet_mobile_bulk_request_path
         end
       else
         render :new, status: :unprocessable_entity

--- a/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
@@ -1,4 +1,4 @@
-class ResponsibleBody::Mobile::ManualRequestsController < ResponsibleBody::BaseController
+class ResponsibleBody::Internet::Mobile::ManualRequestsController < ResponsibleBody::BaseController
   def index
     @extra_mobile_data_requests = @user.extra_mobile_data_requests
   end
@@ -24,7 +24,7 @@ class ResponsibleBody::Mobile::ManualRequestsController < ResponsibleBody::BaseC
         @extra_mobile_data_request.save_and_notify_account_holder!
 
         flash[:success] = build_success_message(@extra_mobile_data_request.mobile_network.participating?)
-        redirect_to responsible_body_mobile_extra_data_requests_path
+        redirect_to responsible_body_internet_mobile_extra_data_requests_path
       else
         # store given params in session,so that we don't have to pass them back in the URL
         # if the user clicks 'Change' on the confirmation page

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -11,7 +11,7 @@
   <%- else %>
     <%= nav_item( title: "Guidance", url: guidance_page_path )  %>
     <%- if @user&.is_responsible_body_user? %>
-      <%= nav_item( title: "Tell us who needs more data", url: responsible_body_mobile_extra_data_requests_path )  %>
+      <%= nav_item( title: "Tell us who needs more data", url: responsible_body_internet_mobile_extra_data_requests_path )  %>
     <%- end %>
   <%- end %>
 

--- a/app/views/responsible_body/home/_bt_wifi_offer.html.erb
+++ b/app/views/responsible_body/home/_bt_wifi_offer.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
-  <%= govuk_link_to 'Download log-ins for BT wifi hotspots', download_responsible_body_bt_wifi_vouchers_path %>
+  <%= govuk_link_to 'Download log-ins for BT wifi hotspots', download_responsible_body_internet_bt_wifi_vouchers_path %>
 </h2>

--- a/app/views/responsible_body/home/_extra_mobile_data_offer.html.erb
+++ b/app/views/responsible_body/home/_extra_mobile_data_offer.html.erb
@@ -3,5 +3,5 @@
 <p class="govuk-body">Give us mobile numbers and network details and we’ll request extra data for these devices. How much data someone gets will depend on their network.</p>
 
 <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
-  <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_mobile_extra_data_requests_path %>
+  <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_internet_mobile_extra_data_requests_path %>
 </h2>

--- a/app/views/responsible_body/internet/bt_wifi_vouchers/download.html.erb
+++ b/app/views/responsible_body/internet/bt_wifi_vouchers/download.html.erb
@@ -37,7 +37,7 @@
 
     <h2 class="govuk-heading-l">Download</h2>
 
-    <%= govuk_button_link_to 'Download log-ins', responsible_body_bt_wifi_vouchers_path(format: 'csv') %>
+    <%= govuk_button_link_to 'Download log-ins', responsible_body_internet_bt_wifi_vouchers_path(format: 'csv') %>
 
     <p class="govuk-body">Log-ins will be downloaded as a spreadsheet (CSV file).</p>
   </div>

--- a/app/views/responsible_body/internet/mobile/bulk_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/bulk_requests/new.html.erb
@@ -1,8 +1,8 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
 <% content_for :title, title_with_error_prefix(t('page_titles.upload_a_spreadsheet_of_extra_data_requests'), @upload_form.errors.any?) %>
 <div class="govuk-grid-row">
   <%= form_for @upload_form,
-    url: responsible_body_mobile_bulk_requests_path,
+    url: responsible_body_internet_mobile_bulk_requests_path,
     html: {
       class: 'govuk-grid-column-two-thirds',
       multipart: true

--- a/app/views/responsible_body/internet/mobile/bulk_requests/summary.html.erb
+++ b/app/views/responsible_body/internet/mobile/bulk_requests/summary.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', new_responsible_body_mobile_bulk_request_path, class: 'govuk-back-link') %>
+  <%= govuk_link_to('Back', new_responsible_body_internet_mobile_bulk_request_path, class: 'govuk-back-link') %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -81,4 +81,4 @@
     </tbody>
   </table>
 <%- end %>
-<%= govuk_button_link_to('Finish', responsible_body_mobile_extra_data_requests_path) %>
+<%= govuk_button_link_to('Finish', responsible_body_internet_mobile_extra_data_requests_path) %>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -20,7 +20,7 @@
     <% end %>
     <p class="govuk-body">
       <%= govuk_button_link_to 'New request',
-        responsible_body_mobile_extra_data_requests_type_path
+        responsible_body_internet_mobile_extra_data_requests_type_path
       %>
     </p>
   </div>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/new.html.erb
@@ -1,9 +1,9 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', responsible_body_mobile_extra_data_requests_path, class: 'govuk-back-link') %>
+  <%= govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_path, class: 'govuk-back-link') %>
 <% end %>
 <% content_for :title, title_with_error_prefix(t('page_titles.how_would_you_like_to_submit_information'), @submission_type.errors.any?) %>
 <div class="govuk-grid-row">
-  <%= form_for @submission_type, url: responsible_body_mobile_extra_data_requests_type_path, method: :get, html: { class: 'govuk-grid-column-two-thirds' } do |f| %>
+  <%= form_for @submission_type, url: responsible_body_internet_mobile_extra_data_requests_type_path, method: :get, html: { class: 'govuk-grid-column-two-thirds' } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :submission_type,

--- a/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', new_responsible_body_mobile_manual_request_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_link_to('Back', new_responsible_body_internet_mobile_manual_request_path, class: 'govuk-back-link') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -14,7 +14,7 @@
           <%= @extra_mobile_data_request.account_holder_name %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path( anchor: 'extra-mobile-data-request-account-holder-name-field') ) do %>
+          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-account-holder-name-field') ) do %>
             Change<span class="govuk-visually-hidden"> Account holder name</span>
           <%- end %>
         </dd>
@@ -28,7 +28,7 @@
           <%= @extra_mobile_data_request.device_phone_number %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path( anchor: 'extra-mobile-data-request-device-phone-number-field') ) do %>
+          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-device-phone-number-field') ) do %>
             Change<span class="govuk-visually-hidden"> Mobile phone number</span>
           <%- end %>
         </dd>
@@ -42,7 +42,7 @@
           <%= @extra_mobile_data_request.network_name_with_participation_status %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path(anchor: "extra-mobile-data-request-mobile-network-id-#{@extra_mobile_data_request.mobile_network_id}-field") ) do %>
+          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-mobile-network-id-#{@extra_mobile_data_request.mobile_network_id}-field") ) do %>
             Change<span class="govuk-visually-hidden"> Mobile network</span>
           <%- end %>
         </dd>
@@ -57,7 +57,7 @@
               scope: 'responsible_body.extra_mobile_data_requests.new') %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path(anchor: "extra-mobile-data-request-contract_type-#{@extra_mobile_data_request.contract_type}-field") ) do %>
+          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-contract_type-#{@extra_mobile_data_request.contract_type}-field") ) do %>
             Change<span class="govuk-visually-hidden"> pay monthly or pay as you go</span>
           <%- end %>
         </dd>
@@ -71,7 +71,7 @@
           <%= @extra_mobile_data_request.agrees_with_privacy_statement ? 'Yes' : 'No' %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_mobile_manual_request_path( anchor: 'extra-mobile-data-request-agrees-with-privacy-statement-true-field') ) do %>
+          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-agrees-with-privacy-statement-true-field') ) do %>
             Change<span class="govuk-visually-hidden"> Agrees with privacy statement</span>
           <%- end %>
         </dd>
@@ -79,7 +79,7 @@
     </dl>
     <p class="govuk-body"><%= @extra_mobile_data_request.passing_data_to_provider_message %></p>
 
-    <%= form_for @extra_mobile_data_request, url: responsible_body_mobile_manual_requests_path do |f| %>
+    <%= form_for @extra_mobile_data_request, url: responsible_body_internet_mobile_manual_requests_path do |f| %>
       <%= f.hidden_field :account_holder_name %>
       <%= f.hidden_field :device_phone_number %>
       <%= f.hidden_field :mobile_network_id %>

--- a/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
@@ -1,9 +1,9 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
 <% content_for :title, title_with_error_prefix(t('page_titles.who_needs_the_data'), @extra_mobile_data_request.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @extra_mobile_data_request, url: responsible_body_mobile_manual_requests_path do |f| %>
+    <%= form_for @extra_mobile_data_request, url: responsible_body_internet_mobile_manual_requests_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,14 +49,16 @@ Rails.application.routes.draw do
 
   namespace :responsible_body, path: '/responsible-body' do
     get '/', to: 'home#show', as: :home
-    resources :bt_wifi_vouchers, only: %i[index], path: '/bt-wifi-vouchers' do
-      get 'download', to: 'bt_wifi_vouchers#download', on: :collection
-    end
-    namespace :mobile, path: '/mobile' do
-      get '/', to: 'extra_data_requests#index', as: :extra_data_requests
-      get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type
-      resources :manual_requests, only: %i[new create], path: '/manual'
-      resources :bulk_requests, only: %i[new create], path: '/bulk'
+    namespace :internet do
+      resources :bt_wifi_vouchers, only: %i[index], path: '/bt-wifi-vouchers' do
+        get 'download', to: 'bt_wifi_vouchers#download', on: :collection
+      end
+      namespace :mobile, path: '/mobile' do
+        get '/', to: 'extra_data_requests#index', as: :extra_data_requests
+        get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type
+        resources :manual_requests, only: %i[new create], path: '/manual'
+        resources :bulk_requests, only: %i[new create], path: '/bulk'
+      end
     end
   end
 

--- a/spec/controllers/responsible_body/internet/bt_wifi_vouchers_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/bt_wifi_vouchers_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ResponsibleBody::BTWifiVouchersController, type: :controller do
+RSpec.describe ResponsibleBody::Internet::BTWifiVouchersController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
   context 'when authenticated' do

--- a/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ResponsibleBody::Mobile::BulkRequestsController, type: :controller do
+RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
   context 'when authenticated' do

--- a/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ResponsibleBody::Mobile::ExtraDataRequestsController, type: :controller do
+RSpec.describe ResponsibleBody::Internet::Mobile::ExtraDataRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
   context 'when authenticated' do
@@ -17,7 +17,7 @@ RSpec.describe ResponsibleBody::Mobile::ExtraDataRequestsController, type: :cont
           commit: 'Continue',
         }
         get :new, params: request_data
-        expect(response).to redirect_to(new_responsible_body_mobile_bulk_request_path)
+        expect(response).to redirect_to(new_responsible_body_internet_mobile_bulk_request_path)
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe ResponsibleBody::Mobile::ExtraDataRequestsController, type: :cont
           commit: 'Continue',
         }
         get :new, params: request_data
-        expect(response).to redirect_to(new_responsible_body_mobile_manual_request_path)
+        expect(response).to redirect_to(new_responsible_body_internet_mobile_manual_request_path)
       end
     end
   end

--- a/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ResponsibleBody::Mobile::ManualRequestsController, type: :controller do
+RSpec.describe ResponsibleBody::Internet::Mobile::ManualRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
   context 'when authenticated' do

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     end
 
     scenario 'the user can see their previous requests' do
-      visit responsible_body_mobile_extra_data_requests_path
+      visit responsible_body_internet_mobile_extra_data_requests_path
 
       expect(page).to have_css('h2', text: 'Your requests')
 
@@ -56,7 +56,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
       sign_out
       sign_in_as another_user_from_the_same_rb
 
-      visit responsible_body_mobile_extra_data_requests_path
+      visit responsible_body_internet_mobile_extra_data_requests_path
 
       @requests.each do |request|
         expect(page).to have_content(request.device_phone_number)

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
     end
 
     scenario 'visiting the form directly should redirect to sign_in' do
-      visit new_responsible_body_mobile_bulk_request_path
+      visit new_responsible_body_internet_mobile_bulk_request_path
       expect(page).to have_current_path(sign_in_path)
     end
   end
@@ -27,7 +27,7 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
     end
 
     scenario 'Navigating to the form' do
-      visit responsible_body_mobile_extra_data_requests_path
+      visit responsible_body_internet_mobile_extra_data_requests_path
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')
       choose('Using a spreadsheet')
@@ -36,14 +36,14 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
     end
 
     scenario 'submitting the form without making a choice shows errors' do
-      visit new_responsible_body_mobile_bulk_request_path
+      visit new_responsible_body_internet_mobile_bulk_request_path
       click_on 'Upload requests'
       expect(page.status_code).not_to eq(200)
       expect(page).to have_text('There is a problem')
     end
 
     scenario 'submitting the form with a valid file shows a summary page' do
-      visit new_responsible_body_mobile_bulk_request_path
+      visit new_responsible_body_internet_mobile_bulk_request_path
       attach_file('Pick a spreadsheet file', file_fixture('extra-mobile-data-requests.xlsx'))
       click_on 'Upload requests'
 

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'visiting the form directly should redirect to sign_in' do
-      visit new_responsible_body_mobile_manual_request_path
+      visit new_responsible_body_internet_mobile_manual_request_path
       expect(page).to have_current_path(sign_in_path)
     end
   end
@@ -27,7 +27,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'Navigating to the form' do
-      visit responsible_body_mobile_extra_data_requests_path
+      visit responsible_body_internet_mobile_extra_data_requests_path
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')
       choose('Manually (entering details one at a time)')
@@ -36,7 +36,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'submitting the form with invalid params shows errors' do
-      visit new_responsible_body_mobile_manual_request_path
+      visit new_responsible_body_internet_mobile_manual_request_path
       fill_in 'Mobile phone number', with: '-1'
       click_on 'Continue'
       expect(page.status_code).not_to eq(200)
@@ -45,7 +45,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
 
     context 'when the mno is participating' do
       scenario 'submitting the form with valid params goes to confirmation page' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
         click_on 'Continue'
 
@@ -63,7 +63,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
       let(:mobile_network) { create(:mobile_network, :maybe_participating_in_pilot) }
 
       scenario 'submitting the form with valid params goes to confirmation page with extra messaging' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
         click_on 'Continue'
 
@@ -75,7 +75,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'clicking Change on the confirmation page populates the form again' do
-      visit new_responsible_body_mobile_manual_request_path
+      visit new_responsible_body_internet_mobile_manual_request_path
       fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
       fill_in 'Account holder name', with: 'My new account holder name'
       click_on 'Continue'
@@ -94,7 +94,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'confirming a form works' do
-      visit new_responsible_body_mobile_manual_request_path
+      visit new_responsible_body_internet_mobile_manual_request_path
       fill_in_valid_application_form(mobile_network_name: mobile_network.brand)
       fill_in 'Account holder name', with: 'My confirmed account holder name'
 

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Session behaviour', type: :feature do
       end
 
       scenario 'the user can submit a valid form' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
 
@@ -35,14 +35,14 @@ RSpec.feature 'Session behaviour', type: :feature do
       end
 
       scenario 'user session is preserved across requests' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
         expect(page).to have_button('Sign out')
       end
 
       scenario 'clicking "Sign out" signs the user out' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
 
@@ -57,7 +57,7 @@ RSpec.feature 'Session behaviour', type: :feature do
       end
 
       scenario 'visiting with a valid but expired session logs the user out' do
-        visit new_responsible_body_mobile_manual_request_path
+        visit new_responsible_body_internet_mobile_manual_request_path
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
 


### PR DESCRIPTION
### Context

As a precursor to implementing the "Get devices" workflow for responsible bodies, we need to move the existing "Get the internet" workflows under a namespace that can sit alongside it (see [Trello card 455](https://trello.com/c/iWLnm5mC/455-move-bt-mno-pilot-screens-into-url-namespace))

### Changes proposed in this pull request

Move all controllers, views and specs relating to the "Get the internet" journey for responsible bodies under a new internet namespace
i.e. `responsible_body/(mobile_|bt_)` -> `responsible_body/internet/(mobile_|bt_)`

Update all references to a `responsible_body_(.*)_path` correspondingly

### Guidance to review

