### PR TITLE
make email address case-insensitive in validation and signing in…

### DIFF
--- a/app/form_objects/sign_in_token_form.rb
+++ b/app/form_objects/sign_in_token_form.rb
@@ -9,6 +9,6 @@ class SignInTokenForm
             format: { with: URI::MailTo::EMAIL_REGEXP, message: 'Enter an email address in the correct format, like name@example.com' }
 
   def email_is_user?
-    SessionService.find_user_by_email(email_address).present?
+    SessionService.find_user_by_lowercase_email(email_address).present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   validates :email_address,
             presence: true,
-            uniqueness: true,
+            uniqueness: { case_sensitive: false },
             length: { minimum: 2, maximum: 1024 }
 
   include SignInWithToken

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,8 +48,6 @@ class User < ApplicationRecord
   end
 
   def force_email_address_to_lowercase!
-    # the 'self' scope is required, for some reason -
-    # - maybe some artefact of the callback flow?
     self.email_address = email_address.downcase if email_address.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,8 +49,7 @@ class User < ApplicationRecord
 
   def force_email_address_to_lowercase!
     # the 'self' scope is required, for some reason -
-    # .email_address and @email_address both return nil
     # - maybe some artefact of the callback flow?
-    self.email_address = self.email_address.downcase if self.email_address.present?
+    self.email_address = email_address.downcase if email_address.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
             uniqueness: { case_sensitive: false },
             length: { minimum: 2, maximum: 1024 }
 
+  before_validation :force_email_address_to_lowercase!
+
   include SignInWithToken
 
   def is_mno_user?
@@ -43,5 +45,12 @@ class User < ApplicationRecord
 
   def seen_privacy_notice?
     privacy_notice_seen_at.present?
+  end
+
+  def force_email_address_to_lowercase!
+    # the 'self' scope is required, for some reason -
+    # .email_address and @email_address both return nil
+    # - maybe some artefact of the callback flow?
+    self.email_address = self.email_address.downcase if self.email_address.present?
   end
 end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -4,7 +4,7 @@ class SessionService
   class InvalidTokenAndIdentifierCombination < StandardError; end
 
   def self.send_magic_link_email!(email_address)
-    if (user = find_user_by_email(email_address.downcase))
+    if (user = find_user_by_lowercase_email(email_address))
       user.generate_token!
       logger.debug "found user #{user.id} - #{user.email_address}, granted token #{user.sign_in_token}"
       SignInTokenMailer.with(user: user).sign_in_token_email.deliver_later
@@ -35,7 +35,7 @@ class SessionService
   end
 
   # Will expand to cover MNO / MVNO and DfE users too
-  def self.find_user_by_email(email_address)
+  def self.find_user_by_lowercase_email(email_address)
     User.where('lower(email_address) = ?', email_address.downcase).first
   end
 

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -4,7 +4,7 @@ class SessionService
   class InvalidTokenAndIdentifierCombination < StandardError; end
 
   def self.send_magic_link_email!(email_address)
-    if (user = find_user_by_email(email_address))
+    if (user = find_user_by_email(email_address.downcase))
       user.generate_token!
       logger.debug "found user #{user.id} - #{user.email_address}, granted token #{user.sign_in_token}"
       SignInTokenMailer.with(user: user).sign_in_token_email.deliver_later

--- a/db/migrate/20200828105501_destroy_duplicate_users.rb
+++ b/db/migrate/20200828105501_destroy_duplicate_users.rb
@@ -1,0 +1,29 @@
+class DestroyDuplicateUsers < ActiveRecord::Migration[6.0]
+  def change
+    duplicate_users = User.where(
+      'exists(
+        select id from users u2  where  u2.id != users.id
+                                    and u2.email_address = LOWER(users.email_address)
+      )',
+    )
+    log "Found #{duplicate_users.count} duplicate_users"
+    duplicate_users.each do |user|
+      lowercase_user = User.where('id != ? and email_address = LOWER(?)', user.id, user.email_address).first
+      # delete the one with the lowest sign-in count
+      log "#{lowercase_user.email_address} sign_in_count: #{lowercase_user.sign_in_count}, #{user.email_address} sign_in_count: #{user.sign_in_count}"
+      if lowercase_user.sign_in_count > user.sign_in_count
+        log "=> destroying #{user.email_address}"
+        user.destroy!
+      else
+        log "=> destroying #{lowercase_user.email_address}"
+        lowercase_user.destroy!
+      end
+    end
+
+    User.update_all('email_address = LOWER(email_address)')
+  end
+
+  def log(msg)
+    Rails.logger.info msg
+  end
+end

--- a/db/migrate/20200828110244_add_unique_index_on_lowercase_email.rb
+++ b/db/migrate/20200828110244_add_unique_index_on_lowercase_email.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexOnLowercaseEmail < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users,
+              'lower(email_address)',
+              name: 'index_users_on_lower_email_address_unique',
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_145044) do
+ActiveRecord::Schema.define(version: 2020_08_28_110244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_145044) do
     t.boolean "is_support", default: false, null: false
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
+    t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -44,6 +44,14 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
+  scenario 'signing in should not be case-sensitive in matching the email address (bug 555)' do
+    visit sign_in_path
+    fill_in('Email address', with: user.email_address.upcase)
+    click_on 'Continue'
+    expect(page).to have_content 'Check your email'
+    expect(page).not_to have_content('Sign out')
+  end
+
   context 'as a user who belongs to a responsible body' do
     context 'who has already seen the privacy notice' do
       let(:user) { create(:local_authority_user, :has_seen_privacy_notice) }

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -44,14 +44,6 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
-  scenario 'signing in should not be case-sensitive in matching the email address (bug 555)' do
-    visit sign_in_path
-    fill_in('Email address', with: user.email_address.upcase)
-    click_on 'Continue'
-    expect(page).to have_content 'Check your email'
-    expect(page).not_to have_content('Sign out')
-  end
-
   context 'as a user who belongs to a responsible body' do
     context 'who has already seen the privacy notice' do
       let(:user) { create(:local_authority_user, :has_seen_privacy_notice) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,9 +65,12 @@ RSpec.describe User, type: :model do
   describe 'email address should not be case-sensitive (bug 555)' do
     context 'a user with the same email as an existing user, but different case' do
       let(:new_user) { build(:local_authority_user, email_address: 'Email.Address@example.com') }
-      let!(:lowercase_user) { create(:local_authority_user, email_address: new_user.email_address.downcase) }
 
-      it 'should not be valid' do
+      before do
+        create(:local_authority_user, email_address: new_user.email_address.downcase)
+      end
+
+      it 'is not valid' do
         expect(new_user.valid?).to be_falsey
         expect(new_user.errors[:email_address]).not_to be_empty
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'email address should not be case-sensitive (bug 555)' do
-
     context 'a user with the same email as an existing user, but different case' do
       let(:new_user) { build(:local_authority_user, email_address: 'Email.Address@example.com') }
       let!(:lowercase_user) { create(:local_authority_user, email_address: new_user.email_address.downcase) }
@@ -71,6 +70,14 @@ RSpec.describe User, type: :model do
       it 'should not be valid' do
         expect(new_user.valid?).to be_falsey
         expect(new_user.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'creating a user with a mixed-case email address' do
+      let(:new_user) { build(:local_authority_user, email_address: 'Mr.Mixed.Case@SOMEDOMAIN.org') }
+
+      it 'forces the email_address to lower-case' do
+        expect { new_user.save! }.to change(new_user, :email_address).to('mr.mixed.case@somedomain.org')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,4 +61,17 @@ RSpec.describe User, type: :model do
       expect(user.needs_to_see_privacy_notice?).to be_falsey
     end
   end
+
+  describe 'email address should not be case-sensitive (bug 555)' do
+
+    context 'a user with the same email as an existing user, but different case' do
+      let(:new_user) { build(:local_authority_user, email_address: 'Email.Address@example.com') }
+      let!(:lowercase_user) { create(:local_authority_user, email_address: new_user.email_address.downcase) }
+
+      it 'should not be valid' do
+        expect(new_user.valid?).to be_falsey
+        expect(new_user.errors[:email_address]).not_to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

[Trello card #555](https://trello.com/c/e5NVQLBI/555-add-a-responsible-body-user-should-not-allow-case-sensitive-email-addresses) - the default implementation of `:string`-type columns in Rails' Postgres adapter is case-sensitive. This means that the email_address field is case-sensitive.

After bulk-importing lots of users from a Computacenter spreadsheet of contacts, we found that 9 of them created duplicates of users who already existed, due to the spreadsheet giving capital letters in their email addresses. In one case, the responsible body listed in the spreadsheet for a user was different to the RB their existing record was linked to. This caused confusion for them when logging in.

### Changes proposed in this pull request

* add 2 migrations - one to destroy any duplicate users, and another to add a case-insensitive unique constraint on `users.email_address`
* make the uniqueness validation on `user.email_address` case-insensitive
* force `email_address` to downcase before validating
* add specs to explicitly test for desired behaviour

### Guidance to review

