### PR TITLE
Stop the UI crashing when a school does not have a PreorderInformation record

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -21,7 +21,7 @@ class SchoolDetailsSummaryListComponent < ViewComponent::Base
       },
       {
         key: 'Who will order?',
-        value: "The #{@school.preorder_information.who_will_order_devices_label.downcase} orders devices",
+        value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
       },
     ]
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -8,4 +8,13 @@ class ResponsibleBody < ApplicationRecord
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end
+
+  def who_will_order_devices_label
+    case who_will_order_devices
+    when 'school'
+      'School'
+    when 'responsible_body'
+      humanized_type.capitalize
+    end
+  end
 end

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -57,7 +57,7 @@
           <%= school.std_device_allocation&.allocation.to_i %>
         </td>
         <td class="govuk-table__cell">
-          <%= school.preorder_information.who_will_order_devices_label %>
+          <%= (school.preorder_information || school.responsible_body).who_will_order_devices_label %>
         </td>
         <td class="govuk-table__cell">
           <%= render SchoolPreorderStatusTagComponent.new(school: school) %>

--- a/spec/components/school_details_summary_list_component_spec.rb
+++ b/spec/components/school_details_summary_list_component_spec.rb
@@ -14,4 +14,19 @@ describe SchoolDetailsSummaryListComponent do
     expect(result.css('dd')[2].text).to include('Primary school')
     expect(result.css('dd')[3].text).to include('The school orders devices')
   end
+
+  context 'when the school has no PreorderInformation record' do
+    before do
+      school.responsible_body.update(who_will_order_devices: 'responsible_body')
+    end
+
+    it 'does not raise an error' do
+      expect { render_inline(described_class.new(school: school)) }.not_to raise_error
+    end
+
+    it 'gets the default who_will_order_devices value from the responsible_body' do
+      result = render_inline(described_class.new(school: school))
+      expect(result.css('dd')[3].text).to include('The local authority orders devices')
+    end
+  end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -21,10 +21,12 @@ FactoryBot.define do
 
     trait :academy do
       establishment_type { :academy }
+      association :responsible_body, factory: :trust
     end
 
     trait :la_maintained do
       establishment_type { :local_authority }
+      association :responsible_body, factory: :local_authority
     end
   end
 end


### PR DESCRIPTION
### Context

Until we have done [Trello card 476-ensure-data-consistency-when-a-new-school-is-added](https://trello.com/c/31RXvNJF/476-ensure-data-consistency-when-a-new-school-is-added) it's possible (likely, in fact) that a school could have no associated `PreorderInformation` record. The UI will currently raise an error in the schools list and the school details page if this is the case.

### Changes proposed in this pull request

Default the displayed `who_will_order_devices` value to the value from the school's RepsonsibleBody, if it has no `PreorderInformation` record

Make the `:la_maintained` and `:academy` traits on the `school` factory set the `responsible_body` association to a LocalAuthority or a Trust respectively

### Guidance to review

