### PR TITLE
[594] CSV table

### DIFF
--- a/app/models/computacenter/ledger.rb
+++ b/app/models/computacenter/ledger.rb
@@ -1,0 +1,82 @@
+require 'csv'
+
+module Computacenter
+  class Ledger
+    def initialize(users: nil)
+      @users = users
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        csv << headers
+
+        user_changes.each do |user_change|
+          csv << [
+            user_change.first_name,
+            user_change.last_name,
+            user_change.email_address,
+            user_change.telephone,
+            user_change.responsible_body,
+            user_change.responsible_body_urn,
+            user_change.cc_sold_to_number,
+            user_change.school,
+            user_change.school_urn,
+            user_change.cc_ship_to_number,
+            user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+            user_change.updated_at_timestamp.utc.strftime('%R'),
+            user_change.updated_at_timestamp.utc.iso8601,
+            user_change.type_of_update,
+            user_change.original_email_address,
+          ]
+        end
+      end
+    end
+
+  private
+
+    def users
+      @users ||= User.who_can_order_devices.where('privacy_notice_seen_at IS NOT NULL').limit(1)
+    end
+
+    def user_changes
+      users.map do |user|
+        UserChange.new(
+          user_id: user.id,
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email_address: user.email_address,
+          telephone: user.telephone,
+          responsible_body: user.effective_responsible_body.name,
+          responsible_body_urn: user.effective_responsible_body.computacenter_identifier,
+          cc_sold_to_number: user.effective_responsible_body.computacenter_reference,
+          school: user.school&.name,
+          school_urn: user.school&.urn,
+          cc_ship_to_number: user.school&.computacenter_reference,
+          updated_at_timestamp: user.created_at,
+          type_of_update: 'New',
+          original_email_address: nil,
+        )
+      end
+    end
+
+    def headers
+      [
+        'First Name',
+        'Last Name',
+        'Email',
+        'Telephone',
+        'Responsible Body',
+        'Responsible Body URN',
+        'CC Sold To Number',
+        'School',
+        'School URN',
+        'CC Ship To Number',
+        'Date of Update', # "24/08/2020" / "dd/mm/yyyy"
+        'Time of Update', # 24 hour clock
+        'Timestamp of Update', # ISO
+        'Type of Update', # New / Change / Remove
+        'Original Email',
+      ]
+    end
+  end
+end

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -29,4 +29,15 @@ module Computacenter::ResponsibleBodyUrns
       end
     end
   end
+
+  module InstanceMethods
+    def computacenter_identifier
+      case type
+      when 'LocalAuthority'
+        "LEA#{gias_id}"
+      when 'Trust'
+        "t#{companies_house_number.to_i}"
+      end
+    end
+  end
 end

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -1,0 +1,5 @@
+class Computacenter::UserChange < ApplicationRecord
+  self.table_name = 'computacenter_user_changes'
+
+  enum type_of_update: { New: 0, Change: 1, Remove: 2 }
+end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -9,6 +9,7 @@ class ResponsibleBody < ApplicationRecord
   has_many :schools
 
   extend Computacenter::ResponsibleBodyUrns::ClassMethods
+  include Computacenter::ResponsibleBodyUrns::InstanceMethods
 
   def humanized_type
     type.demodulize.underscore.humanize.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,4 +83,16 @@ class User < ApplicationRecord
       (is_computacenter? && 'Computacenter') || \
       (is_support? && 'DfE Support')
   end
+
+  def first_name
+    (full_name || '').strip.split(' ').first.to_s
+  end
+
+  def last_name
+    (full_name || '').strip.split(' ').last.to_s
+  end
+
+  def effective_responsible_body
+    responsible_body || school&.responsible_body
+  end
 end

--- a/db/migrate/20200907114036_create_computacenter_user_changes.rb
+++ b/db/migrate/20200907114036_create_computacenter_user_changes.rb
@@ -1,0 +1,25 @@
+class CreateComputacenterUserChanges < ActiveRecord::Migration[6.0]
+  def change
+    create_table :computacenter_user_changes do |t|
+      t.integer :user_id
+      t.text :first_name
+      t.text :last_name
+      t.text :email_address
+      t.text :telephone
+      t.text :responsible_body
+      t.text :responsible_body_urn
+      t.text :cc_sold_to_number
+      t.text :school
+      t.text :school_urn
+      t.text :cc_ship_to_number
+      t.datetime :updated_at_timestamp
+      t.integer :type_of_update
+      t.text :original_email_address
+
+      t.timestamps
+    end
+
+    add_index :computacenter_user_changes, :user_id
+    add_index :computacenter_user_changes, :updated_at_timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,27 @@ ActiveRecord::Schema.define(version: 2020_09_08_104822) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "computacenter_user_changes", force: :cascade do |t|
+    t.integer "user_id"
+    t.text "first_name"
+    t.text "last_name"
+    t.text "email_address"
+    t.text "telephone"
+    t.text "responsible_body"
+    t.text "responsible_body_urn"
+    t.text "cc_sold_to_number"
+    t.text "school"
+    t.text "school_urn"
+    t.text "cc_ship_to_number"
+    t.datetime "updated_at_timestamp"
+    t.integer "type_of_update"
+    t.text "original_email_address"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["updated_at_timestamp"], name: "index_computacenter_user_changes_on_updated_at_timestamp"
+    t.index ["user_id"], name: "index_computacenter_user_changes_on_user_id"
+  end
+
   create_table "extra_mobile_data_requests", force: :cascade do |t|
     t.string "account_holder_name"
     t.string "device_phone_number"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     full_name { Faker::Name.unique.name }
     email_address { Faker::Internet.unique.email }
     has_seen_privacy_notice
+    telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
 
     trait :has_seen_privacy_notice do
       privacy_notice_seen_at { 3.days.ago }

--- a/spec/models/computacenter/ledger_spec.rb
+++ b/spec/models/computacenter/ledger_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::Ledger do
+  subject(:service) { described_class.new }
+
+  describe '#to_csv' do
+    let(:expected_headers) do
+      [
+        'First Name',
+        'Last Name',
+        'Email',
+        'Telephone',
+        'Responsible Body',
+        'Responsible Body URN',
+        'CC Sold To Number',
+        'School',
+        'School URN',
+        'CC Ship To Number',
+        'Date of Update',
+        'Time of Update',
+        'Timestamp of Update',
+        'Type of Update',
+        'Original Email',
+      ]
+    end
+
+    it 'has correct headers set' do
+      rows = CSV.parse(service.to_csv)
+
+      expect(rows[0]).to eql(expected_headers)
+    end
+
+    context 'when trust user' do
+      let!(:user) { create(:trust_user, orders_devices: true) }
+
+      it 'has correct data' do
+        rows = CSV.parse(service.to_csv)
+
+        expect(rows[1]).to eql([
+          user.first_name,
+          user.last_name,
+          user.email_address,
+          user.telephone,
+          user.responsible_body.name,
+          user.responsible_body.computacenter_identifier,
+          user.responsible_body.computacenter_reference,
+          nil,
+          nil,
+          nil,
+          user.created_at.utc.strftime('%d/%m/%Y'),
+          user.created_at.utc.strftime('%R'),
+          user.created_at.utc.iso8601,
+          'New',
+          nil,
+        ])
+      end
+    end
+
+    context 'when school user' do
+      let!(:user) { create(:school_user, orders_devices: true) }
+
+      it 'has correct data' do
+        rows = CSV.parse(service.to_csv)
+
+        expect(rows[1]).to eql([
+          user.first_name,
+          user.last_name,
+          user.email_address,
+          user.telephone,
+          user.school.responsible_body.name,
+          user.school.responsible_body.computacenter_identifier,
+          user.school.responsible_body.computacenter_reference,
+          user.school.name,
+          user.school.urn.to_s,
+          user.school.computacenter_reference,
+          user.created_at.utc.strftime('%d/%m/%Y'),
+          user.created_at.utc.strftime('%R'),
+          user.created_at.utc.iso8601,
+          'New',
+          nil,
+        ])
+      end
+    end
+  end
+end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe ResponsibleBody, type: :model do
       end
     end
   end
+
+  describe '#computacenter_identifier' do
+    context 'when local authority' do
+      subject(:responsible_body) { build(:local_authority) }
+
+      it 'generates correct identifier' do
+        expect(responsible_body.computacenter_identifier).to eql("LEA#{responsible_body.gias_id}")
+      end
+    end
+
+    context 'when trust' do
+      subject(:responsible_body) { build(:trust, companies_house_number: '0001') }
+
+      it 'generates correct identifier' do
+        expect(responsible_body.computacenter_identifier).to eql('t1')
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -166,4 +166,56 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#first_name' do
+    context 'when full_name provided' do
+      subject(:user) { described_class.new(full_name: 'John Doe') }
+
+      it 'returns first_name' do
+        expect(user.first_name).to eql('John')
+      end
+    end
+
+    context 'when full_name is nil' do
+      subject(:user) { described_class.new(full_name: nil) }
+
+      it 'returns empty string' do
+        expect(user.first_name).to eql('')
+      end
+    end
+
+    context 'when full_name is empty string' do
+      subject(:user) { described_class.new(full_name: '') }
+
+      it 'returns empty string' do
+        expect(user.first_name).to eql('')
+      end
+    end
+  end
+
+  describe '#last_name' do
+    context 'when full_name provided' do
+      subject(:user) { described_class.new(full_name: 'John Doe') }
+
+      it 'returns last_name' do
+        expect(user.last_name).to eql('Doe')
+      end
+    end
+
+    context 'when full_name is nil' do
+      subject(:user) { described_class.new(full_name: nil) }
+
+      it 'returns empty string' do
+        expect(user.last_name).to eql('')
+      end
+    end
+
+    context 'when full_name is empty string' do
+      subject(:user) { described_class.new(full_name: '') }
+
+      it 'returns empty string' do
+        expect(user.last_name).to eql('')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-spike-can-we-generate-the-cc-user-changes-feed-using-papertrail
- Start point on figuring out how to generate data export for computacenter

### Changes proposed in this pull request

- Add migration to form new table which will act as basis for future csv entries
- CSV generator which takes selected users and generates output csv

### Guidance to review

- Take some users and pass to csv generator
- `service = ComputacenterLedgerCsv.new(User.limit(3))`
- Generate the csv
- `service.to_csv`
- output csv should match agreed format