### PR TITLE
Fix bullet styling on privacy notice

### DIFF
--- a/app/views/responsible_body/home/privacy_notice.html.erb
+++ b/app/views/responsible_body/home/privacy_notice.html.erb
@@ -26,7 +26,7 @@
     <h3 class="govuk-heading-m" id="how-personal-information-will-be-shared">How personal information will be shared</h3>
     <p class="govuk-body">We share the following information with a contracted third party (currently Computacenter (UK) Ltd) which administers the ordering and supply of computing devices and other related products and services under the Get help with technology initiative on behalf of DfE:</p>
 
-    <ul>
+    <ul class="govuk-list govuk-list--bullet">
       <li>your name and contact details (specifically, your work email and telephone number)</li>
       <li>the school’s name and address</li>
     </ul>


### PR DESCRIPTION
### Context

Bulleted list on privacy notice was unstyled because I had forgotten the necessary CSS classes.

### Changes proposed in this pull request

* Fix markup

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/91874156-c774c680-ec71-11ea-90d8-d7bf8b1c2439.png)
