### PR TITLE
[567] Add order your own page to wizard

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -19,6 +19,8 @@ class School::WelcomeWizardController < School::BaseController
     @allocation = @school.std_device_allocation&.allocation || 0
   end
 
+  def order_your_own; end
+
 private
 
   def set_wizard

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -7,6 +7,7 @@ class SchoolWelcomeWizard < ApplicationRecord
     welcome: 'welcome',
     privacy: 'privacy',
     allocation: 'allocation',
+    order_your_own: 'order_your_own',
     complete: 'complete',
   }
 
@@ -20,6 +21,8 @@ class SchoolWelcomeWizard < ApplicationRecord
       user.seen_privacy_notice!
       allocation!
     when 'allocation'
+      order_your_own!
+    when 'order_your_own'
       complete!
     else
       raise "Unknown step: #{step}"

--- a/app/views/school/welcome_wizard/order_your_own.html.erb
+++ b/app/views/school/welcome_wizard/order_your_own.html.erb
@@ -1,0 +1,27 @@
+<%- title = t('page_titles.school_user_welcome_wizard.order_your_own.title') %>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
+
+      <p class="govuk-body">If your school is affected by local coronavirus restrictions, we’ll contact you
+      with instructions as soon as you’re able to place orders.</p>
+
+      <p class="govuk-body">Orders placed before 4pm will normally be delivered to schools the next working day.</p>
+
+      <h2 class="govuk-heading-m">Get devices earlier for specific circumstances</h2>
+
+      <p class="govuk-body">You can request devices at any time for disadvantaged children who:</p>
+
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>are extremely clinically vulnerable and must continue shielding on official advice</li>
+    
+        <li>cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+      </ul>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
         title: Privacy notice
       allocation:
         title: "You’ve been allocated %{allocation} laptops and tablets"
+      order_your_own:
+        title: You can only order your full allocation if local restrictions are confirmed
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
     get '/welcome', to: 'welcome_wizard#welcome', as: :welcome_wizard_welcome
     get '/privacy', to: 'welcome_wizard#privacy', as: :welcome_wizard_privacy
     get '/allocation', to: 'welcome_wizard#allocation', as: :welcome_wizard_allocation
+    get '/order-your-own', to: 'welcome_wizard#order_your_own', as: :welcome_wizard_order_your_own
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     resources :users, only: %i[index new create]
   end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_the_allocation_for_my_school
 
     when_i_click_continue
+    then_i_see_the_order_your_own_page
+
+    when_i_click_continue
     then_i_see_the_school_home_page
   end
 
@@ -57,6 +60,11 @@ RSpec.feature 'Navigate school welcome wizard' do
     expect(page).to have_current_path(school_welcome_wizard_allocation_path)
     heading = I18n.t('page_titles.school_user_welcome_wizard.allocation.title', allocation: device_allocation)
     expect(page).to have_text(heading)
+  end
+
+  def then_i_see_the_order_your_own_page
+    expect(page).to have_current_path(school_welcome_wizard_order_your_own_path)
+    expect(page).to have_text('You can only order your full allocation if local restrictions are confirmed')
   end
 
   def then_i_see_the_school_home_page

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         wizard.allocation!
       end
 
+      it 'moves to the order_your_own step' do
+        wizard.update_step!
+        expect(wizard.order_your_own?).to be true
+      end
+    end
+
+    context 'when the step is order_your_own' do
+      before do
+        wizard.order_your_own!
+      end
+
       it 'moves to the completed step' do
         wizard.update_step!
         expect(wizard.complete?).to be true


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/6i0L6qGQ/567-schools-wizard-order-your-own-page)
Add information about ordering devices page to wizard

### Changes proposed in this pull request
Add 'order your own' page to wizard following the allocation page

### Guidance to review

![image](https://user-images.githubusercontent.com/333931/92137794-82819900-ee05-11ea-9f3f-a3e5391a02ea.png)
