### PR TITLE
[475] add a separate field for allocation cap

### DIFF
--- a/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
+++ b/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
@@ -3,6 +3,6 @@ xml.CapAdjustmentRequest(payloadID: assigns[:payload_id], dateTime: Time.zone.no
   assigns[:allocations].each do |allocation|
     xml.Record(capType: allocation.computacenter_cap_type,
                shipTo: allocation.school.computacenter_reference,
-               capAmount: allocation.allocation)
+               capAmount: allocation.cap)
   end
 end

--- a/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
+++ b/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.CapAdjustmentRequest(payloadID: assigns[:payload_id], dateTime: Time.zone.now.iso8601) do
+xml.CapAdjustmentRequest(payloadID: assigns[:payload_id], dateTime: assigns[:timestamp].iso8601) do
   assigns[:allocations].each do |allocation|
     xml.Record(capType: allocation.computacenter_cap_type,
                shipTo: allocation.school.computacenter_reference,

--- a/db/migrate/20200902135234_add_allocation_cap.rb
+++ b/db/migrate/20200902135234_add_allocation_cap.rb
@@ -1,0 +1,6 @@
+class AddAllocationCap < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_device_allocations, :cap, :integer, null: false, default: 0
+    add_index :school_device_allocations, [:cap]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_105909) do
+ActiveRecord::Schema.define(version: 2020_09_02_135234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,8 @@ ActiveRecord::Schema.define(version: 2020_09_02_105909) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "last_updated_by_user_id"
     t.bigint "created_by_user_id"
+    t.integer "cap", default: 0, null: false
+    t.index ["cap"], name: "index_school_device_allocations_on_cap"
     t.index ["created_by_user_id"], name: "index_school_device_allocations_on_created_by_user_id"
     t.index ["last_updated_by_user_id"], name: "index_school_device_allocations_on_last_updated_by_user_id"
     t.index ["school_id"], name: "index_school_device_allocations_on_school_id"

--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     trait :with_std_allocation do
       device_type { 'std_device' }
       allocation { Faker::Number.within(range: 1..100) }
+      cap { 0 }
     end
   end
 end


### PR DESCRIPTION
### Context

See [Trello card 475](https://trello.com/c/am1Ir4o7/475-separate-the-concept-of-device-allocations-and-cc-caps) - we need to separate the concept of allocations (the maximum amount of devices a school will be able to order in the event of a lockdown) from caps (how many they can order right now, and thus by inference, whether there is a lockdown affecting them at the moment)

### Changes proposed in this pull request

* add a `cap` field to `SchoolDeviceAllocation`
* make the `NotifyComputacenterOfCapUpdateJob` send the `cap` field instead of `allocation`

### Guidance to review

