### PR TITLE
Next school link

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -8,4 +8,11 @@ class ResponsibleBody < ApplicationRecord
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end
+
+  def next_school_sorted_ascending_by_name(school)
+    schools
+      .where('name > ?', school.name)
+      .order(name: :asc)
+      .first
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -52,4 +52,8 @@ class School < ApplicationRecord
       'needs_contact'
     end
   end
+
+  def next_school_in_responsible_body_when_sorted_by_name_ascending
+    responsible_body.next_school_sorted_ascending_by_name(self)
+  end
 end

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -7,8 +7,6 @@
       <%= @school.name %>
     </h1>
 
-    <div class="govuk-inset-text govuk-!-padding-top-0">
-      <%= render SchoolDetailsSummaryListComponent.new(school: @school) %>
-    </div>
+    <%= render SchoolDetailsSummaryListComponent.new(school: @school) %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -8,5 +8,12 @@
     </h1>
 
     <%= render SchoolDetailsSummaryListComponent.new(school: @school) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
+      <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
+        or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Setting up the devices ordering' do
   let(:responsible_body_school_page) { PageObjects::ResponsibleBody::SchoolPage.new }
 
   before do
-    _zebra_school = create(:school, :la_maintained, :secondary,
+    @zebra_school = create(:school, :la_maintained, :secondary,
                            responsible_body: responsible_body,
                            name: 'Zebra Secondary School')
     @aardvark_school = create(:school, :la_maintained, :primary,
@@ -27,9 +27,12 @@ RSpec.feature 'Setting up the devices ordering' do
     and_the_list_shows_that_schools_will_place_all_orders
     and_each_school_needs_a_contact
 
-    when_i_click_on_a_school_name
-    then_i_see_the_details_of_the_school
+    when_i_click_on_the_first_school_name
+    then_i_see_the_details_of_the_first_school
     and_that_the_school_orders_devices
+
+    when_i_follow_the_link_to_the_next_school
+    then_i_see_the_details_of_the_second_school
   end
 
   scenario 'devolving device ordering mostly centrally' do
@@ -41,8 +44,8 @@ RSpec.feature 'Setting up the devices ordering' do
     and_the_list_shows_that_the_responsible_body_will_place_all_orders
     and_each_school_needs_information
 
-    when_i_click_on_a_school_name
-    then_i_see_the_details_of_the_school
+    when_i_click_on_the_first_school_name
+    then_i_see_the_details_of_the_first_school
     and_that_the_local_authority_orders_devices
   end
 
@@ -132,14 +135,20 @@ RSpec.feature 'Setting up the devices ordering' do
     expect(responsible_body_schools_page.school_rows[1].who_will_order_devices).to have_content('Local authority')
   end
 
-  def when_i_click_on_a_school_name
+  def when_i_click_on_the_first_school_name
     click_on @aardvark_school.name
   end
 
-  def then_i_see_the_details_of_the_school
+  def then_i_see_the_details_of_the_first_school
     expect(responsible_body_school_page).to have_content(@aardvark_school.name)
     expect(responsible_body_school_page.school_details).to have_content('42 devices')
     expect(responsible_body_school_page.school_details).to have_content('Primary school')
+  end
+
+  def then_i_see_the_details_of_the_second_school
+    expect(responsible_body_school_page).to have_content(@zebra_school.name)
+    expect(responsible_body_school_page.school_details).to have_content('0 devices')
+    expect(responsible_body_school_page.school_details).to have_content('Secondary school')
   end
 
   def and_that_the_school_orders_devices
@@ -150,5 +159,9 @@ RSpec.feature 'Setting up the devices ordering' do
   def and_that_the_local_authority_orders_devices
     expect(responsible_body_school_page.school_details).to have_content('Needs information')
     expect(responsible_body_school_page.school_details).to have_content('The local authority orders devices')
+  end
+
+  def when_i_follow_the_link_to_the_next_school
+    click_on 'go to the next school'
   end
 end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody, type: :model do
+  subject(:local_authority) { create(:local_authority) }
+
+  describe '#next_school_sorted_ascending_by_name' do
+    it 'allows navigating down a list of alphabetically-sorted schools' do
+      zebra = create(:school, name: 'Zebra', responsible_body: local_authority)
+      aardvark = create(:school, name: 'Aardvark', responsible_body: local_authority)
+      tiger = create(:school, name: 'Tiger', responsible_body: local_authority)
+
+      expect(local_authority.next_school_sorted_ascending_by_name(aardvark)).to eq(tiger)
+      expect(local_authority.next_school_sorted_ascending_by_name(tiger)).to eq(zebra)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Responsible body users potentially need to process a large number of schools quickly. We want to save them having to click and search.

### Changes proposed in this pull request

Add a link to the school details page to go to the next school alphabetically.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/90990969-798aff00-e59d-11ea-81fe-a791289a881f.png)
