### PR TITLE
ResponsibleBody::Devices::BaseController which only allows RBs in device pilot

### DIFF
--- a/app/controllers/responsible_body/devices/base_controller.rb
+++ b/app/controllers/responsible_body/devices/base_controller.rb
@@ -1,0 +1,9 @@
+class ResponsibleBody::Devices::BaseController < ResponsibleBody::BaseController
+  before_action :require_device_pilot_participation!
+
+private
+
+  def require_device_pilot_participation!
+    render 'errors/forbidden', status: :forbidden unless @responsible_body.in_devices_pilot
+  end
+end


### PR DESCRIPTION
### Context

We are adding new screens to support the devices work.

### Changes proposed in this pull request

Add a new base controller that ensures access is only given to responsible bodies which are in the devices pilot.

### Guidance to review

No specs for the base controller, I'm assuming that the subclasses will be tested.