### PR TITLE
Prepare school details summary list for showing school contacts

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -1,6 +1,10 @@
 class SchoolDetailsSummaryListComponent < ViewComponent::Base
   validates :school, presence: true
 
+  delegate :school_will_order_devices?,
+           :school_contact,
+           to: :preorder_information
+
   def initialize(school:)
     @school = school
   end
@@ -23,6 +27,31 @@ class SchoolDetailsSummaryListComponent < ViewComponent::Base
         key: 'Who will order?',
         value: "The #{@school.preorder_information.who_will_order_devices_label.downcase} orders devices",
       },
-    ]
+    ] + school_contact_row_if_contact_present
+  end
+
+private
+
+  def school_contact_row_if_contact_present
+    if school_will_order_devices? && school_contact.present?
+      [{
+        key: 'School contact',
+        value: contact_lines.join('<br>'),
+      }]
+    else
+      []
+    end
+  end
+
+  def contact_lines
+    [
+      school_contact.title.present? ? "#{school_contact.title.upcase_first}: #{school_contact.full_name}" : school_contact.full_name,
+      school_contact.email_address,
+      school_contact.phone_number,
+    ].reject(&:blank?)
+  end
+
+  def preorder_information
+    @school.preorder_information
   end
 end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -16,7 +16,7 @@ class PreorderInformation < ApplicationRecord
   enum who_will_order_devices: {
     school: 'school',
     responsible_body: 'responsible_body',
-  }
+  }, _suffix: 'will_order_devices'
 
   def initialize(*args)
     super
@@ -27,7 +27,7 @@ class PreorderInformation < ApplicationRecord
   # with reference to the prototype:
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html
   def infer_status
-    if who_will_order_devices == 'school'
+    if school_will_order_devices?
       'needs_contact'
     else
       'needs_info'

--- a/spec/components/school_details_summary_list_component_spec.rb
+++ b/spec/components/school_details_summary_list_component_spec.rb
@@ -2,16 +2,86 @@ require 'rails_helper'
 
 describe SchoolDetailsSummaryListComponent do
   let(:school) { create(:school, :primary, :la_maintained) }
+  let(:headteacher) do
+    create(:school_contact, :headteacher,
+           full_name: 'Davy Jones',
+           email_address: 'davy.jones@school.sch.uk',
+           phone_number: '12345')
+  end
 
-  it 'renders the status' do
-    create(:preorder_information, school: school, who_will_order_devices: :school)
-    create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+  subject(:result) { render_inline(described_class.new(school: school)) }
 
-    result = render_inline(described_class.new(school: school))
+  context 'when the school will place device orders' do
+    before do
+      create(:preorder_information, school: school, who_will_order_devices: :school)
+      create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+    end
 
-    expect(result.css('dd')[0].text).to include('Needs a contact')
-    expect(result.css('dd')[1].text).to include('3 devices')
-    expect(result.css('dd')[2].text).to include('Primary school')
-    expect(result.css('dd')[3].text).to include('The school orders devices')
+    it 'confirms that fact' do
+      expect(result.css('dd')[3].text).to include('The school orders devices')
+    end
+
+    it 'renders the school allocation' do
+      expect(result.css('dd')[1].text).to include('3 devices')
+    end
+
+    it 'renders the school type' do
+      expect(result.css('dd')[2].text).to include('Primary school')
+    end
+
+    it 'renders the school details' do
+      expect(result.css('dd')[0].text).to include('Needs a contact')
+    end
+
+    context 'and the headteacher has been set as the school contact' do
+      it 'displays the headteacher details' do
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: headteacher)
+
+        expect(result.css('dt')[4].text).to include('School contact')
+        expect(result.css('dd')[4].text).to include('Headteacher: Davy Jones')
+        expect(result.css('dd')[4].text).to include('davy.jones@school.sch.uk')
+        expect(result.css('dd')[4].text).to include('12345')
+      end
+    end
+
+    context 'and someone else has been set as the school contact' do
+      it "displays the new contact's details" do
+        new_contact = create(:school_contact, :contact,
+                             full_name: 'Jane Smith',
+                             email_address: 'abc@example.com',
+                             phone_number: '12345')
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: new_contact)
+
+        expect(result.css('dt')[4].text).to include('School contact')
+        expect(result.css('dd')[4].text).to include('Jane Smith')
+        expect(result.css('dd')[4].text).to include('abc@example.com')
+        expect(result.css('dd')[4].text).to include('12345')
+      end
+    end
+  end
+
+  context 'when the responsible body will place device orders' do
+    let(:school) { create(:school, :primary, :academy) }
+
+    it 'confirms that fact' do
+      create(:preorder_information, school: school, who_will_order_devices: :responsible_body)
+
+      expect(result.css('dd')[3].text).to include('The trust orders devices')
+    end
+
+    it 'does not show the school contact even if the school contact is set' do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :responsible_body,
+             school_contact: headteacher)
+
+      expect(result.css('dl').text).not_to include('School contact')
+    end
   end
 end

--- a/spec/factories/school_contacts.rb
+++ b/spec/factories/school_contacts.rb
@@ -1,10 +1,18 @@
 FactoryBot.define do
   factory :school_contact do
+    trait :headteacher do
+      role { 'headteacher' }
+      title { 'Headteacher' }
+    end
+
+    trait :contact do
+      role { 'contact' }
+    end
+
     school
     full_name { Faker::Name.unique.name }
     email_address { Faker::Internet.unique.email }
-    role { 'headteacher' }
-    title { 'Headteacher' }
     phone_number { Faker::PhoneNumber.phone_number }
+    headteacher
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -21,10 +21,12 @@ FactoryBot.define do
 
     trait :academy do
       establishment_type { :academy }
+      association :responsible_body, factory: :trust
     end
 
     trait :la_maintained do
       establishment_type { :local_authority }
+      association :responsible_body, factory: :local_authority
     end
   end
 end


### PR DESCRIPTION
### Context

A responsible body can see school details when they click on a school from the schools list. This list needs to dynamically show or hide the school contacts, depending on which contact has been chosen and whether that contact has been chosen.

### Changes proposed in this pull request

- make the school details summary list dynamically show or hide the chosen school contact
- improve its spec coverage
- some factory_bot factory improvements

### Guidance to review

It's this bit:

![image](https://user-images.githubusercontent.com/23801/91038237-5d6d7900-e602-11ea-8cfc-d701be9ae6f7.png)
