### PR TITLE
[240] Add and setup paper trail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'mail-notify'
 # pagination
 gem 'pagy'
 
+# auditing of activerecord models
+gem 'paper_trail'
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,9 @@ GEM
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
     pagy (3.8.3)
+    paper_trail (11.0.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -306,6 +309,8 @@ GEM
     redcarpet (3.5.0)
     redis (4.2.1)
     regexp_parser (1.7.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rexml (3.2.4)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
@@ -476,6 +481,7 @@ DEPENDENCIES
   mail-notify
   notifications-ruby-client
   pagy
+  paper_trail
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :identify_user!
+  before_action :set_paper_trail_whodunnit
 
   include Pagy::Backend
 
@@ -14,6 +15,10 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def user_for_paper_trail
+    "#{identify_user!&.class}:#{identify_user!&.id}"
+  end
 
   def identify_user!
     @user ||= (SessionService.identify_user!(session) || User.new)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_paper_trail
+
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
 

--- a/db/migrate/20200903101449_create_versions.rb
+++ b/db/migrate/20200903101449_create_versions.rb
@@ -1,0 +1,35 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.0]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, { null: false }
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20200903101450_add_object_changes_to_versions.rb
+++ b/db/migrate/20200903101450_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_135234) do
+ActiveRecord::Schema.define(version: 2020_09_03_101450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,6 +188,17 @@ ActiveRecord::Schema.define(version: 2020_09_02_135234) do
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
     t.index ["school_id"], name: "index_users_on_school_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -1,7 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Support::UsersController, type: :controller do
-  describe 'create' do
+  describe '#create' do
+    context 'for support users', versioning: true do
+      let(:responsible_body) { create(:local_authority) }
+      let(:dfe_user) { create(:dfe_user) }
+
+      before do
+        sign_in_as dfe_user
+      end
+
+      it 'creates users' do
+        expect {
+          post :create, params: { responsible_body_id: responsible_body.id,
+                                  user: attributes_for(:user),
+                                  pilot: 'devices' }
+        }.to change(User, :count).by(1)
+      end
+
+      it 'audits changes with reference to user that requested the changes' do
+        post :create, params: { responsible_body_id: responsible_body.id,
+                                user: attributes_for(:user),
+                                pilot: 'devices' }
+
+        expect(User.last.versions.last.whodunnit).to eql("User:#{dfe_user.id}")
+      end
+    end
+
     it 'is forbidden for MNO users' do
       sign_in_as create(:mno_user)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ require Rails.root.join('spec/page_objects/base_page.rb')
 Dir[Rails.root.join('spec/page_objects/**/*_section.rb')].sort.each { |f| require f }
 Dir[Rails.root.join('spec/page_objects/**/*_page.rb')].sort.each { |f| require f }
 
+require 'paper_trail/frameworks/rspec'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,9 +53,6 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -63,6 +60,7 @@ RSpec.configure do |config|
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
### Context

- https://trello.com/c/Gi48TlNC/240-put-in-an-auditing-gem-like-audited-or-papertrail-for-the-users-table
- We want to be able to audit changes to the user model so diffs/deltas can be generated
- The `paper_trail` gem should meet our requirements and seems better maintained compared to `audited`
- Below is example of a version from the gem which should be good enough for us to generate deltas

```
pry(main)> u.versions.last
=> #<PaperTrail::Version:0x00007f9516c6e500
 id: 9,
 item_type: "User",
 item_id: 1,
 event: "update",
 whodunnit: "User:1234",
 object:
  "---\nid: 1\n...YAML REPRESENTATION OF OBJECT",
 created_at: Thu, 03 Sep 2020 10:35:37 UTC +00:00,
 object_changes: "---\nupdated_at:\n- 2020-09-03 10:29:05.107686000 Z\n- 2020-09-03 10:35:37.829641000 Z\nis_support:\n- false\n- true\n">
```

### Questions

- `whodunnit` is a `paper_trail` terminology for the user that made then changes 
- Is the concept of `whodunnit` important? Can this be skipped altogether?
- I recall someone mention a CLI. if `whodunnit` is important should I add `whodunnit` to the CLI

### Changes proposed in this pull request

- Add and setup `paper_trail` gem
- Hook up `whodunnit` user in the `ApplicationController`

### Guidance to review

- Create a user via the web interface
- Should see audit log for this user via `User.last.versions`
- ?? Make changes to a user via CLI, should see changes with `user.versions`