### PR TITLE
[594] User delta CSV

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -38,6 +38,15 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
+  def computacenter_identifier
+    case type
+    when "LocalAuthority"
+      "LEA#{gias_id}"
+    when "Trust"
+      "t#{companies_house_number.to_i}" # QUESTION: is `to_i` needed? is it to remove padded zeros?
+    end
+  end
+
   def self.in_devices_pilot
     where(in_devices_pilot: true)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,4 +82,12 @@ class User < ApplicationRecord
       (is_computacenter? && 'Computacenter') || \
       (is_support? && 'DfE Support')
   end
+
+  def first_name
+    (full_name || '').strip.split(' ').first
+  end
+
+  def last_name
+    (full_name || '').strip.split(' ').last
+  end
 end

--- a/app/services/user_delta_csv.rb
+++ b/app/services/user_delta_csv.rb
@@ -1,0 +1,91 @@
+require 'csv'
+
+class UserDeltaCsv
+  attr_reader :start_range, :end_range
+
+  def initialize(start_range: 24.hours.ago, end_range: Time.now)
+    @start_range = start_range
+    @end_range = end_range
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      csv << headers
+
+      versions.each do |version|
+        next unless version.event == 'create'
+
+        user = user_for_version(version)
+
+        csv << [
+          user.first_name,
+          user.last_name,
+          user.email_address,
+          user.telephone,
+          user.responsible_body&.name,
+          user.responsible_body&.computacenter_identifier,
+          user.responsible_body&.computacenter_reference,
+          user.school&.name,
+          user.school&.urn,
+          user.school&.computacenter_reference,
+          version.created_at.utc.strftime('%d/%m/%Y'),
+          version.created_at.utc.strftime('%R'),
+          version.created_at.utc.iso8601,
+          change_type_for_version(version),
+          version.changeset["email_address"][0]
+        ]
+      end
+    end
+  end
+
+private
+
+  def user_for_version(version)
+    case version.event
+    when "create"
+      # TODO needs caching
+      version.item
+    when "update"
+      # TODO needs caching
+      version.item
+    when "destroy"
+      User.new
+    end
+  end
+
+  def change_type_for_version(version)
+    case version.event
+    when "create"
+      "New"
+    when "update"
+      "Change"
+    when "destroy"
+      "Remove"
+    end
+  end
+
+  def versions
+    # TODO eager loading
+    PaperTrail::Version.where(item_type: 'User', created_at: start_range..end_range)
+  end
+
+  def headers
+    [
+      'First Name',
+      'Last Name',
+      'Email',
+      'Telephone',
+      'Responsible Body',
+      'Responsible Body URN',
+      'CC Sold To Number',
+      'School',
+      'School URN',
+      'CC Ship To Number',
+      'Date of Update', # "24/08/2020" / "dd/mm/yyyy"
+      'Time of Update', # 24 hour clock
+      'Timestamp of Update', # ISO
+      'Type of Update', # New / Change / Remove
+      'Original Email'
+    ]
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     full_name { Faker::Name.unique.name }
     email_address { Faker::Internet.unique.email }
     has_seen_privacy_notice
+    telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
 
     trait :has_seen_privacy_notice do
       privacy_notice_seen_at { 3.days.ago }

--- a/spec/services/user_delta_csv_spec.rb
+++ b/spec/services/user_delta_csv_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe UserDeltaCsv, versioning: true do
+  let(:now) { Time.now.utc }
+  let(:expected_headers) do
+    [
+      'First Name',
+      'Last Name',
+      'Email',
+      'Telephone',
+      'Responsible Body',
+      'Responsible Body URN',
+      'CC Sold To Number',
+      'School',
+      'School URN',
+      'CC Ship To Number',
+      'Date of Update',
+      'Time of Update',
+      'Timestamp of Update',
+      'Type of Update',
+      'Original Email'
+    ]
+  end
+
+  describe '#to_csv' do
+    it 'adds headers to csv' do
+      rows = CSV.parse(subject.to_csv)
+
+      expect(rows[0]).to eql(expected_headers)
+    end
+
+    context "when a new trust user is created" do
+      let(:user) { create(:trust_user) }
+
+      before do
+        Timecop.freeze(now) do
+          user
+        end
+      end
+
+      it "adds user details with new type" do
+        rows = CSV.parse(subject.to_csv)
+
+        expect(rows[1]).to eql([
+          user.first_name,
+          user.last_name,
+          user.email_address,
+          user.telephone,
+          user.responsible_body.name,
+          user.responsible_body.computacenter_identifier,
+          user.responsible_body.computacenter_reference,
+          nil,
+          nil,
+          nil,
+          now.strftime('%d/%m/%Y'),
+          now.strftime('%R'),
+          now.iso8601,
+          'New',
+          nil
+        ])
+      end
+    end
+
+    context "when a new school user is created" do
+      let(:user) { create(:school_user) }
+
+      before do
+        Timecop.freeze(now) do
+          user
+        end
+      end
+
+      it "adds user details with new type" do
+        rows = CSV.parse(subject.to_csv)
+
+        expect(rows[1]).to eql([
+          user.first_name,
+          user.last_name,
+          user.email_address,
+          user.telephone,
+          nil,
+          nil,
+          nil,
+          user.school.name,
+          user.school.urn.to_s,
+          user.school.computacenter_reference,
+          now.strftime('%d/%m/%Y'),
+          now.strftime('%R'),
+          now.iso8601,
+          'New',
+          nil
+        ])
+      end
+    end
+
+    context "when a user is updated" do
+      let(:user) { create(:school_user) }
+      let(:original_user) { user.dup }
+
+      before do
+        Timecop.freeze(10.day.ago) do
+          user
+          original_user
+        end
+
+        Timecop.freeze(now) do
+          user.update(full_name: 'John Doe', email_address: 'new@example.com')
+        end
+      end
+
+      xit "adds user details with Change type" do
+        rows = CSV.parse(subject.to_csv)
+
+        expect(rows[1]).to eql([
+          "John",
+          "Doe",
+          'new@example.com',
+          user.telephone,
+          nil,
+          nil,
+          nil,
+          user.school.name,
+          user.school.urn.to_s,
+          user.school.computacenter_reference,
+          now.strftime('%d/%m/%Y'),
+          now.strftime('%R'),
+          now.iso8601,
+          'Change',
+          original_user.email_address,
+        ])
+      end
+    end
+
+    context "when a user is deleted" do
+      let(:user) { create(:school_user) }
+
+      before do
+        Timecop.freeze(10.day.ago) do
+          user
+        end
+
+        Timecop.freeze(now) do
+          user.destroy
+        end
+      end
+
+      xit "adds user details with Change type" do
+        rows = CSV.parse(subject.to_csv)
+
+        expect(rows[1]).to eql([
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          now.strftime('%d/%m/%Y'),
+          now.strftime('%R'),
+          now.iso8601,
+          'Remove',
+          user.email_address
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-spike-can-we-generate-the-cc-user-changes-feed-using-papertrail
- Generate a CSV for new users. Handling of user updates and deletions will be handled later

### Changes proposed in this pull request

- Generate a CSV of new users through the paper_trail audit
- There are commented out tests for user updates and deletions which is being worked on

### Guidance to review

- Login to box with rails console
- `service = UserDeltaCsv.new(start_range: 1.week.ago)`
- `service.to_csv`
- should generate csv to prompt