### PR TITLE
Clearer slack notifications

### DIFF
--- a/app/services/event_notifications_service.rb
+++ b/app/services/event_notifications_service.rb
@@ -14,7 +14,7 @@ class EventNotificationsService
     end
 
     def format_message(event)
-      "[#{event.class.name}] #{event.message}"
+      "[#{event.class.name.demodulize.underscore.humanize}] #{event.message}"
     end
 
     def log(event)

--- a/app/services/event_notifications_service.rb
+++ b/app/services/event_notifications_service.rb
@@ -14,7 +14,7 @@ class EventNotificationsService
     end
 
     def format_message(event)
-      "[#{event.class.name}] #{event.message}\n_timestamp: #{Time.zone.now.iso8601}_"
+      "[#{event.class.name}] #{event.message}"
     end
 
     def log(event)

--- a/spec/services/event_notifications_service_spec.rb
+++ b/spec/services/event_notifications_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe EventNotificationsService do
     let(:msg) { EventNotificationsService.send(:format_message, event) }
 
     it 'adds a prefix of the class name in square brackets' do
-      expect(msg).to start_with("[#{event.class.name}]")
+      expect(msg).to start_with('[Instance verifying double]')
     end
 
     it 'contains the given events message' do

--- a/spec/services/event_notifications_service_spec.rb
+++ b/spec/services/event_notifications_service_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe EventNotificationsService do
       expect(msg).to start_with("[#{event.class.name}]")
     end
 
-    it 'adds a suffix of the current time in iso8601 format, on a new line and italicized' do
-      expect(msg).to end_with("\n_timestamp: #{Time.zone.now.iso8601}_")
-    end
-
     it 'contains the given events message' do
       expect(msg).to include(event.message)
     end


### PR DESCRIPTION
### Context

The Slack messages upon sign-in could be a bit clearer, namely:

- the timestamp is in UTC (so looks like it's off-by-one hour at first glance when it's BST)
- event name is camel-cased

### Changes proposed in this pull request

- remove the timestamp altogether (it's possible to see when the event happened based on the Slack timestamp)
- print the event class with spaces and removing the module part

### Guidance to review

```ruby
[1] pry(main)> Computacenter::CapTypeConverter.name.demodulize.underscore.humanize
=> "Cap type converter"
```