### PR TITLE
[490] Import wave 1 RB contacts from Computacenter CSV file

### DIFF
--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -1,0 +1,32 @@
+module Computacenter::ResponsibleBodyUrns
+  module ClassMethods
+    def find_by_computacenter_urn!(cc_urn)
+      our_identifier = convert_computacenter_urn(cc_urn)
+      # given URNs starting with 't' are for Trusts
+      if cc_urn.starts_with?('t')
+        find_by_companies_house_number!(our_identifier)
+      else
+        # If it's not a Trust, assume it's a school
+        find_by_gias_id!(our_identifier)
+      end
+    end
+
+    # Computacenter's list of RBs has type-dependent prefixes for URNs
+    def convert_computacenter_urn(cc_urn)
+      # Trusts start with 't'
+      if cc_urn.starts_with?('t')
+        # take off the leading 't' and pad it to 8 chars with leading zeroes
+        cc_urn[1..-1].rjust(8, '0')
+      elsif cc_urn.starts_with?('LEA')
+        # just remove the leading 'LEA'
+        cc_urn[3..-1]
+      else
+        # if we can't convert it, just return the given string
+        # - that way we can use it as-is in queries and it will raise
+        # an ActiveRecord::RecordNotFound error. If we'd returned nil, we'd
+        # get spurious matches
+        cc_urn
+      end
+    end
+  end
+end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -1,9 +1,13 @@
+require 'computacenter/responsible_body_urns'
+
 class ResponsibleBody < ApplicationRecord
   has_one :bt_wifi_voucher_allocation
   has_many :bt_wifi_vouchers
   has_many :users
   has_many :extra_mobile_data_requests
   has_many :schools
+
+  extend Computacenter::ResponsibleBodyUrns::ClassMethods
 
   def humanized_type
     type.demodulize.underscore.humanize.downcase
@@ -30,35 +34,6 @@ class ResponsibleBody < ApplicationRecord
       'School'
     when 'responsible_body'
       humanized_type.capitalize
-    end
-  end
-
-  def self.find_by_computacenter_urn!(cc_urn)
-    our_identifier = convert_computacenter_urn(cc_urn)
-    # given URNs starting with 't' are for Trusts
-    if cc_urn.starts_with?('t')
-      find_by_companies_house_number!(our_identifier)
-    else
-      # If it's not a Trust, assume it's a school
-      find_by_gias_id!(our_identifier)
-    end
-  end
-
-  # Computacenter's list of RBs has type-dependent prefixes for URNs
-  def self.convert_computacenter_urn(cc_urn)
-    # Trusts start with 't'
-    if cc_urn.starts_with?('t')
-      # take off the leading 't' and pad it to 8 chars with leading zeroes
-      cc_urn[1..-1].rjust(8, '0')
-    elsif cc_urn.starts_with?('LEA')
-      # just remove the leading 'LEA'
-      cc_urn[3..-1]
-    else
-      # if we can't convert it, just return the given string
-      # - that way we can use it as-is in queries and it will raise
-      # an ActiveRecord::RecordNotFound error. If we'd returned nil, we'd
-      # get spurious matches
-      cc_urn
     end
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -32,4 +32,27 @@ class ResponsibleBody < ApplicationRecord
       humanized_type.capitalize
     end
   end
+
+  def self.find_by_computacenter_urn!(cc_urn)
+    our_identifier = convert_computacenter_urn(cc_urn)
+    if cc_urn.starts_with?('t')
+      find_by_companies_house_number!(our_identifier)
+    else
+      find_by_gias_id!(our_identifier)
+    end
+  end
+
+  # Computacenter's list of RBs has type-dependent prefixes for URNs
+  def self.convert_computacenter_urn(cc_urn)
+    # Trusts start with 't'
+    if cc_urn.starts_with?('t')
+      # take off the leading 't' and pad it to 8 chars with leading zeroes
+      cc_urn[1..-1].rjust(8, '0')
+    elsif cc_urn.starts_with?('LEA')
+      # just remove the leading 'LEA'
+      cc_urn[3..-1]
+    else
+      cc_urn
+    end # return nil if we can't convert it (shou;d we raise?)
+  end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -35,9 +35,11 @@ class ResponsibleBody < ApplicationRecord
 
   def self.find_by_computacenter_urn!(cc_urn)
     our_identifier = convert_computacenter_urn(cc_urn)
+    # given URNs starting with 't' are for Trusts
     if cc_urn.starts_with?('t')
       find_by_companies_house_number!(our_identifier)
     else
+      # If it's not a Trust, assume it's a school
       find_by_gias_id!(our_identifier)
     end
   end
@@ -52,7 +54,11 @@ class ResponsibleBody < ApplicationRecord
       # just remove the leading 'LEA'
       cc_urn[3..-1]
     else
+      # if we can't convert it, just return the given string
+      # - that way we can use it as-is in queries and it will raise
+      # an ActiveRecord::RecordNotFound error. If we'd returned nil, we'd
+      # get spurious matches
       cc_urn
-    end # return nil if we can't convert it (shou;d we raise?)
+    end
   end
 end

--- a/app/services/import_computacenter_references_service.rb
+++ b/app/services/import_computacenter_references_service.rb
@@ -12,7 +12,7 @@ class ImportComputacenterReferencesService
   end
 
   def import
-    csv = open(@csv_uri).read
+    csv = URI.open(@csv_uri).read
     index = 0
     CSV.parse(csv, headers: true).select do |row|
       index += 1
@@ -21,7 +21,7 @@ class ImportComputacenterReferencesService
       @successes << row
     rescue StandardError => e
       log(e.message)
-      @failures << {row: row, error: e}
+      @failures << { row: row, error: e }
     end
 
     log "Processed #{index} rows, of which #{failures.size} failed"
@@ -41,7 +41,7 @@ class ImportComputacenterReferencesService
 private
 
   def log(msg)
-    puts msg
+    @logger.info msg
   end
 
   def find_school!(cc_urn_and_name)

--- a/app/services/import_computacenter_references_service.rb
+++ b/app/services/import_computacenter_references_service.rb
@@ -1,0 +1,54 @@
+require 'open-uri'
+require 'csv'
+
+class ImportComputacenterReferencesService
+  attr_accessor :csv_uri, :logger, :failures, :successes
+
+  def initialize(csv_uri:, logger: Rails.logger)
+    @csv_uri = csv_uri
+    @logger = logger
+    @failures = []
+    @successes = []
+  end
+
+  def import
+    csv = open(@csv_uri).read
+    index = 0
+    CSV.parse(csv, headers: true).select do |row|
+      index += 1
+      log "Importing row #{index} - #{row}"
+      import_row!(row)
+      @successes << row
+    rescue StandardError => e
+      log(e.message)
+      @failures << {row: row, error: e}
+    end
+
+    log "Processed #{index} rows, of which #{failures.size} failed"
+  end
+
+  def import_row!(row)
+    rb = find_responsible_body!(row['Responsible Body URN'])
+    log "> RB given URN: #{row['Responsible Body URN']}, found ENG: #{rb.local_authority_eng}"
+    rb.update!(computacenter_reference: row['Sold To Number'])
+    log ">> computacenter_reference: #{rb.computacenter_reference}"
+    school = find_school!(row['School URN + School Name'])
+    log "School given URN: #{row['School URN + School Name']}, found URN: #{school.urn}"
+    school.update!(computacenter_reference: row['Ship To Number'])
+    log ">> computacenter_reference: #{school.computacenter_reference}"
+  end
+
+private
+
+  def log(msg)
+    puts msg
+  end
+
+  def find_school!(cc_urn_and_name)
+    School.find_by_urn!(cc_urn_and_name.split(' ').first)
+  end
+
+  def find_responsible_body!(cc_urn)
+    ResponsibleBody.find_by_computacenter_urn!(cc_urn)
+  end
+end

--- a/app/services/import_local_authority_gias_ids_service.rb
+++ b/app/services/import_local_authority_gias_ids_service.rb
@@ -11,21 +11,21 @@ class ImportLocalAuthorityGiasIdsService
   end
 
   def import
-    csv = open(@csv_uri).read
+    csv = URI.open(@csv_uri).read
     index = 0
     CSV.parse(csv, headers: true).select do |row|
       index += 1
       import_row(row)
       @successes << row
     rescue StandardError => e
-      @failures << {row: row, error: e}
+      @failures << { row: row, error: e }
     end
-    puts "Processed #{index} rows, #{@successes.size} successes, #{@failures.size} failures"
+    Rails.logger.info "Processed #{index} rows, #{@successes.size} successes, #{@failures.size} failures"
   end
 
   def import_row(row)
     la = LocalAuthority.find_by_local_authority_eng!(row['Local Authority ENG'])
-    puts "updating #{la.name} with GIAS ID #{row['Local Authority GIAS ID']}"
+    Rails.logger.info "updating #{la.name} with GIAS ID #{row['Local Authority GIAS ID']}"
     la.update!(gias_id: row['Local Authority GIAS ID'])
   end
 end

--- a/app/services/import_local_authority_gias_ids_service.rb
+++ b/app/services/import_local_authority_gias_ids_service.rb
@@ -1,0 +1,20 @@
+require 'open-uri'
+require 'csv'
+
+class ImportLocalAuthorityGiasIdsService
+  attr_accessor :csv_uri
+
+  def initialize(csv_uri)
+    @csv_uri = csv_uri
+  end
+
+  def import
+    csv = open(@csv_uri).read
+    index = 0
+    CSV.parse(csv, headers: true).select do |row|
+      la = LocalAuthority.find_by_local_authority_eng!(row['Local Authority ENG'])
+      puts "updating #{la.name} with GIAS ID #{row['Local Authority GIAS ID']}"
+      la.update!(gias_id: row['Local Authority GIAS ID'])
+    end
+  end
+end

--- a/app/services/import_local_authority_gias_ids_service.rb
+++ b/app/services/import_local_authority_gias_ids_service.rb
@@ -2,19 +2,30 @@ require 'open-uri'
 require 'csv'
 
 class ImportLocalAuthorityGiasIdsService
-  attr_accessor :csv_uri
+  attr_accessor :csv_uri, :successes, :failures
 
-  def initialize(csv_uri)
+  def initialize(csv_uri:)
     @csv_uri = csv_uri
+    @successes = []
+    @failures = []
   end
 
   def import
     csv = open(@csv_uri).read
     index = 0
     CSV.parse(csv, headers: true).select do |row|
-      la = LocalAuthority.find_by_local_authority_eng!(row['Local Authority ENG'])
-      puts "updating #{la.name} with GIAS ID #{row['Local Authority GIAS ID']}"
-      la.update!(gias_id: row['Local Authority GIAS ID'])
+      index += 1
+      import_row(row)
+      @successes << row
+    rescue StandardError => e
+      @failures << {row: row, error: e}
     end
+    puts "Processed #{index} rows, #{@successes.size} successes, #{@failures.size} failures"
+  end
+
+  def import_row(row)
+    la = LocalAuthority.find_by_local_authority_eng!(row['Local Authority ENG'])
+    puts "updating #{la.name} with GIAS ID #{row['Local Authority GIAS ID']}"
+    la.update!(gias_id: row['Local Authority GIAS ID'])
   end
 end

--- a/app/services/import_responsible_bodies_service.rb
+++ b/app/services/import_responsible_bodies_service.rb
@@ -18,6 +18,7 @@ class ImportResponsibleBodiesService
         .first_or_create!(
           name: entry['Group Name'],
           organisation_type: entry['Group Type'],
+          gias_group_uid: entry['Group UID'],
         )
     end
   end
@@ -27,5 +28,9 @@ class ImportResponsibleBodiesService
       name: 'Department for Education',
       organisation_type: 'government_department',
     )
+  end
+
+  def import_local_authority_gias_ids
+    ImportLocalAuthorityGiasIDsService.new(Rails.root.join('config/local_authority_data.csv')).import
   end
 end

--- a/app/services/import_responsible_body_users_from_computacenter_csv_service.rb
+++ b/app/services/import_responsible_body_users_from_computacenter_csv_service.rb
@@ -1,6 +1,7 @@
 require 'open-uri'
 require 'csv'
 
+# TODO: find a better name / conceptual structure for this importer and others
 class ImportResponsibleBodyUsersFromComputacenterCsvService
   attr_accessor :csv_uri, :successes, :failures
 
@@ -39,14 +40,13 @@ private
 
   def build_user!(row)
     rb = find_responsible_body!(row)
-    user = User.find_by_email_address(row['Email'] ) || User.new(
+    User.new(
       full_name: [row['Title'], row['First Name'], row['Last Name']].compact.join(' ').strip,
       telephone: row['Telephone'],
       email_address: row['Email'],
       responsible_body: rb,
+      approved_at: Time.zone.now.utc,
     )
-    user.approved_at ||= Time.zone.now.utc
-    user
   end
 
   def find_responsible_body!(row)

--- a/app/services/import_responsible_body_users_from_computacenter_csv_service.rb
+++ b/app/services/import_responsible_body_users_from_computacenter_csv_service.rb
@@ -1,0 +1,65 @@
+require 'open-uri'
+require 'csv'
+
+class ImportResponsibleBodyUsersFromComputacenterCsvService
+  attr_accessor :csv_uri, :successes, :failures
+
+  def initialize(args)
+    @csv_uri = args[:csv_uri]
+    @successes = []
+    @failures = []
+  end
+
+  def import
+    csv = open(@csv_uri).read
+    index = 0
+    CSV.parse(csv, headers: true).select do |row|
+      index += 1
+      log "Importing row #{index} - #{row}"
+      import_row!(row)
+      @successes << row
+    rescue StandardError => e
+      log(e.message)
+      @failures << {row: row, error: e}
+    end
+
+    log "Processed #{index} rows, of which #{failures.size} failed"
+  end
+
+private
+
+  def log(msg)
+    puts msg
+  end
+
+  def import_row!(row)
+    user = build_user!(row)
+    user.save!
+  end
+
+  def build_user!(row)
+    rb = find_responsible_body!(row)
+    user = User.find_by_email_address(row['Email'] ) || User.new(
+      full_name: [row['Title'], row['First Name'], row['Last Name']].compact.join(' ').strip,
+      telephone: row['Telephone'],
+      email_address: row['Email'],
+      responsible_body: rb,
+    )
+    user.approved_at ||= Time.zone.now.utc
+    user
+  end
+
+  def find_responsible_body!(row)
+    # some people in the spreadsheet have multiple 'SoldTos'
+    # so let's look for the default one first
+    computacenter_reference = row['DefaultSoldto'].strip
+    rb = ResponsibleBody.find_by_computacenter_reference(computacenter_reference)
+    unless rb.present?
+      log "> Couldn't find by DefaultSoldto of '#{row['DefaultSoldto']}', trying #{row['SoldTos']}"
+      rb = ResponsibleBody.where('computacenter_reference IN (?)', row['SoldTos'].split(',').map(&:strip)).first
+      raise ActiveRecord::RecordNotFound.new("Couldn't find a ResponsibleBody with any of these computacenter references: #{row['SoldTos']}") unless rb.present?
+      log "> Found #{rb.computacenter_reference} - #{rb.name}"
+    end
+    rb
+  end
+end

--- a/config/local_authority_data.csv
+++ b/config/local_authority_data.csv
@@ -1,0 +1,152 @@
+Local Authority GIAS ID,Local Authority Name,Address Line 1,Address Line 2,Address Line 3,Town/City,Postcode,Local Authority ENG
+201,City of London,"PO Box 270, Guildhall",,,London,EC2P 2EJ,LND
+202,Camden,218 Eversholt Street,,,London,NW1 1PB,CMD
+203,Greenwich,Woolwich Centre,35 Wellington Street,,London,SE18 6HQ,GRE
+204,Hackney,1 Reading Lane,,,London,E8 1GQ,HCK
+205,Hammersmith and Fulham,145-155 King Street,,,Hammersmith,W6 9XY,HMF
+206,Islington,222 Upper Street,,,London,N1 1XR,ISL
+207,Kensington and Chelsea,"Children’s Services Department,",Hammersmith Town Hall,King Street,London,W6 9JU,KEC
+208,Lambeth,"Lambeth Town Hall, 1st floor",Brixton Hill,,Brixton,SW2 1RW,LBH
+209,Lewisham,"1st Floor, Laurence House",1 Catford Road,,London,SE6 4RU,LEW
+210,Southwark,160 Tooley Street,,,London,SE1P 5LX,SWK
+211,Tower Hamlets,Mulberry Place,,,London,E14 2BG,TWH
+212,Wandsworth,The Town Hall,Wandsworth High Street,,London,SW18 2PU,WND
+213,Westminster,"4th Floor, 5 The Strand",,,London,WC2N 5HR,WSM
+301,Barking and Dagenham,Town Hall,,,Barking,IG11 7LU,BDG
+302,Barnet,"Building 4,",North London Business Park,Oakleigh Road South,London,N11 1NP,BNE
+303,Bexley,"Civic Offices, 2 Watling Street",,,Bexleyheath,DA6 7AT,BEX
+304,Brent,Brent Civic Centre,Engineers Way,,Wembley,HA9 0FJ,BEN
+305,Bromley,Bromley Civic Centre,Stockwell Close,,Bromley,BR1 3UH,BRY
+306,Croydon,"9th Floor, Zone B,",Bernard Weatherill House,8 Mint Walk,Croydon,CR0 1EA,CRY
+307,Ealing,Perceval House,14-16 Uxbridge Road,,London,W5 2HL,EAL
+308,Enfield,"PO Box 56, Civic Centre",Silver Street,,Enfield,EN1 3XQ,ENF
+309,Haringey,River Park House,225 High Road,,London,N22 8HQ,HRY
+310,Harrow,Civic Centre,Station Road,,Harrow,HA1 2XF,HRW
+311,Havering,Town Hall,Main Road,,Romford,RM1 3BD,HAV
+312,Hillingdon,Civic Centre,High Street,,Uxbridge,UB8 1UW,HIL
+313,Hounslow,The Civic Centre,Lampton Road,,Hounslow,TW3 4YN,HNS
+314,Kingston upon Thames,42 York Street,,,Twickenham,TW1 3BW,KTT
+315,Merton,Merton Civic Centre,London Road,,Morden,SM4 5DX,MRT
+316,Newham,Newham Dockside,1000 Dockside Road,,London,E16 2QU,NWM
+317,Redbridge,Lynton House,255-259 High Road,,Ilford,IG1 1NN,RDB
+318,Richmond upon Thames,44 York Street,,,Twickenham,TW1 3BZ,RIC
+319,Sutton,Civic Offices,St Nicholas Way,,Sutton,SM1 1EA,STN
+320,Waltham Forest,"Room 206, Town Hall",Forest Road,,London,E17 4JF,WFT
+330,Birmingham,Children & Young People Directorate,PO BOX 17550,,Birmingham,B2 2DP,BIR
+331,Coventry,Civic Centre 1,Little Park Street,,Coventry,CV1 5RS,COV
+332,Dudley,Council House,Priory Road,,Dudley,DY1 1HF,DUD
+333,Sandwell,Sandwell Council House,Freeth Street,,Oldbury,B69 3DE,SAW
+334,Solihull,Council House,PO Box 20,,Solihull,B91 3QU,SOL
+335,Walsall,Council House,Lichfield Street,,Walsall,WS1 1TW,WLL
+336,Wolverhampton,Civic Centre,St Peter’s Square,,Wolverhampton,WV1 1RR,WLV
+340,Knowsley,Municipal Buildings,Archway Road,,Huyton,L36 9YU,KWL
+341,Liverpool,Municipal Buildings,Dale Street,,Liverpool,L2 2DH,LIV
+342,St. Helens,"2nd Floor, Gamble Building",Victoria Square,,St Helens,WA10 1DY,SHN
+343,Sefton,"9th Floor, Merton House",Stanley Road,,Bootle,L20 3JA,SFT
+344,Wirral,Hamilton Building,Conway Street,,Birkenhead,CH41 4FD,WRL
+350,Bolton,Town Hall,,,Bolton,BL1 1RU,BOL
+351,Bury,3 Knowsley Place,Duke Street,,Bury,BL9 0EJ,BUR
+352,Manchester,Town Hall,Albert Square,,Manchester,M60 2LA,MAN
+353,Oldham,Civic Centre,West Street,,Oldham,OL1 1XJ,OLD
+354,Rochdale,"PO Box 70, Municipal Offices",Smith Street,,Rochdale,OL16 1YD,RCH
+355,Salford,"Salford Children’s Services,",Unity House,Chorley Road,Swinton,M27 5AW,SLF
+356,Stockport,"Upper Ground Floor, Stopford House",,,Stockport,SK1 3XE,SKP
+357,Tameside,Hyde Town Hall,Market Street,,Hyde,SK14 1AL,TAM
+358,Trafford,"PO Box 40, Trafford Town Hall",Talbot Rd,,Stretford,M32 OEL,TRF
+359,Wigan,Wigan Town Hall,Library Street,,Wigan,WN1 1YN,WGN
+370,Barnsley,PO Box 609,,,Barnsley,S70 9FH,BNS
+371,Doncaster,The Civic Office,Waterdale,,Doncaster,DN1 3BU,DNC
+372,Rotherham,Riverside House,Main Street,,Rotherham,S60 2NE,ROT
+373,Sheffield,Town Hall,Pinstone Street,,Sheffield,S1 2HH,SHF
+380,Bradford,Margaret McMillan Tower,Princes Way,,Bradford,BD1 1NN,BRD
+381,Calderdale,Town Hall,Crossley Street,,Halifax,HX1 1UJ,CLD
+382,Kirklees,Civic Centre 111,,,Huddersfield,HD1 2EY,KIR
+383,Leeds,Children’s Services,PO BOX 837,,Leeds,LS1 9PZ,LDS
+384,Wakefield,County Hall,Bond Street,,Wakefield,WF1 2QW,WKF
+390,Gateshead,Civic Centre,Regent Street,,Gateshead,NE8 1HH,GAT
+391,Newcastle upon Tyne,Civic Centre,,,Newcastle Upon Tyne,NE1 8QH,NET
+392,North Tyneside,Cobalt Business Park,"Quadrant, The Silverlink North",,North Tyneside,NE27 0BY,NTY
+393,South Tyneside,"Town Hall, Civic Offices",Westoe Road,,South Shields,NE33 2RL,STY
+394,Sunderland,Civic Centre,Burdon Road,,Sunderland,SR2 7DN,SND
+420,Isles Of Scilly,Carn Thomas,St Mary’s,,Isles of Scilly,TR21 OPT,IOS
+800,Bath and NE Somerset,"PO Box 25, Riverside",Temple Street,,"Keynsham, Bristol",BS31 1DN,BAS
+801,"Bristol, City of","PO Box 57, The Council House",College Green,,Bristol,BS99 7EB,BST
+802,North Somerset,Town Hall,Walliscote Grove Road,,Weston-super-Mare,BS23 1UJ,NSM
+803,South Gloucestershire,"PO Box 298,Civic Centre",Dept for Children Adults & Health,High street,Bristol,BS15 0DQ,SGC
+805,Hartlepool,Level 4 Civic Centre,Victoria Road,,Hartlepool,TS24 8AY,HPL
+806,Middlesbrough,"PO Box 69, Vancouver House",Gurney Street,,Middlesbrough,TS1 1EL,MDB
+807,Redcar and Cleveland,Civic Offices PO Box 83,Kirkleatham Street,,Redcar,TS10 1YA,RCC
+808,Stockton-on-Tees,Municipal Buildings,Church Road,,Stockton-on-Tees,TS18 1LD,STT
+810,Kingston upon Hull City,Room 42,Guildhall,,Hull,HU1 2AA,KHL
+811,East Riding of Yorks,County Hall,,,Beverley,HU17 9BA,ERY
+812,North East Lincolnshire,Municipal Offices,,,Grimsby,DN31 1HU,NEL
+813,North Lincolnshire,"PO Box 35, Hewson House",Station Road,,Brigg,DN20 8XJ,NLN
+815,North Yorkshire,County Hall,,,Northallerton,DL7 8AE,NYK
+816,York,West Offices,Station Rise,,York,YO1 6GA,YOR
+821,Luton,111 Stuart Street,,,Luton,LU1 5NP,LUT
+822,Bedford,Borough Hall,Cauldwell Street,,Bedford,MK42 9AP,BDF
+823,Central Bedfordshire,Priory House,Monks Walk,,Shefford,SG17 5TQ,CBF
+825,Buckinghamshire,The Gateway,Gatehouse Road,,Aylesbury,HP19 8FF,BUC
+826,Milton Keynes,Saxon Court,Avebury Boulevard,,Central Milton Keynes,MK9 3HS,MIK
+830,Derbyshire,County Hall,,,Matlock,DE4 3AG,DBY
+831,Derby,Children & Young People Directorate,The Council House,Corporation Street,Derby,DE1 2FS,DER
+838,Dorset,County Hall,,,Dorchester,DT1 1XJ,DST
+839,Bournemouth Chrstchch & Poole,Town Hall,,,Bournemouth,BH2 6DY,BPC
+840,County Durham,County Hall,,,Durham,DH1 5UJ,DUR
+841,Darlington,Town Hall,Feethams,,Darlington,DL1 5QT,DAL
+845,East Sussex,"PO Box 4, County Hall",St Anne’s Crescent,,Lewes,BN7 1SG,ESX
+846,Brighton and Hove,Kings House,Grand Avenue,,Hove,BN3 2SU,BNH
+850,Hampshire,Children’s Services Department,3rd Floor,"Elizabeth II Court North, The Castl",Winchester,SO23 8UG,HAM
+851,Portsmouth,"3rd Floor, Civic Offices",Guildhall Square,,Portsmouth,PO1 2AL,POR
+852,Southampton,Civic Centre,,,Southampton,SO14 7LY,STH
+855,Leicestershire,County Hall,Glenfield,,Leicester,LE3 8RF,LEC
+856,Leicester,"3rd Floor, 115 Charles Street",,,Leicester,LE1 1FZ,LCE
+857,Rutland,Catmose,Oakham,,Rutland,LE15 6HP,RUT
+860,Staffordshire,Staffordshire Place,Tipping Street,,Stafford,ST16 2DH,STS
+861,Stoke-on-Trent,Civic Centre,Glebe Street,,Stoke-On-Trent,ST4 1HH,STE
+865,Wiltshire,County Hall,Bythesea Road,,Trowbridge,BA14 8JN,WIL
+866,Swindon,Swindon Borough Council,"Civic Offices, Euclid Street",,Swindon,SN1 2JH,SWD
+867,Bracknell Forest,Time Square,Market Street,,Bracknell,RG12 1JD,BRC
+868,Windsor and Maidenhead,Town Hall,St Ives Rd,,Maidenhead,SL6 1RF,WNM
+869,West Berkshire,West Street House,West Street,,Newbury,RG14 1BZ,WBK
+870,Reading,"Brighter Futures for Children,",Civic Offices,Bridge Street,Reading,RG1 2LU,RDG
+871,Slough,Town Hall,Bath Rd,,Slough,SL1 3UQ,SLG
+872,Wokingham,Shute End,,,Wokingham,RG40 1BN,WOK
+873,Cambridgeshire,Shire Hall,Castle Hill,,Cambridge,CB3 OAP,CAM
+874,Peterborough,Town Hall,Bridge Street,,Peterborough,PE1 1HF,PTE
+876,Halton,Municipal Building,Kingsway,,Widnes,WA8 7QF,HAL
+877,Warrington,New Town House,Buttermarket Street,,Warrington,WA1 2NH,WRT
+878,Devon,County Hall,Topsham Road,,Exeter,EX2 4QG,DEV
+879,Plymouth,Ballard House,West Hoe Road,,Plymouth,PL1 3BJ,PLY
+880,Torbay,"C/o Townhall, Children’s Services",(Torhill House 1st Floor South),Castle Circus,Torquay,TQ1 3DR,TOB
+881,Essex,Children’s Services,Corporate Directorate,PO Box 11,Chelmsford,CM1 1LX,ESS
+882,Southend-on-Sea,Civic Centre,Victoria Avenue,,Southend on Sea,SS2 6ER,SOS
+883,Thurrock,Civic Offices,New Road Grays,,Thurrock,RM17 6GF,THR
+884,Herefordshire County of,Plough Lane,,,Hereford,HR4 0LE,HEF
+885,Worcestershire,County Hall,Spetchley Road,,Worcester,WR5 2NP,WOR
+886,Kent,Sessions House,,,Maidstone,ME14 1XQ,KEN
+887,Medway,Gun Wharf,Dock Road,,Chatham,ME4 4TR,MDW
+888,Lancashire,PO Box 100,County Hall,,Preston,PR1 0LD,LAN
+889,Blackburn with Darwen,10 Duke Street,,,Blackburn,BB2 1DH,BBD
+890,Blackpool,"Number One, Bickerstaffe Square",,,Blackpool,FY1 3HS,BPL
+891,Nottinghamshire,County Hall,West Bridgford,,Nottingham,NG2 7QP,NTT
+892,Nottingham,Loxley House,Station Street,,Nottingham,NG2 3NG,NGM
+893,Shropshire,Shire Hall,Abbey Foregate,,Shrewsbury,SY2 6ND,SHR
+894,Telford and Wrekin,Addenbrooke House,Ironmasters Way,,Telford,TF3 4NT,TFW
+895,Cheshire East,Westfields,Middlewich Road,,Sandbach,CW11 1HZ,CHE
+896,Cheshire West & Chester,58 Nicholas Street,,,Chester,CH1 2NP,CHW
+908,Cornwall,New County Hall,,,Truro,TR1 3AY,CON
+909,Cumbria,Cumbria House,117 Botchergate,,Carlisle,CA1 1RD,CMA
+916,Gloucestershire,Shire Hall,Westgate Street,,Gloucester,GL1 2TR,GLS
+919,Hertfordshire,County Hall,Peg Lane,,Hertford,SG13 8DF,HRT
+921,Isle of Wight,County Hall,,,Newport,PO30 1UD,IOW
+925,Lincolnshire,County Offices,Newland,,Lincoln,LN1 1YQ,LIN
+926,Norfolk,County Hall,Martineau Lane,,Norwich,NR1 2DH,NFK
+928,Northamptonshire,1 Angel Square,Angel Street,,Northampton,NN1 1ED,NTH
+929,Northumberland,County Hall,,,Morpeth,NE61 2EF,NBL
+931,Oxfordshire,County Hall,New Road,,Oxford,OX1 1ND,OXF
+933,Somerset,The Crescent,,,Taunton,TA1 4DY,SOM
+935,Suffolk,Endeavour House,8 Russell Road,,Ipswich,IP1 2BX,SFK
+936,Surrey,County Hall,,,Kingston upon Thames,KT1 2DN,SRY
+937,Warwickshire,"PO BOX 2, Shire Hall",,,Warwick,CV34 4RR,WAR
+938,West Sussex,County Hall,,,Chichester,PO19 1RQ,WSX

--- a/db/migrate/20200826143548_add_rb_computacenter_reference.rb
+++ b/db/migrate/20200826143548_add_rb_computacenter_reference.rb
@@ -1,0 +1,7 @@
+class AddRbComputacenterReference < ActiveRecord::Migration[6.0]
+  def change
+    add_column :responsible_bodies, :computacenter_reference, :string, null: true
+
+    add_index :responsible_bodies, :computacenter_reference
+  end
+end

--- a/db/migrate/20200826211506_add_gias_id_and_gias_group_uid_to_rbs.rb
+++ b/db/migrate/20200826211506_add_gias_id_and_gias_group_uid_to_rbs.rb
@@ -1,0 +1,6 @@
+class AddGiasIdAndGiasGroupUidToRbs < ActiveRecord::Migration[6.0]
+  def change
+    add_column :responsible_bodies, :gias_group_uid, :string, null: true, unique: true
+    add_column :responsible_bodies, :gias_id, :string, null: true, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 2020_08_26_211506) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
-    t.string "school_or_rb_domain"
-    t.string "recovery_email_address"
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"
+    t.string "school_or_rb_domain"
+    t.string "recovery_email_address"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_080212) do
+ActiveRecord::Schema.define(version: 2020_08_26_211506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 2020_08_25_080212) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
-    t.bigint "school_contact_id"
-    t.string "will_need_chromebooks"
     t.string "school_or_rb_domain"
     t.string "recovery_email_address"
+    t.bigint "school_contact_id"
+    t.string "will_need_chromebooks"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"
@@ -98,6 +98,10 @@ ActiveRecord::Schema.define(version: 2020_08_25_080212) do
     t.boolean "in_devices_pilot", default: false
     t.boolean "in_connectivity_pilot", default: false
     t.string "who_will_order_devices"
+    t.string "computacenter_reference"
+    t.string "gias_group_uid"
+    t.string "gias_id"
+    t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
   end
 
   create_table "school_contacts", force: :cascade do |t|

--- a/lib/tasks/import_contacts.rake
+++ b/lib/tasks/import_contacts.rake
@@ -3,4 +3,9 @@ namespace :import do
   task contacts: :environment do
     ImportContactsService.new.import_contacts
   end
+
+  desc 'Import RB users from computacenter CSV file at RB_USERS_CSV_URL'
+  task rb_users_from_cc_csv: :environment do
+    ImportResponsibleBodyUsersFromComputacenterCsvService.new(ENV['RB_USERS_CSV_URL'])
+  end
 end

--- a/lib/tasks/import_responsible_bodies.rake
+++ b/lib/tasks/import_responsible_bodies.rake
@@ -4,7 +4,7 @@ namespace :import do
     ImportResponsibleBodiesService.new.import_local_authorities
   end
 
-  desc 'Import local authority GIAS IDs' do
+  desc 'Import local authority GIAS IDs'
   task local_authority_gias_ids: :environment do
     ImportResponsibleBodiesService.new.import_local_authority_gias_ids
   end

--- a/lib/tasks/import_responsible_bodies.rake
+++ b/lib/tasks/import_responsible_bodies.rake
@@ -4,6 +4,11 @@ namespace :import do
     ImportResponsibleBodiesService.new.import_local_authorities
   end
 
+  desc 'Import local authority GIAS IDs' do
+  task local_authority_gias_ids: :environment do
+    ImportResponsibleBodiesService.new.import_local_authority_gias_ids
+  end
+
   desc 'Import single and multi-academy trusts'
   task trusts: :environment do
     ImportResponsibleBodiesService.new.import_trusts
@@ -15,5 +20,5 @@ namespace :import do
   end
 
   desc 'Populate the responsible body reference data table'
-  task responsible_bodies: %i[local_authorities_in_england trusts dfe_as_a_responsible_body]
+  task responsible_bodies: %i[local_authorities_in_england local_authority_gias_ids trusts dfe_as_a_responsible_body]
 end

--- a/lib/tasks/import_schools.rake
+++ b/lib/tasks/import_schools.rake
@@ -3,4 +3,8 @@ namespace :import do
   task schools: :environment do
     ImportSchoolsService.new.import_schools
   end
+
+  desc 'Import shipTo and sendTo from file at CC_REFERENCES_FILE_URI' do
+    ImportComputacenterReferencesService.new(csv_uri: ENV['CC_REFERENCES_FILE_URI']).import
+  end
 end

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     local_authority_official_name { [organisation_type, name].join(' of ') }
     local_authority_eng           { name.first(3).upcase }
     companies_house_number        { rand(99_999).to_s }
+    gias_id                       { Faker::Number.number(digits: 3) }
+    computacenter_reference       { Faker::Number.number(digits: 8) }
 
     trait :in_connectivity_pilot do
       in_connectivity_pilot       { true }
@@ -21,6 +23,7 @@ FactoryBot.define do
     local_authority_official_name { nil }
     local_authority_eng           { nil }
     companies_house_number        { Faker::Number.leading_zero_number(digits: 8) }
+    computacenter_reference       { Faker::Number.number(digits: 8) }
 
     trait :single_academy_trust do
       organisation_type           { :single_academy_trust }

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -13,4 +13,44 @@ RSpec.describe ResponsibleBody, type: :model do
       expect(local_authority.next_school_sorted_ascending_by_name(tiger)).to eq(zebra)
     end
   end
+
+  describe '.convert_computacenter_urn' do
+    context 'given a string starting with LEA' do
+      it 'returns the same string with LEA removed' do
+        expect(ResponsibleBody.convert_computacenter_urn('LEA12345')).to eq('12345')
+      end
+    end
+
+    context 'given a string starting with t' do
+      it 'returns the same string with t removed, padded to 8 chars with leading zeroes' do
+        expect(ResponsibleBody.convert_computacenter_urn('t12345')).to eq('00012345')
+      end
+    end
+
+    context 'given a string starting with SC' do
+      it 'returns the same string, untransformed' do
+        expect(ResponsibleBody.convert_computacenter_urn('SC12345')).to eq('SC12345')
+      end
+    end
+  end
+
+  describe '.find_by_computacenter_urn!' do
+    let!(:trust_with_reference) { create(:trust, companies_house_number: '01234567') }
+    let!(:trust_without_reference) { create(:trust, companies_house_number: '98765432') }
+    let!(:la_with_reference) { create(:local_authority, gias_id: '123') }
+    let!(:la_without_reference) { create(:trust, gias_id: '987') }
+
+    context 'given a string starting with LEA' do
+      it 'returns the local authority matched by GIAS id' do
+        expect(ResponsibleBody.find_by_computacenter_urn!('LEA123')).to eq(la_with_reference)
+      end
+    end
+
+    context 'given a string starting with t' do
+      it 'returns the trust matched by companies_house_number' do
+        expect(ResponsibleBody.find_by_computacenter_urn!('t01234567')).to eq(trust_with_reference)
+      end
+    end
+
+  end
 end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
   describe '.find_by_computacenter_urn!' do
     let!(:trust_with_reference) { create(:trust, companies_house_number: '01234567') }
-    let!(:trust_without_reference) { create(:trust, companies_house_number: '98765432') }
     let!(:la_with_reference) { create(:local_authority, gias_id: '123') }
-    let!(:la_without_reference) { create(:trust, gias_id: '987') }
 
     context 'given a string starting with LEA' do
       it 'returns the local authority matched by GIAS id' do
@@ -51,6 +49,5 @@ RSpec.describe ResponsibleBody, type: :model do
         expect(ResponsibleBody.find_by_computacenter_urn!('t01234567')).to eq(trust_with_reference)
       end
     end
-
   end
 end

--- a/spec/services/import_computacenter_references_service_spec.rb
+++ b/spec/services/import_computacenter_references_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe ImportComputacenterReferencesService do
+  let(:csv_content) do
+    <<~CSV
+      Responsible Body URN,School URN + School Name,School Name (overflow),Address Line 1,Address Line 2 ,Address Line 3,Town/City,Postcode,Ship To Number,Sold To Number
+      LEA901,100005 Example school 1,,49 Some Square,,,London,WC1N 2NY,SHIP_TO_1,SOLD_TO_1
+      LEA902,100006 Example school 2,,A Road,,,London,NW3 2NY,SHIP_TO_2,SOLD_TO_2
+      LEA902,100020 Example school 3,,Some Road,,,London,NW1 8JL,SHIP_TO_3,SOLD_TO_2
+      LEA902,100022 Non-existent school,,Some Road,,,London,NW1 8JL,SHIP_TO_4,SOLD_TO_2
+      t90003,100023 Example academy,,Some Road,,,London,NW1 8JL,SHIP_TO_A3,SOLD_TO_3
+    CSV
+  end
+  let(:tmp_csv_file) { Tempfile.new }
+  let!(:local_authority_2) { create(:local_authority, gias_id: '902') }
+  let!(:school_2) { create(:school, name: 'Example school 2', responsible_body: local_authority_2, urn: '100006') }
+  let!(:trust_3) { create(:trust, companies_house_number: '00090003') }
+  let!(:academy_3) { create(:school, :academy, name: 'Example academy', responsible_body: trust_3, urn: '100023') }
+
+  before do
+    tmp_csv_file << csv_content
+    tmp_csv_file.flush
+  end
+
+  subject(:importer) { ImportComputacenterReferencesService.new(csv_uri: tmp_csv_file.path) }
+
+  describe 'import' do
+    before do
+      importer.import
+    end
+
+    it 'updates the computacenter_reference on any matched ResponsibleBodies' do
+      expect(local_authority_2.reload.computacenter_reference).to eq('SOLD_TO_2')
+      expect(trust_3.reload.computacenter_reference).to eq('SOLD_TO_3')
+    end
+
+    it 'updates the computacenter_reference on any matched Schools' do
+      expect(school_2.reload.computacenter_reference).to eq('SHIP_TO_2')
+      expect(academy_3.reload.computacenter_reference).to eq('SHIP_TO_A3')
+    end
+
+    it 'stores any failures' do
+      expect(importer.failures.size).to eq(3)
+    end
+  end
+end

--- a/spec/services/import_local_authority_gias_ids_service_spec.rb
+++ b/spec/services/import_local_authority_gias_ids_service_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe ImportLocalAuthorityGiasIdsService do
+  let(:csv_content) {
+    <<~CSV
+    Local Authority GIAS ID,Local Authority Name,Address Line 1,Address Line 2,Address Line 3,Town/City,Postcode,Local Authority ENG
+    991,City of Test 1,"PO Box 270, Guildhall",,,London,EC2P 2EJ,TST1
+    992,Test council 2,218 Eversholt Street,,,London,NW1 1PB,TST2
+    993,Test council 3,Woolwich Centre,35 Wellington Street,,London,SE18 6HQ,TST3
+    CSV
+  }
+  let(:tmp_csv_file) { Tempfile.new }
+  let!(:test_la_1) { create(:local_authority, local_authority_eng: 'TST1') }
+  let!(:test_la_2) { create(:local_authority, local_authority_eng: 'TST2') }
+
+  before do
+    tmp_csv_file << csv_content
+    tmp_csv_file.flush
+  end
+
+  subject(:importer) { ImportLocalAuthorityGiasIdsService.new(csv_uri: tmp_csv_file.path) }
+
+  describe '#import' do
+    before do
+      importer.import
+    end
+
+    it 'updates the GIAS IDs on any LAs with matching ENG' do
+      expect( test_la_1.reload.gias_id ).to eq('991')
+      expect( test_la_2.reload.gias_id ).to eq('992')
+    end
+
+    it 'stores any failed rows' do
+      expect(importer.failures.size).to eq(1)
+    end
+  end
+end

--- a/spec/services/import_local_authority_gias_ids_service_spec.rb
+++ b/spec/services/import_local_authority_gias_ids_service_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 describe ImportLocalAuthorityGiasIdsService do
-  let(:csv_content) {
+  let(:csv_content) do
     <<~CSV
-    Local Authority GIAS ID,Local Authority Name,Address Line 1,Address Line 2,Address Line 3,Town/City,Postcode,Local Authority ENG
-    991,City of Test 1,"PO Box 270, Guildhall",,,London,EC2P 2EJ,TST1
-    992,Test council 2,218 Eversholt Street,,,London,NW1 1PB,TST2
-    993,Test council 3,Woolwich Centre,35 Wellington Street,,London,SE18 6HQ,TST3
+      Local Authority GIAS ID,Local Authority Name,Address Line 1,Address Line 2,Address Line 3,Town/City,Postcode,Local Authority ENG
+      991,City of Test 1,"PO Box 270, Guildhall",,,London,EC2P 2EJ,TST1
+      992,Test council 2,218 Eversholt Street,,,London,NW1 1PB,TST2
+      993,Test council 3,Woolwich Centre,35 Wellington Street,,London,SE18 6HQ,TST3
     CSV
-  }
+  end
   let(:tmp_csv_file) { Tempfile.new }
   let!(:test_la_1) { create(:local_authority, local_authority_eng: 'TST1') }
   let!(:test_la_2) { create(:local_authority, local_authority_eng: 'TST2') }
@@ -26,8 +26,8 @@ describe ImportLocalAuthorityGiasIdsService do
     end
 
     it 'updates the GIAS IDs on any LAs with matching ENG' do
-      expect( test_la_1.reload.gias_id ).to eq('991')
-      expect( test_la_2.reload.gias_id ).to eq('992')
+      expect(test_la_1.reload.gias_id).to eq('991')
+      expect(test_la_2.reload.gias_id).to eq('992')
     end
 
     it 'stores any failed rows' do

--- a/spec/services/import_responsible_bodies_service_spec.rb
+++ b/spec/services/import_responsible_bodies_service_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe ImportResponsibleBodiesService, type: :model do
 
   it 'imports single- and multi-academy trusts only once' do
     data = [
-      'Group Name,Companies House Number,Group Type,Group Status',
-      'AAA,12345,Federation,Open',
-      'AA TRUST,67890,Single-academy trust,Open',
-      'ABC MAT,13579,Multi-academy trust,Open',
+      'Group UID,Group Name,Companies House Number,Group Type,Group Status',
+      '1111,AAA,12345,Federation,Open',
+      '2222,AA TRUST,67890,Single-academy trust,Open',
+      '3333,ABC MAT,13579,Multi-academy trust,Open',
     ].join("\n")
 
     stub_request(:get, GetInformationAboutSchools.groups_url)
@@ -71,10 +71,12 @@ RSpec.describe ImportResponsibleBodiesService, type: :model do
     expect(Trust.count).to eq(2)
 
     trusts = Trust.all.order('name asc')
+    expect(trusts.first.gias_group_uid).to eq('2222')
     expect(trusts.first.name).to eq('AA TRUST')
     expect(trusts.first.companies_house_number).to eq('67890')
     expect(trusts.first.organisation_type).to eq('single_academy_trust')
 
+    expect(trusts.second.gias_group_uid).to eq('3333')
     expect(trusts.second.name).to eq('ABC MAT')
     expect(trusts.second.companies_house_number).to eq('13579')
     expect(trusts.second.organisation_type).to eq('multi_academy_trust')

--- a/spec/services/import_responsible_body_users_from_computacenter_csv_file_service_spec.rb
+++ b/spec/services/import_responsible_body_users_from_computacenter_csv_file_service_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ImportResponsibleBodyUsersFromComputacenterCsvService do
+  let(:csv_content) do
+    <<~CSV
+      UserID,Title,First Name,Last Name,Telephone,Email,SoldTos,DefaultSoldto,Default Language,Active,MobileNumber,Guid,,
+      a.person@sometrust.co.uk,,Andrea,Person,,a.person@sometrust.co.uk,SOLD_TO_1,SOLD_TO_1,en,TRUE,,536c953b-2a7e-4a3d-8ec5-cfc09cb4d67c,,
+      b.someone@aschool.sch.uk,,Brian,Someone,01234 567890,b.someone@aschool.sch.uk,SOLD_TO_2,SOLD_TO_2,en,TRUE,,39404dd9-f579-4e25-997d-440bf3f74815,,
+      c.mee@anotherschool.org,,Carole,Mee,,c.mee@anotherschool.org,SOLD_TO_3,SOLD_TO_3,en,TRUE,,ff6083c0-d000-478d-83bb-5cdfe717cd21,,
+      d.barkel@alocalauthority.gov.uk,,Dee,Barkel,,d.barkel@alocalauthority.gov.uk,"SOLD_TO_4, SOLD_TO_5, SOLD_TO_6, SOLD_TO_7",SOLD_TO_6,en,TRUE,,5d8f62f3-133f-42bc-8569-f265e94c0021,,
+      e.baigum@nowhere.org,,Eric,Baigum,,e.baigum@nowhere.org,NON_EXISTING_SOLD_TO,NON_EXISTING_SOLD_TO,en,TRUE,,ff6083c0-d000-478d-83bb-5cdfe717cd24,,
+      x.istinguser@some.sch.uk,,Xavier,Istinguser,,x.istinguser@some.sch.uk,SOLD_TO_3,SOLD_TO_3,en,TRUE,,ff6083c0-d000-478d-83bb-5cdfe717cd25,,
+    CSV
+  end
+  let(:tmp_csv_file) { Tempfile.new }
+  let!(:trust) { create(:trust, computacenter_reference: 'SOLD_TO_1') }
+  let!(:local_authority_2) { create(:local_authority, computacenter_reference: 'SOLD_TO_2') }
+  let!(:local_authority_3) { create(:local_authority, computacenter_reference: 'SOLD_TO_3') }
+  let!(:local_authority_4) { create(:local_authority, computacenter_reference: 'SOLD_TO_4') }
+  let!(:local_authority_5) { create(:local_authority, computacenter_reference: 'SOLD_TO_5') }
+  let!(:existing_user) { create(:local_authority_user, responsible_body: local_authority_3, email_address: 'x.istinguser@some.sch.uk') }
+
+  before do
+    tmp_csv_file << csv_content
+    tmp_csv_file.flush
+  end
+
+  subject(:importer) { ImportResponsibleBodyUsersFromComputacenterCsvService.new(csv_uri: tmp_csv_file.path) }
+
+  describe 'import' do
+    before do
+      importer.import
+    end
+
+    context 'when the DefaultSoldto exists on a ResponsibleBody' do
+      it 'creates a User record on the responsible_body for each email address that does not already exist' do
+        expect(trust.users.pluck(:email_address)).to eq(['a.person@sometrust.co.uk'])
+        expect(local_authority_2.users.pluck(:email_address)).to eq(['b.someone@aschool.sch.uk'])
+        expect(local_authority_3.users.pluck(:email_address)).to include('c.mee@anotherschool.org')
+      end
+
+      it 'records any existing users as failures' do
+        expect(importer.failures.map { |f| f[:row]['Email'] }).to include('x.istinguser@some.sch.uk')
+      end
+    end
+
+    context 'when the DefaultSoldto does not exist on a ResponsibleBody' do
+      it 'assigns the user to the first entry in their SoldTos that matches an RB' do
+        expect(User.find_by_email_address!('d.barkel@alocalauthority.gov.uk').responsible_body).to eq(local_authority_4)
+      end
+
+      context 'when it cannot match any of the SoldTos to an RB' do
+        it 'does not create the user' do
+          expect { User.find_by_email_address!('e.baigum@nowhere.org') }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'records the row as a failure' do
+          expect(importer.failures.map { |f| f[:row]['Email'] }).to include('e.baigum@nowhere.org')
+        end
+      end
+    end
+
+
+    it 'stores any failures' do
+      expect(importer.failures.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We have some spreadsheets from Computacenter with the contacts they hold for each of their accounts from wave 1.
We need to import those contacts into the DB as users, but also make sure they're linked to the right Responsible Bodies.
The task is made more complex by the fact that the source data we have, uses Computacenter references & GIAS UIDs to link things together.

### Changes proposed in this pull request

* Add db fields to store GIAS Id, GIAS Group UID, and computacenter_reference
* Add a new `ImportComputacenterReferencesService` to import Computacenter's 'SoldTo' (RB account ID) and `ShipTo` (school as shipping location) references to our schools & responsible_bodies
* Add a new `ImportLocalAuthorityGiasIdsService` to import GIAS Ids for Local Authorities from @benilovj 's manually-constructed CSV file
* Add  a new `ImportResponsibleBodyUsersFromComputacenterCsvService` to import the contacts
* Add rake task wrappers for all the above importers

### Guidance to review

You'll need to run the importers in this order:

```bash
# re-run existing importer to pick up the GIAS Group UIDs for trusts:
rake import:trusts
rake import:local_authority_gias_ids 
rake import:school_and_rb_computacenter_references CC_REFERENCES_FILE_URI=(file path or URI)
rake import:rb_users_from_cc_csv RB_USERS_CSV_URL=(file path or URI)
```

Ask @aldavidson or @benilovj for the data files if you need to run those last 2 cmds