### PR TITLE
568 schools wizard user will place orders

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -21,6 +21,8 @@ class School::WelcomeWizardController < School::BaseController
 
   def order_your_own; end
 
+  def will_you_order; end
+
 private
 
   def set_wizard
@@ -34,6 +36,7 @@ private
   def wizard_params
     params.require(:school_welcome_wizard).permit(
       :step,
+      :orders_devices,
     )
   end
 

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -2,16 +2,20 @@ class SchoolWelcomeWizard < ApplicationRecord
   belongs_to :user
 
   validates :step, presence: true
+  validates :orders_devices, inclusion: { in: %w[yes no] }, if: :will_you_order?
 
   enum step: {
     welcome: 'welcome',
     privacy: 'privacy',
     allocation: 'allocation',
     order_your_own: 'order_your_own',
+    will_you_order: 'will_you_order',
     complete: 'complete',
   }
 
-  def update_step!(_params = {})
+  attr_accessor :orders_devices
+
+  def update_step!(params = {})
     return true if complete?
 
     case step
@@ -23,9 +27,35 @@ class SchoolWelcomeWizard < ApplicationRecord
     when 'allocation'
       order_your_own!
     when 'order_your_own'
-      complete!
+      if show_will_you_order_section?
+        will_you_order!
+      else
+        complete!
+      end
+    when 'will_you_order'
+      update_will_you_order(params)
+      if valid?
+        complete!
+      else
+        false
+      end
     else
       raise "Unknown step: #{step}"
     end
+  end
+
+private
+
+  def update_will_you_order(params)
+    self.orders_devices = params.fetch(:orders_devices, nil)
+  end
+
+  def show_will_you_order_section?
+    true
+  end
+
+  def set_first_user_flag!
+    is_first_user_for_school = user.school.users.count == 1
+    update!(first_school_user: is_first_user_for_school)
   end
 end

--- a/app/views/school/welcome_wizard/will_you_order.html.erb
+++ b/app/views/school/welcome_wizard/will_you_order.html.erb
@@ -11,12 +11,11 @@
       <h1 class="govuk-heading-xl"><%= title %></h1>
 
       <%= f.govuk_radio_buttons_fieldset(:orders_devices) do %>
-      <!-- , legend: {size: 'xl', text: title }) do %> -->
         <%= f.govuk_radio_button :orders_devices,
-                                 'yes',
+                                 '1',
                                  label: { text: t(:yes_label, scope: scope) } %>
         <%= f.govuk_radio_button :orders_devices,
-                                 'no',
+                                 '0',
                                  label: { text: t(:no_label, scope: scope) } %>
       <%- end %>
 

--- a/app/views/school/welcome_wizard/will_you_order.html.erb
+++ b/app/views/school/welcome_wizard/will_you_order.html.erb
@@ -1,0 +1,26 @@
+<%-
+  scope = 'page_titles.school_user_welcome_wizard.will_you_order'
+  title = t('title', scope: scope)
+%>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset(:orders_devices) do %>
+      <!-- , legend: {size: 'xl', text: title }) do %> -->
+        <%= f.govuk_radio_button :orders_devices,
+                                 'yes',
+                                 label: { text: t(:yes_label, scope: scope) } %>
+        <%= f.govuk_radio_button :orders_devices,
+                                 'no',
+                                 label: { text: t(:no_label, scope: scope) } %>
+      <%- end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
         title: Will you be one of the people placing orders for your school?
         yes_label: Yes, I will order devices
         no_label: 'No'
+        errors:
+          choose_option: Tell us whether you will order devices
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:
@@ -345,10 +347,6 @@ en:
               invalid: The URN must be 6 digits
             name:
               blank: Enter the name of the establishment
-        school_welcome_wizard:
-          attributes:
-            orders_devices:
-              inclusion: Tell us whether you will order devices
   time:
     formats:
       time_only: "%l:%M%P"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,10 @@ en:
         title: "You’ve been allocated %{allocation} laptops and tablets"
       order_your_own:
         title: You can only order your full allocation if local restrictions are confirmed
+      will_you_order:
+        title: Will you be one of the people placing orders for your school?
+        yes_label: Yes, I will order devices
+        no_label: 'No'
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:
@@ -341,6 +345,10 @@ en:
               invalid: The URN must be 6 digits
             name:
               blank: Enter the name of the establishment
+        school_welcome_wizard:
+          attributes:
+            orders_devices:
+              inclusion: Tell us whether you will order devices
   time:
     formats:
       time_only: "%l:%M%P"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,9 @@ Rails.application.routes.draw do
     get '/privacy', to: 'welcome_wizard#privacy', as: :welcome_wizard_privacy
     get '/allocation', to: 'welcome_wizard#allocation', as: :welcome_wizard_allocation
     get '/order-your-own', to: 'welcome_wizard#order_your_own', as: :welcome_wizard_order_your_own
+    get '/will-you-order', to: 'welcome_wizard#will_you_order', as: :welcome_wizard_will_you_order
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
+    patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]
   end
 

--- a/db/migrate/20200904141052_add_orders_devices_to_school_welcome_wizard.rb
+++ b/db/migrate/20200904141052_add_orders_devices_to_school_welcome_wizard.rb
@@ -1,0 +1,6 @@
+class AddOrdersDevicesToSchoolWelcomeWizard < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_welcome_wizards, :orders_devices, :boolean
+    add_column :school_welcome_wizards, :first_school_user, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_101450) do
+ActiveRecord::Schema.define(version: 2020_09_04_141052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,8 @@ ActiveRecord::Schema.define(version: 2020_09_03_101450) do
     t.string "step", default: "welcome", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "orders_devices"
+    t.boolean "first_school_user"
     t.index ["user_id"], name: "index_school_welcome_wizards_on_user_id"
   end
 

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -3,8 +3,28 @@ require 'rails_helper'
 RSpec.feature 'Navigate school welcome wizard' do
   let(:school) { create(:school, :with_std_device_allocation) }
 
-  scenario 'step through the wizard' do
+  scenario 'step through the wizard as the first user for a school' do
     as_a_new_school_user
+    when_i_sign_in_for_the_first_time
+    then_i_see_a_welcome_page_for_my_school
+
+    when_i_click_continue
+    then_i_see_a_privacy_notice
+
+    when_i_click_continue
+    then_i_see_the_allocation_for_my_school
+
+    when_i_click_continue
+    then_i_see_the_order_your_own_page
+
+    when_i_click_continue
+    then_i_see_the_will_you_order_page
+    when_i_choose_yes_and_click_continue
+    then_i_see_the_school_home_page
+  end
+
+  scenario 'step through wizard as subsequent user' do
+    as_a_subsequent_school_user
     when_i_sign_in_for_the_first_time
     then_i_see_a_welcome_page_for_my_school
 
@@ -36,6 +56,10 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def as_a_new_school_user
     @user = create(:school_user, :new_visitor, school: school)
+  end
+
+  def as_a_subsequent_school_user
+    @user = create_list(:school_user, 2, :new_visitor, school: school).last
   end
 
   def when_i_sign_in_for_the_first_time
@@ -71,6 +95,16 @@ RSpec.feature 'Navigate school welcome wizard' do
     expect(page).to have_current_path(school_home_path)
     expect(page).to have_text(school.name)
     expect(page).to have_text('Get devices for your school')
+  end
+
+  def then_i_see_the_will_you_order_page
+    expect(page).to have_current_path(school_welcome_wizard_will_you_order_path)
+    expect(page).to have_text('Will you be one of the people placing orders for your school?')
+  end
+
+  def when_i_choose_yes_and_click_continue
+    choose 'Yes, I will order devices'
+    click_on 'Continue'
   end
 
   def when_i_sign_out


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/37TI1qBj/568-schools-wizard-user-will-place-orders)

### Changes proposed in this pull request
Page that requires the user to choose whether they will place orders for devices. This is only shown to the first user for a school (when there is only 1 user for the school).
The selected choice is saved both on the user and in the wizard model (as `:orders_devices`)
Whether the user is determined to be the 'first' user or not is recorded so the journey could be replayed / backed up at a later stage.

### Guidance to review
User must be the only user for that school to see the page
![image](https://user-images.githubusercontent.com/333931/92263692-f2128980-eed4-11ea-9bbe-29b8ec364a8b.png)

