### PR TITLE
Send slack events when RBs make choices about who orders

### DIFF
--- a/app/controllers/responsible_body/devices/who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/who_will_order_controller.rb
@@ -15,6 +15,9 @@ class ResponsibleBody::Devices::WhoWillOrderController < ResponsibleBody::Device
           school.create_preorder_information!(who_will_order_devices: @form.who_will_order.singularize)
         end
       end
+
+      event = WhoWillOrderEvent.new(responsible_body: @responsible_body)
+      EventNotificationsService.broadcast(event)
       flash[:notice] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
       redirect_to responsible_body_devices_who_will_order_path
     else

--- a/app/models/who_will_order_event.rb
+++ b/app/models/who_will_order_event.rb
@@ -1,0 +1,27 @@
+class WhoWillOrderEvent < Event
+  def notifiable?
+    FeatureFlag.active?(:who_will_order_slack_notifications)
+  end
+
+  def message
+    I18n.t(
+      message_key,
+      scope: [:events],
+      responsible_body: @params[:responsible_body].name,
+    )
+  end
+
+private
+
+  def message_key
+    if schools_will_order?
+      :schools_will_order_event
+    else
+      :responsible_body_will_order_event
+    end
+  end
+
+  def schools_will_order?
+    @params[:responsible_body].who_will_order_devices == 'schools'
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     rate_limiting
     public_account_creation
     sign_in_slack_notifications
+    who_will_order_slack_notifications
     rbs_can_manage_users
   ].freeze
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,3 +291,5 @@ en:
   events:
     default: An event just happened
     sign_in_event: A user from %{organisation} just signed in
+    responsible_body_will_order_event: "%{responsible_body} will manage orders centrally"
+    schools_will_order_event: "%{responsible_body} has devolved ordering to schools"


### PR DESCRIPTION
Send notifications to Slack when each local authority or trust decides that schools or themselves should manage orders.

Examples:
```
CASTLE SCHOOL EDUCATION TRUST has devolved ordering to schools
CASTLE SCHOOL EDUCATION TRUST will manage orders centrally
```