### PR TITLE
Correct the colour of the 'ready' status tag

### DIFF
--- a/app/components/school_preorder_status_tag_component.rb
+++ b/app/components/school_preorder_status_tag_component.rb
@@ -16,7 +16,7 @@ class SchoolPreorderStatusTagComponent < ViewComponent::Base
     when 'school_contacted', 'school_will_be_contacted'
       :yellow
     when 'ready'
-      :green
+      :blue
     else
       :default
     end


### PR DESCRIPTION
### Context

The ready status badge is the wrong colour.

### Changes proposed in this pull request

Adjust the badge class.
