### PR TITLE
Remove local authorities that don't maintain schools

### DIFF
--- a/app/models/local_authorities_in_england_register.rb
+++ b/app/models/local_authorities_in_england_register.rb
@@ -3,12 +3,18 @@ require 'open-uri'
 class LocalAuthoritiesInEnglandRegister
   URL = 'https://local-authority-eng.register.gov.uk/records.json?page-size=5000'.freeze
 
-  def self.entries
+  # we believe that
+  # - combined authorities
+  # - strategic regional authorities and
+  # - non-metropolitan districts
+  # don't maintain schools
+  def self.local_authorities_that_maintain_schools
     local_authorities_register_results = JSON.parse(URI.open(URL).read)
 
     local_authorities_register_results
       .values
       .map { |result| result['item'].first }
       .reject { |result| result['end-date'].present? }
+      .reject { |result| result['local-authority-type'].in?(%w[COMB SRA NMD]) }
   end
 end

--- a/app/services/import_responsible_bodies_service.rb
+++ b/app/services/import_responsible_bodies_service.rb
@@ -1,6 +1,6 @@
 class ImportResponsibleBodiesService
   def import_local_authorities
-    LocalAuthoritiesInEnglandRegister.entries.each do |entry|
+    LocalAuthoritiesInEnglandRegister.local_authorities_that_maintain_schools.each do |entry|
       LocalAuthority
         .where(local_authority_eng: entry['local-authority-eng'])
         .first_or_create!(

--- a/db/migrate/20200819215502_remove_local_authorities_that_dont_maintain_schools.rb
+++ b/db/migrate/20200819215502_remove_local_authorities_that_dont_maintain_schools.rb
@@ -1,0 +1,11 @@
+class RemoveLocalAuthoritiesThatDontMaintainSchools < ActiveRecord::Migration[6.0]
+  def up
+    LocalAuthority.where(
+      organisation_type: %w[combined_authority non_metropolitan_district strategic_regional_authority],
+    ).delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_123617) do
+ActiveRecord::Schema.define(version: 2020_08_19_215502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/local_authorities_in_england_register_spec.rb
+++ b/spec/models/local_authorities_in_england_register_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
-  it 'returns a list of entries' do
+  it 'returns a list of local authorities that maintain schools' do
     stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
       .to_return(body: '
         {
@@ -20,23 +20,22 @@ RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
               }
             ]
           },
-          "TEI": {
-            "index-entry-number": "128",
-            "entry-number": "128",
+          "SHF": {
+            "index-entry-number": "64",
+            "entry-number": "64",
             "entry-timestamp": "2016-10-21T16:11:20Z",
-            "key": "TEI",
-            "item": [
-              {
-                "local-authority-type": "NMD",
-                "official-name": "Teignbridge District Council",
-                "local-authority-eng": "TEI",
-                "name": "Teignbridge"
-              }
-            ]
+            "key": "SHF",
+            "item": [{
+              "local-authority-type": "MD",
+              "official-name": "Sheffield City Council",
+              "local-authority-eng": "SHF",
+              "name": "Sheffield",
+              "start-date": "1905-06-08"
+            }]
           }
         }')
 
-    entries = LocalAuthoritiesInEnglandRegister.entries
+    entries = LocalAuthoritiesInEnglandRegister.local_authorities_that_maintain_schools
 
     expect(entries.size).to eq(2)
     expect(entries.first).to include({
@@ -46,10 +45,10 @@ RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
       'name' => 'Bradford',
     })
     expect(entries.second).to include({
-      'local-authority-type' => 'NMD',
-      'official-name' => 'Teignbridge District Council',
-      'local-authority-eng' => 'TEI',
-      'name' => 'Teignbridge',
+      'local-authority-type' => 'MD',
+      'official-name' => 'Sheffield City Council',
+      'local-authority-eng' => 'SHF',
+      'name' => 'Sheffield',
     })
   end
 
@@ -73,6 +72,31 @@ RSpec.describe LocalAuthoritiesInEnglandRegister, type: :model do
           }
         }')
 
-    expect(LocalAuthoritiesInEnglandRegister.entries).to be_empty
+    expect(LocalAuthoritiesInEnglandRegister.local_authorities_that_maintain_schools).to be_empty
+  end
+
+  it "filters out local authority types that don't maintain schools" do
+    stub_request(:get, LocalAuthoritiesInEnglandRegister::URL)
+      .to_return(body: '
+        {
+          "TEI": {
+            "index-entry-number": "128",
+            "entry-number": "128",
+            "entry-timestamp": "2016-10-21T16:11:20Z",
+            "key": "TEI",
+            "item": [
+              {
+                "local-authority-type": "NMD",
+                "official-name": "Teignbridge District Council",
+                "local-authority-eng": "TEI",
+                "name": "Teignbridge"
+              }
+            ]
+          }
+        }')
+
+    entries = LocalAuthoritiesInEnglandRegister.local_authorities_that_maintain_schools
+
+    expect(entries).to be_empty
   end
 end

--- a/spec/services/import_responsible_bodies_service_spec.rb
+++ b/spec/services/import_responsible_bodies_service_spec.rb
@@ -20,19 +20,18 @@ RSpec.describe ImportResponsibleBodiesService, type: :model do
               }
             ]
           },
-          "TEI": {
-            "index-entry-number": "128",
-            "entry-number": "128",
+          "SHF": {
+            "index-entry-number": "64",
+            "entry-number": "64",
             "entry-timestamp": "2016-10-21T16:11:20Z",
-            "key": "TEI",
-            "item": [
-              {
-                "local-authority-type": "NMD",
-                "official-name": "Teignbridge District Council",
-                "local-authority-eng": "TEI",
-                "name": "Teignbridge"
-              }
-            ]
+            "key": "SHF",
+            "item": [{
+              "local-authority-type": "MD",
+              "official-name": "Sheffield City Council",
+              "local-authority-eng": "SHF",
+              "name": "Sheffield",
+              "start-date": "1905-06-08"
+            }]
           }
         }')
 
@@ -46,10 +45,10 @@ RSpec.describe ImportResponsibleBodiesService, type: :model do
     expect(local_authorities.first.local_authority_eng).to eq('BRD')
     expect(local_authorities.first.name).to eq('Bradford')
 
-    expect(local_authorities.second.organisation_type).to eq('non_metropolitan_district')
-    expect(local_authorities.second.local_authority_official_name).to eq('Teignbridge District Council')
-    expect(local_authorities.second.local_authority_eng).to eq('TEI')
-    expect(local_authorities.second.name).to eq('Teignbridge')
+    expect(local_authorities.second.organisation_type).to eq('metropolitan_district')
+    expect(local_authorities.second.local_authority_official_name).to eq('Sheffield City Council')
+    expect(local_authorities.second.local_authority_eng).to eq('SHF')
+    expect(local_authorities.second.name).to eq('Sheffield')
 
     # re-run import again to check idempotence
     ImportResponsibleBodiesService.new.import_local_authorities


### PR DESCRIPTION
### Context

We have a large number of local authorities that don't actually maintain schools, as evidenced by no schools being associated with them within Get Information About Schools. These LAs are also not involved in the connectivity pilots or have any users:

```ruby
[1] pry(main)> LocalAuthority.where(organisation_type: %w[combined_authority non_metropolitan_district strategic_regional_authority], in_connectivity_pilot: true).count
=> 0
[2] pry(main)> LocalAuthority.where(organisation_type: %w[combined_authority non_metropolitan_district strategic_regional_authority]).select {|la| la.users.count > 0 }
=> []
```

### Changes proposed in this pull request

- remove those LAs from the database
- don't import them from the LAs in England register in the first place


