### PR TITLE
add user journey for ordering devices outside of lockdown

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,10 +1,11 @@
 class School::DevicesController < School::BaseController
   def order
-    # always false, until we've developed the other branch of the user journey
-    if false && @school.can_order_devices?
-    else
-      render :cannot_order
-    end
+    # replace with if conditon below when we've developed the other
+    # branch of the user journey
+    # if false && @school.can_order_devices?
+    # else
+    render :cannot_order
+    # end
   end
 
   def request_devices

--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,0 +1,13 @@
+class School::DevicesController < School::BaseController
+  def order
+    # always false, until we've developed the other branch of the user journey
+    if false && @school.can_order_devices?
+    else
+      render :cannot_order
+    end
+  end
+
+  def request_devices
+    render 'shared/devices/request_devices'
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -62,7 +62,7 @@ class School < ApplicationRecord
     responsible_body.next_school_sorted_ascending_by_name(self)
   end
 
-  def can_order_devices?(device_type='std_device')
+  def can_order_devices?(device_type = 'std_device')
     allocation = device_allocations.by_device_type(device_type).first
     allocation&.cap.to_i > allocation&.devices_ordered.to_i
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -61,4 +61,9 @@ class School < ApplicationRecord
   def next_school_in_responsible_body_when_sorted_by_name_ascending
     responsible_body.next_school_sorted_ascending_by_name(self)
   end
+
+  def can_order_devices?(device_type='std_device')
+    allocation = device_allocations.by_device_type(device_type).first
+    allocation&.cap.to_i > allocation&.devices_ordered.to_i
+  end
 end

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -1,0 +1,23 @@
+<%- title = t('page_titles.school_cannot_order_devices') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { t('page_titles.school_home') => school_home_path },
+    title,
+  ]) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <p class="govuk-body">You can only place orders when local coronavirus restrictions are confirmed.</p>
+    <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
+    <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', school_request_devices_path %> who:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>are extremely clinically vulnerable and must continue shielding on&nbsp;official&nbsp;advice</li>
+      <li>cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -6,6 +6,17 @@
     </h1>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.school_order_devices'), school_order_devices_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check if you can place orders</li>
+      <li>access the Computacenter TechSource website to order devices</li>
+    </ul>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.school_request_devices'), school_request_devices_path %>
     </h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,8 @@ en:
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     school_home: Get devices for your school
+    school_cannot_order_devices: You cannot order devices yet
+    school_order_devices: Order devices
     school_request_devices: Request devices for specific circumstances
     school_details: Check your school details
     school_edit_chromebooks: Will your school need to order Chromebooks?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,8 @@ Rails.application.routes.draw do
 
   namespace :school do
     get '/', to: 'home#show', as: :home
-    get '/request-devices', to: 'home#request_devices'
+    get '/request-devices', to: 'devices#request_devices'
+    get '/order-devices', to: 'devices#order'
     get '/details', to: 'details#show', as: :details
     get '/chromebooks/edit', to: 'chromebooks#edit'
     patch '/chromebooks', to: 'chromebooks#update'

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.feature 'Order devices (outside lockdown)' do
+  let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
+
+  context 'logged in as a school user' do
+    before do
+      sign_in_as school_user
+    end
+
+    scenario 'Finding out about ordering devices' do
+      click_on 'Order devices'
+
+      expect(page).to have_content('You cannot order devices yet')
+      expect(page).to have_link('request devices for disadvantaged children')
+    end
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -214,6 +214,5 @@ RSpec.describe School, type: :model do
         expect(school.can_order_devices?).to eq(false)
       end
     end
-
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -166,4 +166,54 @@ RSpec.describe School, type: :model do
       it { is_expected.to be_blank }
     end
   end
+
+  describe '#can_order_devices?' do
+    let(:school) { create(:school) }
+
+    context 'when there is no allocation of the given type' do
+      it 'is false' do
+        expect(school.can_order_devices?).to eq(false)
+      end
+    end
+
+    context 'when there is an allocation of the given type with cap = devices_ordered' do
+      let(:cap) { 0 }
+      let(:devices_ordered) { 0 }
+
+      before do
+        school.device_allocations << build(:school_device_allocation, device_type: 'std_device', cap: cap, devices_ordered: devices_ordered)
+      end
+
+      it 'is false' do
+        expect(school.can_order_devices?).to eq(false)
+      end
+    end
+
+    context 'when there is an allocation of the given type with cap > devices_ordered' do
+      let(:cap) { 2 }
+      let(:devices_ordered) { 1 }
+
+      before do
+        school.device_allocations << build(:school_device_allocation, device_type: 'std_device', cap: cap, devices_ordered: devices_ordered)
+      end
+
+      it 'is true' do
+        expect(school.can_order_devices?).to eq(true)
+      end
+    end
+
+    context 'when there is an allocation of the given type with cap < devices_ordered' do
+      let(:cap) { 1 }
+      let(:devices_ordered) { 2 }
+
+      before do
+        school.device_allocations << create(:school_device_allocation, school: school, device_type: 'std_device', cap: cap, devices_ordered: devices_ordered)
+      end
+
+      it 'is false' do
+        expect(school.can_order_devices?).to eq(false)
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/hN0YNKbM/561-schools-order-devices-outside-lockdown)

### Changes proposed in this pull request

* add school homepage section 'Order devices'
* add `can_order_devices?` method to school, with correct(?) logic
* add content page for "You cannot order devices yet" - always shown, until we've developed [the other branch of the user journey](https://trello.com/c/6SoAV292/562-schools-order-devices-in-lockdown)
* move existing `request_devices` method from `school/home_controller` to new `school/devices_controller`

### Guidance to review

<img width="484" alt="Screen Shot 2020-09-04 at 15 02 29" src="https://user-images.githubusercontent.com/134501/92248271-524b0080-eec0-11ea-9210-1bbf8023065b.png">
<img width="494" alt="Screen Shot 2020-09-04 at 15 07 45" src="https://user-images.githubusercontent.com/134501/92248341-6ee73880-eec0-11ea-95af-aa4d74151985.png">

