### PR TITLE
Fix display of school contacts

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -38,7 +38,7 @@ private
     if school_will_order_devices? && school_contact.present?
       [{
         key: 'School contact',
-        value: contact_lines.join('<br>'),
+        value: contact_lines.map { |line| h(line) }.join('<br>').html_safe,
       }]
     else
       []

--- a/spec/components/school_details_summary_list_component_spec.rb
+++ b/spec/components/school_details_summary_list_component_spec.rb
@@ -41,9 +41,7 @@ describe SchoolDetailsSummaryListComponent do
                school_contact: headteacher)
 
         expect(result.css('dt')[4].text).to include('School contact')
-        expect(result.css('dd')[5].text).to include('Headteacher: Davy Jones')
-        expect(result.css('dd')[5].text).to include('davy.jones@school.sch.uk')
-        expect(result.css('dd')[5].text).to include('12345')
+        expect(result.css('dd')[5].inner_html).to include('Headteacher: Davy Jones<br>davy.jones@school.sch.uk<br>12345')
       end
     end
 


### PR DESCRIPTION
### Context

The `<br>` was being eaten and so the contact details ran into each other as one long string.

### Changes proposed in this pull request

Escape the user-generated content but mark the `<br>` tags as safe.

### Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/91101107-4f4d4600-e65e-11ea-8ab5-445deffdecf9.png)

After:

![image](https://user-images.githubusercontent.com/23801/91101074-42305700-e65e-11ea-91ba-fc259666b4b5.png)


