### PR TITLE
Update content to latest version

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -71,13 +71,13 @@ module ViewHelper
     [
       OpenStruct.new(
         id: 'schools',
-        label: 'Most schools will manage their own orders (recommended)',
+        label: 'Most schools will place their own orders (recommended)',
         description: 'We’ll need contact details for each school',
       ),
       OpenStruct.new(
         id: 'responsible_body',
-        label: 'Most orders will be managed centrally',
-        description: 'You’ll need to order devices for all schools and give technical settings for any school that wants to order Chromebooks.',
+        label: 'Most orders will be placed centrally',
+        description: 'You’ll need to place orders for schools and give technical information for any school that wants to order Chromebooks.',
       ),
     ]
   end

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -15,36 +15,38 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">Get laptops and tablets</span>
       <%= t('page_titles.responsible_body_devices_home') %>
     </h1>
 
-    <h2 class="govuk-heading-m">Schools can now order their own devices</h2>
-    <p class=govuk-body>
-      We recommend you let schools order their own devices. You will need to nominate someone in each school for us to contact.</p>
+    <h2 class="govuk-heading-m">Decide if schools can order their own devices</h2>
+    <p class="govuk-body">You can allow schools to order their own devices. Or you can manage some, or all, orders centrally.</p>
+    <p class="govuk-body">We recommend letting schools place orders because it’s the quickest way to get help to those who need it.</p>
+    <p class="govuk-body">You’ll need to nominate someone in each school for us to contact.</p>
 
-    <p class=govuk-body>Each contact will be able to:</p>
+    <p class="govuk-body">Each contact will be able to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>manage who can order devices for their school</li>
+      <li>manage who can order devices</li>
       <li>order devices themselves</li>
     </ul>
 
-    <h2 class="govuk-heading-m">Prepare before a lockdown</h2>
+    <h2 class="govuk-heading-m">Help schools prepare for disruption</h2>
 
-    <p class=govuk-body>Give us school details as soon as you can so we can contact them, and they can prepare before a local lockdown.</p>
+    <p class="govuk-body">Give us contact details as soon as you can so we can help schools prepare to deliver remote education if they need to.</p>
 
-    <h2 class="govuk-heading-m">Orders can only be placed during a lockdown</h2>
+    <h2 class="govuk-heading-m">Orders can only be placed when local coronavirus restrictions are confirmed</h2>
 
-    <p class=govuk-body>Schools that are closed or partially closed because of a local lockdown will be notified that they can now place orders for devices.</p>
+    <p class="govuk-body">We’ll contact people as soon as they’re able to place orders.</p>
 
-    <p class=govuk-body>Orders placed before 4pm will be delivered to schools the next working day.</p>
+    <p class="govuk-body">Orders placed before 4pm will normally be delivered to schools the next working day.</p>
 
     <h2 class="govuk-heading-m">Each school has their own allocation</h2>
 
-    <p class=govuk-body>Every school has its own allocation of devices. Allocations are based on free school meals and estimates of the number of devices a school already has.</p>
+    <p class="govuk-body">Every school has its own provisional allocation of laptops and tablets. Allocations are based on free school meal data and estimates of how many devices a school has already received.</p>
 
-    <p class=govuk-body>Numbers will be re-assessed at the time of ordering based on availability and the extent of coronavirus outbreaks.</p>
+    <p class="govuk-body">Numbers will be reassessed at the time of ordering based on availability and the extent of coronavirus restrictions.</p>
 
-    <%= govuk_button_link_to 'Continue', responsible_body_devices_who_will_order_edit_path, classes: 'govuk-!-margin-top-6' %>
+    <div class="govuk-!-margin-top-6">
+      <%= govuk_button_link_to 'Continue', responsible_body_devices_who_will_order_edit_path %>
+    </div>
   </div>
 </div>

--- a/app/views/responsible_body/devices/who_will_order/edit.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/edit.html.erb
@@ -20,6 +20,8 @@
                                             :label,
                                             :description %>
 
+      <p class="govuk-body">You can change this setting for each school later.</p>
+
       <%= f.govuk_submit %>
 
     <%- end %>

--- a/app/views/responsible_body/devices/who_will_order/show.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/show.html.erb
@@ -7,32 +7,34 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%- if @responsible_body.who_will_order_devices == 'schools' %>
-      <p class="govuk-body">We’ve set each school as managing their own orders. If a school cannot order its own devices, you can change this setting on a school by school basis.</p>
+      <p class="govuk-body">If a school cannot order its own devices, you can change this setting on a school-by-school basis.</p>
 
       <h2 class="govuk-heading-m">What you need to do now</h2>
 
-      <p class="govuk-body">For each school we need you to nominate a contact. Each contact will be able to:</p>
+      <p class="govuk-body">We need you to nominate a contact for each school.</p>
+
+      <p class="govuk-body">They can:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>manage who can order devices for their school</li>
-        <li>order devices for their schools</li>
+        <li>order devices for their school</li>
       </ul>
 
-      <p class="govuk-body">We’ll email everyone you nominate with instructions on how to order devices and what to do during a lockdown.</p>
-
-      <p class="govuk-body">If a school doesn’t respond, we’ll ask you to chase them or give us new contact details.</p>
+      <p class="govuk-body">If a school does not respond, we’ll ask you to chase them or give us different contact details.</p>
     <%- else %>
       <%- content_for :title, t(:responsible_body, scope: %i[page_titles who_will_order_show]) %>
-      <p class="govuk-body">We’ve set each school as having their orders managed centrally. If a school needs to order its own devices, you can change this setting on a school by school basis.</p>
+      <p class="govuk-body">If a school needs to order its own devices, you can change this setting on a school-by-school basis.</p>
 
       <h2 class="govuk-heading-m">What you need to do now</h2>
 
       <p class="govuk-body">For each school you’ll need to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>find out if they want Chromebooks </li>
+        <li>find out if they want Chromebooks</li>
         <li>give details of the school domain and recovery email address needed to configure them</li>
       </ul>
     <%- end %>
 
-    <%= govuk_button_link_to 'Go to your list of schools', responsible_body_devices_schools_path, classes: 'govuk-!-margin-top-6' %>
+    <div class="govuk-!-margin-top-6">
+      <%= govuk_button_link_to 'Go to your list of schools', responsible_body_devices_schools_path %>
+    </div>
   </div>
 </div>

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -12,10 +12,8 @@
 
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>give schools access</li>
-        <li>tell us who will order a school’s laptops and tablets</li>
-        <li>manage how schools order devices</li>
-        <li>give any details needed to order devices</li>
+        <li>tell us who will place orders for schools</li>
+        <li>give schools access to the services they need</li>
       </ul>
     <%- end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,10 +43,10 @@ en:
     accessibility: Accessibility statement
     support_responsible_bodies: On-boarded responsible bodies
     computacenter_home: Users with permission to place orders and receive support through Computacenter
-    who_will_order: Who will order a school’s laptops and tablets?
+    who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
-      schools: Each school will manage their own orders
-      responsible_body: All orders will be managed centrally
+      schools: Each school will place their own orders
+      responsible_body: Orders will be placed centrally
     request_a_change: Contact our support team to request this change
     change_who_will_order: Who will place orders for laptops and tablets?
     change_who_will_order_edit:

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -112,26 +112,26 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_i_continue_through_the_guidance
-    expect(page).to have_content 'Schools can now order their own devices'
+    expect(page).to have_content 'Decide if schools can order their own devices'
     expect(page).to have_link 'Continue'
     click_on 'Continue'
-    expect(page).to have_content 'Who will order a school’s laptops and tablets?'
-    expect(page).to have_field 'Most schools will manage their own orders (recommended)'
+    expect(page).to have_content 'Who will place orders for laptops and tablets?'
+    expect(page).to have_field 'Most schools will place their own orders (recommended)'
   end
 
   def and_i_choose_ordering_through_schools
-    choose 'Most schools will manage their own orders (recommended)'
+    choose 'Most schools will place their own orders (recommended)'
     click_on 'Continue'
     expect(page).to have_http_status(:ok)
-    expect(page).to have_content('We’ve set each school as managing their own orders')
+    expect(page).to have_content('Each school will place their own orders')
     click_on 'Go to your list of schools'
   end
 
   def and_i_choose_ordering_centrally
-    choose 'Most orders will be managed centrally'
+    choose 'Most orders will be placed centrally'
     click_on 'Continue'
     expect(page).to have_http_status(:ok)
-    expect(page).to have_content('We’ve set each school as having their orders managed centrally')
+    expect(page).to have_content('Orders will be placed centrally')
     click_on 'Go to your list of schools'
   end
 


### PR DESCRIPTION
Match prototype. Remove mentions of outbreaks and lockdowns. Say "place orders" not "manage orders", favour "place order" over "ordering device".

