### PR TITLE
Add school contact to preorder information

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -2,6 +2,7 @@ class PreorderInformation < ApplicationRecord
   self.table_name = 'preorder_information'
 
   belongs_to :school
+  belongs_to :school_contact, optional: true
 
   validates :status, presence: true
 

--- a/db/migrate/20200823134357_add_contact_reference_to_preorder_information.rb
+++ b/db/migrate/20200823134357_add_contact_reference_to_preorder_information.rb
@@ -1,0 +1,5 @@
+class AddContactReferenceToPreorderInformation < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :preorder_information, :school_contact, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,8 @@ ActiveRecord::Schema.define(version: 2020_08_23_233442) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
+    t.bigint "school_contact_id"
+    t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"
   end
@@ -171,6 +173,7 @@ ActiveRecord::Schema.define(version: 2020_08_23_233442) do
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
   add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
+  add_foreign_key "preorder_information", "school_contacts"
   add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "schools", "responsible_bodies"
 end


### PR DESCRIPTION
### Context

When device ordering has been devolved to the school, the responsible body is asked to nominate a contact for that school. We need to store this information somewhere (on the preorder information record).

### Changes proposed in this pull request

Added DB migration and ActiveRecord associations.
