### PR TITLE
rejig the sign-in behaviour to only actually sign the user in once they click the button

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -1,6 +1,4 @@
 class SignInTokensController < ApplicationController
-  before_action :require_sign_in!, only: :destroy
-
   def new
     @sign_in_token_form ||= SignInTokenForm.new
     if FeatureFlag.active?(:public_account_creation)
@@ -10,27 +8,25 @@ class SignInTokensController < ApplicationController
     end
   end
 
+  # GET /token/validate
+  # This does NOT sign the user in, but validates the token and renders a
+  # form with hidden fields that they must submit to actually sign-in
+  # We do it this way because we have found many users are hitting this page
+  # multiple times from different IPs, almost simultaneously - which implies
+  # that it's some automatic email link-scanning security software.
   def validate
-    @user = SessionService.validate_token!(token: params[:token], identifier: params[:identifier])
-    save_user_to_session!
-    EventNotificationsService.broadcast(SignInEvent.new(user: @user))
-    start_user_journey(@user)
-  rescue SessionService::TokenValidButExpired
-    # If it's the same user who already has a valid session, and they've just
-    # re-clicked a link with a token that's expired, but a session that _hasn't_
-    if SessionService.is_signed_in?(session) && @user.id == session[:user_id]
-      # - that's ok, we'll allow it
-      render :you_are_signed_in
-    else
-      render :token_is_valid_but_expired, status: :bad_request
+    validate_token_and do
+      render :click_to_sign_in
     end
-  rescue SessionService::TokenNotRecognised, SessionService::InvalidTokenAndIdentifierCombination
-    render :token_not_recognised, status: :bad_request
   end
 
   def destroy
-    @user.clear_token!
-    redirect_to root_url_for(@user)
+    validate_token_and do
+      save_user_to_session!
+      EventNotificationsService.broadcast(SignInEvent.new(user: @user))
+      @user.clear_token!
+      redirect_to root_url_for(@user)
+    end
   end
 
   def validate_manual
@@ -56,16 +52,6 @@ class SignInTokensController < ApplicationController
 
   def sent
     @user = User.where(sign_in_token: params[:token]).first
-    # NOTE: this is purely to allow us to display the link in the footer
-    # REMOVE when we have emails actually being sent
-    if @user
-      identifier = @user.sign_in_identifier(@user.sign_in_token)
-      @debug_info = {
-        sign_in_token: @user.sign_in_token,
-        sign_in_identifier: identifier,
-        sign_in_link: validate_sign_in_token_url(token: @user.sign_in_token, identifier: identifier),
-      }
-    end
   end
 
   def hide_nav_menu?
@@ -73,6 +59,24 @@ class SignInTokensController < ApplicationController
   end
 
 private
+
+  # if the token is valid, yield to the given block
+  # if not, handle appropriately
+  def validate_token_and
+    @user = SessionService.validate_token!(token: params[:token], identifier: params[:identifier])
+    yield
+  rescue SessionService::TokenValidButExpired
+    # If it's the same user who already has a valid session, and they've just
+    # re-clicked a link with a token that's expired, but a session that _hasn't_
+    if SessionService.is_signed_in?(session) && @user.id == session[:user_id]
+      # - that's ok, we'll allow it
+      yield
+    else
+      render :token_is_valid_but_expired, status: :bad_request
+    end
+  rescue SessionService::TokenNotRecognised, SessionService::InvalidTokenAndIdentifierCombination
+    render :token_not_recognised, status: :bad_request
+  end
 
   def sign_in_token_form_params
     params.require(:sign_in_token_form).permit(
@@ -83,14 +87,6 @@ private
     )
   end
 
-  def start_user_journey(user)
-    if user.is_school_user? && !user.school_welcome_wizard&.complete?
-      redirect_to school_welcome_wizard_welcome_path
-    else
-      render :you_are_signed_in
-    end
-  end
-
   def root_url_for(user)
     if user.is_mno_user?
       mno_extra_mobile_data_requests_path
@@ -99,13 +95,21 @@ private
     elsif user.is_responsible_body_user?
       responsible_body_home_path
     elsif user.is_school_user?
-      school_home_path
+      school_user_start_url(user)
     elsif user.is_computacenter?
       computacenter_home_path
     elsif user.is_support?
       support_internet_service_performance_path
     else
       '/'
+    end
+  end
+
+  def school_user_start_url(user)
+    if user.school_welcome_wizard&.complete?
+      school_home_path
+    else
+      school_welcome_wizard_welcome_path
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,4 +73,13 @@ class User < ApplicationRecord
       errors.add(:orders_devices, I18n.t('activerecord.errors.models.user.attributes.orders_devices.user_limit'))
     end
   end
+
+  def organisation_name
+    mobile_network&.brand || \
+      responsible_body&.local_authority_official_name || \
+      responsible_body&.name || \
+      school&.name || \
+      (is_computacenter? && 'Computacenter') || \
+      (is_support? && 'DfE Support')
+  end
 end

--- a/app/views/sign_in_tokens/click_to_sign_in.html.erb
+++ b/app/views/sign_in_tokens/click_to_sign_in.html.erb
@@ -1,4 +1,5 @@
-<%- title = t('page_titles.click_to_sign_in', organisation: @user.organisation_name) %>
+<%- i18n_key = (@user.is_computacenter? || @user.is_support?) ? :standard : :related_organisation %>
+<%- title = t(i18n_key, scope: %i[page_titles click_to_sign_in], organisation: @user.organisation_name) %>
 <%- content_for :title, title %>
 
 <div class="govuk-grid-row">

--- a/app/views/sign_in_tokens/click_to_sign_in.html.erb
+++ b/app/views/sign_in_tokens/click_to_sign_in.html.erb
@@ -1,4 +1,4 @@
-<%- title = t('page_titles.click_to_sign_in') %>
+<%- title = t('page_titles.click_to_sign_in', organisation: @user.organisation_name) %>
 <%- content_for :title, title %>
 
 <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
       <%= form_with url: destroy_sign_in_token_path, method: 'delete' do |f| %>
         <%= hidden_field_tag :token, params[:token] %>
         <%= hidden_field_tag :identifier, params[:identifier] %>
-        <%= f.govuk_submit 'Sign in' %>
+        <%= f.govuk_submit 'Continue' %>
       <% end %>
     </p>
   </div>

--- a/app/views/sign_in_tokens/click_to_sign_in.html.erb
+++ b/app/views/sign_in_tokens/click_to_sign_in.html.erb
@@ -1,13 +1,16 @@
-<%- content_for :title, t('page_titles.you_are_signed_in') %>
+<%- title = t('page_titles.click_to_sign_in') %>
+<%- content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.you_are_signed_in') %>
+      <%= title %>
     </h1>
     <p class="govuk-body">
       <%= form_with url: destroy_sign_in_token_path, method: 'delete' do |f| %>
-        <%= f.govuk_submit 'Continue' %>
+        <%= hidden_field_tag :token, params[:token] %>
+        <%= hidden_field_tag :identifier, params[:identifier] %>
+        <%= f.govuk_submit 'Sign in' %>
       <% end %>
     </p>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,9 @@
     devices_guidance_index: "Get help with technology: devices"
     devices_guidance_how_to_order: "How to order laptops and tablets during coronavirus (COVID-19)"
     download_bt_hotspots: Download your BT hotspot log-ins
-    click_to_sign_in: You're signed in as %{organisation}
+    click_to_sign_in:
+      standard: You’re signed in
+      related_organisation: You're signed in as %{organisation}
     you_are_signed_in: You’re signed in
     devices_service_performance: Devices service performance
     internet_service_performance: Internet service performance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
-en:
+ en:
   service_name: Get help with technology
   page_titles:
     about_bt_wifi: Increasing children’s internet access through free BT hotspots
@@ -40,7 +40,7 @@ en:
     devices_guidance_index: "Get help with technology: devices"
     devices_guidance_how_to_order: "How to order laptops and tablets during coronavirus (COVID-19)"
     download_bt_hotspots: Download your BT hotspot log-ins
-    click_to_sign_in: Click the button below to sign in
+    click_to_sign_in: You're signed in as %{organisation}
     you_are_signed_in: You’re signed in
     devices_service_performance: Devices service performance
     internet_service_performance: Internet service performance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     devices_guidance_index: "Get help with technology: devices"
     devices_guidance_how_to_order: "How to order laptops and tablets during coronavirus (COVID-19)"
     download_bt_hotspots: Download your BT hotspot log-ins
+    click_to_sign_in: Click the button below to sign in
     you_are_signed_in: You’re signed in
     devices_service_performance: Devices service performance
     internet_service_performance: Internet service performance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@
     download_bt_hotspots: Download your BT hotspot log-ins
     click_to_sign_in:
       standard: You’re signed in
-      related_organisation: You're signed in as %{organisation}
+      related_organisation: You’re signed in as %{organisation}
     you_are_signed_in: You’re signed in
     devices_service_performance: Devices service performance
     internet_service_performance: Internet service performance

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -2,43 +2,61 @@ require 'rails_helper'
 
 RSpec.describe SignInTokensController, type: :controller do
   let(:user) { create(:local_authority_user, :who_has_requested_a_magic_link) }
+  let(:valid_token_params) { { token: user.sign_in_token, identifier: user.sign_in_identifier(user.sign_in_token) } }
+  let(:mock_event) { instance_double(SignInEvent, notifiable?: false) }
+
+  before do
+    allow(controller).to receive(:save_user_to_session!)
+    allow(SignInEvent).to receive(:new).with(user: user).and_return(mock_event)
+    allow(EventNotificationsService).to receive(:broadcast)
+  end
 
   describe 'destroy' do
-    it 'clears the token when the user is signed in' do
-      sign_in_as user
+    before do
+      # Test-only hack - TestSession doesn't auto-create session IDs in
+      # controller specs like a Rack Session does.
+      create_session_id!
+      allow(EventNotificationsService).to receive(:broadcast)
+    end
 
-      delete :destroy
+    it 'clears the token when the user provides recognised token & identifier' do
+      delete :destroy, params: valid_token_params
 
       expect(user.reload.sign_in_token).to be_nil
     end
 
-    it 'redirects to the sign-in path if the user is not signed in' do
-      delete :destroy
+    it 'responds with bad request when the user provides a recognised but expired token & identifier' do
+      user.update!(sign_in_token_expires_at: Time.zone.now.utc - 1.hour)
+      delete :destroy, params: valid_token_params
 
       expect(user.reload.sign_in_token).not_to be_nil
-      expect(response).to redirect_to(sign_in_path)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'saves the user to session' do
+      allow(controller).to receive(:save_user_to_session!)
+      delete :destroy, params: valid_token_params
+      expect(controller).to have_received(:save_user_to_session!)
+    end
+
+    it 'broadcasts a SignInEvent for the user' do
+      delete :destroy, params: valid_token_params
+      expect(EventNotificationsService).to have_received(:broadcast).with(mock_event)
     end
   end
 
   describe 'GET #validate' do
     context 'with a valid token' do
       let(:params) { { token: user.sign_in_token, identifier: user.sign_in_identifier(user.sign_in_token) } }
-      let(:mock_event) { instance_double(SignInEvent, notifiable?: false) }
 
-      before do
-        allow(controller).to receive(:save_user_to_session!)
-        allow(SignInEvent).to receive(:new).with(user: user).and_return(mock_event)
-        allow(EventNotificationsService).to receive(:broadcast)
+      it 'does not save the user to session' do
+        get :validate, params: params
+        expect(controller).not_to have_received(:save_user_to_session!)
       end
 
-      it 'saves the user to session' do
+      it 'does not broadcast a SignInEvent for the user' do
         get :validate, params: params
-        expect(controller).to have_received(:save_user_to_session!)
-      end
-
-      it 'broadcasts a SignInEvent for the user' do
-        get :validate, params: params
-        expect(EventNotificationsService).to have_received(:broadcast).with(mock_event)
+        expect(EventNotificationsService).not_to have_received(:broadcast)
       end
     end
   end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def when_i_sign_in_for_the_first_time
     visit validate_token_url_for(@user)
+    click_on 'Sign in'
   end
 
   def then_i_see_a_welcome_page_for_my_school
@@ -79,6 +80,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def and_then_sign_in_again
     visit validate_token_url_for(@user)
+    click_on 'Sign in'
   end
 
   def device_allocation

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def when_i_sign_in_for_the_first_time
     visit validate_token_url_for(@user)
-    click_on 'Sign in'
+    click_on 'Continue'
   end
 
   def then_i_see_a_welcome_page_for_my_school
@@ -80,7 +80,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def and_then_sign_in_again
     visit validate_token_url_for(@user)
-    click_on 'Sign in'
+    click_on 'Continue'
   end
 
   def device_allocation

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 're-using the same magic-link redirects to the home page for user' do
       visit validate_token_url
-      click_on 'Sign in'
+      click_on 'Continue'
       expect(page).to have_current_path(responsible_body_home_path)
     end
 
@@ -93,7 +93,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 'using a magic link from a different user signs in as the different user' do
       visit other_user_magic_link
-      click_on 'Sign in'
+      click_on 'Continue'
       expect(page).to have_content(other_user.email_address)
     end
   end

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 're-using the same magic-link redirects to the home page for user' do
       visit validate_token_url
-      click_on 'Continue'
+      click_on 'Sign in'
       expect(page).to have_current_path(responsible_body_home_path)
     end
 
@@ -93,7 +93,7 @@ RSpec.feature 'Session behaviour', type: :feature do
 
     scenario 'using a magic link from a different user signs in as the different user' do
       visit other_user_magic_link
-      click_on 'Continue'
+      click_on 'Sign in'
       expect(page).to have_content(other_user.email_address)
     end
   end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         visit validate_token_url
         expect(page).not_to have_text(user.email_address)
         expect(page).not_to have_button('Sign out')
-        expect(page).to have_text('You\'re signed in')
-        expect(page).to have_button('Sign in')
+        expect(page).to have_text('You’re signed in')
+        expect(page).to have_button('Continue')
       end
 
       it 'does not increment sign-in count' do
@@ -31,7 +31,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         3.times do
           visit validate_token_url
           expect(page).to have_http_status(:ok)
-          expect(page).to have_text('You\'re signed in')
+          expect(page).to have_text('You’re signed in')
         end
       end
     end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         visit validate_token_url
         expect(page).not_to have_text(user.email_address)
         expect(page).not_to have_button('Sign out')
-        expect(page).to have_text('You\'re signed in as')
+        expect(page).to have_text('You\'re signed in')
         expect(page).to have_button('Sign in')
       end
 
@@ -31,7 +31,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         3.times do
           visit validate_token_url
           expect(page).to have_http_status(:ok)
-          expect(page).to have_text('You\'re signed in as')
+          expect(page).to have_text('You\'re signed in')
         end
       end
     end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -6,66 +6,74 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
   let(:token) { user.generate_token!(ttl: ttl) }
   let(:identifier) { user.sign_in_identifier(token) }
 
-  context 'with a valid sign_in_token link' do
+  context 'with a valid sign_in_token link that has not expired' do
+    let(:ttl) { 3600 }
     let(:validate_token_url) { validate_sign_in_token_url(token: token, identifier: identifier) }
 
-    context 'that has not expired' do
-      let(:ttl) { 3600 }
-
-      scenario 'Visiting a valid sign_in_token link signs the user in' do
+    describe 'Visiting a valid sign_in_token link' do
+      it 'does not sign the user in' do
         visit validate_token_url
         expect(page).not_to have_text(user.email_address)
         expect(page).not_to have_button('Sign out')
-        expect(page).to have_text('You’re signed in')
-        expect(page).to have_button('Continue')
+        expect(page).to have_text('Click the button below to sign in')
+        expect(page).to have_button('Sign in')
       end
 
-      scenario 'Visiting the valid sign_in_token link increments sign-in count and timestamp' do
+      it 'does not increment sign-in count' do
+        expect { visit validate_token_url }.not_to change(user.reload, :sign_in_count)
+      end
+
+      it 'does not change last_signed_in_at' do
+        expect { visit validate_token_url }.not_to change(user.reload, :last_signed_in_at)
+      end
+
+      it 'works multiple times' do
+        3.times do
+          visit validate_token_url
+          expect(page).to have_http_status(:ok)
+          expect(page).to have_text('Click the button below to sign in')
+        end
+      end
+    end
+
+    describe 'clicking the Sign in button' do
+      it 'increments sign-in count and last_signed_in_at' do
         timestamp = Date.new(2020, 6, 1)
         Timecop.freeze(timestamp) do
           visit validate_token_url
+          click_on 'Sign in'
         end
 
         expect(user.reload.sign_in_count).to eq(1)
         expect(user.reload.last_signed_in_at).to eq(timestamp)
       end
 
-      scenario 'Visiting a sign_in_token link twice does not work the second time if the user continued through the interstitial page' do
+      it 'does not work a second time' do
         visit validate_token_url
-        click_on 'Continue'
+        click_on 'Sign in'
         click_on 'Sign out'
 
         visit validate_token_url
         expect(page).to have_http_status(:bad_request)
         expect(page).not_to have_text('Sign out')
       end
+    end
+  end
 
-      scenario 'Visiting a sign_in_token link twice does not work the second time if the user did not continue through the interstitial page' do
-        visit validate_token_url
-        expect(page).to have_text(I18n.t('page_titles.you_are_signed_in'))
+  context 'with a valid sign_in_token link that has expired' do
+    let(:ttl) { -1 }
+    let(:validate_token_url) { validate_sign_in_token_url(token: token, identifier: identifier) }
 
-        visit validate_token_url
-        expect(page).to have_http_status(:ok)
-        expect(page).to have_text(I18n.t('page_titles.you_are_signed_in'))
-        click_on 'Continue'
-        expect(page).to have_selector('h1', text: I18n.t('page_titles.responsible_body_home'))
-      end
+    it 'does not sign the user in' do
+      visit validate_token_url
+      expect(page).to have_http_status(:bad_request)
+      expect(page).not_to have_text('Sign out')
     end
 
-    context 'that has expired' do
-      let(:ttl) { -1 }
-
-      scenario 'Visiting a valid sign_in_token link after it expires does not sign the user in' do
-        visit validate_token_url
-        expect(page).to have_http_status(:bad_request)
-        expect(page).not_to have_text('Sign out')
-      end
-
-      scenario 'Visiting a valid but expired token tells the user it has expired' do
-        visit validate_token_url
-        expect(page).to have_text('The link you clicked has expired')
-        expect(page).to have_link('Request a new sign-in link')
-      end
+    it 'tells the user it has expired' do
+      visit validate_token_url
+      expect(page).to have_text('The link you clicked has expired')
+      expect(page).to have_link('Request a new sign-in link')
     end
   end
 

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         visit validate_token_url
         expect(page).not_to have_text(user.email_address)
         expect(page).not_to have_button('Sign out')
-        expect(page).to have_text('Click the button below to sign in')
+        expect(page).to have_text('You\'re signed in as')
         expect(page).to have_button('Sign in')
       end
 
@@ -31,7 +31,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         3.times do
           visit validate_token_url
           expect(page).to have_http_status(:ok)
-          expect(page).to have_text('Click the button below to sign in')
+          expect(page).to have_text('You\'re signed in as')
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
         timestamp = Date.new(2020, 6, 1)
         Timecop.freeze(timestamp) do
           visit validate_token_url
-          click_on 'Sign in'
+          click_on 'Continue'
         end
 
         expect(user.reload.sign_in_count).to eq(1)
@@ -50,7 +50,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
 
       it 'does not work a second time' do
         visit validate_token_url
-        click_on 'Sign in'
+        click_on 'Continue'
         click_on 'Sign out'
 
         visit validate_token_url

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -81,6 +81,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
 
     scenario 'it redirects to the school welcome wizard welcome page' do
       visit validate_token_url_for(user)
+      click_on 'Sign in'
       expect(page).to have_current_path(school_welcome_wizard_welcome_path)
       expect(page).to have_text "You’re signed in as #{user.school.name}"
     end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
 
     scenario 'it redirects to the school welcome wizard welcome page' do
       visit validate_token_url_for(user)
-      click_on 'Sign in'
+      click_on 'Continue'
       expect(page).to have_current_path(school_welcome_wizard_welcome_path)
       expect(page).to have_text "You’re signed in as #{user.school.name}"
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -110,4 +110,56 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#organisation_name' do
+    let(:user) { build(:user) }
+
+    context 'when the user is from a mobilenetwork' do
+      before { user.mobile_network = build(:mobile_network) }
+
+      it 'returns the mobile networks brand' do
+        expect(user.organisation_name).to eq(user.mobile_network.brand)
+      end
+    end
+
+    context 'when the user is from a trust' do
+      before { user.responsible_body = build(:trust) }
+
+      it 'returns the trusts name' do
+        expect(user.organisation_name).to eq(user.responsible_body.name)
+      end
+    end
+
+    context 'when the user is from a local authority' do
+      before { user.responsible_body = build(:local_authority) }
+
+      it 'returns the local authoritys official name' do
+        expect(user.organisation_name).to eq(user.responsible_body.local_authority_official_name)
+      end
+    end
+
+    context 'when the user is from a school' do
+      before { user.school = build(:school) }
+
+      it 'returns the schools name' do
+        expect(user.organisation_name).to eq(user.school.name)
+      end
+    end
+
+    context 'when the user is from computacenter' do
+      before { user.is_computacenter = true }
+
+      it 'returns Computacenter' do
+        expect(user.organisation_name).to eq('Computacenter')
+      end
+    end
+
+    context 'when the user is a support user' do
+      before { user.is_support = true }
+
+      it 'returns DfE Support' do
+        expect(user.organisation_name).to eq('DfE Support')
+      end
+    end
+  end
 end

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -8,7 +8,7 @@ module CapybaraHelper
 
   def sign_in_as(user)
     visit validate_token_url_for(user)
-    click_on 'Sign in'
+    click_on 'Continue'
   end
 
   def sign_out

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -8,7 +8,7 @@ module CapybaraHelper
 
   def sign_in_as(user)
     visit validate_token_url_for(user)
-    click_on 'Continue'
+    click_on 'Sign in'
   end
 
   def sign_out

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,7 +1,11 @@
 module ControllerHelper
-  def sign_in_as(user)
+  def create_session_id!
     # TestSession doesn't do this automatically like a real session
     session[:session_id] = SecureRandom.uuid
+  end
+
+  def sign_in_as(user)
+    create_session_id!
     controller.send(:save_user_to_session!, user)
   end
 end


### PR DESCRIPTION
### Context

[Trello card 548](https://trello.com/c/aHrdHDJv/548-can-we-rejig-the-sign-in-process-to-fix-the-multiple-event-notifications-issue) (also many slack threads & Zendesk tickets) - For some users, we've been seeing multiple almost-simultaneous "A user from X has just signed in" notifications in Slack when they sign-in. We think this is due to their email software scanning links in emails for malicious behaviour before the user even sees them.

### Changes proposed in this pull request

Rework the sign-in process slightly so that when the user clicks the magic link:
* it renders hidden fields for `token` & `identifier` in to the `DELETE` form 
* it does not actually sign the user in (and send the notification & clear the token, etc) until they click the button to sign in

Adjust the school wizard entry point slightly to fit
Adjust the specs to match & test the new behaviour

**NOTE**: I've altered the wording on the interstitial form page slightly, to make it clearer that they're not signed in until they click the button -

<img width="483" alt="Screen Shot 2020-09-04 at 16 07 54" src="https://user-images.githubusercontent.com/134501/92254546-f6d14080-eec8-11ea-8b50-fa10df8c4834.png">


...but as far as the user is concerned that's the only change they'll see. My interaction design / content design skills are not the best, however, so I'm particularly keen to get @fofr 's input on this. Maybe we should add a `flash[:success]` message after clicking the button, to just give the user some obvious feedback that they really are signed in now?

### Guidance to review

Sign in as normal. Everything should Just Work (TM), including entry to the schools wizard, and re-entry partway through it if you sign out halfway through (@tonyheadford please double-check this)
