### PR TITLE
Devices guidance tweaks

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -26,6 +26,10 @@ module ViewHelper
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
 
+  def link_to_devices_guidance_subpage(body, slug, html_options = {})
+    govuk_link_to body, devices_guidance_subpage_path(subpage_slug: slug), html_options
+  end
+
   def sortable_table_header(title, value = title, opts = params)
     if opts[:sort] == value.to_s
       if opts[:dir] == 'd'

--- a/app/views/devices_guidance/device_allocations.md
+++ b/app/views/devices_guidance/device_allocations.md
@@ -2,7 +2,7 @@
 
 ### Laptops and tablets for schools, academy trusts and local authorities after August 2020
 
-The number of devices available to order through the [Get help with technology service](https://get-help-with-tech.education.gov.uk/start) reflects the number of laptops and tablets we estimate are needed by each school. This calculation is based on:
+The number of devices available to order through the [Get help with technology service](/start) reflects the number of laptops and tablets we estimate are needed by each school. This calculation is based on:
 
 * free school meals data
 * an estimate of the number of devices a school already has

--- a/app/views/devices_guidance/device_specification.md
+++ b/app/views/devices_guidance/device_specification.md
@@ -1,4 +1,4 @@
-When [placing an order](https://get-help-with-tech.education.gov.uk/start), schools, academy trusts and local authorities can choose from:
+When [placing an order](/start), schools, academy trusts and local authorities can choose from:
 
 * Microsoft Windows laptop
 * Microsoft Windows tablet
@@ -11,7 +11,7 @@ For future orders, Microsoft devices can be supplied with factory settings to al
 
 Find out more about [preparing Microsoft devices](/devices/preparing-microsoft-windows-laptops-and-tablets) that have pre-installed software and settings.
 
-For Google and Apple devices, we need the credentials described in the [order process guidance](https://get-help-with-tech.education.gov.uk/devices/how-to-order) to allow us to set devices up for a school.
+For Google and Apple devices, we need the credentials described in the [order process guidance](/devices/how-to-order) to allow us to set devices up for a school.
 
 If an education platform is not currently in use, schools, local authorities and academy trusts can apply for DfE-funded support to get access to either G Suite for Education or Office 365 Education. More information is available from [The Key for School Leaders](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/).
 

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -248,26 +248,27 @@
               <li>Google Chromebook</li>
               <li>Apple iPad</li>
             </ul>
-            
-                        <p class="app-step-nav__paragraph">
 
-                          View the <a href="https://get-help-with-tech.education.gov.uk/devices/device-specification" class="govuk-link">full specifications</a> of these devices.
+            <p class="app-step-nav__paragraph">
+              View the <a href="https://get-help-with-tech.education.gov.uk/devices/device-specification" class="govuk-link">full specifications</a> of these devices.
             </p>
 
             <p class="app-step-nav__paragraph">
              When ordering Microsoft devices, a selection can be made between:
             </p>
-             <ul class="govuk-list govuk-list--bullet">
-              <li>not having DfE settings installed - these devices can be configured with your preferred safeguarding software and brought into your existing device management framework. </li>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>not having DfE settings installed - these devices can be configured with your preferred safeguarding software and brought into your existing device management framework.</li>
               <li>having DfE settings installed - these devices are not configurable, with limitations on downloading certain software and changing the strict content filters that may prevent some browsers and conferencing tools from functioning. You will be reliant on DfE for technical support.</li>
             </ul>
-<p class="app-step-nav__paragraph">
-  Read more information about <a href="https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets" class="govuk-link">preparing Microsoft devices</a>.</p>
-            
-                      <p class="app-step-nav__paragraph">
-                        For Google and Apple devices we’ll require the credentials described in the ‘Prepare to place an order’ step of this process to allow us to set devices up for a school.
+
+            <p class="app-step-nav__paragraph">
+              Read more information about <a href="https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets" class="govuk-link">preparing Microsoft devices</a>.
             </p>
-            
+
+            <p class="app-step-nav__paragraph">
+              For Google and Apple devices we’ll require the credentials described in the ‘Prepare to place an order’ step of this process to allow us to set devices up for a school.
+            </p>
+
             <p class="app-step-nav__paragraph">
               If an education platform is not currently in use, schools, local authorities and academy trusts can apply
               for DfE-funded support to get access to either G Suite for Education or Office 365 Education. More
@@ -321,9 +322,7 @@
             </ul>
 
             <p class="app-step-nav__paragraph">
-              All distribution and return of loan devices should be done in accordance with the
-              <a href="https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19" class="govuk-link">
-                social distancing guidelines relevant to your local area</a>.
+              All distribution and return of loan devices should be done in accordance with the <a href="https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19" class="govuk-link"> social distancing guidelines relevant to your local area</a>.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -331,9 +330,9 @@
               provides information on how to request admin passwords, report device
               faults and arrange a repair or replacement under warranty terms.
             </p>
-            
-                      <p class="app-step-nav__paragraph">
-  We are also providing <a href="https://get-help-with-tech.education.gov.uk/internet-access" class="govuk-link">internet connections</a> where they are needed. 
+
+            <p class="app-step-nav__paragraph">
+              We are also providing <a href="https://get-help-with-tech.education.gov.uk/internet-access" class="govuk-link">internet connections</a> where they are needed.
             </p>
           </div>
 

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -8,7 +8,7 @@
     </h1>
 
     <p class="govuk-body">
-      Prepare to <a href="https://get-help-with-tech.education.gov.uk/start" class="govuk-link">order laptops and tablets</a>
+      Prepare to <%= govuk_link_to 'order laptops and tablets', start_path %>
       for disadvantaged children in certain year groups when schools are  affected by disruption to face to face
       education due to coronavirus (COVID-19).
     </p>
@@ -44,7 +44,7 @@
             <p class="app-step-nav__paragraph">
               This choice can be adapted individually for each school. Additional users from within a local authority
               or academy trust can be invited to provide this information
-              <a href="https://get-help-with-tech.education.gov.uk/start" class="govuk-link">through the service</a>.
+              <%= govuk_link_to 'through the service', start_path %>.
             </p>
           </div>
 
@@ -136,7 +136,7 @@
             </p>
 
             <p class="app-step-nav__paragraph">
-              <a href="https://get-help-with-tech.education.gov.uk/devices/device_allocations" class="govuk-link">Find out about allocations</a> and what information is required if you would like to request additional devices for a school.
+              <%= link_to_devices_guidance_subpage 'Find out about allocations', 'device-allocations' %> and what information is required if you would like to request additional devices for a school.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -163,7 +163,7 @@
 
             <p class="app-step-nav__paragraph">
               If you’re ordering Chromebooks, you’ll need to add the following to the
-              <a href="https://get-help-with-tech.education.gov.uk/start" class="govuk-link">Get help with technology service</a>
+              <%= govuk_link_to 'Get help with technology service', start_path %>
               before orders can be placed:
             </p>
 
@@ -250,7 +250,7 @@
             </ul>
 
             <p class="app-step-nav__paragraph">
-              View the <a href="https://get-help-with-tech.education.gov.uk/devices/device-specification" class="govuk-link">full specifications</a> of these devices.
+              View the <%= link_to_devices_guidance_subpage 'full specifications', 'device-specification' %> of these devices.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -262,7 +262,7 @@
             </ul>
 
             <p class="app-step-nav__paragraph">
-              Read more information about <a href="https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets" class="govuk-link">preparing Microsoft devices</a>.
+              Read more information about <%= link_to_devices_guidance_subpage 'preparing Microsoft devices', 'preparing-microsoft-windows-laptops-and-tablets' %>.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -332,7 +332,7 @@
             </p>
 
             <p class="app-step-nav__paragraph">
-              We are also providing <a href="https://get-help-with-tech.education.gov.uk/internet-access" class="govuk-link">internet connections</a> where they are needed.
+              We are also providing <%= govuk_link_to 'internet connections', connectivity_home_path %> where they are needed.
             </p>
           </div>
 

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -52,7 +52,7 @@
 
     <h2 class="govuk-heading-m">Each school has their own allocation</h2>
 
-    <p class="govuk-body">Every school has its own provisional allocation of laptops and tablets. Allocations are based on free school meal data and estimates of how many devices a school has already received. <%= govuk_link_to 'Read more about allocations', devices_guidance_subpage_path(subpage_slug: 'device-allocations'), target: '_blank', rel: 'noopener noreferrer' %>.</p>
+    <p class="govuk-body">Every school has its own provisional allocation of laptops and tablets. Allocations are based on free school meal data and estimates of how many devices a school has already received. <%= link_to_devices_guidance_subpage 'Read more about allocations', 'device-allocations', target: '_blank', rel: 'noopener noreferrer' %>.</p>
 
     <p class="govuk-body">Numbers will be reassessed at the time of ordering based on availability and the extent of coronavirus restrictions.</p>
 


### PR DESCRIPTION
### Context

Some absolute links were introduced during recent devices guidance changes. This makes it harder to test those pages because the links aren't relative and take you off to the production site.

### Changes proposed in this pull request

- replace absolute links with relative links
- use Rails path helpers where possible (so that if content moves, the path doesn't break)
- fix some indentation issues that have crept in
- extract a view helper for generating links to devices guidance subpages


