### PR TITLE
Bring the responsible body homepage heading in line with the content

### DIFF
--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @responsible_body.name %></span>
       <%= t('page_titles.responsible_body_home') %>
     </h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
     confirm: Check your answers before confirming
     new_user: Create an account
     error_prefix: "Error: "
-    responsible_body_home: Increase children’s internet access
+    responsible_body_home: Get help with technology
     responsible_body_devices_home: Tell us who will order a school’s laptops and tablets
     responsible_body_internet_home: Get the internet
     requests_for_extra_mobile_data: Requests for extra mobile data

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     scenario 'it redirects to the responsible_body_home page' do
       sign_in_as user
       expect(page).to have_current_path(responsible_body_home_path)
-      expect(page).to have_text 'Increase children’s internet access'
+      expect(page).to have_text 'Get help with technology'
     end
   end
 


### PR DESCRIPTION
### Context

We changed the responsible body homepage copy but forgot to change the heading.

### Changes proposed in this pull request

Align heading with content, add responsible body name.

### Guidance to review

Before:
![image](https://user-images.githubusercontent.com/23801/90784860-9ef7de80-e2f9-11ea-8728-f48ca3a71034.png)

After:
![image](https://user-images.githubusercontent.com/23801/90784879-a28b6580-e2f9-11ea-892e-bd7a4c7dd2c3.png)
