### PR TITLE
510 allow responsible bodies to change who will order for a school

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -26,6 +26,8 @@ class SchoolDetailsSummaryListComponent < ViewComponent::Base
       {
         key: 'Who will order?',
         value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
+        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+        action: 'who will order',
       },
     ] + school_contact_row_if_contact_present + chromebook_rows_if_needed
   end
@@ -64,16 +66,19 @@ private
           key: 'Ordering Chromebooks?',
           value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
           change_path: change_path,
+          action: 'whether Chromebooks are needed',
         },
         info.school_or_rb_domain && {
           key: 'Domain',
           value: info.school_or_rb_domain,
           change_path: change_path,
+          action: 'Domain',
         },
         info.recovery_email_address && {
           key: 'Recovery email',
           value: info.recovery_email_address,
           change_path: change_path,
+          action: 'Recovery email',
         },
       ].compact
     else

--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -1,0 +1,39 @@
+class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::Devices::BaseController
+  before_action :set_school
+
+  def edit
+    @form = ResponsibleBody::Devices::WhoWillOrderForm.new(
+      who_will_order: who_will_order,
+    )
+  end
+
+  def update
+    @form = ResponsibleBody::Devices::WhoWillOrderForm.new(who_will_order_params)
+    if @form.valid?
+      @school.preorder_information.change_who_will_order_devices!(@form.who_will_order.singularize)
+
+      flash[:notice] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
+      redirect_to responsible_body_devices_school_path(@school.urn)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  rescue ActionController::ParameterMissing
+    @form = ResponsibleBody::Devices::WhoWillOrderForm.new
+    render :edit, status: :unprocessable_entity
+  end
+
+private
+
+  def set_school
+    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
+  end
+
+  def who_will_order
+    who = @school.preorder_information.who_will_order_devices
+    who == 'school' ? 'schools' : who
+  end
+
+  def who_will_order_params(opts = params)
+    opts.require(:responsible_body_devices_who_will_order_form).permit(:who_will_order)
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -82,6 +82,20 @@ module ViewHelper
     ]
   end
 
+  def change_who_will_order_devices_options
+    scope = 'page_titles.change_who_will_order_edit'
+    [
+      OpenStruct.new(
+        id: 'schools',
+        label: t('schools', scope: scope),
+      ),
+      OpenStruct.new(
+        id: 'responsible_body',
+        label: t('responsible_body', scope: scope),
+      ),
+    ]
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -37,6 +37,12 @@ class PreorderInformation < ApplicationRecord
     end
   end
 
+  def change_who_will_order_devices!(who)
+    self.who_will_order_devices = who
+    self.status = infer_status
+    save!
+  end
+
   def who_will_order_devices_label
     case who_will_order_devices
     when 'school'

--- a/app/views/responsible_body/devices/change_who_will_order/edit.html.erb
+++ b/app/views/responsible_body/devices/change_who_will_order/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.change_who_will_order'), @form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: responsible_body_devices_school_change_who_will_order_path(@school.urn), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%- # this hidden field prevents ActionController::ParameterMissing errors
+          # if the user clicks submit without selecting anything,
+          # and therefore we don't actually get any params %>
+      <%= f.hidden_field :placeholder, value: '' %>
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <%= t('page_titles.change_who_will_order') %>
+      </h1>
+
+      <%= f.govuk_collection_radio_buttons  :who_will_order,
+                                            change_who_will_order_devices_options,
+                                            :id,
+                                            :label %>
+
+      <%= f.govuk_submit %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,10 @@ en:
       schools: Each school will manage their own orders
       responsible_body: All orders will be managed centrally
     request_a_change: Contact our support team to request this change
+    change_who_will_order: Who will place orders for laptops and tablets?
+    change_who_will_order_edit:
+      schools: The school will place their own orders
+      responsible_body: Orders will be placed centrally
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
       resources :schools, only: %i[index show update], param: :urn do
         get '/who-to-contact', to: 'who_to_contact#new'
         post '/who-to-contact', to: 'who_to_contact#create'
+        get '/change-who-will-order', to: 'change_who_will_order#edit'
+        patch '/change-who-will-order', to: 'change_who_will_order#update'
       end
     end
     namespace :internet do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 2020_08_24_125255) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
-    t.string "school_or_rb_domain"
-    t.string "recovery_email_address"
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"
+    t.string "school_or_rb_domain"
+    t.string "recovery_email_address"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/spec/components/school_details_summary_list_component_spec.rb
+++ b/spec/components/school_details_summary_list_component_spec.rb
@@ -41,9 +41,9 @@ describe SchoolDetailsSummaryListComponent do
                school_contact: headteacher)
 
         expect(result.css('dt')[4].text).to include('School contact')
-        expect(result.css('dd')[4].text).to include('Headteacher: Davy Jones')
-        expect(result.css('dd')[4].text).to include('davy.jones@school.sch.uk')
-        expect(result.css('dd')[4].text).to include('12345')
+        expect(result.css('dd')[5].text).to include('Headteacher: Davy Jones')
+        expect(result.css('dd')[5].text).to include('davy.jones@school.sch.uk')
+        expect(result.css('dd')[5].text).to include('12345')
       end
     end
 
@@ -59,9 +59,9 @@ describe SchoolDetailsSummaryListComponent do
                school_contact: new_contact)
 
         expect(result.css('dt')[4].text).to include('School contact')
-        expect(result.css('dd')[4].text).to include('Jane Smith')
-        expect(result.css('dd')[4].text).to include('abc@example.com')
-        expect(result.css('dd')[4].text).to include('12345')
+        expect(result.css('dd')[5].text).to include('Jane Smith')
+        expect(result.css('dd')[5].text).to include('abc@example.com')
+        expect(result.css('dd')[5].text).to include('12345')
       end
     end
   end

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature 'Setting up the devices ordering' do
     when_i_click_on_the_first_school_name
     then_i_see_the_details_of_the_first_school
     and_that_the_school_orders_devices
+    and_i_see_a_link_to_change_who_orders_devices
     and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
 
     when_i_select_to_contact_the_headteacher
@@ -69,6 +70,7 @@ RSpec.feature 'Setting up the devices ordering' do
     when_i_click_on_the_first_school_name
     then_i_see_the_details_of_the_first_school
     and_that_the_local_authority_orders_devices
+    and_i_see_a_link_to_change_who_orders_devices
   end
 
   scenario 'submitting the form without choosing an option shows an error' do
@@ -83,6 +85,26 @@ RSpec.feature 'Setting up the devices ordering' do
     when_i_visit_the_responsible_body_homepage
     when_i_follow_the_get_devices_link
     then_i_see_a_list_of_the_schools_i_am_responsible_for
+
+    when_i_click_on_the_first_school_name
+    then_i_see_the_details_of_the_first_school
+    and_that_the_school_orders_devices
+    and_i_see_a_link_to_change_who_orders_devices
+
+    when_i_follow_the_change_who_will_order_link
+    then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+
+    when_i_select_orders_will_be_placed_centrally
+    then_i_see_the_details_of_the_first_school
+    and_that_the_local_authority_orders_devices
+
+    when_i_follow_the_change_who_will_order_link
+    then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+
+    when_i_select_the_school_to_order_devices
+    then_i_see_the_details_of_the_first_school
+    and_that_the_school_orders_devices
+    and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
   end
 
   def when_i_follow_the_get_devices_link
@@ -221,5 +243,27 @@ RSpec.feature 'Setting up the devices ordering' do
     expect(responsible_body_school_page.school_details).to have_content('Bob Leigh')
     expect(responsible_body_school_page.school_details).to have_content('bob.leigh@sharedservices.co.uk')
     expect(responsible_body_school_page.school_details).to have_content('020 123456')
+  end
+
+  def and_i_see_a_link_to_change_who_orders_devices
+    expect(page).to have_link('Change who will order')
+  end
+
+  def when_i_follow_the_change_who_will_order_link
+    click_on 'Change who will order'
+  end
+
+  def then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+    expect(page).to have_content('Who will place orders for laptops and tablets?')
+  end
+
+  def when_i_select_the_school_to_order_devices
+    choose('The school will place their own orders')
+    click_on 'Continue'
+  end
+
+  def when_i_select_orders_will_be_placed_centrally
+    choose('Orders will be placed centrally')
+    click_on 'Continue'
   end
 end

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def when_i_click_on_the_change_link
-    first('a', text: 'Change').click
+    first('a', text: 'Change whether Chromebooks are needed').click
   end
 
   def and_choose_yes_they_will_need_chromebooks


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/tzMqOCU1/510-allow-responsible-bodies-to-change-who-will-order-for-a-school) Enable a responsible body to change who orders devices after the initial choice (mostly centralised/school) has been made

### Changes proposed in this pull request
Additional forms and choices, journey has deviated from prototype following discussion with @benilovj 

### Guidance to review
![Screenshot 2020-08-24 at 17 31 22](https://user-images.githubusercontent.com/333931/91071178-c7e8de00-e62f-11ea-8ad7-8e3a0e054fa1.png)
![Screenshot 2020-08-24 at 17 31 35](https://user-images.githubusercontent.com/333931/91071199-cf0fec00-e62f-11ea-8951-df3cea1b6fbd.png)
![Screenshot 2020-08-24 at 17 31 53](https://user-images.githubusercontent.com/333931/91071222-d6cf9080-e62f-11ea-84ed-de6c6ddb7cbe.png)

