### PR TITLE
Make sure success message is show when choosing who will order at RB level

### DIFF
--- a/app/controllers/computacenter/api_tokens_controller.rb
+++ b/app/controllers/computacenter/api_tokens_controller.rb
@@ -28,7 +28,7 @@ class Computacenter::APITokensController < Computacenter::BaseController
   def destroy
     @api_token = @user.api_tokens.find(params[:id])
     @api_token.destroy!
-    flash[:notice] = I18n.t(:success, scope: %i[computacenter api_tokens destroy], name: @api_token.name)
+    flash[:success] = I18n.t(:success, scope: %i[computacenter api_tokens destroy], name: @api_token.name)
     redirect_to computacenter_api_tokens_path
   end
 

--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -12,7 +12,7 @@ class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::
     if @form.valid?
       @school.preorder_information.change_who_will_order_devices!(@form.who_will_order.singularize)
 
-      flash[:notice] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
+      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
       redirect_to responsible_body_devices_school_path(@school.urn)
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/responsible_body/devices/who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/who_will_order_controller.rb
@@ -18,7 +18,7 @@ class ResponsibleBody::Devices::WhoWillOrderController < ResponsibleBody::Device
 
       event = WhoWillOrderEvent.new(responsible_body: @responsible_body)
       EventNotificationsService.broadcast(event)
-      flash[:notice] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
+      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update])
       redirect_to responsible_body_devices_who_will_order_path
     else
       render :edit, status: :unprocessable_entity

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -193,6 +193,7 @@ RSpec.feature 'Setting up the devices ordering' do
     click_on 'Continue'
     expect(page).to have_http_status(:ok)
     expect(page).to have_content('Each school will place their own orders')
+    expect(page).to have_content('We’ve saved your choice')
     click_on 'Go to your list of schools'
   end
 
@@ -200,6 +201,7 @@ RSpec.feature 'Setting up the devices ordering' do
     choose 'Most orders will be placed centrally'
     click_on 'Continue'
     expect(page).to have_http_status(:ok)
+    expect(page).to have_content('We’ve saved your choice')
     expect(page).to have_content('Orders will be placed centrally')
     click_on 'Go to your list of schools'
   end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

* replace `flash[:notice]` with `flash[:success]` (which is actually rendered in the layout)
* add a test that this message is shown 

### Guidance to review

screenshot:
<img width="892" alt="Screen Shot 2020-08-28 at 15 24 02" src="https://user-images.githubusercontent.com/134501/91578934-c591c700-e942-11ea-992d-5e3b39630752.png">

