### PR TITLE
[566] Add school device allocation wizard page

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -15,6 +15,10 @@ class School::WelcomeWizardController < School::BaseController
 
   def privacy; end
 
+  def allocation
+    @allocation = @school.std_device_allocation&.allocation || 0
+  end
+
 private
 
   def set_wizard

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -6,6 +6,7 @@ class SchoolWelcomeWizard < ApplicationRecord
   enum step: {
     welcome: 'welcome',
     privacy: 'privacy',
+    allocation: 'allocation',
     complete: 'complete',
   }
 
@@ -17,6 +18,8 @@ class SchoolWelcomeWizard < ApplicationRecord
       privacy!
     when 'privacy'
       user.seen_privacy_notice!
+      allocation!
+    when 'allocation'
       complete!
     else
       raise "Unknown step: #{step}"

--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -1,0 +1,26 @@
+<%- title = t('page_titles.school_user_welcome_wizard.allocation.title', allocation: @allocation) %>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p class="govuk-body">Your allocation of <%= @allocation %> is based on:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>the number of children in years 3 to 10</li>
+    
+        <li>free school meals data</li>
+    
+        <li>an estimate of the number of devices your school already has</li>
+      </ul>
+      <p class="govuk-body">Numbers will be reassessed at the time of ordering based on availability and the extent of coronavirus restrictions.</p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        <%= govuk_link_to 'Read more about allocations', devices_allocation_and_specification_path, target: '_blank' %>
+      </p>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
         title: "You’re signed in as %{school}"
       privacy:
         title: Privacy notice
+      allocation:
+        title: "You’ve been allocated %{allocation} laptops and tablets"
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
     patch '/chromebooks', to: 'chromebooks#update'
     get '/welcome', to: 'welcome_wizard#welcome', as: :welcome_wizard_welcome
     get '/privacy', to: 'welcome_wizard#privacy', as: :welcome_wizard_privacy
+    get '/allocation', to: 'welcome_wizard#allocation', as: :welcome_wizard_allocation
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     resources :users, only: %i[index new create]
   end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -1,19 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature 'Navigate school welcome wizard' do
-  scenario 'view the welcome page' do
-    as_a_new_school_user
-    when_i_sign_in_for_the_first_time
-    then_i_see_a_welcome_page_for_my_school
-  end
+  let(:school) { create(:school, :with_std_device_allocation) }
 
-  scenario 'view the privacy page' do
+  scenario 'step through the wizard' do
     as_a_new_school_user
     when_i_sign_in_for_the_first_time
     then_i_see_a_welcome_page_for_my_school
 
     when_i_click_continue
     then_i_see_a_privacy_notice
+
+    when_i_click_continue
+    then_i_see_the_allocation_for_my_school
+
+    when_i_click_continue
+    then_i_see_the_school_home_page
   end
 
   scenario 'the wizard resumes where left off' do
@@ -30,7 +32,7 @@ RSpec.feature 'Navigate school welcome wizard' do
   end
 
   def as_a_new_school_user
-    @user = create(:school_user, :new_visitor)
+    @user = create(:school_user, :new_visitor, school: school)
   end
 
   def when_i_sign_in_for_the_first_time
@@ -39,7 +41,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def then_i_see_a_welcome_page_for_my_school
     expect(page).to have_current_path(school_welcome_wizard_welcome_path)
-    expect(page).to have_text("You’re signed in as #{@user.school.name}")
+    expect(page).to have_text("You’re signed in as #{school.name}")
   end
 
   def when_i_click_continue
@@ -51,11 +53,27 @@ RSpec.feature 'Navigate school welcome wizard' do
     expect(page).to have_text('Privacy notice')
   end
 
+  def then_i_see_the_allocation_for_my_school
+    expect(page).to have_current_path(school_welcome_wizard_allocation_path)
+    heading = I18n.t('page_titles.school_user_welcome_wizard.allocation.title', allocation: device_allocation)
+    expect(page).to have_text(heading)
+  end
+
+  def then_i_see_the_school_home_page
+    expect(page).to have_current_path(school_home_path)
+    expect(page).to have_text(school.name)
+    expect(page).to have_text('Get devices for your school')
+  end
+
   def when_i_sign_out
     sign_out
   end
 
   def and_then_sign_in_again
     visit validate_token_url_for(@user)
+  end
+
+  def device_allocation
+    school.std_device_allocation&.allocation || 0
   end
 end

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         wizard.privacy!
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the allocation step' do
         wizard.update_step!
-        expect(wizard.complete?).to be true
+        expect(wizard.allocation?).to be true
       end
 
       it 'records when the privacy notice was seen' do
@@ -36,6 +36,17 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
           wizard.update_step!
           expect(school_user.privacy_notice_seen_at).to eq(Time.zone.now)
         end
+      end
+    end
+
+    context 'when the step is allocation' do
+      before do
+        wizard.allocation!
+      end
+
+      it 'moves to the completed step' do
+        wizard.update_step!
+        expect(wizard.complete?).to be true
       end
     end
   end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/QKBDBoXD/566-schools-wizard-allocations)
Add school allocation info page to wizard

### Changes proposed in this pull request
Add school device allocation as the page following the privacy notice in the welcome wizard

### Guidance to review
As a new school user, when signing in you should be taken through the wizard. You should see the device allocation for the school on the page after the privacy notice.

![image](https://user-images.githubusercontent.com/333931/92124691-0469c600-edf6-11ea-8b66-722177e1d1a4.png)
