### PR TITLE
Added phase and type to schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -5,6 +5,22 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
+  enum phase: {
+    primary: 'primary',
+    secondary: 'secondary',
+    all_through: 'all_through',
+    sixteen_plus: 'sixteen_plus',
+    phase_not_applicable: 'phase_not_applicable',
+  }
+
+  enum establishment_type: {
+    academy: 'academy',
+    free: 'free',
+    local_authority: 'local_authority',
+    special: 'special',
+    other_type: 'other_type',
+  }
+
   def allocation_for_type!(device_type)
     device_allocations.find_by_device_type!(device_type)
   end

--- a/app/models/school_data_file.rb
+++ b/app/models/school_data_file.rb
@@ -3,6 +3,7 @@ require 'csv'
 class SchoolDataFile
   EXCLUDED_TYPES = [
     'British schools overseas',
+    'City technology college',
     'Further education',
     'Higher education institutions',
     'Institution funded by other government department',
@@ -49,6 +50,8 @@ private
       town: row['Town'],
       county: row['County (name)'],
       postcode: row['Postcode'],
+      phase: phase(row),
+      establishment_type: establishment_type(row),
     }
   end
 
@@ -62,11 +65,44 @@ private
     end
   end
 
+  def phase(row)
+    phase_name = row['PhaseOfEducation (name)']
+    case phase_name
+    when 'Primary', 'Middle deemed primary'
+      'primary'
+    when 'Secondary', 'Middle deemed secondary'
+      'secondary'
+    when 'All-through'
+      'all_through'
+    when '16 plus'
+      'sixteen_plus'
+    else
+      'phase_not_applicable'
+    end
+  end
+
+  def establishment_type(row)
+    est_type = row['EstablishmentTypeGroup (name)']
+    case est_type
+    when 'Academies'
+      'academy'
+    when 'Free Schools'
+      'free'
+    when 'Local authority maintained schools'
+      'local_authority'
+    when 'Special schools'
+      'special'
+    else
+      Rails.logger.info("Other establishment type? '#{est_type}' (urn: #{row['URN']}")
+      'other_type'
+    end
+  end
+
   def skip_school?(row)
     row['EstablishmentStatus (name)'] != 'Open' ||
-      row['LA (name)'] == 'Does not apply' ||
       row['LA (name)'] == 'Vale of Glamorgan' ||
       row['LA (name)'] == 'Isles Of Scilly' ||
+      row['PhaseOfEducation (name)'] == 'Nursery' ||
       EXCLUDED_TYPES.include?(row['TypeOfEstablishment (name)'])
   end
 end

--- a/db/migrate/20200819082723_add_phase_and_establishment_type_to_schools.rb
+++ b/db/migrate/20200819082723_add_phase_and_establishment_type_to_schools.rb
@@ -1,0 +1,6 @@
+class AddPhaseAndEstablishmentTypeToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :phase, :string, index: true
+    add_column :schools, :establishment_type, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_170851) do
+ActiveRecord::Schema.define(version: 2020_08_19_082723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,8 @@ ActiveRecord::Schema.define(version: 2020_08_18_170851) do
     t.string "town"
     t.string "county"
     t.string "postcode"
+    t.string "phase"
+    t.string "establishment_type"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/models/school_data_file_spec.rb
+++ b/spec/models/school_data_file_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SchoolDataFile, type: :model do
     context 'when a school is open and not an excluded type' do
       let(:attrs) do
         {
-          urn: '100001',
-          name: 'Big School',
+          urn: '103001',
+          name: 'Little School',
           responsible_body: 'Camden',
           address_1: '12 High St',
           town: 'London',
@@ -16,6 +16,8 @@ RSpec.describe SchoolDataFile, type: :model do
           status: 'Open',
           type: 'Voluntary aided school',
           trusts_flag: '0',
+          phase: 'Primary',
+          group_type: 'Local authority maintained schools',
         }
       end
 
@@ -30,12 +32,14 @@ RSpec.describe SchoolDataFile, type: :model do
       it 'retrieves the school data' do
         schools = SchoolDataFile.new(filename).schools
         expect(schools[0]).to include(
-          urn: '100001',
-          name: 'Big School',
+          urn: '103001',
+          name: 'Little School',
           responsible_body: 'Camden',
           address_1: '12 High St',
           town: 'London',
           postcode: 'NW1 1AA',
+          phase: 'primary',
+          establishment_type: 'local_authority',
         )
       end
     end
@@ -52,6 +56,8 @@ RSpec.describe SchoolDataFile, type: :model do
           status: 'Closed',
           type: 'Voluntary aided school',
           trusts_flag: '0',
+          phase: 'Secondary',
+          group_type: 'Local authority maintained schools',
         }
       end
 
@@ -81,6 +87,8 @@ RSpec.describe SchoolDataFile, type: :model do
           status: 'Open',
           type: 'Other independent school',
           trusts_flag: '0',
+          phase: 'Secondary',
+          group_type: 'Independent schools',
         }
       end
 
@@ -111,6 +119,8 @@ RSpec.describe SchoolDataFile, type: :model do
           type: 'Academy sponsor led',
           trusts_flag: '3',
           trusts_name: 'The Multi-Trust Academy',
+          phase: 'Secondary',
+          group_type: 'Academies',
         }
       end
 
@@ -131,6 +141,8 @@ RSpec.describe SchoolDataFile, type: :model do
           address_1: '12 High St',
           town: 'London',
           postcode: 'NW1 1AA',
+          phase: 'secondary',
+          establishment_type: 'academy',
         )
       end
     end
@@ -138,8 +150,8 @@ RSpec.describe SchoolDataFile, type: :model do
     context 'when a school is managed by a Single-Academy Trust' do
       let(:attrs) do
         {
-          urn: '100001',
-          name: 'Big School',
+          urn: '100021',
+          name: 'All Phase School',
           responsible_body: 'Camden',
           address_1: '12 High St',
           town: 'London',
@@ -148,6 +160,8 @@ RSpec.describe SchoolDataFile, type: :model do
           type: 'Academy sponsor led',
           trusts_flag: '5',
           trusts_name: 'The Single-Trust Academy',
+          phase: 'All-through',
+          group_type: 'Academies',
         }
       end
 
@@ -162,12 +176,14 @@ RSpec.describe SchoolDataFile, type: :model do
       it 'retrieves the school data' do
         schools = SchoolDataFile.new(filename).schools
         expect(schools[0]).to include(
-          urn: '100001',
-          name: 'Big School',
+          urn: '100021',
+          name: 'All Phase School',
           responsible_body: 'The Single-Trust Academy',
           address_1: '12 High St',
           town: 'London',
           postcode: 'NW1 1AA',
+          phase: 'all_through',
+          establishment_type: 'academy',
         )
       end
     end

--- a/spec/services/import_schools_service_spec.rb
+++ b/spec/services/import_schools_service_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe ImportSchoolsService, type: :model do
+  describe 'importing schools' do
+    let(:filename) { Rails.root.join('tmp/school_test_data.csv') }
+    let!(:local_authority) { create(:local_authority, name: 'Camden') }
+
+    context 'when a school does not already exist' do
+      let(:attrs) do
+        {
+          urn: '103001',
+          name: 'Little School',
+          responsible_body: 'Camden',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          status: 'Open',
+          type: 'Voluntary aided school',
+          trusts_flag: '0',
+          phase: 'Primary',
+          group_type: 'Local authority maintained schools',
+        }
+      end
+
+      before do
+        create_school_csv_file(filename, [attrs])
+        @service = described_class.new(SchoolDataFile.new(filename))
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'creates a new school record' do
+        expect {
+          @service.import_schools
+        }.to change { School.count }.by(1)
+      end
+
+      it 'sets the correct values on the School record' do
+        @service.import_schools
+        expect(School.last).to have_attributes(
+          urn: 103_001,
+          name: 'Little School',
+          responsible_body_id: local_authority.id,
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          phase: 'primary',
+          establishment_type: 'local_authority',
+        )
+      end
+    end
+
+    context 'when a school already exists' do
+      let(:school) { create(:school, urn: '103001') }
+
+      let(:attrs) do
+        {
+          urn: '103001',
+          name: 'Little School',
+          responsible_body: 'Camden',
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          status: 'Open',
+          type: 'Voluntary aided school',
+          trusts_flag: '0',
+          phase: 'Primary',
+          group_type: 'Local authority maintained schools',
+        }
+      end
+
+      before do
+        create_school_csv_file(filename, [attrs])
+        @service = described_class.new(SchoolDataFile.new(filename))
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'updates the existing school record' do
+        @service.import_schools
+        expect(School.last).to have_attributes(
+          urn: 103_001,
+          name: 'Little School',
+          responsible_body_id: local_authority.id,
+          address_1: '12 High St',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          phase: 'primary',
+          establishment_type: 'local_authority',
+        )
+      end
+    end
+  end
+end

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -15,6 +15,8 @@ module CSVFileHelper
     type: 'TypeOfEstablishment (name)',
     trusts_flag: 'TrustSchoolFlag (code)',
     trusts_name: 'Trusts (name)',
+    phase: 'PhaseOfEducation (name)',
+    group_type: 'EstablishmentTypeGroup (name)',
   }.freeze
 
   def create_school_csv_file(filename, array_of_hashes)


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/mB4EMZMP/445-pull-in-phase-of-school-from-gias-primary-secondary) Add phase of education and establishment type to `School` model from GIAS data.

### Changes proposed in this pull request
Add migration for `:phase` and `:establishment_type`.
Create `enum`s for both attributes and map during import
`:phase` values are `primary`, `secondary`, `all_through`, `sixteen_plus` and `phase_not_applicable`
`:establishment_type` values are `academy`, `free`, `local_authority`, `special` and `other_type`
School importer will now update the attributes of matching school records, not just create new ones.  It cannot yet determine if imported schools have closed, been removed or have changed URN.
Prevented `Nursery` and `City technical college` types from being imported.

### Guidance to review
There are additional filters in this so you will have to remove any already imported schools or just perform a new import and then remove schools that do not have a `phase` or `establishment_type` set
Run school importer `bundle exec rails import:schools` from command line or `ImportSchoolsService.new.import_schools` from the Rails console.  School records should now be populated with `phase` and `establishment_type`.
From Rails console, you should now be able to execute queries such as `School.primary.count` and `School.local_authority.count`
