### PR TITLE
add verbose explicit logging of computacenter api requests

### DIFF
--- a/app/controllers/computacenter/api/base_controller.rb
+++ b/app/controllers/computacenter/api/base_controller.rb
@@ -7,7 +7,7 @@
 # So we're pulling this out to a dedicated controller in order to keep the
 # rest of the application 'clean' and RESTful.
 class Computacenter::API::BaseController < ApplicationController
-  before_action :require_cc_user!, :read_xml_from_body!
+  before_action :require_cc_user!, :read_xml_from_body!, :log_request_verbosely
   rescue_from Computacenter::API::APIError, with: :api_error!
 
 private
@@ -42,6 +42,13 @@ private
       status: :bad_request,
       message: 'The request body you provided was not valid XML',
     )
+  end
+
+  def log_request_verbosely
+    logger.info "request.headers = #{request.headers.to_h.reject { |k, _| k.starts_with?('puma.', 'rack.', 'action_') }.inspect}"
+    logger.info "request.format = #{request.format}"
+    logger.info "request.accept = #{request.accept}"
+    logger.info "request.body: \n#{@xml}"
   end
 
   def validate_xml!(schema_name, xml_doc = @xml_doc)


### PR DESCRIPTION
### Context

Computacenter are experiencing an issue on staging that we can't replicate based on the information available to us. 
When they POST a cap usage update to the computacenter API, they get a `500 Internal Server Error` - based on the [info in Sentry](https://sentry.io/organizations/dfe-get-help-with-tech/issues/1846682979/?project=5320558&query=is%3Aunresolved#exception) it looks like the server is trying to interpret it as a HTML request and failing when looking for a HTML template to render. This happens even though Sentry says they're supplying a correct `"Content-Type: application/xml"` header.

### Changes proposed in this pull request

Add some explicit verbose logging so that we can see in the logs exactly what they're supplying in terms of headers & body.

### Guidance to review

