### PR TITLE
Introduce email validation

### DIFF
--- a/app/models/school_contact.rb
+++ b/app/models/school_contact.rb
@@ -6,8 +6,11 @@ class SchoolContact < ApplicationRecord
     contact: 'contact',
   }
 
-  validates :email_address, presence: true
-  validates :email_address, uniqueness: { scope: :school_id }
+  validates :email_address,
+            presence: true,
+            uniqueness: { scope: :school_id },
+            email_address: true
+
   validates :full_name, presence: true
   validates :role, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
   validates :email_address,
             presence: true,
             uniqueness: { case_sensitive: false },
-            length: { minimum: 2, maximum: 1024 }
+            length: { minimum: 2, maximum: 1024 },
+            email_address: true
 
   validates :orders_devices,
             inclusion: { in: [true, false] },

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,0 +1,16 @@
+class EmailAddressValidator < ActiveModel::EachValidator
+  ALPHANUMERIC = 'a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ' + # Number and letters including accented characters
+    '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'.freeze # Chinese/Japanese/Korean characters
+  EMAIL_REGEX = %r{\A[#{ALPHANUMERIC}.!\#$%&'*+\/=?^_`{|}~-] # Local part
+                  +@[#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-] # Domain name
+                  {0,61}[#{ALPHANUMERIC}])?(?:\. # Allow periods in domain name
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61}[#{ALPHANUMERIC}])?)*\.
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61} # # End of domain
+                  [#{ALPHANUMERIC}])\z}x.freeze
+
+  def validate_each(record, attribute, value)
+    if value.blank? || !value.match?(EMAIL_REGEX)
+      record.errors[attribute] << I18n.t!('activerecord.errors.models.user.attributes.email_address.invalid')
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,7 @@
               blank: Enter an email address in the correct format, like name@example.com
               taken: Email address has already been used
               too_short: Enter an email address that is at least %{count} characters
+              invalid: Enter an email address in the correct format, like name@example.com
             orders_devices:
               inclusion: Tell us whether the user will order devices
               user_limit: There are already 3 users who can order devices. Change or remove another user.

--- a/spec/models/school_contact_spec.rb
+++ b/spec/models/school_contact_spec.rb
@@ -16,5 +16,6 @@ RSpec.describe SchoolContact, type: :model do
     it { is_expected.to validate_uniqueness_of(:email_address).scoped_to(:school_id) }
     it { is_expected.to validate_presence_of(:full_name) }
     it { is_expected.to validate_presence_of(:role) }
+    it { is_expected.not_to allow_value('invalid.email').for(:email_address) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'email address validation' do
+    it { is_expected.not_to allow_value('invalid.email').for(:email_address) }
+  end
+
   describe 'email address should not be case-sensitive (bug 555)' do
     context 'a user with the same email as an existing user, but different case' do
       let(:new_user) { build(:local_authority_user, email_address: 'Email.Address@example.com') }

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe EmailAddressValidator do
+  before do
+    stub_const('Validatable', Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :email_address
+      validates :email_address, email_address: true
+    end
+  end
+
+  context 'when an email address has a valid format' do
+    let(:model) { Validatable.new }
+    let(:valid_emails) do
+      [
+        'email@domain.com',
+        'email@domain.COM',
+        'firstname.lastname@domain.com',
+        'firstname.o\'lastname@domain.com',
+        'email@subdomain.domain.com',
+        'firstname+lastname@domain.com',
+        '1234567890@domain.com',
+        'email@domain-one.com',
+        '_______@domain.com',
+        'email@domain.name',
+        'email@domain.superlongtld',
+        'email@domain.co.jp',
+        'firstname-lastname@domain.com',
+        'info@german-financial-services.vermögensberatung',
+        'info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase',
+        'japanese-info@例え.テスト',
+      ]
+    end
+
+    it 'returns valid' do
+      valid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).to be_valid
+      end
+    end
+  end
+
+  context 'when an email address is in an invalid format' do
+    let(:model) { Validatable.new }
+    let(:invalid_emails) do
+      [
+        'email@[123.123.123.123]',
+        'plainaddress',
+        '@no-local-part.com',
+        'Outlook Contact <outlook-contact@domain.com>',
+        'no-at.domain.com',
+        'no-tld@domain',
+        ';beginning-semicolon@domain.co.uk',
+        'middle-semicolon@domain.co;uk',
+        'trailing-semicolon@domain.com;',
+        '"email+leading-quotes@domain.com',
+        'email+middle"-quotes@domain.com',
+        '"quoted-local-part"@domain.com',
+        '"quoted@domain.com"',
+        'lots-of-dots@domain..gov..uk',
+        'multiple@domains@domain.com',
+        'spaces in local@domain.com',
+        'spaces-in-domain@dom ain.com',
+        'underscores-in-domain@dom_ain.com',
+        'pipe-in-domain@example.com|gov.uk',
+        'comma,in-local@gov.uk',
+        'comma-in-domain@domain,gov.uk',
+        'pound-sign-in-local£@domain.com',
+        'local-with-’-apostrophe@domain.com',
+        'local-with-”-quotes@domain.com',
+        'domain-starts-with-a-dot@.domain.com',
+        'brackets(in)local@domain.com',
+      ]
+    end
+
+    it 'returns invalid' do
+      invalid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).not_to be_valid
+      end
+    end
+
+    it 'returns the correct error message' do
+      model.email_address = 'foo'
+      model.validate(:no_context)
+      expect(model.errors[:email_address]).to include(I18n.t!('activerecord.errors.models.user.attributes.email_address.invalid'))
+    end
+  end
+end


### PR DESCRIPTION
### Context

Current email validation in the service is ... no validation at all. We've already seen cases where users have mistyped the address when inviting new users or setting school contacts, which breaks the journey for the user and creates extra ops and support effort for the service team.

### Changes proposed in this pull request

This change introduces user email address validation. The approach uses a regular expression that matches what's used within GOV.UK Notify, thereby reducing the risk that we allow email addresses that we can't subsequently deliver emails to because they're rejected by Notify.

This code is lifted from [DfE's 'Apply for teacher training' service](https://github.com/DFE-Digital/apply-for-teacher-training), which is a mature, battle-tested service with a large development team that watches their errors very carefully, so should be a reasonable place to borrow from.

The code was introduced into Apply via [this pull request](DFE-Digital/apply-for-teacher-training#960) which contains more context. The specs are based on the validation tests that the Notify service used as of Feb 2018:

https://github.com/alphagov/notifications-utils/blob/e428bdd0ca82f7b97833e707eea95dae849713fb/tests/test_recipient_validation.py#L103-L149

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92333003-d5638680-f079-11ea-9a4e-dd8a349c4ba7.png)
