### PR TITLE
add CsvDataFileImporter, and 2 implementations for computacenter imports

### DIFF
--- a/app/models/computacenter/ship_to_data_file.rb
+++ b/app/models/computacenter/ship_to_data_file.rb
@@ -1,0 +1,14 @@
+class Computacenter::ShipToDataFile < CsvDataFile
+  def extract_record(row)
+    {
+      urn: row['URN'],
+      name: row['Name 1'],
+      ship_to: row['Ship to acct'],
+    }
+  end
+
+  def import_record!(record)
+    school = School.find_by_urn!(record[:urn])
+    school.update!(computacenter_reference: record[:ship_to])
+  end
+end

--- a/app/models/computacenter/sold_to_data_file.rb
+++ b/app/models/computacenter/sold_to_data_file.rb
@@ -1,0 +1,16 @@
+class Computacenter::SoldToDataFile < CsvDataFile
+  attr_accessor :logger, :failures, :successes
+
+  def extract_record(row)
+    {
+      urn: row['URN'],
+      name: row['Name 1'],
+      sold_to: row['Customer'],
+    }
+  end
+
+  def import_record!(record)
+    rb = ResponsibleBody.find_by_computacenter_urn!(record[:urn])
+    rb.update!(computacenter_reference: record[:sold_to])
+  end
+end

--- a/app/models/csv_data_file_importer.rb
+++ b/app/models/csv_data_file_importer.rb
@@ -1,0 +1,31 @@
+class CsvDataFileImporter
+  attr_accessor :csv_data_file, :logger, :failures, :successes
+
+  def initialize(csv_data_file:, logger: Rails.logger)
+    @csv_data_file = csv_data_file
+    @logger = logger
+    @failures = []
+    @successes = []
+  end
+
+  def import!
+    index = 0
+    @csv_data_file.send(:records) do |record|
+      index += 1
+      log "Importing row #{index} - #{record}"
+      @csv_data_file.import_record!(record)
+      @successes << record
+    rescue StandardError => e
+      log(e.message)
+      @failures << { record: record, error: e }
+    end
+
+    log "Processed #{index} rows, of which #{failures.size} failed"
+  end
+
+private
+
+  def log(msg)
+    @logger.info msg
+  end
+end

--- a/spec/models/computacenter/ship_to_data_file_spec.rb
+++ b/spec/models/computacenter/ship_to_data_file_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ShipToDataFile do
+  subject(:data_file) { described_class.new('/dev/null') }
+
+  let(:row) do
+    {
+      'URN' => '999900',
+      'Name 1' => 'the name',
+      'Ship to acct' => 'account id',
+    }
+  end
+  let(:expected_record) do
+    {
+      urn: '999900',
+      name: 'the name',
+      ship_to: 'account id',
+    }
+  end
+
+  describe '#extract_record' do
+    it 'returns a hash with the expected fields' do
+      expect(data_file.extract_record(row)).to eq(expected_record)
+    end
+  end
+
+  describe '#import_record!' do
+    let(:school) { create(:school, urn: '999900', computacenter_reference: nil) }
+
+    it 'updates the school that matches the urn, setting computacenter_reference to :sold_to' do
+      expect { data_file.import_record!(expected_record) }.to change { school.reload.computacenter_reference }.from(nil).to('account id')
+    end
+  end
+end

--- a/spec/models/computacenter/sold_to_data_file_spec.rb
+++ b/spec/models/computacenter/sold_to_data_file_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::SoldToDataFile do
+  subject(:data_file) { described_class.new('/dev/null') }
+
+  let(:row) do
+    {
+      'URN' => 'LEA000',
+      'Name 1' => 'the name',
+      'Customer' => 'customer id',
+    }
+  end
+  let(:expected_record) do
+    {
+      urn: 'LEA000',
+      name: 'the name',
+      sold_to: 'customer id',
+    }
+  end
+
+  describe '#extract_record' do
+    it 'returns a hash with the expected fields' do
+      expect(data_file.extract_record(row)).to eq(expected_record)
+    end
+  end
+
+  describe '#import_record!' do
+    let(:local_authority) { create(:local_authority, gias_id: '000', computacenter_reference: nil) }
+
+    it 'updates the ResponsibleBody that matches the urn, setting computacenter_reference to :sold_to' do
+      expect { data_file.import_record!(expected_record) }.to change { local_authority.reload.computacenter_reference }.from(nil).to('customer id')
+    end
+  end
+end

--- a/spec/models/csv_data_file_importer_spec.rb
+++ b/spec/models/csv_data_file_importer_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CsvDataFileImporter do
+  context 'given a CsvDataFile object' do
+    let(:mock_csv_data_file) { instance_double(Computacenter::SoldToDataFile) }
+    subject(:importer) { CsvDataFileImporter.new(csv_data_file: mock_csv_data_file) }
+
+    describe '#import!' do
+      let(:record_1) { {id: 'ID 1', a_field: 'a field 1'} }
+      let(:record_2) { {id: 'ID 2', a_field: 'a field 2'} }
+
+      before do
+        allow(mock_csv_data_file).to receive(:records).and_yield(record_1).and_yield(record_2)
+        allow(mock_csv_data_file).to receive(:import_record!)
+      end
+
+      it 'calls import_record! with each record in the given csv_data_file' do
+        importer.import!
+        expect(mock_csv_data_file).to have_received(:import_record!).with(record_1).ordered
+        expect(mock_csv_data_file).to have_received(:import_record!).with(record_2).ordered
+      end
+
+      context 'when importing a record raises an error' do
+        before do
+          allow(mock_csv_data_file).to receive(:import_record!).with(record_1)
+          allow(mock_csv_data_file).to receive(:import_record!).with(record_2).and_raise(ActiveRecord::RecordNotFound, 'could not find some things')
+        end
+
+        it 'does not let the error bubble out' do
+          expect { importer.import! }.not_to raise_error
+        end
+
+        it 'stores the error and record as a failure' do
+          importer.import!
+          expect(importer.failures.size).to eq(1)
+          expect(importer.failures[0][:record]).to eq(record_2)
+          expect(importer.failures[0][:error].message).to eq('could not find some things')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/csv_data_file_importer_spec.rb
+++ b/spec/models/csv_data_file_importer_spec.rb
@@ -3,39 +3,39 @@ require 'rails_helper'
 RSpec.describe CsvDataFileImporter do
   context 'given a CsvDataFile object' do
     let(:mock_csv_data_file) { instance_double(Computacenter::SoldToDataFile) }
+    let(:record_1) { { id: 'ID 1', a_field: 'a field 1' } }
+    let(:record_2) { { id: 'ID 2', a_field: 'a field 2' } }
+
     subject(:importer) { CsvDataFileImporter.new(csv_data_file: mock_csv_data_file) }
 
+    before do
+      allow(mock_csv_data_file).to receive(:records).and_yield(record_1).and_yield(record_2)
+      allow(mock_csv_data_file).to receive(:import_record!)
+    end
+
     describe '#import!' do
-      let(:record_1) { {id: 'ID 1', a_field: 'a field 1'} }
-      let(:record_2) { {id: 'ID 2', a_field: 'a field 2'} }
-
-      before do
-        allow(mock_csv_data_file).to receive(:records).and_yield(record_1).and_yield(record_2)
-        allow(mock_csv_data_file).to receive(:import_record!)
-      end
-
       it 'calls import_record! with each record in the given csv_data_file' do
         importer.import!
         expect(mock_csv_data_file).to have_received(:import_record!).with(record_1).ordered
         expect(mock_csv_data_file).to have_received(:import_record!).with(record_2).ordered
       end
+    end
 
-      context 'when importing a record raises an error' do
-        before do
-          allow(mock_csv_data_file).to receive(:import_record!).with(record_1)
-          allow(mock_csv_data_file).to receive(:import_record!).with(record_2).and_raise(ActiveRecord::RecordNotFound, 'could not find some things')
-        end
+    context 'when importing a record raises an error' do
+      before do
+        allow(mock_csv_data_file).to receive(:import_record!).with(record_1)
+        allow(mock_csv_data_file).to receive(:import_record!).with(record_2).and_raise(ActiveRecord::RecordNotFound, 'could not find some things')
+      end
 
-        it 'does not let the error bubble out' do
-          expect { importer.import! }.not_to raise_error
-        end
+      it 'does not let the error bubble out' do
+        expect { importer.import! }.not_to raise_error
+      end
 
-        it 'stores the error and record as a failure' do
-          importer.import!
-          expect(importer.failures.size).to eq(1)
-          expect(importer.failures[0][:record]).to eq(record_2)
-          expect(importer.failures[0][:error].message).to eq('could not find some things')
-        end
+      it 'stores the error and record as a failure' do
+        importer.import!
+        expect(importer.failures.size).to eq(1)
+        expect(importer.failures[0][:record]).to eq(record_2)
+        expect(importer.failures[0][:error].message).to eq('could not find some things')
       end
     end
   end


### PR DESCRIPTION
### Context

Relates to two Trello cards: [589-import-computacenter-shipto-identifiers-into-the-service](https://trello.com/c/Tz9AU70M/589-import-computacenter-shipto-identifiers-into-the-service) and [543-refactor-the-importer-services-based-on-tonys-new-abstractions](https://trello.com/c/oggGswho/543-refactor-the-importer-services-based-on-tonys-new-abstractions).

While working out a one-off import of computacenter IDs, it became clear that the simplest way to do it was actually to add a generic `CsvDataFileImporter` class that uses @tonyheadford's `CsvDataFile` abstraction. This makes the implementation code trivial, and also gives us a way to refactor most of the existing `(XYZ)Importer` classes to remove the boilerplate code and simplify them.

### Changes proposed in this pull request

* add a `CsvDataFileImporter` class & spec
* add 2 new `CsvDataFile` subclasses for computacenter imports, each of which has an `import_record!` method for use with the  `CsvDataFileImporter` (plus specs)

### Guidance to review

