### PR TITLE
Fix issue with generating Computacenter cap types in outgoing API

### DIFF
--- a/app/models/computacenter/cap_type_converter.rb
+++ b/app/models/computacenter/cap_type_converter.rb
@@ -10,6 +10,6 @@ class Computacenter::CapTypeConverter
   end
 
   def self.to_computacenter_type(dfe_type)
-    CAP_TYPES_MAP.key(dfe_type).first
+    CAP_TYPES_MAP.key(dfe_type)
   end
 end

--- a/spec/models/computacenter/cap_type_converter_spec.rb
+++ b/spec/models/computacenter/cap_type_converter_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::CapTypeConverter do
+  describe '.to_dfe_type' do
+    context 'given a valid computacenter capType' do
+      it 'returns the correct device_type' do
+        expect(Computacenter::CapTypeConverter.to_dfe_type('DfE_RemainThresholdQty|Std_Device')).to eq('std_device')
+        expect(Computacenter::CapTypeConverter.to_dfe_type('DfE_RemainThresholdQty|Coms_Device')).to eq('coms_device')
+      end
+    end
+
+    context 'given an invalid computacenter capType' do
+      it 'returns nil' do
+        expect(Computacenter::CapTypeConverter.to_dfe_type('Some|Incorrect_Device_Type')).to be_nil
+      end
+    end
+  end
+
+  describe '.to_computacenter_type' do
+    context 'given a valid DfE device_type' do
+      it 'returns the correct computacenter capType' do
+        expect(Computacenter::CapTypeConverter.to_computacenter_type('std_device')).to eq('DfE_RemainThresholdQty|Std_Device')
+        expect(Computacenter::CapTypeConverter.to_computacenter_type('coms_device')).to eq('DfE_RemainThresholdQty|Coms_Device')
+      end
+    end
+
+    context 'given an invalid DfE device_type' do
+      it 'returns nil' do
+        expect(Computacenter::CapTypeConverter.to_computacenter_type('???')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

`Computacenter::CapTypeConverter` was only returning first character of matched device types. This was causing `500 internal server error` responses on their API

### Changes proposed in this pull request

Fix it to return the full match
Add a spec to explicitly test this behaviour

### Guidance to review

