### PR TITLE
Fix issue with orders_devices being null for existing school users

### DIFF
--- a/db/migrate/20200902105909_set_default_for_orders_devices_on_existing_school_users.rb
+++ b/db/migrate/20200902105909_set_default_for_orders_devices_on_existing_school_users.rb
@@ -1,0 +1,10 @@
+class SetDefaultForOrdersDevicesOnExistingSchoolUsers < ActiveRecord::Migration[6.0]
+  def change
+    connection.execute <<~SQL
+      UPDATE users
+      SET orders_devices = false
+      WHERE orders_devices IS NULL
+      AND school_id IS NOT NULL
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_142852) do
+ActiveRecord::Schema.define(version: 2020_09_02_105909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Context
Adding `:orders_devices` without a default has meant that existing school users do not have a `:orders_devices` value and this prevents the users from signing in.

### Changes proposed in this pull request
Migration that will set `:orders_devices` to `false` for existing school users that do not have a value already set.

### Guidance to review
Run the migration. Existing school users should now have `:orders_devices` set to `false` and are able to sign in.
