### PR TITLE
574 schools manage who can order devices add users

### DIFF
--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -2,4 +2,30 @@ class School::UsersController < School::BaseController
   def index
     @users = @school.users.order(:full_name)
   end
+
+  def new
+    @user = @school.users.build
+  end
+
+  def create
+    @user = @school.users.new(user_params)
+    if @user.valid?
+      @user.save!
+      InviteSchoolUserMailer.with(user: @user).nominated_contact_email.deliver_later
+      redirect_to school_users_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def user_params
+    params.require(:user).permit(
+      :full_name,
+      :email_address,
+      :telephone,
+      :orders_devices,
+    )
+  end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -100,6 +100,21 @@ module ViewHelper
     ]
   end
 
+  def can_user_order_devices_options
+    scope = 'page_titles.invite_school_user'
+    [
+      OpenStruct.new(
+        value: '1',
+        label: t('can_order_devices', scope: scope),
+        hint: t('can_order_devices_hint', scope: scope),
+      ),
+      OpenStruct.new(
+        value: '0',
+        label: t('cannot_order_devices', scope: scope),
+      ),
+    ]
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/mailers/invite_school_user_mailer.rb
+++ b/app/mailers/invite_school_user_mailer.rb
@@ -1,0 +1,23 @@
+class InviteSchoolUserMailer < ApplicationMailer
+  def nominated_contact_email
+    @user = params[:user]
+
+    template_mail(
+      invite_user_template_id,
+      to: @user.email_address,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def personalisation
+    {
+      email_address: @user.email_address,
+    }
+  end
+
+  def invite_user_template_id
+    Settings.govuk_notify.templates.devices.school_nominated_contact
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,8 @@ class User < ApplicationRecord
   end
 
   def orders_devices_user_limit
-    errors.add(:orders_devices,
-               I18n.t('activerecord.errors.models.user.attributes.orders_devices.user_limit')) if orders_devices? && school.users.who_can_order_devices.count >= 3
+    if orders_devices? && school.users.who_can_order_devices.count >= 3
+      errors.add(:orders_devices, I18n.t('activerecord.errors.models.user.attributes.orders_devices.user_limit'))
+    end
   end
 end

--- a/app/views/school/users/_form.html.erb
+++ b/app/views/school/users/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form.govuk_error_summary %>
+
+<%= form.govuk_text_field :full_name,
+                          label: { text: 'Name', size: 'm' } %>
+
+<%= form.govuk_email_field  :email_address,
+                            label: { text: 'Email address', size: 'm' } %>
+
+<%= form.govuk_text_field :telephone,
+                          width: 10,
+                          label: { text: 'Telephone number', size: 'm' } %>
+
+<%= form.govuk_collection_radio_buttons :orders_devices,
+        can_user_order_devices_options,
+        :value,
+        :label,
+        :hint,
+        legend: { text: t('page_titles.invite_school_user.will_they_order_devices'), size: 'm' },
+        hint_text: t('page_titles.invite_school_user.will_they_order_devices_hint'),
+        classes: 'govuk-!-margin-top-3'
+      %>
+
+<%= form.govuk_submit submit_text %>

--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -18,7 +18,12 @@
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>
-
+    <p class="govuk-body">Up to 3 users can be added. Everyone with access can:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>add or edit existing users</li>
+      <li>place orders for devices</li>
+    </ul>
+    <%= govuk_button_link_to 'Invite a new user', new_school_user_path %>
     <%- unless @users.empty? %>
       <div id="user-list">
         <h2 class="govuk-heading-l">Users</h2>

--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -18,10 +18,11 @@
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>
-    <p class="govuk-body">Up to 3 users can be added. Everyone with access can:</p>
+    <p class="govuk-body">No more than 3 users will be allowed to place orders</p>
+    <p class="govuk-body">Everyone with access can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
       <li>add or edit existing users</li>
-      <li>place orders for devices</li>
+      <li>change who places orders for devices</li>
     </ul>
     <%= govuk_button_link_to 'Invite a new user', new_school_user_path %>
     <%- unless @users.empty? %>

--- a/app/views/school/users/new.html.erb
+++ b/app/views/school/users/new.html.erb
@@ -1,0 +1,33 @@
+<%- title = t('page_titles.invite_school_user.title') %>
+<%- content_for :title, title_with_error_prefix(title, @user.errors.any?) %>
+<%- content_for :before_content do %>
+<div class="govuk-breadcrumbs ">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to t('page_titles.school_users'), school_users_path, class: 'govuk-breadcrumbs__link' %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= title %>
+    </li>
+  </ol>
+</div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+    <p class="govuk-body">Invite someone in your school who:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>understands what devices are needed and who will get them</li>
+      <li>can configure devices or give technical information</li>
+    </ul>
+    <%= form_for @user, url: school_users_path do |f| %>
+      <%= render partial: 'form', locals: { submit_text: 'Send invite', form: f } %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     school_home: Get devices for your school
-    school_users: Manage who can order devices
+    school_users: Manage users
     invite_school_user:
       title: Invite a new user
       will_they_order_devices: Will they place orders for devices?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,13 @@ en:
     privacy_notice: Privacy notice
     school_home: Get devices for your school
     school_users: Manage who can order devices
+    invite_school_user:
+      title: Invite a new user
+      will_they_order_devices: Will they place orders for devices?
+      will_they_order_devices_hint: No more than 3 users will be allowed to place orders.
+      can_order_devices: Yes, give them access to the TechSource website
+      can_order_devices_hint: This is where they'll place orders.
+      cannot_order_devices: 'No'
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:
@@ -281,6 +288,9 @@ en:
               blank: Enter an email address in the correct format, like name@example.com
               taken: Email address has already been used
               too_short: Enter an email address that is at least %{count} characters
+            orders_devices:
+              inclusion: Tell us whether the user will order devices
+              user_limit: There are already 3 users that can order devices
         school:
           attributes:
             urn:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
       will_they_order_devices: Will they place orders for devices?
       will_they_order_devices_hint: No more than 3 users will be allowed to place orders.
       can_order_devices: Yes, give them access to the TechSource website
-      can_order_devices_hint: This is where they'll place orders.
+      can_order_devices_hint: This is where they’ll place orders.
       cannot_order_devices: 'No'
   cookie_preferences:
     success: Your cookie preferences have been saved
@@ -290,7 +290,7 @@ en:
               too_short: Enter an email address that is at least %{count} characters
             orders_devices:
               inclusion: Tell us whether the user will order devices
-              user_limit: There are already 3 users that can order devices
+              user_limit: There are already 3 users who can order devices. Change or remove another user.
         school:
           attributes:
             urn:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Rails.application.routes.draw do
 
   namespace :school do
     get '/', to: 'home#show', as: :home
-    resources :users, only: %i[index]
+    resources :users, only: %i[index new create]
   end
 
   namespace :support do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,7 @@ govuk_notify:
     devices:
       invite_responsible_body_user: '42e5cd7a-deaa-4234-bdea-db63b7c4ad90'
       nominate_contacts: 'ef964a6f-d984-4f35-a074-6f3cb79bfec7'
-
+      school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000
 

--- a/db/migrate/20200901142852_add_orders_devices_to_users.rb
+++ b/db/migrate/20200901142852_add_orders_devices_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrdersDevicesToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :orders_devices, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_200056) do
+ActiveRecord::Schema.define(version: 2020_09_01_142852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_200056) do
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
     t.bigint "school_id"
+    t.boolean "orders_devices"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/spec/controllers/school/users_controller_spec.rb
+++ b/spec/controllers/school/users_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe School::UsersController, type: :controller do
+  let(:school_user) { create(:school_user) }
+  let(:new_user) { build(:school_user, school: school_user.school) }
+
+  context 'when authenticated' do
+    before do
+      sign_in_as school_user
+    end
+
+    describe 'create' do
+      let(:request_data) do
+        { user: { full_name: new_user.full_name, email_address: new_user.email_address, orders_devices: false } }
+      end
+
+      it 'adds the new user to the school' do
+        expect {
+          post :create, params: request_data
+        }.to change { school_user.school.users.count }.by(1)
+      end
+
+      it 'sends an email to the new user' do
+        expect {
+          post :create, params: request_data
+        }.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,6 +43,11 @@ FactoryBot.define do
 
     factory :school_user do
       school
+      orders_devices { false }
+
+      trait :orders_devices do
+        orders_devices { true }
+      end
     end
 
     factory :mno_user do

--- a/spec/features/school/manage_users_spec.rb
+++ b/spec/features/school/manage_users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Manage school users' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
   let(:user_from_same_school) { create(:school_user, full_name: 'ZZZ Jones', school: school_user.school) }
+  let(:new_school_user) { build(:school_user, full_name: 'BBB Brown', school: school_user.school) }
   let(:user_from_other_school) { create(:school_user) }
   let(:school_users_page) { PageObjects::School::UsersPage.new }
 
@@ -19,6 +20,16 @@ RSpec.feature 'Manage school users' do
     and_i_dont_see_users_from_other_schools
   end
 
+  scenario 'adding a new school user' do
+    when_i_follow_the_link_to_manage_who_can_order_devices
+    and_i_click_the_link_to_invite_a_new_user
+    then_i_see_the_form_to_invite_a_new_user
+
+    when_i_fill_in_the_form_with_user_details
+    and_i_submit_form
+    then_i_see_an_updated_list_of_users_for_my_school
+  end
+
   def when_i_follow_the_link_to_manage_who_can_order_devices
     click_on 'Manage who can order devices'
 
@@ -33,5 +44,32 @@ RSpec.feature 'Manage school users' do
 
   def and_i_dont_see_users_from_other_schools
     expect(school_users_page).not_to have_content(user_from_other_school.full_name)
+  end
+
+  def and_i_click_the_link_to_invite_a_new_user
+    click_link 'Invite a new user'
+  end
+
+  def then_i_see_the_form_to_invite_a_new_user
+    expect(page).to have_field('Name')
+    expect(page).to have_field('Email address')
+    expect(page).to have_field('Telephone number')
+  end
+
+  def when_i_fill_in_the_form_with_user_details
+    fill_in 'Name', with: new_school_user.full_name
+    fill_in 'Email address', with: new_school_user.email_address
+    fill_in 'Telephone', with: new_school_user.telephone
+    choose 'No'
+  end
+
+  def and_i_submit_form
+    click_button 'Send invite'
+  end
+
+  def then_i_see_an_updated_list_of_users_for_my_school
+    expect(school_users_page.user_rows[0]).to have_content('AAA Smith')
+    expect(school_users_page.user_rows[1]).to have_content('BBB Brown')
+    expect(school_users_page.user_rows[2]).to have_content('ZZZ Jones')
   end
 end

--- a/spec/features/school/manage_users_spec.rb
+++ b/spec/features/school/manage_users_spec.rb
@@ -31,10 +31,10 @@ RSpec.feature 'Manage school users' do
   end
 
   def when_i_follow_the_link_to_manage_who_can_order_devices
-    click_on 'Manage who can order devices'
+    click_on 'Manage users'
 
     expect(school_users_page).to be_displayed
-    expect(page).to have_content 'Manage who can order devices'
+    expect(page).to have_content 'Manage users'
   end
 
   def then_i_see_a_list_of_users_for_my_school

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,5 +95,19 @@ RSpec.describe User, type: :model do
         expect { new_user.save! }.to change(new_user, :email_address).to('mr.mixed.case@somedomain.org')
       end
     end
+
+    context 'school user' do
+      let(:school) { create(:school) }
+      let(:user) { build(:school_user, :orders_devices, school: school) }
+
+      before do
+        create_list(:school_user, 3, :orders_devices, school: school)
+      end
+
+      it 'validates that only 3 users can order devices for a school' do
+        expect(user.valid?).to be false
+        expect(user.errors.keys).to include(:orders_devices)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/sw0yu93Z/574-schools-manage-who-can-order-devices-add-users)
Enable schools to invite users

### Changes proposed in this pull request
Journey to invite a new school user, choose whether the user can order devices and send the `School nominate contact` email to the new user.

### Guidance to review
`bundle exec rake db:migrate`
Users added via the form should be sent an email via notify
Enforces limit of 3 users per school that can order devices

![image](https://user-images.githubusercontent.com/333931/91904167-62829600-ec9c-11ea-89b3-3dc6da02159d.png)

![image](https://user-images.githubusercontent.com/333931/91884207-8aaecc80-ec7d-11ea-92e3-0b14aef27538.png)
