### PR TITLE
Update support content to match footer support details

### DIFF
--- a/app/views/sign_in_tokens/email_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/email_not_recognised.html.erb
@@ -18,8 +18,7 @@
     </p>
     <ul class="govuk-list">
       <li>Email: <%= ghwt_contact_mailto(subject: nil) %></li>
-      <li>Monday to Friday (except public holidays)</li>
-      <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+      <li>We aim to respond within 3 working days.</li>
     </ul>
   </div>
 </div>

--- a/public/429.html
+++ b/public/429.html
@@ -91,8 +91,7 @@
             <h2 class="govuk-heading-m">Need help?</h2>
             <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
               <li>Email: <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a></li>
-              <li>Monday to Friday (except public holidays)</li>
-              <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+              <li>We aim to respond within 3 working days.</li>
             </ul>
 
             <h2 class="govuk-visually-hidden">Support links</h2>


### PR DESCRIPTION
### Context
We recently update the support copy in the footer as part of PR #272. This PR updates any content in the service were we might have mentioned the support contact email, Monday-Friday and within 5 working days.

### Changes proposed in this pull request

### Guidance to review

