### PR TITLE
Add a page which points users to our support inbox

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,4 +14,6 @@ class PagesController < ApplicationController
   def about_increasing_mobile_data; end
 
   def accessibility; end
+
+  def request_a_change; end
 end

--- a/app/views/pages/request_a_change.html.erb
+++ b/app/views/pages/request_a_change.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.request_a_change') %>
+    </h1>
+
+    <p class="govuk-body">
+      Email <%= ghwt_contact_mailto(subject: 'Request a change') %> with details of what you want to change. We’ll let you know once we’ve updated things for you.
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
     who_will_order_show:
       schools: Each school will manage their own orders
       responsible_body: All orders will be managed centrally
+    request_a_change: Contact our support team to request this change
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get '/increasing-mobile-data/privacy-notice', to: 'pages#increasing_mobile_data_privacy_notice'
   get '/accessibility', to: 'pages#accessibility'
   get '/mobile-privacy', to: redirect('/increasing-mobile-data/privacy-notice')
+  get '/request-a-change', to: 'pages#request_a_change'
 
   # redirects for moved guidance pages
   get '/pages/guidance', to: redirect('/')


### PR DESCRIPTION
### Context

When we've not built the self-serve functionality for stuff that users want to change, we will point them to support instead.

### Changes proposed in this pull request

Add a static page that can be linked to from the UI, when a user clicks a change link.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/91047890-b513e080-e612-11ea-83cc-5517d74f43a8.png)


