### PR TITLE
Choosing contacts for schools

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -1,6 +1,10 @@
 class SchoolDetailsSummaryListComponent < ViewComponent::Base
   validates :school, presence: true
 
+  delegate :school_will_order_devices?,
+           :school_contact,
+           to: :preorder_information
+
   def initialize(school:)
     @school = school
   end
@@ -23,6 +27,31 @@ class SchoolDetailsSummaryListComponent < ViewComponent::Base
         key: 'Who will order?',
         value: "The #{@school.preorder_information.who_will_order_devices_label.downcase} orders devices",
       },
-    ]
+    ] + school_contact_row_if_contact_present
+  end
+
+private
+
+  def school_contact_row_if_contact_present
+    if school_will_order_devices? && school_contact.present?
+      [{
+        key: 'School contact',
+        value: contact_lines.join('<br>'),
+      }]
+    else
+      []
+    end
+  end
+
+  def contact_lines
+    [
+      school_contact.title.present? ? "#{school_contact.title.upcase_first}: #{school_contact.full_name}" : school_contact.full_name,
+      school_contact.email_address,
+      school_contact.phone_number,
+    ].reject(&:blank?)
+  end
+
+  def preorder_information
+    @school.preorder_information
   end
 end

--- a/app/components/school_preorder_status_tag_component.rb
+++ b/app/components/school_preorder_status_tag_component.rb
@@ -13,12 +13,12 @@ class SchoolPreorderStatusTagComponent < ViewComponent::Base
     case status
     when 'needs_contact', 'needs_info'
       :grey
-    when 'school_contacted'
+    when 'school_contacted', 'school_will_be_contacted'
       :yellow
     when 'ready'
       :green
     else
-      raise "You need to define a colour for the #{status} state"
+      :default
     end
   end
 

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -8,5 +8,6 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::Devices::Ba
 
   def show
     @school = @responsible_body.schools.find_by!(urn: params[:urn])
+    redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn) if @school.preorder_information.needs_contact?
   end
 end

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -1,0 +1,39 @@
+class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Devices::BaseController
+  before_action :find_school!
+
+  def new
+    @form = ResponsibleBody::Devices::WhoToContactForm.new(
+      school: @school,
+      headteacher_contact: @school.headteacher_contact,
+    )
+  end
+
+  def create
+    @form = ResponsibleBody::Devices::WhoToContactForm.new({
+      school: @school,
+      headteacher_contact: @school.headteacher_contact,
+    }.merge(who_to_contact_form_params))
+
+    if @form.invalid?
+      render :new, status: :unprocessable_entity
+    else
+      chosen_contact = @form.chosen_contact
+      chosen_contact.save! unless chosen_contact.persisted?
+      @school.preorder_information.update!(school_contact: chosen_contact)
+      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices schools who_to_contact create], email_address: chosen_contact.email_address)
+      redirect_to responsible_body_devices_school_path(@school.urn)
+    end
+  end
+
+private
+
+  def find_school!
+    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
+  end
+
+  def who_to_contact_form_params
+    params
+      .require(:responsible_body_devices_who_to_contact_form)
+      .permit(:who_to_contact, :full_name, :email_address, :phone_number)
+  end
+end

--- a/app/form_objects/responsible_body/devices/who_to_contact_form.rb
+++ b/app/form_objects/responsible_body/devices/who_to_contact_form.rb
@@ -1,0 +1,55 @@
+class ResponsibleBody::Devices::WhoToContactForm
+  include ActiveModel::Model
+
+  attr_accessor :school, :who_to_contact, :headteacher_contact, :full_name, :email_address, :phone_number
+
+  validates :who_to_contact, inclusion: %w[headteacher someone_else]
+
+  validates :full_name,
+            presence: true,
+            length: { minimum: 2, maximum: 1024 },
+            if: :someone_else_chosen?
+
+  validates :email_address,
+            presence: true,
+            format: { with: URI::MailTo::EMAIL_REGEXP },
+            length: { minimum: 2, maximum: 1024 },
+            if: :someone_else_chosen?
+
+  validates :phone_number,
+            presence: true,
+            length: { minimum: 2, maximum: 30 },
+            if: :someone_else_chosen?
+
+  def headteacher_option_label
+    @headteacher_contact.title.upcase_first
+  end
+
+  def headteacher_option_hint_text
+    "#{@headteacher_contact.full_name} (#{@headteacher_contact.email_address})"
+  end
+
+  def chosen_contact
+    if headteacher_chosen?
+      headteacher_contact
+    elsif someone_else_chosen?
+      SchoolContact.new(
+        school: school,
+        role: :contact,
+        full_name: full_name,
+        email_address: email_address,
+        phone_number: phone_number,
+      )
+    end
+  end
+
+private
+
+  def headteacher_chosen?
+    who_to_contact.to_sym == :headteacher
+  end
+
+  def someone_else_chosen?
+    who_to_contact.to_sym == :someone_else
+  end
+end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -10,6 +10,7 @@ class PreorderInformation < ApplicationRecord
     needs_contact: 'needs_contact',
     needs_info: 'needs_info',
     ready: 'ready',
+    school_will_be_contacted: 'school_will_be_contacted',
     school_contacted: 'school_contacted',
   }
 
@@ -28,7 +29,7 @@ class PreorderInformation < ApplicationRecord
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html
   def infer_status
     if school_will_order_devices?
-      'needs_contact'
+      school_contact.present? ? 'school_will_be_contacted' : 'needs_contact'
     else
       'needs_info'
     end
@@ -41,6 +42,11 @@ class PreorderInformation < ApplicationRecord
     when 'responsible_body'
       school.responsible_body.humanized_type.capitalize
     end
+  end
+
+  def school_contact=(value)
+    super(value)
+    self.status = infer_status
   end
 
 private

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -16,7 +16,7 @@ class PreorderInformation < ApplicationRecord
   enum who_will_order_devices: {
     school: 'school',
     responsible_body: 'responsible_body',
-  }
+  }, _suffix: 'will_order_devices'
 
   def initialize(*args)
     super
@@ -27,7 +27,7 @@ class PreorderInformation < ApplicationRecord
   # with reference to the prototype:
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html
   def infer_status
-    if who_will_order_devices == 'school'
+    if school_will_order_devices?
       'needs_contact'
     else
       'needs_info'

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -40,6 +40,10 @@ class School < ApplicationRecord
     end
   end
 
+  def headteacher_contact
+    contacts.find_by(role: :headteacher)
+  end
+
   # TODO: update this method as preorder_information gets more fields
   # as per the prototype at
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html

--- a/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_for form, url: responsible_body_devices_school_who_to_contact_path(form.school.urn), method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-inset-text govuk-!-padding-top-0">
+    <%= render SchoolDetailsSummaryListComponent.new(school: form.school) %>
+  </div>
+
+  <%= f.govuk_radio_buttons_fieldset(:who_to_contact, legend: { text: "Who can we contact at the school?", size: 'l', tag: 'h2' }) do %>
+    <%= f.govuk_radio_button :who_to_contact, 'headteacher', label: { text: form.headteacher_option_label }, hint_text: form.headteacher_option_hint_text, link_errors: true %>
+    <%= f.govuk_radio_button :who_to_contact, 'someone_else', label: { text: 'Someone else' } do %>
+      <p class="govuk-body">Nominate someone who:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>is planning the response to local coronavirus restrictions</li>
+        <li>understands what devices are needed and who will get them</li>
+        <li>can configure devices or give technical information</li>
+      </ul>
+
+      <%= f.govuk_text_field :full_name,
+          label: { text: 'Name' } %>
+
+      <%= f.govuk_email_field :email_address,
+          label: { text: 'Email address' },
+          hint_text: 'They will use this email address to sign in' %>
+
+      <%= f.govuk_text_field :phone_number,
+          label: { text: 'Telephone number' },
+          width: 10 %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit 'Save' %>
+
+<%- end %>

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -1,0 +1,19 @@
+<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_schools_path, class: 'govuk-back-link') %>
+<%- content_for :title, @school.name %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+      <%= @school.name %>
+    </h1>
+
+    <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
+      <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
+        or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,19 @@ en:
           attributes:
             who_will_order:
               inclusion: Tell us who will order devices and laptops
+        responsible_body/devices/who_to_contact_form:
+          attributes:
+            who_to_contact:
+              inclusion: Tell us who we can contact at the school
+            full_name:
+              blank: Enter the contact’s full name
+              length: Enter a name that is between 2 and 1024 characters
+            email_address:
+              blank: Enter an email address in the correct format, like name@example.com
+              too_short: Enter an email address that is at least %{count} characters
+              invalid: Enter an email address in the correct format, like name@example.com
+            phone_number:
+              blank: Enter the contact’s telephone
   activerecord:
     attributes:
       api_token:
@@ -173,6 +186,7 @@ en:
           needs_info: Needs information
           ready: Ready
           school_contacted: School contacted
+          school_will_be_contacted: School to be contacted shortly
       school_device_allocation:
         device_type:
           std_device: 'Standard device (laptop etc)'
@@ -226,6 +240,10 @@ en:
       who_will_order:
         update:
           success: We’ve saved your choice
+      schools:
+        who_to_contact:
+          create:
+            success: "Saved. We will email %{email_address} shortly"
     home:
       bt_wifi_offer:
         number_eligible: Eligible young people

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,11 @@ Rails.application.routes.draw do
       get '/who-will-order', to: 'who_will_order#show'
       get '/who-will-order/edit', to: 'who_will_order#edit'
       patch '/who-will-order', to: 'who_will_order#update'
+
+      resources :schools, only: %i[index show update], param: :urn do
+        get '/who-to-contact', to: 'who_to_contact#new'
+        post '/who-to-contact', to: 'who_to_contact#create'
+      end
     end
     namespace :internet do
       get '/', to: 'home#show'
@@ -71,9 +76,6 @@ Rails.application.routes.draw do
       end
     end
     resources :users
-    namespace :devices do
-      resources :schools, only: %i[index show], param: :urn
-    end
   end
 
   namespace :support do

--- a/spec/components/school_details_summary_list_component_spec.rb
+++ b/spec/components/school_details_summary_list_component_spec.rb
@@ -2,16 +2,86 @@ require 'rails_helper'
 
 describe SchoolDetailsSummaryListComponent do
   let(:school) { create(:school, :primary, :la_maintained) }
+  let(:headteacher) do
+    create(:school_contact, :headteacher,
+           full_name: 'Davy Jones',
+           email_address: 'davy.jones@school.sch.uk',
+           phone_number: '12345')
+  end
 
-  it 'renders the status' do
-    create(:preorder_information, school: school, who_will_order_devices: :school)
-    create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+  subject(:result) { render_inline(described_class.new(school: school)) }
 
-    result = render_inline(described_class.new(school: school))
+  context 'when the school will place device orders' do
+    before do
+      create(:preorder_information, school: school, who_will_order_devices: :school)
+      create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+    end
 
-    expect(result.css('dd')[0].text).to include('Needs a contact')
-    expect(result.css('dd')[1].text).to include('3 devices')
-    expect(result.css('dd')[2].text).to include('Primary school')
-    expect(result.css('dd')[3].text).to include('The school orders devices')
+    it 'confirms that fact' do
+      expect(result.css('dd')[3].text).to include('The school orders devices')
+    end
+
+    it 'renders the school allocation' do
+      expect(result.css('dd')[1].text).to include('3 devices')
+    end
+
+    it 'renders the school type' do
+      expect(result.css('dd')[2].text).to include('Primary school')
+    end
+
+    it 'renders the school details' do
+      expect(result.css('dd')[0].text).to include('Needs a contact')
+    end
+
+    context 'and the headteacher has been set as the school contact' do
+      it 'displays the headteacher details' do
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: headteacher)
+
+        expect(result.css('dt')[4].text).to include('School contact')
+        expect(result.css('dd')[4].text).to include('Headteacher: Davy Jones')
+        expect(result.css('dd')[4].text).to include('davy.jones@school.sch.uk')
+        expect(result.css('dd')[4].text).to include('12345')
+      end
+    end
+
+    context 'and someone else has been set as the school contact' do
+      it "displays the new contact's details" do
+        new_contact = create(:school_contact, :contact,
+                             full_name: 'Jane Smith',
+                             email_address: 'abc@example.com',
+                             phone_number: '12345')
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: new_contact)
+
+        expect(result.css('dt')[4].text).to include('School contact')
+        expect(result.css('dd')[4].text).to include('Jane Smith')
+        expect(result.css('dd')[4].text).to include('abc@example.com')
+        expect(result.css('dd')[4].text).to include('12345')
+      end
+    end
+  end
+
+  context 'when the responsible body will place device orders' do
+    let(:school) { create(:school, :primary, :academy) }
+
+    it 'confirms that fact' do
+      create(:preorder_information, school: school, who_will_order_devices: :responsible_body)
+
+      expect(result.css('dd')[3].text).to include('The trust orders devices')
+    end
+
+    it 'does not show the school contact even if the school contact is set' do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :responsible_body,
+             school_contact: headteacher)
+
+      expect(result.css('dl').text).not_to include('School contact')
+    end
   end
 end

--- a/spec/factories/school_contacts.rb
+++ b/spec/factories/school_contacts.rb
@@ -1,10 +1,18 @@
 FactoryBot.define do
   factory :school_contact do
+    trait :headteacher do
+      role { 'headteacher' }
+      title { 'Headteacher' }
+    end
+
+    trait :contact do
+      role { 'contact' }
+    end
+
     school
     full_name { Faker::Name.unique.name }
     email_address { Faker::Internet.unique.email }
-    role { 'headteacher' }
-    title { 'Headteacher' }
     phone_number { Faker::PhoneNumber.phone_number }
+    headteacher
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -21,10 +21,12 @@ FactoryBot.define do
 
     trait :academy do
       establishment_type { :academy }
+      association :responsible_body, factory: :trust
     end
 
     trait :la_maintained do
       establishment_type { :local_authority }
+      association :responsible_body, factory: :local_authority
     end
   end
 end


### PR DESCRIPTION
### Context

Responsible bodies want to nominate school contacts for managing device orders. These contacts can either be someone they already work with or a headteacher who might be able to identify the right person within the school.

### Changes proposed in this pull request

Add a form for capturing the school contact.

## Screenshots

![image](https://user-images.githubusercontent.com/23801/91052172-fe672e80-e618-11ea-83df-1bd739f87d4b.png)
