### PR TITLE
607 schools wizard techsource account

### DIFF
--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -9,6 +9,7 @@ class SchoolWelcomeWizard < ApplicationRecord
     allocation: 'allocation',
     order_your_own: 'order_your_own',
     will_you_order: 'will_you_order',
+    techsource_account: 'techsource_account',
     complete: 'complete',
   }
 
@@ -31,10 +32,16 @@ class SchoolWelcomeWizard < ApplicationRecord
       end
     when 'will_you_order'
       if update_will_you_order(params)
-        complete!
+        if orders_devices?
+          techsource_account!
+        else
+          complete!
+        end
       else
         false
       end
+    when 'techsource_account'
+      complete!
     else
       raise "Unknown step: #{step}"
     end

--- a/app/views/school/welcome_wizard/techsource_account.html.erb
+++ b/app/views/school/welcome_wizard/techsource_account.html.erb
@@ -1,0 +1,18 @@
+<%- title = t('page_titles.school_user_welcome_wizard.techsource_account.title') %>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p class="govuk-body">You will need to place orders on a website called TechSource, which is run by Computacenter.</p>
+
+      <p class="govuk-body">In the next few days you’ll get an email from Computacenter containing instructions on setting up your account.</p>
+
+      <p class="govuk-body">You’ll be asked to reset your password and choose a new one. Keep this password safe, as you’ll need it in the event of local coronavirus restrictions.</p>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,8 @@
         no_label: 'No'
         errors:
           choose_option: Tell us whether you will order devices
+      techsource_account:
+        title: You will get an invite to the Computacenter TechSource website
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
     get '/allocation', to: 'welcome_wizard#allocation', as: :welcome_wizard_allocation
     get '/order-your-own', to: 'welcome_wizard#order_your_own', as: :welcome_wizard_order_your_own
     get '/will-you-order', to: 'welcome_wizard#will_you_order', as: :welcome_wizard_will_you_order
+    get '/techsource-account', to: 'welcome_wizard#techsource_account', as: :welcome_wizard_techsource_account
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -19,7 +19,11 @@ RSpec.feature 'Navigate school welcome wizard' do
 
     when_i_click_continue
     then_i_see_the_will_you_order_page
+
     when_i_choose_yes_and_click_continue
+    then_i_see_the_techsource_account_page
+
+    when_i_click_continue
     then_i_see_the_school_home_page
   end
 
@@ -101,6 +105,11 @@ RSpec.feature 'Navigate school welcome wizard' do
   def then_i_see_the_will_you_order_page
     expect(page).to have_current_path(school_welcome_wizard_will_you_order_path)
     expect(page).to have_text('Will you be one of the people placing orders for your school?')
+  end
+
+  def then_i_see_the_techsource_account_page
+    expect(page).to have_current_path(school_welcome_wizard_techsource_account_path)
+    expect(page).to have_text('You will get an invite to the Computacenter TechSource website')
   end
 
   def when_i_choose_yes_and_click_continue

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         wizard.will_you_order!
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the techsource_account step' do
         wizard.update_step!({ orders_devices: '1' })
-        expect(wizard.complete?).to be true
+        expect(wizard.techsource_account?).to be true
       end
 
       it 'records the choice and updates the user' do
@@ -122,6 +122,17 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
       it 'adds an error message' do
         wizard.update_step!({ step: 'will_you_order' })
         expect(wizard.errors.keys).to include(:orders_devices)
+      end
+    end
+
+    context 'when the step is techsource_account' do
+      before do
+        wizard.techsource_account!
+      end
+
+      it 'moves to the completed step' do
+        wizard.update_step!
+        expect(wizard.complete?).to be true
       end
     end
   end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/uhZJNNc8/607-schools-wizard-techsource-account)

### Changes proposed in this pull request
Add page explaining that the user will receive an invite to techsource to the wizard. This page follows choosing 'Yes' the user will order devices.

### Guidance to review

![image](https://user-images.githubusercontent.com/333931/92276880-c221b100-eee9-11ea-8e34-2aba2c2734c8.png)
