### PR TITLE
Support: show the school URN in the responsible body schools list

### DIFF
--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -47,7 +47,7 @@
       <caption class="govuk-table__caption">Schools managed by <%= @responsible_body.name %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Name and URN</th>
           <th scope="col" class="govuk-table__header">Status</th>
           <th scope="col" class="govuk-table__header">Device allocation</th>
           <th scope="col" class="govuk-table__header">Device cap</th>
@@ -57,7 +57,7 @@
       <tbody class="govuk-table__body">
         <% @schools.each do |school| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= school.name %><br><%= school.type_label %></td>
+            <td class="govuk-table__cell"><%= school.name %> (<%= school.urn %>)<br><%= school.type_label %></td>
             <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
             <%- device_allocations_data = school.device_allocations.detect(&:std_device?) %>
             <td class="govuk-table__cell"><%= device_allocations_data&.allocation || 0 %></td>

--- a/spec/features/support/devices/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/devices/viewing_responsible_body_info_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
 
   def and_it_has_some_schools
     alpha = create(:school, :primary, :with_std_device_allocation,
+                   urn: 567_890,
                    name: 'Alpha Primary School',
                    responsible_body: local_authority)
     alpha.std_device_allocation.update!(
@@ -44,6 +45,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     )
 
     create(:school, :secondary, :with_std_device_allocation,
+           urn: 123_456,
            name: 'Beta Secondary School',
            responsible_body: local_authority)
   end
@@ -80,7 +82,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     expect(responsible_body_page.school_rows.size).to eq(2)
 
     first_row = responsible_body_page.school_rows[0]
-    expect(first_row).to have_text('Alpha Primary School')
+    expect(first_row).to have_text('Alpha Primary School (567890)')
     expect(first_row).to have_text('Needs a contact')
     expect(first_row).to have_text('5') # allocations
     expect(first_row).to have_text('3') # caps
@@ -88,7 +90,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
 
     second_row = responsible_body_page.school_rows[1]
     expect(second_row).to have_text('Needs a contact')
-    expect(second_row).to have_text('Beta Secondary School')
+    expect(second_row).to have_text('Beta Secondary School (123456)')
     expect(second_row).to have_text('0') # allocations or caps or device orders
   end
 end


### PR DESCRIPTION
### Context

It's useful to quickly find a school by its URN

### Changes proposed in this pull request

Show the URN in the devices RB schools list in the support area.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92258513-db693400-eece-11ea-81eb-2376768205c1.png)

