### PR TITLE
Show schools in support

### DIFF
--- a/app/controllers/support/devices/responsible_bodies_controller.rb
+++ b/app/controllers/support/devices/responsible_bodies_controller.rb
@@ -12,5 +12,6 @@ class Support::Devices::ResponsibleBodiesController < Support::BaseController
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
     @users = @responsible_body.users.order('last_signed_in_at desc nulls last, updated_at desc')
+    @schools = @responsible_body.schools.includes(:device_allocations).order(name: :asc)
   end
 end

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">Internet pilot</span>
+      <span class="govuk-caption-xl">Devices pilot</span>
       <%= @responsible_body.name %>
     </h1>
 

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">Internet pilot</span>
       <%= @responsible_body.name %>
@@ -44,5 +44,34 @@
     </table>
 
     <%= govuk_button_link_to 'Add a user', new_support_responsible_body_user_path(@responsible_body, pilot: 'devices') %>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Schools</h2>
+
+    <table id="responsible-body-schools" class="govuk-table">
+      <caption class="govuk-table__caption">Schools managed by <%= @responsible_body.name %></caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Device allocation</th>
+          <th scope="col" class="govuk-table__header">Device cap</th>
+          <th scope="col" class="govuk-table__header">Devices ordered</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @schools.each do |school| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= school.name %><br><%= school.type_label %></td>
+            <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
+            <%- device_allocations_data = school.device_allocations.detect(&:std_device?) %>
+            <td class="govuk-table__cell"><%= device_allocations_data&.allocation || 0 %></td>
+            <td class="govuk-table__cell"><%= device_allocations_data&.cap || 0 %></td>
+            <td class="govuk-table__cell"><%= device_allocations_data&.devices_ordered || 0 %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -1,15 +1,9 @@
 <% content_for :title, "#{@responsible_body.name} – Support" %>
 <%- content_for :before_content do %>
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to t('page_titles.support_responsible_bodies'), support_devices_responsible_bodies_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= @responsible_body.name %>
-      </li>
-    </ol>
-  </div>
+  <%= breadcrumbs([
+    { t('page_titles.support_responsible_bodies') => support_devices_responsible_bodies_path },
+    @responsible_body.name,
+  ]) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/support/devices/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/devices/viewing_responsible_body_info_spec.rb
@@ -1,21 +1,23 @@
 require 'rails_helper'
 
-RSpec.feature 'Viewing responsible body users in the support area', type: :feature do
+RSpec.feature 'Viewing responsible body information in the support area', type: :feature do
   let(:local_authority) { create(:local_authority, name: 'Coventry', in_devices_pilot: true) }
   let(:responsible_bodies_page) { PageObjects::Support::Devices::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::Devices::ResponsibleBodyPage.new }
 
   scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
-    given_there_are_responsible_bodies_that_have_users
+    given_a_responsible_body_with_users
+    and_it_has_some_schools
 
     when_i_sign_in_as_a_dfe_user
     and_i_visit_the_support_responsible_bodies_page
     and_i_visit_a_support_responsible_body_page
 
-    then_i_can_see_the_responsible_body_with_users
+    then_i_can_see_the_users_assigned_to_that_responsible_body
+    and_i_can_see_the_schools_managed_by_that_responsible_body
   end
 
-  def given_there_are_responsible_bodies_that_have_users
+  def given_a_responsible_body_with_users
     create(:user,
            full_name: 'Amy Adams',
            email_address: 'amy.adams@coventry.gov.uk',
@@ -31,6 +33,21 @@ RSpec.feature 'Viewing responsible body users in the support area', type: :featu
            responsible_body: local_authority)
   end
 
+  def and_it_has_some_schools
+    alpha = create(:school, :primary, :with_std_device_allocation,
+                   name: 'Alpha Primary School',
+                   responsible_body: local_authority)
+    alpha.std_device_allocation.update!(
+      allocation: 5,
+      cap: 3,
+      devices_ordered: 1,
+    )
+
+    create(:school, :secondary, :with_std_device_allocation,
+           name: 'Beta Secondary School',
+           responsible_body: local_authority)
+  end
+
   def when_i_sign_in_as_a_dfe_user
     sign_in_as create(:dfe_user)
   end
@@ -43,7 +60,7 @@ RSpec.feature 'Viewing responsible body users in the support area', type: :featu
     click_on local_authority.name
   end
 
-  def then_i_can_see_the_responsible_body_with_users
+  def then_i_can_see_the_users_assigned_to_that_responsible_body
     expect(responsible_body_page.user_rows.size).to eq(2)
 
     first_row = responsible_body_page.user_rows[0]
@@ -57,5 +74,21 @@ RSpec.feature 'Viewing responsible body users in the support area', type: :featu
     expect(second_row).to have_text('amy.adams@coventry.gov.uk')
     expect(second_row).to have_text('0') # sign-ins
     expect(second_row).to have_text('Never')
+  end
+
+  def and_i_can_see_the_schools_managed_by_that_responsible_body
+    expect(responsible_body_page.school_rows.size).to eq(2)
+
+    first_row = responsible_body_page.school_rows[0]
+    expect(first_row).to have_text('Alpha Primary School')
+    expect(first_row).to have_text('Needs a contact')
+    expect(first_row).to have_text('5') # allocations
+    expect(first_row).to have_text('3') # caps
+    expect(first_row).to have_text('1') # device orders
+
+    second_row = responsible_body_page.school_rows[1]
+    expect(second_row).to have_text('Needs a contact')
+    expect(second_row).to have_text('Beta Secondary School')
+    expect(second_row).to have_text('0') # allocations or caps or device orders
   end
 end

--- a/spec/page_objects/support/responsible_body_page.rb
+++ b/spec/page_objects/support/responsible_body_page.rb
@@ -5,6 +5,7 @@ module PageObjects
         set_url '/support/devices/responsible-bodies{/id}'
 
         elements :user_rows, '#responsible-body-users tbody tr'
+        elements :school_rows, '#responsible-body-schools tbody tr'
       end
     end
     module Internet


### PR DESCRIPTION
### Context

Support users need to be able to see the allocations, caps and devices ordered for schools, when queries come in.

### Changes proposed in this pull request

Add a schools table to the RB devices pilot support page.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92149800-66d2be80-ee16-11ea-9418-835f88a75add.png)

