### PR TITLE
Add 'devices you can order' page to school wizard

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -25,6 +25,8 @@ class School::WelcomeWizardController < School::BaseController
 
   def will_other_order; end
 
+  def devices_you_can_order; end
+
 private
 
   def set_wizard

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -11,6 +11,7 @@ class SchoolWelcomeWizard < ApplicationRecord
     will_you_order: 'will_you_order',
     techsource_account: 'techsource_account',
     will_other_order: 'will_other_order',
+    devices_you_can_order: 'devices_you_can_order',
     complete: 'complete',
   }
 
@@ -33,7 +34,7 @@ class SchoolWelcomeWizard < ApplicationRecord
       if show_will_you_order_section?
         will_you_order!
       else
-        complete!
+        devices_you_can_order!
       end
     when 'will_you_order'
       if update_will_you_order(params)
@@ -42,7 +43,7 @@ class SchoolWelcomeWizard < ApplicationRecord
         elsif less_than_3_users_can_order?
           will_other_order!
         else
-          complete!
+          devices_you_can_order!
         end
       else
         false
@@ -51,14 +52,16 @@ class SchoolWelcomeWizard < ApplicationRecord
       if less_than_3_users_can_order?
         will_other_order!
       else
-        complete!
+        devices_you_can_order!
       end
     when 'will_other_order'
       if update_will_other_order(params)
-        complete!
+        devices_you_can_order!
       else
         false
       end
+    when 'devices_you_can_order'
+      complete!
     else
       raise "Unknown step: #{step}"
     end

--- a/app/views/school/welcome_wizard/devices_you_can_order.html.erb
+++ b/app/views/school/welcome_wizard/devices_you_can_order.html.erb
@@ -1,0 +1,25 @@
+<%- title = t('page_titles.school_user_welcome_wizard.devices_you_can_order.title') %>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p class="govuk-body">Your school will own the devices. It’s up to you to decide who will benefit most from them.</p>
+
+      <p class="govuk-body">You can choose from:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Microsoft Windows laptop</li>
+        <li>Microsoft Windows tablet</li>
+        <li>Google Chromebook</li>
+        <li>Apple iPad</li>
+      </ul>
+
+      <p class="govuk-body govuk-!-margin-bottom-6"><%= link_to_devices_guidance_subpage 'Read more about the device specifications', 'device-specification', target: '_blank' %></p>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,8 @@
         no_label: No, not at the moment
         errors:
           will_other_order: Tell us whether you need to add someone
+      devices_you_can_order:
+        title: You can order a range of laptops and tablets
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
     get '/will-you-order', to: 'welcome_wizard#will_you_order', as: :welcome_wizard_will_you_order
     get '/techsource-account', to: 'welcome_wizard#techsource_account', as: :welcome_wizard_techsource_account
     get '/will-other-order', to: 'welcome_wizard#will_other_order', as: :welcome_wizard_will_other_order
+    get '/devices-you-can-order', to: 'welcome_wizard#devices_you_can_order', as: :welcome_wizard_devices_you_can_order
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_the_will_other_order_page
 
     when_i_choose_yes_and_submit_the_form
+    then_i_see_information_about_devices_i_can_order
+
+    when_i_click_continue
     then_i_see_the_school_home_page
   end
 
@@ -43,6 +46,9 @@ RSpec.feature 'Navigate school welcome wizard' do
 
     when_i_click_continue
     then_i_see_the_order_your_own_page
+
+    when_i_click_continue
+    then_i_see_information_about_devices_i_can_order
 
     when_i_click_continue
     then_i_see_the_school_home_page
@@ -129,6 +135,11 @@ RSpec.feature 'Navigate school welcome wizard' do
       choose 'Yes, give them access to the TechSource website'
     end
     click_on 'Continue'
+  end
+
+  def then_i_see_information_about_devices_i_can_order
+    expect(page).to have_current_path(school_welcome_wizard_devices_you_can_order_path)
+    expect(page).to have_text('You can order a range of laptops and tablets')
   end
 
   def when_i_choose_yes_and_click_continue

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         wizard.order_your_own!
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the devices_you_can_order step' do
         wizard.update_step!
-        expect(wizard.complete?).to be true
+        expect(wizard.devices_you_can_order?).to be true
       end
     end
 
@@ -141,9 +141,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         wizard.will_other_order!
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the devices_you_can_order step' do
         wizard.update_step!({ invite_user: 'no' })
-        expect(wizard.complete?).to be true
+        expect(wizard.devices_you_can_order?).to be true
       end
     end
 
@@ -176,9 +176,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         }.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the devices_you_can_order step' do
         wizard.update_step!(new_user_attrs.merge({ invite_user: 'yes' }))
-        expect(wizard.complete?).to be true
+        expect(wizard.devices_you_can_order?).to be true
       end
     end
 
@@ -213,6 +213,17 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
       it 'remains on the will_other_order step' do
         wizard.update_step!
         expect(wizard.will_other_order?).to be true
+      end
+    end
+
+    context 'when the step is devices_you_can_order' do
+      before do
+        wizard.devices_you_can_order!
+      end
+
+      it 'moves to the will_other_order step' do
+        wizard.update_step!
+        expect(wizard.complete?).to be true
       end
     end
   end


### PR DESCRIPTION
### Context

School users, who are ordering devices for the first time, need to know what kind of devices they could potentially get.

### Changes proposed in this pull request

Add a guidance page to the school wizard that covers the devices that can be ordered.

### Guidance to review

This PR will need rebasing after @tonyheadford merges in his work on the preceding page in the wizard.

![image](https://user-images.githubusercontent.com/23801/92302896-ede37c00-ef67-11ea-89de-1731018c7f6f.png)