### PR TITLE
Add 'what happens next' page to school wizard

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -29,6 +29,8 @@ class School::WelcomeWizardController < School::BaseController
 
   def chromebooks; end
 
+  def what_happens_next; end
+
 private
 
   def set_wizard

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -13,6 +13,7 @@ class SchoolWelcomeWizard < ApplicationRecord
     will_other_order: 'will_other_order',
     devices_you_can_order: 'devices_you_can_order',
     chromebooks: 'chromebooks',
+    what_happens_next: 'what_happens_next',
     complete: 'complete',
   }
 
@@ -66,14 +67,16 @@ class SchoolWelcomeWizard < ApplicationRecord
       if will_need_chromebooks.nil?
         chromebooks!
       else
-        complete!
+        what_happens_next!
       end
     when 'chromebooks'
       if update_chromebooks(params)
-        complete!
+        what_happens_next!
       else
         false
       end
+    when 'what_happens_next'
+      complete!
     else
       raise "Unknown step: #{step}"
     end

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -1,0 +1,23 @@
+<%- title = t('page_titles.school_user_welcome_wizard.what_happens_next.title') %>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p class="govuk-body">You can continue to use this service to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>add more users</li>
+        <li>change your Chromebook settings</li>
+        <li>review your allocation</li>
+        <li>request devices for clinically vulnerable children who are shielding</li>
+      </ul>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">If your school is affected by local coronavirus restrictions, we’ll contact you as soon as you’re able to place orders.</p>
+
+      <%= f.govuk_submit 'Finish and go to homepage' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,8 @@
         i_dont_know: I don’t know
         errors:
           choice: Tell us whether your school will need Chromebooks
+      what_happens_next:
+        title: What happens next
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
     get '/will-other-order', to: 'welcome_wizard#will_other_order', as: :welcome_wizard_will_other_order
     get '/devices-you-can-order', to: 'welcome_wizard#devices_you_can_order', as: :welcome_wizard_devices_you_can_order
     get '/chromebooks', to: 'welcome_wizard#chromebooks', as: :welcome_wizard_chromebooks
+    get '/what-happens-next', to: 'welcome_wizard#what_happens_next', as: :welcome_wizard_what_happens_next
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -33,6 +33,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_im_asked_whether_my_school_will_order_chromebooks
 
     when_i_choose_yes_and_submit_the_chromebooks_form
+    then_i_see_information_about_what_happens_next
+
+    when_i_click_to_finish_and_go_to_homepage
     then_i_see_the_school_home_page
   end
 
@@ -57,6 +60,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_im_asked_whether_my_school_will_order_chromebooks
 
     when_i_choose_yes_and_submit_the_chromebooks_form
+    then_i_see_information_about_what_happens_next
+
+    when_i_click_to_finish_and_go_to_homepage
     then_i_see_the_school_home_page
   end
 
@@ -93,6 +99,10 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def when_i_click_continue
     click_on 'Continue'
+  end
+
+  def when_i_click_to_finish_and_go_to_homepage
+    click_on 'Finish and go to homepage'
   end
 
   def then_i_see_a_privacy_notice
@@ -160,6 +170,11 @@ RSpec.feature 'Navigate school welcome wizard' do
       fill_in 'Recovery email address', with: 'admin@trust.com'
     end
     click_on 'Continue'
+  end
+
+  def then_i_see_information_about_what_happens_next
+    expect(page).to have_current_path(school_welcome_wizard_what_happens_next_path)
+    expect(page).to have_text('we’ll contact you as soon as you’re able to place orders')
   end
 
   def when_i_choose_yes_and_click_continue

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature 'Navigate school welcome wizard' do
   def when_i_choose_yes_and_submit_the_chromebooks_form
     choose 'Yes, we will need Chromebooks'
     within('#school-welcome-wizard-will-need-chromebooks-yes-conditional') do
-      fill_in 'School or trust domain', with: 'example.com'
+      fill_in "School or #{school.responsible_body.humanized_type} domain", with: 'example.com'
       fill_in 'Recovery email address', with: 'admin@trust.com'
     end
     click_on 'Continue'

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -235,9 +235,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         school.preorder_information.update!(will_need_chromebooks: 'yes')
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the what_happens_next step' do
         wizard.update_step!
-        expect(wizard.complete?).to be true
+        expect(wizard.what_happens_next?).to be true
       end
     end
 
@@ -255,9 +255,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         expect(school.preorder_information.recovery_email_address).to eq(request[:recovery_email_address])
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the what_happens_next step' do
         wizard.update_step!(request)
-        expect(wizard.complete?).to be true
+        expect(wizard.what_happens_next?).to be true
       end
     end
 
@@ -291,9 +291,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         expect(school.preorder_information.will_need_chromebooks).to eq('no')
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the what_happens_next step' do
         wizard.update_step!(request)
-        expect(wizard.complete?).to be true
+        expect(wizard.what_happens_next?).to be true
       end
     end
 
@@ -309,8 +309,19 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         expect(school.preorder_information.will_need_chromebooks).to be_nil
       end
 
-      it 'moves to the completed step' do
+      it 'moves to the what_happens_next step' do
         wizard.update_step!(request)
+        expect(wizard.what_happens_next?).to be true
+      end
+    end
+
+    context 'when the step is what_happens_next' do
+      before do
+        wizard.what_happens_next!
+      end
+
+      it 'moves to the completed step' do
+        wizard.update_step!
         expect(wizard.complete?).to be true
       end
     end


### PR DESCRIPTION
### Context

**Depends on #404. rebase this once that PR is merged.**

After the school users have gone through the wizard, they need to know what else they can do on the service.

### Changes proposed in this pull request

Add the final static page in the school wizard.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92335601-29796580-f090-11ea-8590-b273230ceed7.png)
