### PR TITLE
[527, 528] fix bugs with preorder information around schools needing chromebooks

### DIFF
--- a/app/components/school_details_summary_list_component.rb
+++ b/app/components/school_details_summary_list_component.rb
@@ -61,26 +61,31 @@ private
     info = @school.preorder_information
     if info&.needs_chromebook_information?
       change_path = responsible_body_devices_school_chromebooks_edit_path(school_urn: @school.urn)
-      [
+      rows = [
         info.will_need_chromebooks && {
           key: 'Ordering Chromebooks?',
           value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
           change_path: change_path,
           action: 'whether Chromebooks are needed',
         },
-        info.school_or_rb_domain && {
-          key: 'Domain',
-          value: info.school_or_rb_domain,
-          change_path: change_path,
-          action: 'Domain',
-        },
-        info.recovery_email_address && {
-          key: 'Recovery email',
-          value: info.recovery_email_address,
-          change_path: change_path,
-          action: 'Recovery email',
-        },
-      ].compact
+      ]
+      if info.will_need_chromebooks?
+        rows += [
+          info.school_or_rb_domain && {
+            key: 'Domain',
+            value: info.school_or_rb_domain,
+            change_path: change_path,
+            action: 'Domain',
+          },
+          info.recovery_email_address && {
+            key: 'Recovery email',
+            value: info.recovery_email_address,
+            change_path: change_path,
+            action: 'Recovery email',
+          },
+        ]
+      end
+      rows.compact
     else
       []
     end

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -16,7 +16,8 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
       { school: @school }.merge(chromebook_params),
     )
     if @chromebook_information_form.valid?
-      @preorder_info.update!(chromebook_params.merge(status: @preorder_info.infer_status))
+      @preorder_info.update!(chromebook_params)
+      @preorder_info.update!(status: @preorder_info.infer_status)
       redirect_to responsible_body_devices_school_path(urn: @school.urn)
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -16,8 +16,7 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
       { school: @school }.merge(chromebook_params),
     )
     if @chromebook_information_form.valid?
-      @preorder_info.update!(chromebook_params)
-      @preorder_info.update!(status: @preorder_info.infer_status)
+      @preorder_info.update_chromebook_information_and_status!(chromebook_params)
       redirect_to responsible_body_devices_school_path(urn: @school.urn)
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -75,6 +75,11 @@ class PreorderInformation < ApplicationRecord
     end
   end
 
+  def update_chromebook_information_and_status!(params)
+    update!(params)
+    update!(status: infer_status)
+  end
+
 private
 
   def set_defaults

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -61,6 +61,12 @@ class PreorderInformation < ApplicationRecord
     who_will_order_devices == 'responsible_body'
   end
 
+  # prevent edge case where the built-in syntactic sugar for allows
+  # a value of 'no' to return will_need_chromebooks? as true (as it's not nil)
+  def will_need_chromebooks?
+    will_need_chromebooks == 'yes'
+  end
+
   def chromebook_information_complete?
     if will_need_chromebooks == 'yes'
       school_or_rb_domain.present? && recovery_email_address.present?

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -61,7 +61,7 @@ class PreorderInformation < ApplicationRecord
     who_will_order_devices == 'responsible_body'
   end
 
-  # prevent edge case where the built-in syntactic sugar for allows
+  # prevent edge case where the built-in (attribute name)? method allows
   # a value of 'no' to return will_need_chromebooks? as true (as it's not nil)
   def will_need_chromebooks?
     will_need_chromebooks == 'yes'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 2020_08_25_080212) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
-    t.bigint "school_contact_id"
-    t.string "will_need_chromebooks"
     t.string "school_or_rb_domain"
     t.string "recovery_email_address"
+    t.bigint "school_contact_id"
+    t.string "will_need_chromebooks"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Setting up the devices ordering' do
     when_i_choose_no_they_will_not_need_chromebooks
     and_i_click_save
     it_shows_me_that_they_will_not_need_chromebooks
+    and_the_status_has_changed_to_ready
     and_shows_me_a_link_to_change_whether_they_need_chromebooks
     when_i_click_on_the_change_link
     and_choose_yes_they_will_need_chromebooks
@@ -27,6 +28,7 @@ RSpec.feature 'Setting up the devices ordering' do
     it_shows_me_an_error
     when_i_provide_valid_entries_for_both_fields
     it_shows_the_chromebook_information_i_entered
+    and_it_shows_me_the_domain_and_recovery_email_rows
     and_the_status_has_changed_to_ready
   end
 
@@ -53,6 +55,20 @@ RSpec.feature 'Setting up the devices ordering' do
   def it_shows_me_that_they_will_not_need_chromebooks
     within('.govuk-summary-list') do
       expect(page).to have_content 'No, they will not need Chromebooks'
+    end
+  end
+
+  def and_it_shows_me_the_domain_and_recovery_email_rows
+    within('.govuk-summary-list') do
+      expect(page).to have_content 'Domain'
+      expect(page).to have_content 'Recovery email'
+    end
+  end
+
+  def and_it_does_not_show_me_the_domain_and_recovery_email_rows
+    within('.govuk-summary-list') do
+      expect(page).not_to have_content 'Domain'
+      expect(page).not_to have_content 'Recovery email'
     end
   end
 

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Setting up the devices ordering' do
     it_shows_me_that_they_will_not_need_chromebooks
     and_the_status_has_changed_to_ready
     and_shows_me_a_link_to_change_whether_they_need_chromebooks
+    and_it_does_not_show_me_the_domain_and_recovery_email_rows
     when_i_click_on_the_change_link
     and_choose_yes_they_will_need_chromebooks
     it_shows_me_fields_for_domain_and_recovery_email_address


### PR DESCRIPTION
### Context

[Trello card 528](https://trello.com/c/UwDJhUpJ/528-bug-school-preorder-info-status-should-update-to-ready-when-they-dont-need-chromebooks) In the RB interface, clicking 'No, they will not need chromebooks' + 'save' on a school should update its status to READY.
It was not doing that, because of Rails' auto-created methods & type inference meaning that `will_need_chromebooks?` was returning `true` when the field had a value of 'no' (because it's not `nil`, therefore '(attr_name)?' is true)

[Trello card 527](https://trello.com/c/IuWBUbSX/527-dont-show-chromebook-details-if-chromebooks-wont-be-ordered) - it was still showing the domain & recovery email fields when `will_need_chromebooks` was `no` 

### Changes proposed in this pull request

Fix both bugs, and add explicit tests for this behaviour

### Guidance to review

