### PR TITLE
Use correct status for sums in dashboard

### DIFF
--- a/app/models/support/devices/service_performance.rb
+++ b/app/models/support/devices/service_performance.rb
@@ -41,7 +41,7 @@ class Support::Devices::ServicePerformance
   end
 
   def number_of_schools_managed_centrally
-    needs_information = preorder_information_counts_by_status['needs_information'] || 0
+    needs_information = preorder_information_counts_by_status['needs_info'] || 0
     ready = preorder_information_counts_by_status['ready'] || 0
 
     needs_information + ready

--- a/spec/models/support/devices/service_performance_spec.rb
+++ b/spec/models/support/devices/service_performance_spec.rb
@@ -101,5 +101,17 @@ RSpec.describe Support::Devices::ServicePerformance, type: :model do
         expect(stats.preorder_information_by_status('ready')).to eq(3)
       end
     end
+
+    it 'calculates the number of schools managed centrally' do
+      expect(stats.number_of_schools_managed_centrally).to eq(8)
+    end
+
+    it 'calculates the number of schools that decisions have been devolved to' do
+      expect(stats.number_of_schools_devolved_to).to eq(4)
+    end
+
+    it 'calculates the total number of schools devolved or managed centrally' do
+      expect(stats.number_of_schools_with_a_decision_made).to eq(12)
+    end
   end
 end


### PR DESCRIPTION
`needs_information` is always 0, as the actual status is `needs_info`