### PR TITLE
Add device allocation importer

### DIFF
--- a/app/models/allocation_data_file.rb
+++ b/app/models/allocation_data_file.rb
@@ -1,0 +1,16 @@
+class AllocationDataFile < CsvDataFile
+  def allocations(&block)
+    records(&block)
+  end
+
+protected
+
+  def extract_record(row)
+    {
+      urn: row['URN'],
+      name: row['Name'],
+      y3_10: row['Y3-Y10'].to_i,
+      y10: row['Y10 Allocation'].to_i,
+    }
+  end
+end

--- a/app/models/csv_data_file.rb
+++ b/app/models/csv_data_file.rb
@@ -1,0 +1,44 @@
+require 'csv'
+
+class CsvDataFile
+  def initialize(csv_path)
+    @csv_path = csv_path
+  end
+
+protected
+
+  def records
+    all_records = []
+
+    read_file do |row|
+      record = extract_record(row)
+
+      if block_given?
+        yield record
+      else
+        all_records << record
+      end
+    end
+    all_records unless block_given?
+  end
+
+  def extract_record(row)
+    # override me
+    row
+  end
+
+  def skip?(_row)
+    # override me
+    false
+  end
+
+private
+
+  def read_file
+    CSV.foreach(@csv_path, headers: true, encoding: 'ISO8859-1:utf-8') do |row|
+      next if skip?(row)
+
+      yield row
+    end
+  end
+end

--- a/app/models/get_information_about_schools.rb
+++ b/app/models/get_information_about_schools.rb
@@ -1,6 +1,5 @@
 require 'open-uri'
 require 'csv'
-require 'net/http'
 
 class GetInformationAboutSchools
   EDUBASE_URL = 'https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/'.freeze
@@ -31,33 +30,11 @@ class GetInformationAboutSchools
   end
 
   def self.fetch_latest_edubase_file(file)
-    download_csv_file(schools_url, file)
+    RemoteFile.download(schools_url, file)
   end
 
   def self.fetch_contacts_file(file)
-    download_csv_file(school_contacts_url, file)
-  end
-
-  def self.download_csv_file(file_url, file, limit = 10)
-    raise StandardError, 'Too many redirects for download' if limit <= 0
-
-    url = URI.parse(file_url)
-    Net::HTTP.start(url.host, url.port,
-                    use_ssl: url.scheme == 'https') do |http|
-      http.request_get(url.request_uri) do |resp|
-        case resp
-        when Net::HTTPRedirection
-          download_csv_file(resp['location'], file, limit - 1)
-        when Net::HTTPSuccess
-          resp.read_body do |chunk|
-            file.write(chunk.force_encoding(Encoding::ISO8859_1))
-          end
-        else
-          resp.error!
-        end
-      end
-    end
-    file.rewind
+    RemoteFile.download(school_contacts_url, file)
   end
 
   def self.groups_url

--- a/app/services/import_device_allocations_service.rb
+++ b/app/services/import_device_allocations_service.rb
@@ -1,0 +1,44 @@
+class ImportDeviceAllocationsService
+  attr_reader :datasource
+
+  def initialize(allocations_datasource)
+    @datasource = allocations_datasource
+  end
+
+  def import_device_allocations
+    datasource.allocations do |allocation|
+      school = School.find_by(urn: allocation[:urn])
+
+      if school
+        apply_allocation_to_school!(school, allocation[:y3_10])
+      else
+        Rails.logger.warn("Could not find school (#{allocation[:urn]} - #{allocation[:name]})")
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error(e.message)
+    end
+  end
+
+  def self.import_from_url(url)
+    file = Tempfile.new
+    RemoteFile.download(url, file)
+    new(AllocationDataFile.new(file.path)).import_device_allocations
+  ensure
+    file.close
+    file.unlink
+  end
+
+private
+
+  def apply_allocation_to_school!(school, allocation)
+    sda = school.std_device_allocation
+    if sda
+      sda.update!(allocation: allocation)
+    else
+      school.device_allocations.create!(
+        device_type: :std_device,
+        allocation: allocation,
+      )
+    end
+  end
+end

--- a/app/services/remote_file.rb
+++ b/app/services/remote_file.rb
@@ -1,0 +1,25 @@
+require 'net/http'
+
+module RemoteFile
+  def self.download(file_url, destination_file, redirect_limit = 10)
+    raise StandardError, 'Too many redirects for download' if redirect_limit <= 0
+
+    url = URI.parse(file_url)
+    Net::HTTP.start(url.host, url.port,
+                    use_ssl: url.scheme == 'https') do |http|
+      http.request_get(url.request_uri) do |resp|
+        case resp
+        when Net::HTTPRedirection
+          download(resp['location'], destination_file, redirect_limit - 1)
+        when Net::HTTPSuccess
+          resp.read_body do |chunk|
+            destination_file.write(chunk.force_encoding(Encoding::ISO8859_1))
+          end
+        else
+          resp.error!
+        end
+      end
+    end
+    destination_file.rewind
+  end
+end

--- a/lib/tasks/import_device_allocations.rake
+++ b/lib/tasks/import_device_allocations.rake
@@ -1,0 +1,6 @@
+namespace :import do
+  desc 'Import school device allocations from url specified in ALLOCATIONS_FILE_URL env-var'
+  task allocations: :environment do
+    ImportDeviceAllocationsService.import_from_url(ENV.fetch('ALLOCATIONS_FILE_URL'))
+  end
+end

--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     association :created_by_user, factory: :dfe_user
     association :last_updated_by_user, factory: :dfe_user
     device_type { SchoolDeviceAllocation.device_types.keys.sample }
+    trait :with_std_allocation do
+      device_type { 'std_device' }
+      allocation { Faker::Number.within(range: 1..100) }
+    end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -28,5 +28,9 @@ FactoryBot.define do
       establishment_type { :local_authority }
       association :responsible_body, factory: :local_authority
     end
+
+    trait :with_std_device_allocation do
+      association :std_device_allocation, factory: %i[school_device_allocation with_std_allocation]
+    end
   end
 end

--- a/spec/models/allocation_data_file_spec.rb
+++ b/spec/models/allocation_data_file_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe AllocationDataFile, type: :model do
+  describe '#allocations' do
+    let(:filename) { Rails.root.join('tmp/allocation_test_data.csv') }
+
+    context 'when a school has an allocation entry' do
+      let(:attrs) do
+        {
+          urn: '103001',
+          school_name: 'Little School',
+          y3_10: '23',
+          y10: '0',
+        }
+      end
+
+      before do
+        create_allocations_csv_file(filename, [attrs])
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'retrieves the allocation data' do
+        allocations = described_class.new(filename).allocations
+        expect(allocations.first).to include(
+          urn: '103001',
+          name: 'Little School',
+          y3_10: 23,
+          y10: 0,
+        )
+      end
+    end
+  end
+end

--- a/spec/services/import_device_allocations_service_spec.rb
+++ b/spec/services/import_device_allocations_service_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ImportDeviceAllocationsService, type: :model do
+  describe 'importing device allocations' do
+    let(:filename) { Rails.root.join('tmp/allocations_test_data.csv') }
+
+    context 'when a standard device allocation does not exist' do
+      let(:school) { create(:school) }
+      let(:attrs) do
+        {
+          urn: school.urn,
+          school_name: school.name,
+          y3_10: '50',
+          y_10: '10',
+        }
+      end
+
+      before do
+        create_allocations_csv_file(filename, [attrs])
+        @service = described_class.new(AllocationDataFile.new(filename))
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'creates a new device allocation record' do
+        expect {
+          @service.import_device_allocations
+        }.to change { SchoolDeviceAllocation.count }.by(1)
+      end
+
+      it 'sets the correct allocation on the device allocation record' do
+        @service.import_device_allocations
+        expect(school.std_device_allocation.allocation).to eq 50
+      end
+    end
+
+    context 'when an allocation already exists' do
+      let(:school) { create(:school, :with_std_device_allocation) }
+      let(:allocation_id) { school.std_device_allocation.id }
+
+      let(:attrs) do
+        {
+          urn: school.urn,
+          school_name: school.name,
+          y3_10: 123,
+          y10: 22,
+        }
+      end
+
+      before do
+        create_school_csv_file(filename, [attrs])
+        service = described_class.new(AllocationDataFile.new(filename))
+        service.import_device_allocations
+        school.reload
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'updates the existing device allocation record' do
+        expect(school.std_device_allocation.id).to eq allocation_id
+        expect(school.std_device_allocation.allocation).to eq 123
+      end
+    end
+  end
+end

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -25,10 +25,25 @@ module CSVFileHelper
     head_email: 'HeadEmail',
     main_email: 'MainEmail',
     alt_email: 'AlternativeEmail',
+    school_name: 'Name',
+    y3_10: 'Y3-Y10',
+    y10: 'Y10 Allocation',
   }.freeze
 
   def create_school_csv_file(filename, array_of_hashes)
     create_csv_file(filename, SCHOOL_ATTRS.values, array_of_hashes)
+  end
+
+  def create_allocations_csv_file(filename, array_of_hashes)
+    head_keys = array_of_hashes.first.keys
+    headings = head_keys.map { |k| SCHOOL_ATTRS[k] }
+
+    CSV.open(filename, 'w') do |csv|
+      csv << headings
+      array_of_hashes.each do |row|
+        csv << head_keys.map { |k| row.fetch(k) }
+      end
+    end
   end
 
   def remove_file(filename)


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/geNW8AEG/392-import-devices-allocations-into-the-service-from-an-online-csv)
Import school device allocations into the system from a private CSV file.  These are the `std_device` type allocations for years 3-10.  CSV data file is private so will be accessed via a URL held in `ALLOCATIONS_FILE_URL` environment variable.

### Changes proposed in this pull request
Add importer for allocations data, refactor downloading of data files into separate `RemoteFile` module.
Importer will add or update existing device allocations on School records.
The importer creates a `WARN` level entry in the Rails logs for any schools specified in the allocations file that we do not currently have in the DB.

### Guidance to review
Assumes that Schools have already been imported and that you have the allocations csv data file.
Run `ALLOCATIONS_FILE_URL="<file location url>" bundle exec rake import:allocations` to import the allocation data
From the rails console you can check allocations with `School.find_by(urn: <urn>).std_device_allocation` and see that the `allocation` field represents the value for the school in the csv data.
