### PR TITLE
fix styling issue when only some rows of a summary list had Change links

### DIFF
--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -26,7 +26,7 @@
         <dd class="govuk-summary-list__actions">
           <%= link_to row[:action], row[:action_path], class: 'govuk-link govuk-!-display-none-print' %>
         </dd>
-      <% elsif any_row_has_action_span? %>
+      <% elsif any_row_has_action_or_change? %>
         <span class="govuk-summary-list__actions"></span>
       <% end %>
     </div>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -6,8 +6,8 @@ class SummaryListComponent < ViewComponent::Base
     @rows = rows
   end
 
-  def any_row_has_action_span?
-    @rows.select { |row| row.key?(:action) }.any?
+  def any_row_has_action_or_change?
+    @rows.select { |row| row.key?(:action) || row.key?(:change_path) }.any?
   end
 
 private

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -93,4 +93,20 @@ describe SummaryListComponent do
 
     expect(result.to_html).to include('<span class="govuk-summary-list__actions"></span>')
   end
+
+  it 'does render a span if any row has a change_path' do
+    rows = [{ key: 'Job',
+              value: ['Teacher', 'Clearcourt High'] },
+            { key: 'Working pattern',
+              value: "Full-time\n Omnis itaque rerum. Velit in ." },
+            { key: 'Description',
+              value: 'Cumque autem veritatis..' },
+            { key: 'Dates',
+              value: 'May 2003 - November 2019',
+              change_path: '/some/url' }]
+
+    result = render_inline(SummaryListComponent.new(rows: rows))
+
+    expect(result.to_html).to include('<span class="govuk-summary-list__actions"></span>')
+  end
 end


### PR DESCRIPTION
### Context

When some-but-not-all rows of a summary list had `change_path` given, the Change links would appear outside the extent of the divider lines, like this:

![Screen Shot 2020-08-24 at 12 09 07](https://user-images.githubusercontent.com/134501/91045614-1043d400-e60f-11ea-9817-1075ef8678af.png)


### Changes proposed in this pull request

Fix the issue above, so that it now looks like this:

![Screen Shot 2020-08-24 at 13 38 34](https://user-images.githubusercontent.com/134501/91045672-23ef3a80-e60f-11ea-8fe2-4eff87d59121.png)


### Guidance to review

