### PR TITLE
Update deprecated option in webpacker config

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend/govuk']
+  additional_paths: ['node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
Without this change, running specs printed out loads of warnings:

The resolved_paths option has been deprecated. Use additional_paths instead.
