### PR TITLE
Set initial status on PreorderInformation and disallow it to be null

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -3,6 +3,8 @@ class PreorderInformation < ApplicationRecord
 
   belongs_to :school
 
+  validates :status, presence: true
+
   enum status: {
     needs_contact: 'needs_contact',
     needs_info: 'needs_info',

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -15,6 +15,11 @@ class PreorderInformation < ApplicationRecord
     responsible_body: 'responsible_body',
   }
 
+  def initialize(*args)
+    super
+    set_defaults
+  end
+
   # Update this method as we add more fields (e.g. chromebook info)
   # with reference to the prototype:
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html
@@ -33,5 +38,11 @@ class PreorderInformation < ApplicationRecord
     when 'responsible_body'
       school.responsible_body.humanized_type.capitalize
     end
+  end
+
+private
+
+  def set_defaults
+    self.status ||= infer_status
   end
 end

--- a/db/migrate/20200823233442_disallow_null_preorder_information_status.rb
+++ b/db/migrate/20200823233442_disallow_null_preorder_information_status.rb
@@ -1,0 +1,8 @@
+class DisallowNullPreorderInformationStatus < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up   { change_column :preorder_information, :status, :string, null: false }
+      dir.down { change_column :preorder_information, :status, :string, null: true }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_202014) do
+ActiveRecord::Schema.define(version: 2020_08_23_233442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2020_08_21_202014) do
     t.string "who_will_order_devices", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status"
+    t.string "status", null: false
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -107,12 +107,11 @@ RSpec.describe School, type: :model do
     end
 
     context 'when the school has a preorder_information record without a status' do
-      before do
-        PreorderInformation.new(school: school, status: nil)
-      end
-
       it 'infers the status' do
+        school.build_preorder_information
+        school.preorder_information.status = nil
         allow(school.preorder_information).to receive(:infer_status).and_return('inferred_status')
+
         expect(school.preorder_status_or_default).to eq('inferred_status')
       end
     end


### PR DESCRIPTION
### Context

There's no good reason for `PreorderInformation#status` to ever be null. It would introduce lots of conditional complexity if we allowed this to creep into the data.

### Changes proposed in this pull request

- infer the status when `PreorderInformation` is initialised
- validate `status` in the AR model
- disallow `status` to be null in the DB

### Guidance to review

We don't need a data migration because these records haven't been created anywhere yet.