### PR TITLE
Explicitly style the status column on the schools table

### DIFF
--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -61,7 +61,7 @@
         <td class="govuk-table__cell">
           <%= (school.preorder_information || school.responsible_body).who_will_order_devices_label %>
         </td>
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell govuk-table__cell--nowrap">
           <%= render SchoolPreorderStatusTagComponent.new(school: school) %>
         </td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
           needs_info: Needs information
           ready: Ready
           school_contacted: School contacted
-          school_will_be_contacted: School to be contacted shortly
+          school_will_be_contacted: School will be contacted
       school_device_allocation:
         device_type:
           std_device: 'Standard device (laptop etc)'

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_the_status_reflects_that_the_school_will_be_contacted_shortly
-    expect(responsible_body_school_page.school_details).to have_content('School to be contacted shortly')
+    expect(responsible_body_school_page.school_details).to have_content('School will be contacted')
   end
 
   def when_i_follow_the_link_to_the_next_school


### PR DESCRIPTION
### Context

The status for a school can be quite long and we don't want it to wrap.

### Changes proposed in this pull request

Add a fixed width on the status column, as in the prototype.

### Guidance to review

Is the CSS defined in the right place?
Is the name right?