### PR TITLE
Use a common header across service

### DIFF
--- a/app/components/nav_component.rb
+++ b/app/components/nav_component.rb
@@ -56,6 +56,7 @@ class NavComponent < ViewComponent::Base
 
   def responsible_body_links
     [
+      NavLinkComponent.new(title: 'Home', url: responsible_body_home_path),
       NavLinkComponent.new(title: 'Guidance', url: guidance_page_path),
     ]
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,21 +48,15 @@
             </span>
           <% end %>
         </div>
-        <% if content_for(:devices_service) %>
-          <div class="govuk-header__content">
-            <%= link_to t('service_name'), "/devices", class: "govuk-header__link govuk-header__link--service-name" %>
-          </div>
-        <% else %>
-          <div class="govuk-header__content">
-            <%= render partial: 'layouts/service_link' %>
-            <% unless controller.hide_nav_menu? %>
-              <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-              <nav>
-                <%= render partial: 'layouts/nav' %>
-              </nav>
-            <%- end %>
-          </div>
-        <% end %>
+        <div class="govuk-header__content">
+          <%= render partial: 'layouts/service_link' %>
+          <% unless controller.hide_nav_menu? %>
+            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+            <nav>
+              <%= render partial: 'layouts/nav' %>
+            </nav>
+          <%- end %>
+        </div>
       </div>
     </header>
     <div class="govuk-width-container">


### PR DESCRIPTION
- Devices are now part of the service, we should show the guidance link and the sign in link.
- Add a home link to help signed in RBs find their way back to the signed in home page if they're lost (eg in guidance)

