### PR TITLE
Breadcrumb component

### DIFF
--- a/app/components/breadcrumb_component.html.erb
+++ b/app/components/breadcrumb_component.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <% items.each do |item| %>
+      <li class="govuk-breadcrumbs__list-item">
+        <% if item[:path].present? %>
+          <%= link_to item[:label], item[:path], class: 'govuk-breadcrumbs__link' %>
+        <% else %>
+          <%= item[:label] %>
+        <% end %>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/app/components/breadcrumb_component.rb
+++ b/app/components/breadcrumb_component.rb
@@ -1,0 +1,22 @@
+class BreadcrumbComponent < ViewComponent::Base
+  validates :items, presence: true
+
+  def initialize(items)
+    items = transform_array(items) if items.is_a?(Array) && items.first[:label].nil?
+    @items = items
+  end
+
+private
+
+  attr_reader :items
+
+  def transform_array(items)
+    items.map do |entry|
+      if entry.is_a?(Hash)
+        { label: entry.keys.first, path: entry.values.first }
+      else
+        { label: entry }
+      end
+    end
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -30,7 +30,7 @@ module ViewHelper
     govuk_link_to body, devices_guidance_subpage_path(subpage_slug: slug), html_options
   end
 
-  def breadcrumb(items)
+  def breadcrumbs(items)
     render BreadcrumbComponent.new(items)
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -30,6 +30,10 @@ module ViewHelper
     govuk_link_to body, devices_guidance_subpage_path(subpage_slug: slug), html_options
   end
 
+  def breadcrumb(items)
+    render BreadcrumbComponent.new(items)
+  end
+
   def sortable_table_header(title, value = title, opts = params)
     if opts[:sort] == value.to_s
       if opts[:dir] == 'd'

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -1,16 +1,10 @@
 <%- title = t('page_titles.responsible_body_devices_home') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <div class="govuk-breadcrumbs ">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to t('page_titles.responsible_body_home'), responsible_body_home_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= title %>
-      </li>
-    </ol>
-  </div>
+  <% breadcrumb([
+    { t('page_titles.responsible_body_home') => responsible_body_home_path },
+    title,
+  ]) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.responsible_body_devices_home') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumb([
+  <% breadcrumbs([
     { t('page_titles.responsible_body_home') => responsible_body_home_path },
     title,
   ]) %>

--- a/spec/components/breadcrumb_component_spec.rb
+++ b/spec/components/breadcrumb_component_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe BreadcrumbComponent do
+  it 'renders breadcrumb items from the provided list' do
+    items = [
+      { label: 'GOV.UK', path: 'https://www.gov.uk' },
+      { label: 'BBC', path: 'https://www.bbc.co.uk' },
+    ]
+    result = render_inline(BreadcrumbComponent.new(items))
+
+    expect(result.css('.govuk-breadcrumbs li a')[0].text).to eq('GOV.UK')
+    expect(result.css('.govuk-breadcrumbs li a')[0].attr('href')).to eq('https://www.gov.uk')
+
+    expect(result.css('.govuk-breadcrumbs li a')[1].text).to eq('BBC')
+    expect(result.css('.govuk-breadcrumbs li a')[1].attr('href')).to eq('https://www.bbc.co.uk')
+  end
+
+  it 'renders a list of key-values correctly' do
+    items = [
+      { 'GOV.UK' => 'https://www.gov.uk' },
+      { 'BBC' => 'https://www.bbc.co.uk' },
+    ]
+    result = render_inline(BreadcrumbComponent.new(items))
+
+    expect(result.css('.govuk-breadcrumbs li a')[0].text).to eq('GOV.UK')
+    expect(result.css('.govuk-breadcrumbs li a')[0].attr('href')).to eq('https://www.gov.uk')
+
+    expect(result.css('.govuk-breadcrumbs li a')[1].text).to eq('BBC')
+    expect(result.css('.govuk-breadcrumbs li a')[1].attr('href')).to eq('https://www.bbc.co.uk')
+  end
+
+  it 'renders string items as strings' do
+    items = [
+      { 'GOV.UK' => 'https://www.gov.uk' },
+      'BBC',
+    ]
+    result = render_inline(BreadcrumbComponent.new(items))
+
+    expect(result.css('.govuk-breadcrumbs li a')[0].text).to eq('GOV.UK')
+    expect(result.css('.govuk-breadcrumbs li a')[0].attr('href')).to eq('https://www.gov.uk')
+
+    expect(result.css('.govuk-breadcrumbs li')[1].inner_html.strip).to eq('BBC')
+  end
+end


### PR DESCRIPTION
### Context

Breadcrumb markup is repetitive and hard to parse at a glance. We want to abstract it away to clean up view templates.

### Changes proposed in this pull request

- Introduce a breadcrumb component and a view helper
- Apply it in the first view

### Guidance to review

Usage example:

```ruby
<%- content_for :before_content do %>
  <% breadcrumb([
    { t('page_titles.responsible_body_home') => responsible_body_home_path },
    title,
  ]) %>
<% end %>
```

Is the syntactic sugar sensible?