### PR TITLE
School users can sign in and see who can order devices

### DIFF
--- a/app/components/user_summary_list_component.html.erb
+++ b/app/components/user_summary_list_component.html.erb
@@ -1,0 +1,3 @@
+<div class="user-summary-list">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/user_summary_list_component.rb
+++ b/app/components/user_summary_list_component.rb
@@ -1,0 +1,24 @@
+class UserSummaryListComponent < ViewComponent::Base
+  validates :user, presence: true
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def rows
+    [
+      {
+        key: 'Email address',
+        value: @user.email_address,
+      },
+      {
+        key: 'Telephone',
+        value: @user.telephone,
+      },
+      {
+        key: 'Last sign in',
+        value: @user.last_signed_in_at ? l(@user.last_signed_in_at, format: :short) : 'Never',
+      },
+    ]
+  end
+end

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -1,0 +1,17 @@
+class School::BaseController < ApplicationController
+  before_action :require_school_user!, :set_school
+
+private
+
+  def require_school_user!
+    if SessionService.is_signed_in?(session)
+      render 'errors/forbidden', status: :forbidden unless @user.is_school_user?
+    else
+      redirect_to_sign_in
+    end
+  end
+
+  def set_school
+    @school = @user.school
+  end
+end

--- a/app/controllers/school/home_controller.rb
+++ b/app/controllers/school/home_controller.rb
@@ -1,0 +1,3 @@
+class School::HomeController < School::BaseController
+  def show; end
+end

--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -1,0 +1,5 @@
+class School::UsersController < School::BaseController
+  def index
+    @users = @school.users.order(:full_name)
+  end
+end

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -90,6 +90,8 @@ private
       responsible_body_privacy_notice_path
     elsif user.is_responsible_body_user?
       responsible_body_home_path
+    elsif user.is_school_user?
+      school_home_path
     elsif user.is_computacenter?
       computacenter_home_path
     elsif user.is_support?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -4,6 +4,7 @@ class School < ApplicationRecord
   has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
+  has_many :users
   has_one :preorder_information
 
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true
+  belongs_to :school, optional: true
 
   scope :approved, -> { where.not(approved_at: nil) }
   scope :signed_in_at_least_once, -> { where('sign_in_count > 0') }
@@ -29,6 +30,10 @@ class User < ApplicationRecord
 
   def is_responsible_body_user?
     responsible_body.present?
+  end
+
+  def is_school_user?
+    school.present?
   end
 
   def update_sign_in_count_and_timestamp!

--- a/app/views/responsible_body/users/_user.html.erb
+++ b/app/views/responsible_body/users/_user.html.erb
@@ -5,30 +5,5 @@
       <%= govuk_link_to 'Edit user', edit_responsible_body_user_path(user) %>
     </p>
   <%- end %>
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Email address
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= user.email_address %>
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Telephone
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= user.telephone %>
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Last sign in
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= user.last_signed_in_at ? l(user.last_signed_in_at, format: :short) : '-'%>
-      </dd>
-    </div>
-  </dl>
+  <%= render UserSummaryListComponent.new(user: user) %>
 </div>

--- a/app/views/responsible_body/users/_user.html.erb
+++ b/app/views/responsible_body/users/_user.html.erb
@@ -1,5 +1,5 @@
 <div class="user">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h2>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
   <%- if FeatureFlag.active?(:rbs_can_manage_users) %>
     <p class="govuk-body">
       <%= govuk_link_to 'Edit user', edit_responsible_body_user_path(user) %>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -4,5 +4,15 @@
       <span class="govuk-caption-xl"><%= @school.name %></span>
       <%= t('page_titles.school_home') %>
     </h1>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.school_users'), school_users_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>give others in your school access to this service</li>
+      <li>set up accounts for your school to order devices</li>
+    </ul>
   </div>
 </div>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= t('page_titles.school_home') %>
+    </h1>
+  </div>
+</div>

--- a/app/views/school/users/_user.html.erb
+++ b/app/views/school/users/_user.html.erb
@@ -1,0 +1,3 @@
+<div class="user">
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+</div>

--- a/app/views/school/users/_user.html.erb
+++ b/app/views/school/users/_user.html.erb
@@ -1,3 +1,4 @@
 <div class="user">
   <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+  <%= render UserSummaryListComponent.new(user: user) %>
 </div>

--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -1,0 +1,29 @@
+<%- title = t('page_titles.school_users') -%>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <div class="govuk-breadcrumbs ">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= title %>
+    </li>
+  </ol>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%- unless @users.empty? %>
+      <div id="user-list">
+        <h2 class="govuk-heading-l">Users</h2>
+        <%= render partial: 'user', collection: @users %>
+      </div>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
       schools: The school will place their own orders
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
+    school_home: Get devices for your school
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:
@@ -70,7 +71,7 @@ en:
     device_specification:
       title: Device specification
       description: Get the technical specifications of the devices for vulnerable and disadvantaged children and young people.
-      audience: responsible_body_users   
+      audience: responsible_body_users
     preparing_microsoft_windows_laptops_and_tablets:
       title: Preparing Microsoft Windows laptops and tablets
       description: Guidance on how to set up Microsoft Windows devices with safeguarding and mobile device management software and how to install your own software.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     school_home: Get devices for your school
+    school_users: Manage who can order devices
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :school do
+    get '/', to: 'home#show', as: :home
+  end
+
   namespace :support do
     get '/', to: 'service_performance#index', as: :service_performance
     namespace :devices do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
 
   namespace :school do
     get '/', to: 'home#show', as: :home
+    resources :users, only: %i[index]
   end
 
   namespace :support do

--- a/db/migrate/20200831200056_user_can_belong_to_school.rb
+++ b/db/migrate/20200831200056_user_can_belong_to_school.rb
@@ -1,0 +1,5 @@
+class UserCanBelongToSchool < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :school, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_123318) do
+ActiveRecord::Schema.define(version: 2020_08_31_200056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,11 +177,13 @@ ActiveRecord::Schema.define(version: 2020_08_28_123318) do
     t.boolean "is_support", default: false, null: false
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
+    t.bigint "school_id"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
+    t.index ["school_id"], name: "index_users_on_school_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true
   end
 
@@ -192,4 +194,5 @@ ActiveRecord::Schema.define(version: 2020_08_28_123318) do
   add_foreign_key "responsible_bodies", "users", column: "key_contact_id"
   add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "schools", "responsible_bodies"
+  add_foreign_key "users", "schools"
 end

--- a/spec/components/user_summary_list_component_spec.rb
+++ b/spec/components/user_summary_list_component_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe UserSummaryListComponent do
+  let(:user) { create(:school_user, email_address: 'davy.jones@school.sch.uk', telephone: '12345') }
+
+  subject(:result) { render_inline(described_class.new(user: user)) }
+
+  it 'displays the user email address' do
+    expect(result.css('dd')[0].text).to include('davy.jones@school.sch.uk')
+  end
+
+  it 'displays the user telephone' do
+    expect(result.css('dd')[1].text).to include('12345')
+  end
+
+  context 'when the user has never signed in' do
+    before do
+      user.update(last_signed_in_at: nil)
+    end
+
+    it 'displays that they have never signed in' do
+      expect(result.css('dd')[2].text).to include('Never')
+    end
+  end
+
+  context 'when the user has signed in before' do
+    before do
+      user.update(last_signed_in_at: Time.zone.local(2020, 8, 28, 14, 3))
+    end
+
+    it 'displays when they last signed in' do
+      expect(result.css('dd')[2].text).to include('28 Aug 14:03')
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
       approved
     end
 
+    factory :school_user do
+      school
+    end
+
     factory :mno_user do
       association :mobile_network
     end

--- a/spec/features/school/manage_users_spec.rb
+++ b/spec/features/school/manage_users_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Manage school users' do
+  let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
+  let(:user_from_same_school) { create(:school_user, full_name: 'ZZZ Jones', school: school_user.school) }
+  let(:user_from_other_school) { create(:school_user) }
+  let(:school_users_page) { PageObjects::School::UsersPage.new }
+
+  before do
+    user_from_same_school
+    user_from_other_school
+
+    sign_in_as school_user
+  end
+
+  scenario 'viewing the list of school users who can order devices' do
+    when_i_follow_the_link_to_manage_who_can_order_devices
+    then_i_see_a_list_of_users_for_my_school
+    and_i_dont_see_users_from_other_schools
+  end
+
+  def when_i_follow_the_link_to_manage_who_can_order_devices
+    click_on 'Manage who can order devices'
+
+    expect(school_users_page).to be_displayed
+    expect(page).to have_content 'Manage who can order devices'
+  end
+
+  def then_i_see_a_list_of_users_for_my_school
+    expect(school_users_page.user_rows[0]).to have_content('AAA Smith')
+    expect(school_users_page.user_rows[1]).to have_content('ZZZ Jones')
+  end
+
+  def and_i_dont_see_users_from_other_schools
+    expect(school_users_page).not_to have_content(user_from_other_school.full_name)
+  end
+end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -66,6 +66,16 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
+  context 'as a school user' do
+    let(:user) { create(:school_user) }
+
+    scenario 'it redirects to the school homepage' do
+      sign_in_as user
+      expect(page).to have_current_path(school_home_path)
+      expect(page).to have_text 'Get devices for your school'
+    end
+  end
+
   context 'as a support user' do
     let(:user) { create(:dfe_user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#is_school_user?' do
+    it 'is true when the user is associated with a school' do
+      user = build(:user, school: build(:school))
+      expect(user.is_school_user?).to be_truthy
+    end
+
+    it 'is false when the user is not associated with a school' do
+      user = build(:user, school: nil)
+      expect(user.is_school_user?).to be_falsey
+    end
+  end
+
   describe 'privacy notice' do
     it 'needs to be seen by responsible body users who havent seen it' do
       user = build(:local_authority_user, privacy_notice_seen_at: nil)

--- a/spec/page_objects/school/users_page.rb
+++ b/spec/page_objects/school/users_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module School
+    class UsersPage < PageObjects::BasePage
+      set_url '/school/users'
+
+      elements :user_rows, '#user-list .user'
+    end
+  end
+end


### PR DESCRIPTION
### Context

School users should be able to:

- sign into the service
- see a list of other users (who can place orders) for their school

### Changes proposed in this pull request

- Bring in the plumbing needed to allow school users to sign in (routes, updates to the user model, being able to associate users with schools)
- Introduce a school base controller
- Start building out the school home page
- Add a read-only school users page

Additionally:

- Extract a user summary list component that is shared between the RB and school areas of the service
- Fix the heading hierarchy on the RB users page

### Guidance to review

Best reviewed commit by commit.

![image](https://user-images.githubusercontent.com/23801/91774726-630a2680-ebe1-11ea-9eee-33249f87c9bd.png)

![image](https://user-images.githubusercontent.com/23801/91774759-761cf680-ebe1-11ea-8053-9d32b07979e4.png)

