### PR TITLE
School details design changes

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -1,4 +1,5 @@
 class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
+  include ViewHelper
   validates :school, presence: true
 
   delegate :school_will_order_devices?,
@@ -26,6 +27,10 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
         value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
         action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
         action: 'Query allocation',
+      },
+      {
+        key: 'Can place orders?',
+        value: ['No, no local lockdown restrictions', govuk_link_to('Get devices early for specific circumstances', responsible_body_devices_request_devices_path)].join('<br>').html_safe,
       },
       {
         key: 'Type of school',

--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -16,6 +16,12 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
         value: render(SchoolPreorderStatusTagComponent.new(school: @school)),
       },
       {
+        key: 'Who will order?',
+        value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
+        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+        action: 'who will order',
+      },
+      {
         key: 'Provisional allocation',
         value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
         action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
@@ -24,12 +30,6 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
       {
         key: 'Type of school',
         value: @school.type_label,
-      },
-      {
-        key: 'Who will order?',
-        value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
-        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
-        action: 'who will order',
       },
     ] + school_contact_row_if_contact_present + chromebook_rows_if_needed
   end

--- a/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
@@ -1,10 +1,6 @@
 <%= form_for form, url: responsible_body_devices_school_who_to_contact_path(form.school.urn), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
-  <div class="govuk-inset-text govuk-!-padding-top-0">
-    <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: form.school) %>
-  </div>
-
   <%= f.govuk_radio_buttons_fieldset(:who_to_contact, legend: { text: "Who can we contact at the school?", size: 'l', tag: 'h2' }) do %>
     <%- if f.object.headteacher_contact.present? %>
       <%= f.govuk_radio_button :who_to_contact, 'headteacher', label: { text: form.headteacher_option_label }, hint_text: form.headteacher_option_hint_text, link_errors: true %>

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -3,11 +3,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-8">
       <%= @school.name %>
     </h1>
 
     <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-4">School details</h2>
+
+    <div class="govuk-inset-text govuk-!-padding-top-0">
+      <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @form.school) %>
+    </div>
 
     <p class="govuk-body">
       <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -18,19 +18,19 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'confirms that fact' do
-      expect(result.css('dd')[4].text).to include('The school orders devices')
+      expect(result.css('.govuk-summary-list__row')[1].text).to include('The school orders devices')
     end
 
     it 'renders the school allocation' do
-      expect(result.css('dd')[1].text).to include('3 devices')
+      expect(result.css('.govuk-summary-list__row')[2].text).to include('3 devices')
     end
 
     it 'renders the school type' do
-      expect(result.css('dd')[3].text).to include('Primary school')
+      expect(result.css('.govuk-summary-list__row')[3].text).to include('Primary school')
     end
 
     it 'renders the school details' do
-      expect(result.css('dd')[0].text).to include('Needs a contact')
+      expect(result.css('.govuk-summary-list__row')[0].text).to include('Needs a contact')
     end
 
     context 'and the headteacher has been set as the school contact' do
@@ -70,7 +70,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     it 'confirms that fact' do
       create(:preorder_information, school: school, who_will_order_devices: :responsible_body)
 
-      expect(result.css('dd')[4].text).to include('The trust orders devices')
+      expect(result.css('.govuk-summary-list__row')[1].text).to include('The trust orders devices')
     end
 
     it 'does not show the school contact even if the school contact is set' do

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -26,11 +26,17 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school type' do
-      expect(result.css('.govuk-summary-list__row')[3].text).to include('Primary school')
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('Primary school')
     end
 
     it 'renders the school details' do
       expect(result.css('.govuk-summary-list__row')[0].text).to include('Needs a contact')
+    end
+
+    context "when the school isn't under lockdown restrictions or has any shielding children" do
+      it 'cannot place orders' do
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('No, no local lockdown restrictions')
+      end
     end
 
     context 'and the headteacher has been set as the school contact' do
@@ -40,8 +46,8 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
                who_will_order_devices: :school,
                school_contact: headteacher)
 
-        expect(result.css('dt')[4].text).to include('School contact')
-        expect(result.css('dd')[6].inner_html).to include('Headteacher: Davy Jones<br>davy.jones@school.sch.uk<br>12345')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('School contact')
+        expect(result.css('.govuk-summary-list__row')[5].inner_html).to include('Headteacher: Davy Jones<br>davy.jones@school.sch.uk<br>12345')
       end
     end
 
@@ -56,10 +62,10 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
                who_will_order_devices: :school,
                school_contact: new_contact)
 
-        expect(result.css('dt')[4].text).to include('School contact')
-        expect(result.css('dd')[6].text).to include('Jane Smith')
-        expect(result.css('dd')[6].text).to include('abc@example.com')
-        expect(result.css('dd')[6].text).to include('12345')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('School contact')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('Jane Smith')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('abc@example.com')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('12345')
       end
     end
   end


### PR DESCRIPTION
### Context

The school details page for responsible bodies has been redesigned.

### Changes proposed in this pull request

- move the school details table below the 'who to contact' form
- reorder table rows
- add a link which shows how to request devices in specific circumstances

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92040916-22d8ae80-ed6f-11ea-909c-0d13519f77c1.png)
