### PR TITLE
Tweaks to the primary navigation

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -10,9 +10,6 @@
     <%= nav_item( title: "Your requests", url: mno_extra_mobile_data_requests_path )  %>
   <%- else %>
     <%= nav_item( title: "Guidance", url: guidance_page_path )  %>
-    <%- if @user&.is_responsible_body_user? %>
-      <%= nav_item( title: "Tell us who needs more data", url: responsible_body_internet_mobile_extra_data_requests_path )  %>
-    <%- end %>
   <%- end %>
 
   <%- if SessionService.is_signed_in?(session) && @user %>

--- a/app/views/layouts/_service_link.html.erb
+++ b/app/views/layouts/_service_link.html.erb
@@ -1,0 +1,2 @@
+<% home_page_link = @user&.is_responsible_body_user? ? responsible_body_home_path : "/" %>
+<%= link_to t('service_name'), home_page_link, class: "govuk-header__link govuk-header__link--service-name" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,8 +54,7 @@
           </div>
         <% else %>
           <div class="govuk-header__content">
-            <%= link_to t('service_name'), "/", class: "govuk-header__link govuk-header__link--service-name" %>
-
+            <%= render partial: 'layouts/service_link' %>
             <% unless controller.hide_nav_menu? %>
               <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
               <nav>

--- a/app/webpacker/styles/overrides.scss
+++ b/app/webpacker/styles/overrides.scss
@@ -33,6 +33,7 @@
     display: inline-block;
 
     .nav-button-as-link {
+      cursor: pointer;
       background-color: transparent;
       border: none;
       color: govuk-colour("white");


### PR DESCRIPTION
### Context

- Remove "Tell us who needs more data" link, it's not part of the design
- Fix cursor mouse over styles on Sign out button
- When signed in as a responsible body, make the service name link to the signed in home page