### PR TITLE
Show timestamps correctly in the service

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module GovukRailsBoilerplate
     # allow customisation of error messages at model level
     # see https://blog.bigbinary.com/2019/04/22/rails-6-allows-to-override-the-activemodel-errors-full_message-format-at-the-model-level-and-at-the-attribute-level.html
     config.active_model.i18n_customize_full_message = true
+
+    config.time_zone = 'London'
   end
 end

--- a/spec/controllers/responsible_body/internet/bt_wifi_vouchers_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/bt_wifi_vouchers_controller_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe ResponsibleBody::Internet::BTWifiVouchersController, type: :contr
       end
 
       it 'sets the `distributed_at` for vouchers that have not been distributed yet' do
-        timestamp = Date.new(2020, 6, 1)
+        timestamp = Time.zone.parse('2020-06-01')
         @vouchers[0].update!(distributed_at: timestamp)
         expect(@vouchers[1].distributed_at).to be_nil
 
-        some_time_later = Date.new(2020, 6, 5)
+        some_time_later = Time.zone.parse('2020-06-05')
         Timecop.freeze(some_time_later) do
           get :index, format: :csv
         end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
 
     describe 'clicking the Sign in button' do
       it 'increments sign-in count and last_signed_in_at' do
-        timestamp = Date.new(2020, 6, 1)
+        timestamp = Time.zone.parse('2020-06-01')
         Timecop.freeze(timestamp) do
           visit validate_token_url
           click_on 'Continue'


### PR DESCRIPTION
### Context

All timestamps were showing as one hour earlier right now, as they were being displayed in UTC, not BST.

### Changes proposed in this pull request

Set the default timezone to London, since all the users of this service are in England.

