### PR TITLE
Fix crash when 'who to contact' form submitted empty

### DIFF
--- a/app/form_objects/responsible_body/devices/who_to_contact_form.rb
+++ b/app/form_objects/responsible_body/devices/who_to_contact_form.rb
@@ -46,10 +46,10 @@ class ResponsibleBody::Devices::WhoToContactForm
 private
 
   def headteacher_chosen?
-    who_to_contact.to_sym == :headteacher
+    who_to_contact&.to_sym == :headteacher
   end
 
   def someone_else_chosen?
-    who_to_contact.to_sym == :someone_else
+    who_to_contact&.to_sym == :someone_else
   end
 end

--- a/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
@@ -1,0 +1,24 @@
+# "responsible_body_devices_who_to_contact_form"=>{"full_name"=>"", "email_address"=>"", "phone_number"=>""}
+
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::WhoToContactController do
+  let(:school) { create(:school, :with_headteacher_contact) }
+  let(:local_authority) { create(:local_authority, schools: [school], in_devices_pilot: true) }
+  let(:rb_user) { create(:local_authority_user, responsible_body: local_authority) }
+
+  before do
+    sign_in_as rb_user
+  end
+
+  describe '#create' do
+    it "displays errors if the user doesn't select anything" do
+      post :create, params: {
+        responsible_body_devices_who_to_contact_form: { full_name: '', email_address: '', phone_number: '' },
+        school_urn: school.urn,
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -11,6 +11,12 @@ FactoryBot.define do
       preorder_information
     end
 
+    trait :with_headteacher_contact do
+      after :create do |school|
+        school.contacts << create(:school_contact, :headteacher)
+      end
+    end
+
     trait :primary do
       phase { :primary }
     end


### PR DESCRIPTION
### Context

The 'who to contact' form was crashing if submitted empty.

[Sentry error](https://sentry.io/organizations/dfe-get-help-with-tech/issues/1858158448/?project=5320558&query=is%3Aunresolved)

### Changes proposed in this pull request

- fix the crash by dealing with missing data in a more robust way
