### PR TITLE
Make the 'devices distribution and ownership' page available again

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
     device_specification:
       title: Device specification
       description: Get the technical specifications of the devices for vulnerable and disadvantaged children and young people.
-      audience: responsible_body_users   
+      audience: responsible_body_users
     preparing_microsoft_windows_laptops_and_tablets:
       title: Preparing Microsoft Windows laptops and tablets
       description: Guidance on how to set up Microsoft Windows devices with safeguarding and mobile device management software and how to install your own software.
@@ -83,7 +83,7 @@ en:
       title: Preparing 4G routers
       description: Find out how 4G wireless routers are secured, how much data users get, how long the contract is and records you should keep.
       audience: responsible_body_users
-    distributing_devices:
+    device_distribution_and_ownership:
       title: Device distribution and ownership
       description: Advice on how to get devices to children and young people via schools, social workers and deliveries to their homes. Information on insuring devices, asset management and loan agreements.
       audience: responsible_body_users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get '/pages/guidance', to: redirect('/')
   get '/devices/choosing-devices', to: redirect('/devices/device-allocations')
   get '/devices/allocation-and-specification', to: redirect('/devices/device-allocations')
+  get '/devices/distributing-devices', to: redirect('/devices/device-distribution-and-ownership')
 
   get '/internet-access', to: 'pages#internet_access', as: :connectivity_home
 


### PR DESCRIPTION
### Context

#361 inadvertently broke the 'devices distribution' devices guidance subpage. This was because the page filename and its metadata didn't match, meaning users saw 500 errors when following the link.

### Changes proposed in this pull request

Re-align the devices guidance subpage name with its metadata.


