### PR TITLE
Layout fixes for Computacenter API screen

### DIFF
--- a/app/views/computacenter/api_tokens/index.html.erb
+++ b/app/views/computacenter/api_tokens/index.html.erb
@@ -10,43 +10,41 @@
 </div>
 
 <%- if @api_tokens.empty? %>
-  <p class="govuk-body">
-    (You don't have any API tokens at the moment)
+  <p class="govuk-body-l">
+    You don’t have any API tokens yet
   </p>
 <%- else %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header">
-              Name
-            </th>
-            <th class="govuk-table__header govuk-table__header--numeric">
-              Token
-            </th>
-            <th class="govuk-table__header">
-              Created
-            </th>
-            <th class="govuk-table__header">
-              Status
-            </th>
-            <th class="govuk-table__header">Actions</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <%= render partial: 'api_token', collection: @api_tokens %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">
+          Name
+        </th>
+        <th class="govuk-table__header govuk-table__header--numeric">
+          Token
+        </th>
+        <th class="govuk-table__header">
+          Created
+        </th>
+        <th class="govuk-table__header">
+          Status
+        </th>
+        <th class="govuk-table__header">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <%= render partial: 'api_token', collection: @api_tokens %>
+    </tbody>
+  </table>
 <%- end %>
 
 <div class="govuk-grid-row">
-  <h2 class="govuk-heading-l"><%= t('.form_header') %>.</h2>
-  <%= form_for @api_token, url: computacenter_api_tokens_path do |f| %>
-    <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :name, label: { size: 'm', text: t('.name') }, hint_text: t('.name_hint') %>
-    <%= f.govuk_submit t('.create') %>
-  <%- end %>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l"><%= t('.form_header') %></h2>
+    <%= form_for @api_token, url: computacenter_api_tokens_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :name, label: { size: 'm', text: t('.name') }, hint_text: t('.name_hint') %>
+      <%= f.govuk_submit t('.create') %>
+    <%- end %>
+  </div>
 </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -4,7 +4,6 @@
     <%= nav_item( title: "Responsible bodies", url: support_responsible_bodies_path )  %>
     <%= nav_item( title: "Background jobs", url: support_sidekiq_admin_path, html_options: {target: '_blank'} )  %>
   <%- elsif @user&.is_computacenter? %>
-    <%= nav_item( title: 'Home', url: '#') %>
     <%= nav_item( title: 'API tokens', url: computacenter_api_tokens_path) %>
   <%- elsif @user&.is_mno_user? %>
     <%= nav_item( title: "Your requests", url: mno_extra_mobile_data_requests_path )  %>


### PR DESCRIPTION
- Fix indenting of form, make it 2/3rds width
- Remove unnecessary wrapper from table
- Remove brackets from "No tokens yet" message
- Remove full stop from title

![Screen Shot 2020-08-25 at 15 21 29](https://user-images.githubusercontent.com/319055/91186218-aeef3400-e6e6-11ea-95e8-3981509000c5.png)
