### PR TITLE
add in_connectivity_pilot flag to RB

### DIFF
--- a/db/migrate/20200818170851_add_responsible_body_in_connectivity_pilot.rb
+++ b/db/migrate/20200818170851_add_responsible_body_in_connectivity_pilot.rb
@@ -1,0 +1,5 @@
+class AddResponsibleBodyInConnectivityPilot < ActiveRecord::Migration[6.0]
+  def change
+    add_column :responsible_bodies, :in_connectivity_pilot, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_163708) do
+ActiveRecord::Schema.define(version: 2020_08_18_170851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 2020_08_14_163708) do
     t.string "companies_house_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "in_devices_pilot", default: false
+    t.boolean "in_connectivity_pilot", default: true
   end
 
   create_table "school_device_allocations", force: :cascade do |t|


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Add a boolean flag (default `false`) to the responsible_bodies table to indicate whether they are in the connectivity pilot or not

### Guidance to review

`bundle exec rails db:migrate`