### PR TITLE
Show different guidance and options for multi-academy trusts

### DIFF
--- a/app/components/school_details_summary_list_component.html.erb
+++ b/app/components/school_details_summary_list_component.html.erb
@@ -1,1 +1,3 @@
-<%= render SummaryListComponent.new(rows: rows) %>
+<div class="school-details-summary-list">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -67,17 +67,17 @@ module ViewHelper
     humanized_seconds(Settings.sign_in_token_ttl_seconds)
   end
 
-  def who_will_order_devices_options
+  def who_will_order_devices_options(show_recommendation: true)
     [
       OpenStruct.new(
         id: 'schools',
-        label: 'Most schools will place their own orders (recommended)',
+        label: "Most schools will place their own orders#{' (recommended)' if show_recommendation}",
         description: 'We’ll need contact details for each school',
       ),
       OpenStruct.new(
         id: 'responsible_body',
         label: 'Most orders will be placed centrally',
-        description: 'You’ll need to place orders for schools and give technical information for any school that wants to order Chromebooks.',
+        description: 'You’ll need to place orders for schools and give technical information for any school that wants to order Chromebooks',
       ),
     ]
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -9,6 +9,14 @@ class ResponsibleBody < ApplicationRecord
     type.demodulize.underscore.humanize.downcase
   end
 
+  def is_a_trust?
+    type == 'Trust'
+  end
+
+  def is_a_local_authority?
+    type == 'LocalAuthority'
+  end
+
   def next_school_sorted_ascending_by_name(school)
     schools
       .where('name > ?', school.name)

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -19,19 +19,30 @@
     </h1>
 
     <h2 class="govuk-heading-m">Decide if schools can order their own devices</h2>
+
     <p class="govuk-body">You can allow schools to order their own devices. Or you can manage some, or all, orders centrally.</p>
-    <p class="govuk-body">We recommend letting schools place orders because it’s the quickest way to get help to those who need it.</p>
-    <p class="govuk-body">You’ll need to nominate someone in each school for us to contact.</p>
 
-    <p class="govuk-body">Each contact will be able to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>manage who can order devices</li>
-      <li>order devices themselves</li>
-    </ul>
+    <% if @responsible_body.is_a_trust? %>
+      <p class="govuk-body">If you let schools place orders you’ll need to nominate someone in each school for us to contact.</p>
+      <p class="govuk-body">Each contact will be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>manage who can order devices</li>
+        <li>order devices themselves</li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">We recommend letting schools place orders because it’s the quickest way to get help to those who need it.</p>
+      <p class="govuk-body">You’ll need to nominate someone in each school for us to contact.</p>
 
-    <h2 class="govuk-heading-m">Help schools prepare for disruption</h2>
+      <p class="govuk-body">Each contact will be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>manage who can order devices</li>
+        <li>order devices themselves</li>
+      </ul>
 
-    <p class="govuk-body">Give us contact details as soon as you can so we can help schools prepare to deliver remote education if they need to.</p>
+      <h2 class="govuk-heading-m">Help schools prepare for disruption</h2>
+
+      <p class="govuk-body">Give us contact details as soon as you can so we can help schools prepare to deliver remote education if they need to.</p>
+    <% end %>
 
     <h2 class="govuk-heading-m">Orders can only be placed when local coronavirus restrictions are confirmed</h2>
 

--- a/app/views/responsible_body/devices/who_will_order/edit.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/edit.html.erb
@@ -15,7 +15,7 @@
       </h1>
 
       <%= f.govuk_collection_radio_buttons  :who_will_order,
-                                            who_will_order_devices_options,
+                                            who_will_order_devices_options(show_recommendation: @responsible_body.is_a_local_authority?),
                                             :id,
                                             :label,
                                             :description %>

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -1,110 +1,112 @@
 require 'rails_helper'
 
 RSpec.feature 'Setting up the devices ordering' do
-  let(:responsible_body) { create(:local_authority, in_devices_pilot: true) }
-  let(:rb_user) { create(:local_authority_user, responsible_body: responsible_body) }
-  let(:responsible_body_schools_page) { PageObjects::ResponsibleBody::SchoolsPage.new }
-  let(:responsible_body_school_page) { PageObjects::ResponsibleBody::SchoolPage.new }
+  context "as a local authority user" do
+    let(:responsible_body) { create(:local_authority, in_devices_pilot: true) }
+    let(:local_authority_user) { create(:local_authority_user, responsible_body: responsible_body) }
+    let(:responsible_body_schools_page) { PageObjects::ResponsibleBody::SchoolsPage.new }
+    let(:responsible_body_school_page) { PageObjects::ResponsibleBody::SchoolPage.new }
 
-  before do
-    @zebra_school = create(:school, :la_maintained, :secondary,
-                           responsible_body: responsible_body,
-                           name: 'Zebra Secondary School')
-    @aardvark_school = create(:school, :la_maintained, :primary,
-                              responsible_body: responsible_body,
-                              name: 'Aardvark Primary School')
+    before do
+      @zebra_school = create(:school, :la_maintained, :secondary,
+                             responsible_body: responsible_body,
+                             name: 'Zebra Secondary School')
+      @aardvark_school = create(:school, :la_maintained, :primary,
+                                responsible_body: responsible_body,
+                                name: 'Aardvark Primary School')
 
-    create(:school_device_allocation, school: @aardvark_school, device_type: 'std_device', allocation: 42)
-    create(:school_contact,
-           school: @aardvark_school,
-           role: :headteacher,
-           title: 'Executive Head',
-           full_name: 'Anne Jones',
-           email_address: 'anne.jones@aardvark.sch.uk')
-    create(:school_contact,
-           school: @zebra_school,
-           role: :headteacher,
-           title: 'Headteacher',
-           full_name: 'Jane Smith',
-           email_address: 'jane.smith@zebra.sch.uk')
+      create(:school_device_allocation, school: @aardvark_school, device_type: 'std_device', allocation: 42)
+      create(:school_contact,
+             school: @aardvark_school,
+             role: :headteacher,
+             title: 'Executive Head',
+             full_name: 'Anne Jones',
+             email_address: 'anne.jones@aardvark.sch.uk')
+      create(:school_contact,
+             school: @zebra_school,
+             role: :headteacher,
+             title: 'Headteacher',
+             full_name: 'Jane Smith',
+             email_address: 'jane.smith@zebra.sch.uk')
 
-    sign_in_as rb_user
-  end
+      sign_in_as local_authority_user
+    end
 
-  scenario 'devolving device ordering mostly to schools' do
-    when_i_follow_the_get_devices_link
-    and_i_continue_through_the_guidance
-    and_i_choose_ordering_through_schools
-    then_i_see_a_list_of_the_schools_i_am_responsible_for
-    and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
-    and_the_list_shows_that_schools_will_place_all_orders
-    and_each_school_needs_a_contact
+    scenario 'devolving device ordering mostly to schools' do
+      when_i_follow_the_get_devices_link
+      and_i_continue_through_the_guidance
+      and_i_choose_ordering_through_schools
+      then_i_see_a_list_of_the_schools_i_am_responsible_for
+      and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
+      and_the_list_shows_that_schools_will_place_all_orders
+      and_each_school_needs_a_contact
 
-    when_i_click_on_the_first_school_name
-    then_i_see_the_details_of_the_first_school
-    and_that_the_school_orders_devices
-    and_i_see_a_link_to_change_who_orders_devices
-    and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
+      when_i_click_on_the_first_school_name
+      then_i_see_the_details_of_the_first_school
+      and_that_the_school_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
+      and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
 
-    when_i_select_to_contact_the_headteacher
-    then_i_see_a_confirmation_and_the_headteacher_as_the_contact
-    and_the_status_reflects_that_the_school_will_be_contacted_shortly
+      when_i_select_to_contact_the_headteacher
+      then_i_see_a_confirmation_and_the_headteacher_as_the_contact
+      and_the_status_reflects_that_the_school_will_be_contacted_shortly
 
-    when_i_follow_the_link_to_the_next_school
-    then_i_see_the_details_of_the_second_school
+      when_i_follow_the_link_to_the_next_school
+      then_i_see_the_details_of_the_second_school
 
-    when_i_select_to_contact_someone_else_and_save_their_details
-    then_i_see_a_confirmation_and_the_someone_else_as_the_contact
-    and_the_status_reflects_that_the_school_will_be_contacted_shortly
-  end
+      when_i_select_to_contact_someone_else_and_save_their_details
+      then_i_see_a_confirmation_and_the_someone_else_as_the_contact
+      and_the_status_reflects_that_the_school_will_be_contacted_shortly
+    end
 
-  scenario 'devolving device ordering mostly centrally' do
-    when_i_follow_the_get_devices_link
-    and_i_continue_through_the_guidance
-    and_i_choose_ordering_centrally
-    then_i_see_a_list_of_the_schools_i_am_responsible_for
-    and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
-    and_the_list_shows_that_the_responsible_body_will_place_all_orders
-    and_each_school_needs_information
+    scenario 'devolving device ordering mostly centrally' do
+      when_i_follow_the_get_devices_link
+      and_i_continue_through_the_guidance
+      and_i_choose_ordering_centrally
+      then_i_see_a_list_of_the_schools_i_am_responsible_for
+      and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
+      and_the_list_shows_that_the_responsible_body_will_place_all_orders
+      and_each_school_needs_information
 
-    when_i_click_on_the_first_school_name
-    then_i_see_the_details_of_the_first_school
-    and_that_the_local_authority_orders_devices
-    and_i_see_a_link_to_change_who_orders_devices
-  end
+      when_i_click_on_the_first_school_name
+      then_i_see_the_details_of_the_first_school
+      and_that_the_local_authority_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
+    end
 
-  scenario 'submitting the form without choosing an option shows an error' do
-    visit responsible_body_devices_who_will_order_edit_path
-    click_on 'Continue'
-    expect(page).to have_http_status(:unprocessable_entity)
-    expect(page).to have_content('There is a problem')
-  end
+    scenario 'submitting the form without choosing an option shows an error' do
+      visit responsible_body_devices_who_will_order_edit_path
+      click_on 'Continue'
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content('There is a problem')
+    end
 
-  scenario 'changing the settings for each school after making the choice about who will order' do
-    given_the_responsible_body_has_decided_to_order_centrally
-    when_i_visit_the_responsible_body_homepage
-    when_i_follow_the_get_devices_link
-    then_i_see_a_list_of_the_schools_i_am_responsible_for
+    scenario 'changing the settings for each school after making the choice about who will order' do
+      given_the_responsible_body_has_decided_to_order_centrally
+      when_i_visit_the_responsible_body_homepage
+      when_i_follow_the_get_devices_link
+      then_i_see_a_list_of_the_schools_i_am_responsible_for
 
-    when_i_click_on_the_first_school_name
-    then_i_see_the_details_of_the_first_school
-    and_that_the_school_orders_devices
-    and_i_see_a_link_to_change_who_orders_devices
+      when_i_click_on_the_first_school_name
+      then_i_see_the_details_of_the_first_school
+      and_that_the_school_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
 
-    when_i_follow_the_change_who_will_order_link
-    then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+      when_i_follow_the_change_who_will_order_link
+      then_i_am_prompted_to_choose_who_orders_devices_for_the_school
 
-    when_i_select_orders_will_be_placed_centrally
-    then_i_see_the_details_of_the_first_school
-    and_that_the_local_authority_orders_devices
+      when_i_select_orders_will_be_placed_centrally
+      then_i_see_the_details_of_the_first_school
+      and_that_the_local_authority_orders_devices
 
-    when_i_follow_the_change_who_will_order_link
-    then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+      when_i_follow_the_change_who_will_order_link
+      then_i_am_prompted_to_choose_who_orders_devices_for_the_school
 
-    when_i_select_the_school_to_order_devices
-    then_i_see_the_details_of_the_first_school
-    and_that_the_school_orders_devices
-    and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
+      when_i_select_the_school_to_order_devices
+      then_i_see_the_details_of_the_first_school
+      and_that_the_school_orders_devices
+      and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
+    end
   end
 
   def when_i_follow_the_get_devices_link

--- a/spec/page_objects/responsible_body/school_page.rb
+++ b/spec/page_objects/responsible_body/school_page.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module ResponsibleBody
     class SchoolPage < PageObjects::BasePage
-      element :school_details, 'dl'
+      element :school_details, '.school-details-summary-list dl'
     end
   end
 end


### PR DESCRIPTION
### Context

Update design to match https://increasing-access-history.herokuapp.com/devolving-for-trusts/

For trusts we don't want to recommend any option – it will depend on how the trust is set up whether they devolve or manage centrally.

