### PR TITLE
replace is_dfe?/is_computacenter? methods with explicit user flags

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -86,7 +86,7 @@ private
   def root_url_for(user)
     if user.is_mno_user?
       mno_extra_mobile_data_requests_path
-    elsif user.is_dfe?
+    elsif user.is_support?
       support_service_performance_path
     elsif user.is_responsible_body_user?
       responsible_body_home_path

--- a/app/controllers/support/base_controller.rb
+++ b/app/controllers/support/base_controller.rb
@@ -6,7 +6,7 @@ private
   def require_dfe_user!
     if !SessionService.is_signed_in?(session)
       redirect_to_sign_in
-    elsif !@user.is_dfe?
+    elsif !@user.is_support?
       render 'errors/forbidden', status: :forbidden
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,14 +29,6 @@ class User < ApplicationRecord
     responsible_body.present?
   end
 
-  def is_dfe?
-    email_address.present? && email_address.match?(/[\.@]education.gov.uk$/)
-  end
-
-  def is_computacenter?
-    email_address.present? && email_address.match?(/@computacenter.com$/)
-  end
-
   def update_sign_in_count_and_timestamp!
     update(sign_in_count: sign_in_count + 1, last_signed_in_at: Time.zone.now)
   end

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,5 +1,5 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-  <%- if @user&.is_dfe? %>
+  <%- if @user&.is_support? %>
     <%= nav_item( title: "Service performance", url: support_service_performance_path )  %>
     <%= nav_item( title: "Responsible bodies", url: support_responsible_bodies_path )  %>
     <%= nav_item( title: "Background jobs", url: support_sidekiq_admin_path, html_options: {target: '_blank'} )  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[new create]
     end
 
-    mount Sidekiq::Web => '/sidekiq', constraints: RequireDFEUserConstraint.new, as: :sidekiq_admin
+    mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin
   end
 
   namespace :computacenter do

--- a/db/migrate/20200825080212_add_user_support_and_computacenter_flags.rb
+++ b/db/migrate/20200825080212_add_user_support_and_computacenter_flags.rb
@@ -1,0 +1,17 @@
+class AddUserSupportAndComputacenterFlags < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |migrate|
+      migrate.up do
+        add_column :users, :is_support, :boolean, null: false, default: false
+        add_column :users, :is_computacenter, :boolean, null: false, default: false
+
+        User.where('email_address LIKE ?', '%education.gov.uk').update!(is_support: true)
+        User.where('email_address LIKE ?', '%computacenter.com').update!(is_computacenter: true)
+      end
+      migrate.down do
+        remove_column :users, :is_support
+        remove_column :users, :is_computacenter
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_125255) do
+ActiveRecord::Schema.define(version: 2020_08_25_080212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,6 +166,8 @@ ActiveRecord::Schema.define(version: 2020_08_24_125255) do
     t.integer "sign_in_count", default: 0
     t.datetime "last_signed_in_at"
     t.string "telephone"
+    t.boolean "is_support", default: false, null: false
+    t.boolean "is_computacenter", default: false, null: false
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"

--- a/lib/constraints/require_dfe_user_constraint.rb
+++ b/lib/constraints/require_dfe_user_constraint.rb
@@ -1,8 +1,8 @@
-class RequireDFEUserConstraint
+class RequireSupportUserConstraint
   def matches?(request)
     return false unless request.session[:user_id]
 
     user = SessionService.identify_user!(request.session)
-    user&.is_dfe?
+    user&.is_support?
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -37,16 +37,18 @@ FactoryBot.define do
     end
 
     factory :mno_user do
-      association   :mobile_network
+      association :mobile_network
     end
 
     factory :dfe_user do
+      is_support { true }
       email_address do
         full_name.downcase.gsub(' ', '.') + ['@digital.education.gov.uk', '@education.gov.uk'].sample
       end
     end
 
     factory :computacenter_user do
+      is_computacenter { true }
       email_address do
         full_name.downcase.gsub(' ', '.') + '@computacenter.com'
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,33 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe '#is_dfe?' do
-    it 'is true when email address ends in education.gov.uk' do
-      user = build(:user, email_address: 'someone@education.gov.uk')
-      expect(user.is_dfe?).to be_truthy
-    end
-
-    it 'is true when email address ends in digital.education.gov.uk' do
-      user = build(:user, email_address: 'someone@digital.education.gov.uk')
-      expect(user.is_dfe?).to be_truthy
-    end
-
-    it 'is false when email address ends in education.gov' do
-      user = build(:user, email_address: 'someone@education.gov')
-      expect(user.is_dfe?).to be_falsey
-    end
-
-    it 'is false when email address contains education.gov.uk but does not end with it' do
-      user = build(:user, email_address: 'phishing@education.gov.uk.spamdomain.com')
-      expect(user.is_dfe?).to be_falsey
-    end
-
-    it 'is false when email address ends in computacenter.com' do
-      user = build(:user, email_address: 'someone@computacenter.com')
-      expect(user.is_dfe?).to be_falsey
-    end
-  end
-
   describe '#is_mno_user?' do
     it 'is true when the user is from an MNO participating in the pilot' do
       user = build(:user, mobile_network: build(:mobile_network))
@@ -64,28 +37,6 @@ RSpec.describe User, type: :model do
     it 'is false for DfE users' do
       user = build(:user, responsible_body: nil, email_address: 'ab@education.gov.uk')
       expect(user.is_responsible_body_user?).to be_falsey
-    end
-  end
-
-  describe '#is_computacenter?' do
-    it 'is true when email address ends in computacenter.com' do
-      user = build(:user, email_address: 'someone@computacenter.com')
-      expect(user.is_computacenter?).to be_truthy
-    end
-
-    it 'is false when email address ends in education.gov.uk' do
-      user = build(:user, email_address: 'someone@education.gov.uk')
-      expect(user.is_computacenter?).to be_falsey
-    end
-
-    it 'is false when email address contains computacenter.com but does not end with it' do
-      user = build(:user, email_address: 'phishing@computacenter.com.spamdomain.com')
-      expect(user.is_computacenter?).to be_falsey
-    end
-
-    it 'is false when email address ends in some other .com' do
-      user = build(:user, email_address: 'someone@gmail.com')
-      expect(user.is_computacenter?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
### Context

We've been inferring whether users could access the support & computacenter interfaces based on their email domain.
This has worked OK, but it makes testing difficult - and especially for the external pentesting company, who haven't been able to test the support or computacenter interfaces yet as their email domain is their company.

### Changes proposed in this pull request

Replace the `is_dfe?` and `is_computacenter?` methods on `User` with explicit boolean flags
*NOTE* I also changed `is_dfe?` to `is_support?` - as it's more reflective of reality, and better matches the application file structure.

### Guidance to review

