### PR TITLE
466 display allocations per school

### DIFF
--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -2,6 +2,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::Devices::Ba
   def index
     @schools = @responsible_body.schools
                                 .includes(:preorder_information)
+                                .includes(:std_device_allocation)
                                 .order(name: :asc)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,6 +1,7 @@
 class School < ApplicationRecord
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
+  has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
   has_one :preorder_information

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -40,7 +40,8 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" style="width: 50%">School</th>
-        <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">Allocation</th>
+      <th class="govuk-table__header">Status</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -48,6 +49,9 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= school.name %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= school.std_device_allocation&.allocation.to_i %>
         </td>
         <%- status = school.preorder_status_or_default %>
         <td class="govuk-table__cell">

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Setting up the devices ordering' do
     create(:preorder_information, school: zebra_school, who_will_order_devices: 'school')
     create(:preorder_information, school: aardvark_school, who_will_order_devices: 'responsible_body')
 
+    create(:school_device_allocation, school: aardvark_school, device_type: 'std_device', allocation: 42)
     sign_in_as rb_user
   end
 
@@ -21,6 +22,7 @@ RSpec.feature 'Setting up the devices ordering' do
     and_i_choose_ordering_through_schools
     then_i_see_a_list_of_the_schools_i_am_responsible_for
     and_each_school_has_a_status
+    and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
   end
 
   scenario 'devolving device ordering mostly centrally' do
@@ -81,6 +83,11 @@ RSpec.feature 'Setting up the devices ordering' do
   def and_each_school_has_a_status
     expect(responsible_body_schools_page.school_rows[0]).to have_content('Needs information')
     expect(responsible_body_schools_page.school_rows[1]).to have_content('Needs a contact')
+  end
+
+  def and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
+    expect(responsible_body_schools_page.school_rows[0]).to have_content('42')
+    expect(responsible_body_schools_page.school_rows[1]).to have_content('0')
   end
 
   def given_the_responsible_body_has_decided_to_order_centrally


### PR DESCRIPTION
### Context

See [Trello card 466](https://trello.com/c/UwR8CDhJ/466-display-allocations-per-school-in-the-schools-table)

~_NOTE: this PR depends on #287, so merge that one first!_~ ✅ 

### Changes proposed in this pull request

Show each school's "standard device" (i.e. laptop/chromebook) allocation in the schools list
If there is no `SchoolDeviceAllocation` record, show zero

### Guidance to review

_NOTE: this PR depends on #287, so merge that one first!_

Screenshot:

![Screen Shot 2020-08-21 at 23 42 23](https://user-images.githubusercontent.com/134501/90940796-fdab7e00-e407-11ea-8ecd-fb0898b4fbbf.png)

