### PR TITLE
Run jest as part of the GitHub Actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,8 @@ jobs:
         run: bundle exec rspec
       - name: Run rubocop
         run: bundle exec rubocop app config db lib spec Gemfile --format clang
+      - name: Run jest
+        run: bundle exec rake test_js
       - name: Run scss linter
         run: bundle exec scss-lint app/webpacker/styles
       - name: Run brakeman


### PR DESCRIPTION
### Context

PR #333 introduced Jest into the project as the test runner for JS tests. It is currently not being called as part of the GitHub Actions build.

### Changes proposed in this pull request

- add a GH Actions step to run jest

