### PR TITLE
478 set RB.in_connectivity_pilot default to false

### DIFF
--- a/db/migrate/20200819123617_change_responsible_body_in_connectivity_pilot_default_to_false.rb
+++ b/db/migrate/20200819123617_change_responsible_body_in_connectivity_pilot_default_to_false.rb
@@ -1,0 +1,15 @@
+class ChangeResponsibleBodyInConnectivityPilotDefaultToFalse < ActiveRecord::Migration[6.0]
+  def change
+    change_column :responsible_bodies, :in_connectivity_pilot, :boolean, null: true, default: false
+
+    # Only set this flag to true if there is at least one user for the RB
+    connection.execute <<~SQL
+      UPDATE  responsible_bodies
+      SET     in_connectivity_pilot = EXISTS(
+        SELECT id
+        FROM users
+        WHERE responsible_body_id = responsible_bodies.id
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 2020_08_19_123617) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "in_devices_pilot", default: false
     t.boolean "in_connectivity_pilot", default: false
-    t.string "who_will_order_devices"
   end
 
   create_table "school_device_allocations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_170851) do
+ActiveRecord::Schema.define(version: 2020_08_19_123617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,8 @@ ActiveRecord::Schema.define(version: 2020_08_18_170851) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "in_devices_pilot", default: false
-    t.boolean "in_connectivity_pilot", default: true
+    t.boolean "in_connectivity_pilot", default: false
+    t.string "who_will_order_devices"
   end
 
   create_table "school_device_allocations", force: :cascade do |t|


### PR DESCRIPTION
### Context

PR #247 introduced a flag to ResponsibleBody called `in_connectivity_pilot`, and set the default to `true`.
In discussion with @benilovj it later became clear that this is not accurate, and we should instead default it to false, only setting it to true for those RBs who have at least one user.

### Changes proposed in this pull request

* Add a migration to do the above

### Guidance to review

