### PR TITLE
560 Change whether school needs to order chromebooks

### DIFF
--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -35,7 +35,7 @@ private
         info.will_need_chromebooks && {
           key: 'Will your school need to order Chromebooks?',
           value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
-          change_path: school_edit_chromebooks_details_path,
+          change_path: school_chromebooks_edit_path,
           action: 'whether Chromebooks are needed',
         },
       ]

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -35,6 +35,8 @@ private
         info.will_need_chromebooks && {
           key: 'Will your school need to order Chromebooks?',
           value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
+          change_path: school_edit_chromebooks_details_path,
+          action: 'whether Chromebooks are needed',
         },
       ]
       if info.will_need_chromebooks?

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -11,7 +11,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::Devices::Ba
     if @school.preorder_information.needs_contact?
       redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn)
     elsif @school.preorder_information.needs_chromebook_information?
-      @chromebook_information_form = ResponsibleBody::Devices::ChromebookInformationForm.new
+      @chromebook_information_form = ChromebookInformationForm.new
     end
   end
 end

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -11,7 +11,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::Devices::Ba
     if @school.preorder_information.needs_contact?
       redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn)
     elsif @school.preorder_information.needs_chromebook_information?
-      @chromebook_information_form = ChromebookInformationForm.new
+      @chromebook_information_form = ChromebookInformationForm.new(school: @school)
     end
   end
 end

--- a/app/controllers/school/chromebooks_controller.rb
+++ b/app/controllers/school/chromebooks_controller.rb
@@ -15,6 +15,7 @@ class School::ChromebooksController < School::BaseController
     )
     if @chromebook_information_form.valid?
       @preorder_info.update_chromebook_information_and_status!(chromebook_params)
+      flash[:success] = t(:success, scope: %w[school chromebooks])
       redirect_to school_details_path
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/school/chromebooks_controller.rb
+++ b/app/controllers/school/chromebooks_controller.rb
@@ -1,6 +1,4 @@
-class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBody::Devices::BaseController
-  before_action :find_school!
-
+class School::ChromebooksController < School::BaseController
   def edit
     @chromebook_information_form = ChromebookInformationForm.new(
       school: @school,
@@ -17,17 +15,13 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
     )
     if @chromebook_information_form.valid?
       @preorder_info.update_chromebook_information_and_status!(chromebook_params)
-      redirect_to responsible_body_devices_school_path(urn: @school.urn)
+      redirect_to school_details_path
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
 private
-
-  def find_school!
-    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
-  end
 
   def chromebook_params
     params.require(:chromebook_information_form).permit(

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -1,4 +1,4 @@
-class ResponsibleBody::Devices::ChromebookInformationForm
+class ChromebookInformationForm
   include ActiveModel::Model
 
   attr_accessor :school, :will_need_chromebooks, :school_or_rb_domain, :recovery_email_address

--- a/app/views/responsible_body/devices/chromebook_information/edit.html.erb
+++ b/app/views/responsible_body/devices/chromebook_information/edit.html.erb
@@ -8,7 +8,10 @@
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>
-    <%= render partial: 'responsible_body/devices/shared/chromebook_information_form' %>
+
+    <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
+    <%= render partial: 'shared/chromebook_information_intro' %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: responsible_body_devices_school_chromebooks_path(@school.urn), form_object: @chromebook_information_form } %>
   </div>
 </div>
 

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -13,7 +13,9 @@
 
     <%- if @school.preorder_information.needs_chromebook_information? %>
       <%- unless @school.preorder_information.chromebook_information_complete? %>
-        <%= render partial: 'responsible_body/devices/shared/chromebook_information_form' %>
+      <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
+      <%= render partial: 'shared/chromebook_information_intro' %>
+      <%= render partial: 'shared/chromebook_information_form', locals: { url: responsible_body_devices_school_chromebooks_path(@school.urn), form_object: @chromebook_information_form } %>
       <%- end %>
     <%- end %>
 

--- a/app/views/school/chromebooks/edit.html.erb
+++ b/app/views/school/chromebooks/edit.html.erb
@@ -9,42 +9,8 @@
       <span class="govuk-caption-xl"><%= @school.name %></span>
       <%= title %>
     </h1>
-    <p class="govuk-body">
-      If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
-    </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the domain a school uses for its Google services</li>
-      <li>the school’s recovery email address</li>
-    </ul>
-    <p class="govuk-body">
-      We need this information so we can secure the devices.
-    </p>
-    <p class="govuk-body">
-      If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
-    </p>
-
-    <%= form_for @chromebook_information_form, url: school_chromebooks_path, method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: nil } ) do %>
-        <%= f.govuk_radio_button  :will_need_chromebooks,
-                                  'yes',
-                                  label: { text: t(:yes, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } do %>
-          <%= f.govuk_text_field  :school_or_rb_domain,
-                                  label: { text: "School or #{@school.responsible_body.humanized_type} domain", size: 's' },
-                                  hint_text: "For example, ‘school.co.uk’" %>
-          <%= f.govuk_text_field  :recovery_email_address,
-                                  label: { text: "Recovery email address", size: 's' },
-                                  hint_text: "This email address must be on a different domain to the school domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." %>
-        <%- end %>
-        <%= f.govuk_radio_button  :will_need_chromebooks,
-                                  'no',
-                                  label: { text: t(:no, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
-
-      <%- end %>
-      <%= f.govuk_submit 'Save' %>
-    <%- end %>
-
+    <%= render partial: 'shared/chromebook_information_intro' %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_chromebooks_path, form_object: @chromebook_information_form } %>
   </div>
 </div>

--- a/app/views/school/chromebooks/edit.html.erb
+++ b/app/views/school/chromebooks/edit.html.erb
@@ -1,0 +1,50 @@
+<%- title = t('page_titles.school_edit_chromebooks') %>
+<%- content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', school_details_path, class: 'govuk-back-link') %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+    <p class="govuk-body">
+      If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the domain a school uses for its Google services</li>
+      <li>the school’s recovery email address</li>
+    </ul>
+    <p class="govuk-body">
+      We need this information so we can secure the devices.
+    </p>
+    <p class="govuk-body">
+      If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
+    </p>
+
+    <%= form_for @chromebook_information_form, url: school_chromebooks_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: nil } ) do %>
+        <%= f.govuk_radio_button  :will_need_chromebooks,
+                                  'yes',
+                                  label: { text: t(:yes, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } do %>
+          <%= f.govuk_text_field  :school_or_rb_domain,
+                                  label: { text: "School or #{@school.responsible_body.humanized_type} domain", size: 's' },
+                                  hint_text: "For example, ‘school.co.uk’" %>
+          <%= f.govuk_text_field  :recovery_email_address,
+                                  label: { text: "Recovery email address", size: 's' },
+                                  hint_text: "This email address must be on a different domain to the school domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." %>
+        <%- end %>
+        <%= f.govuk_radio_button  :will_need_chromebooks,
+                                  'no',
+                                  label: { text: t(:no, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
+
+      <%- end %>
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+
+  </div>
+</div>

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -1,20 +1,4 @@
-<h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
-<p class="govuk-body">
-  If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
-</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li>the domain a school uses for its Google services</li>
-  <li>the school’s recovery email address</li>
-</ul>
-<p class="govuk-body">
-  We need this information so we can secure the devices.
-</p>
-<p class="govuk-body">
-  If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
-</p>
-
-<%= form_for @chromebook_information_form, url: responsible_body_devices_school_chromebooks_path(@school.urn), method: :patch do |f| %>
+<%= form_for local_assigns[:form_object], url: local_assigns[:url], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: nil } ) do %>
@@ -22,7 +6,7 @@
                               'yes',
                               label: { text: t(:yes, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } do %>
       <%= f.govuk_text_field  :school_or_rb_domain,
-                              label: { text: "School or #{@responsible_body.humanized_type} domain", size: 's' },
+                              label: { text: "School or #{local_assigns[:form_object].school.responsible_body.humanized_type} domain", size: 's' },
                               hint_text: "For example, ‘school.co.uk’" %>
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },

--- a/app/views/shared/_chromebook_information_intro.html.erb
+++ b/app/views/shared/_chromebook_information_intro.html.erb
@@ -1,0 +1,14 @@
+<p class="govuk-body">
+  If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>the domain a school uses for its Google services</li>
+  <li>the school’s recovery email address</li>
+</ul>
+<p class="govuk-body">
+  We need this information so we can secure the devices.
+</p>
+<p class="govuk-body">
+  If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,8 @@ en:
     what_to_do_with_the_vouchers: What to do with the vouchers
     not_offered_vouchers_yet: If you haven’t been offered vouchers yet
   school:
+    chromebooks:
+      success: We've saved your choices
     details:
       n_devices:
         one: "%{count} device"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
     privacy_notice: Privacy notice
     school_home: Get devices for your school
     school_details: Check your school details
+    school_edit_chromebooks: Will your school need to order Chromebooks?
     school_users: Manage users
     invite_school_user:
       title: Invite a new user
@@ -216,7 +217,7 @@ en:
               invalid: Enter an email address in the correct format, like name@example.com
             phone_number:
               blank: Enter the contact’s telephone
-        responsible_body/devices/chromebook_information_form:
+        chromebook_information_form:
           attributes:
             will_need_chromebooks:
               blank: Tell us whether the school will need Chromebooks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,7 @@ en:
     not_offered_vouchers_yet: If you haven’t been offered vouchers yet
   school:
     chromebooks:
-      success: We've saved your choices
+      success: We’ve saved your choices
     details:
       n_devices:
         one: "%{count} device"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Rails.application.routes.draw do
   namespace :school do
     get '/', to: 'home#show', as: :home
     get '/details', to: 'details#show', as: :details
+    get '/chromebooks/edit', to: 'chromebooks#edit', as: :edit_chromebooks_details
+    patch '/chromebooks', to: 'chromebooks#update'
     resources :users, only: %i[index new create]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
   namespace :school do
     get '/', to: 'home#show', as: :home
     get '/details', to: 'details#show', as: :details
-    get '/chromebooks/edit', to: 'chromebooks#edit', as: :edit_chromebooks_details
+    get '/chromebooks/edit', to: 'chromebooks#edit'
     patch '/chromebooks', to: 'chromebooks#update'
     resources :users, only: %i[index new create]
   end

--- a/spec/components/school/school_details_summary_list_component_spec.rb
+++ b/spec/components/school/school_details_summary_list_component_spec.rb
@@ -43,10 +43,11 @@ describe School::SchoolDetailsSummaryListComponent do
       expect(result.css('dl').text).not_to include('School contact')
     end
 
-    it 'shows the chromebook details' do
+    it 'shows the chromebook details with a link to change it' do
       expect(result.css('dd')[2].text).to include('Yes')
-      expect(result.css('dd')[3].text).to include('school.domain.org')
-      expect(result.css('dd')[4].text).to include('admin@school.domain.org')
+      expect(result.css('dd')[3].text).to include('Change')
+      expect(result.css('dd')[4].text).to include('school.domain.org')
+      expect(result.css('dd')[5].text).to include('admin@school.domain.org')
     end
   end
 end

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.feature 'Change school Chromebook information' do
+  let(:school) { create(:school, :la_maintained) }
+  let(:school_user) { create(:school_user, full_name: 'AAA Smith', school: school) }
+
+  before do
+    create(:preorder_information, school: school_user.school, who_will_order_devices: 'responsible_body', will_need_chromebooks: 'yes')
+    create(:school_device_allocation, school: school_user.school, device_type: 'std_device', allocation: 63)
+  end
+
+  context 'logged in as a school user' do
+    before do
+      sign_in_as school_user
+    end
+
+    context 'when I visit the school details and click on the Chromebook information "Change" link' do
+      before do
+        click_on 'Check your school details'
+        first('a', text: 'Change').click
+      end
+
+      it 'allows me to change whether the school will need Chromebooks' do
+        expect(page).to have_content('Will your school need to order Chromebooks?')
+      end
+
+      it 'lets me choose Yes or No' do
+        expect(page).to have_field('Yes, they will need Chromebooks')
+        expect(page).to have_field('No, they will not need Chromebooks')
+      end
+
+      it 'shows fields for domain and recovery email when I choose Yes' do
+        choose('Yes, they will need Chromebooks')
+        expect(page).to have_field('School or local authority domain')
+        expect(page).to have_field('Recovery email address')
+      end
+
+      it 'shows an error when I do not supply valid information' do
+        choose('Yes, they will need Chromebooks')
+        fill_in('School or local authority domain', with: '')
+        click_on 'Save'
+        expect(page).to have_http_status(:unprocessable_entity)
+        expect(page).to have_content('There is a problem')
+      end
+
+      it 'goes back to the school details page when I save valid information' do
+        choose('Yes, they will need Chromebooks')
+        fill_in('School or local authority domain', with: 'some.domain.org')
+        fill_in('Recovery email address', with: 'someone@someotherdomain.org')
+        click_on 'Save'
+        expect(page).to have_http_status(:ok)
+        expect(page).to have_content('Check your school details')
+        expect(page).to have_content('some.domain.org')
+        expect(page).to have_content('someone@someotherdomain.org')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

In #367 we introduced a view-only UI for schools to check their details. This PR allows a school to change their Chromebook information. (Trello card [560](https://trello.com/c/l8h6foA9/560-check-your-school-details-change-whether-school-needs-to-order-chromebooks))

### Changes proposed in this pull request

* Add UI for schools to edit their chromebook information
* Move the `responsible_body/devices/chromebook_information_form` object back to the top level, as it is now used in two contexts

### Guidance to review

Screenshots:
<img width="464" alt="Screen Shot 2020-09-02 at 14 01 25" src="https://user-images.githubusercontent.com/134501/91987654-3f9cc400-ed26-11ea-8434-d8c41313bfa8.png">
<img width="639" alt="Screen Shot 2020-09-02 at 14 01 07" src="https://user-images.githubusercontent.com/134501/91987665-41ff1e00-ed26-11ea-99c6-bf358df7ed70.png">
