### PR TITLE
fix "superclass mismatch for class PreorderInformation"

### DIFF
--- a/db/migrate/20200821161806_add_preorder_information.rb
+++ b/db/migrate/20200821161806_add_preorder_information.rb
@@ -1,4 +1,4 @@
-class PreorderInformation < ActiveRecord::Migration[6.0]
+class AddPreorderInformation < ActiveRecord::Migration[6.0]
   def change
     create_table :preorder_information do |t|
       t.references :school, null: false


### PR DESCRIPTION
### Context

Running the migration added in #283 failed with error:
```
rails aborted!
TypeError: superclass mismatch for class PreorderInformation
(...)/get-help-with-tech/db/migrate/20200821161806_preorder_information.rb:1:in `<main>'
bin/rails:4:in `<main>'
```

On investigation, the migration had the same class name as the model class (`PreorderInformation`) - I suspect the model class was added after the migration had been run?

### Changes proposed in this pull request

Change the name of the migration to `AddPreorderInformation`

### Guidance to review

`rails db:migrate` (rollback first if needed)
