### PR TITLE
452 manage rb users invite an rb user

### DIFF
--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -1,5 +1,5 @@
 class ResponsibleBody::UsersController < ResponsibleBody::BaseController
-  before_action :require_feature_flag!, only: %i[new create edit update]
+  before_action :require_feature_flag!, only: %i[edit update]
 
   def index
     @users = @responsible_body.users.order(:full_name)
@@ -48,6 +48,6 @@ private
   end
 
   def require_feature_flag!
-    render_404_if_feature_flag_inactive(:rbs_can_manage_users) unless params[:action].in?(%i[index show])
+    render_404_if_feature_flag_inactive(:rbs_can_manage_users) #unless params[:action].in?(%i[index show])
   end
 end

--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -17,7 +17,7 @@ class ResponsibleBody::UsersController < ResponsibleBody::BaseController
     )
     if @rb_user.valid?
       @rb_user.save!
-      # TODO: schedule job to send invite email here
+      InviteResponsibleBodyUserMailer.with(user: @rb_user).invite_user_email.deliver_later
       redirect_to responsible_body_users_path
     else
       render :new, status: :unprocessable_entity
@@ -48,6 +48,6 @@ private
   end
 
   def require_feature_flag!
-    render_404_if_feature_flag_inactive(:rbs_can_manage_users) #unless params[:action].in?(%i[index show])
+    render_404_if_feature_flag_inactive(:rbs_can_manage_users)
   end
 end

--- a/app/mailers/invite_responsible_body_user_mailer.rb
+++ b/app/mailers/invite_responsible_body_user_mailer.rb
@@ -1,0 +1,22 @@
+class InviteResponsibleBodyUserMailer < ApplicationMailer
+  def invite_user_email
+    @user = params[:user]
+    rb_name = @user.responsible_body.local_authority_official_name || @user.responsible_body.name
+    personalisation = {
+      email_address: @user.email_address,
+      responsible_body_name: rb_name,
+    }
+
+    template_mail(
+      notify_template_id,
+      to: @user.email_address,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def notify_template_id
+    Settings.govuk_notify.templates.devices.invite_responsible_body_user
+  end
+end

--- a/app/views/responsible_body/users/index.html.erb
+++ b/app/views/responsible_body/users/index.html.erb
@@ -34,7 +34,7 @@
       <%- end %>
     </ul>
 
-      <%= govuk_button_link_to 'Invite a new user', new_responsible_body_user_path %>
+    <%= govuk_button_link_to 'Invite a new user', new_responsible_body_user_path %>
 
     <%- unless @users.empty? %>
       <div id="user-list">

--- a/app/views/responsible_body/users/index.html.erb
+++ b/app/views/responsible_body/users/index.html.erb
@@ -24,8 +24,9 @@
       <%- if FeatureFlag.active?(:rbs_can_manage_users) %>
         <li>add or edit existing users</li>
       <%- else %>
-        <li>view the list of existing users</li>
+        <li>add users</li>
       <%- end %>
+      <li>view the list of existing users</li>
       <li>order devices for centrally managed schools</li>
       <%- if @responsible_body.in_connectivity_pilot? %>
         <li>download BT vouchers</li>
@@ -33,9 +34,7 @@
       <%- end %>
     </ul>
 
-    <%- if FeatureFlag.active?(:rbs_can_manage_users) %>
       <%= govuk_button_link_to 'Invite a new user', new_responsible_body_user_path %>
-    <%- end %>
 
     <%- unless @users.empty? %>
       <div id="user-list">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,8 @@ govuk_notify:
     extra_mobile_data_requests:
       mno_in_scheme_sms: 'a3610e88-4852-4acc-b22c-767899d2d4c7'
       mno_not_in_scheme_sms: '401aed7e-83ac-4e90-abac-3e2f9bc45a95'
+    devices:
+      invite_responsible_body_user: '42e5cd7a-deaa-4234-bdea-db63b7c4ad90'
 
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 2020_08_25_080212) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
-    t.string "school_or_rb_domain"
-    t.string "recovery_email_address"
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"
+    t.string "school_or_rb_domain"
+    t.string "recovery_email_address"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/spec/features/responsible_body/manage_users_spec.rb
+++ b/spec/features/responsible_body/manage_users_spec.rb
@@ -24,6 +24,41 @@ RSpec.feature 'Managing ResponsibleBody users' do
     expect(rb_users_index_page.user_rows[1]).to have_content(rb_user_2.full_name)
   end
 
+  it 'shows a link to Invite a new user' do
+    click_on 'Manage local authority users'
+    expect(page).to have_content 'Invite a new user'
+  end
+
+  context 'clicking "Invite a new user"' do
+    before do
+      click_on 'Manage local authority users'
+      click_on 'Invite a new user'
+    end
+
+    it 'shows the new user form' do
+      expect(new_rb_user_form).to be_displayed
+      expect(page).to have_field 'Name'
+      expect(page).to have_field 'Email address'
+      expect(page).to have_field 'Telephone number'
+    end
+
+    it 'shows an error when I submit the form with missing fields' do
+      click_on('Send invite')
+      expect(page).to have_content('There is a problem')
+      expect(page).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'adds the user when I submit the form with all required fields' do
+      fill_in('Name', with: 'ZZZ New RB User')
+      fill_in('Email address', with: 'new.user@rb.example.com')
+      fill_in('Telephone number', with: '01234 567890')
+      click_on('Send invite')
+
+      expect(rb_users_index_page).to be_displayed
+      expect(rb_users_index_page.user_rows[2]).to have_content('ZZZ New RB User')
+    end
+  end
+
   it 'does not include any users from any other responsible_body' do
     click_on 'Manage local authority users'
     expect(page).not_to have_content(user_from_other_rb.full_name)
@@ -37,11 +72,6 @@ RSpec.feature 'Managing ResponsibleBody users' do
     it 'does not show a link to Edit user' do
       click_on 'Manage local authority users'
       expect(page).not_to have_content 'Edit user'
-    end
-
-    it 'does not show a link to Invite a new user' do
-      click_on 'Manage local authority users'
-      expect(page).not_to have_content 'Invite a new user'
     end
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/vZGLZ3do/452-manage-rb-users-invite-an-rb-user) Take adding RB users out from behind the FeatureFlag curtain and add the invite email to Notify.

### Changes proposed in this pull request
Enabling the invite responsible body user functionality. Sending an invite email to the new user.

### Guidance to review
Invite button enabled and Invite a new user form/functionality accessible without enabling the `:rbs_can_manage_users` feature flag.
![Screenshot 2020-08-25 at 16 03 19](https://user-images.githubusercontent.com/333931/91191658-f2e53780-e6ec-11ea-8a76-22dcea9ce4e8.png)
![Screenshot 2020-08-25 at 16 04 07](https://user-images.githubusercontent.com/333931/91191681-faa4dc00-e6ec-11ea-95a2-a8e4672e1657.png)
