### PR TITLE
Redirect support users, who are also RB users, to RB homepage

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -86,12 +86,12 @@ private
   def root_url_for(user)
     if user.is_mno_user?
       mno_extra_mobile_data_requests_path
-    elsif user.is_support?
-      support_service_performance_path
     elsif user.is_responsible_body_user?
       responsible_body_home_path
     elsif user.is_computacenter?
       computacenter_home_path
+    elsif user.is_support?
+      support_service_performance_path
     else
       '/'
     end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -47,20 +47,30 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   context 'as a user who belongs_to a responsible_body' do
     let(:user) { create(:local_authority_user) }
 
-    scenario 'it redirects to the responsible_body_home page' do
+    scenario 'it redirects to the responsible body homepage' do
       sign_in_as user
       expect(page).to have_current_path(responsible_body_home_path)
       expect(page).to have_text 'Get help with technology'
     end
   end
 
-  context 'as a DfE user' do
+  context 'as a support user' do
     let(:user) { create(:dfe_user) }
 
     scenario 'it redirects to Service performance' do
       sign_in_as user
       expect(page).to have_current_path(support_service_performance_path)
       expect(page).to have_text 'Service performance'
+    end
+
+    context 'who is also attached to a responsible body (for demo purposes)' do
+      let(:user) { create(:local_authority_user, is_support: true) }
+
+      scenario 'it redirects to the responsible body homepage' do
+        sign_in_as user
+        expect(page).to have_current_path(responsible_body_home_path)
+        expect(page).to have_text 'Get help with technology'
+      end
     end
   end
 


### PR DESCRIPTION
### Context

For support users who want to test functionality as an RB should
be redirected to the RB homepage upon login, otherwise there's no way for them
to navigate to that page. If they want to access support functionality,
they can use the nav links.

### Changes proposed in this pull request

If a support user is also something else (e.g. an RB or a CC user too), redirect to that other thing when signing the user in.



