### PR TITLE
[569] Add additional user flow to wizard

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -7,7 +7,7 @@ class School::WelcomeWizardController < School::BaseController
     if @wizard.update_step!(wizard_params)
       redirect_to next_step_path
     else
-      render @wizard.step
+      render @wizard.step, status: :unprocessable_entity
     end
   end
 
@@ -23,6 +23,8 @@ class School::WelcomeWizardController < School::BaseController
 
   def will_you_order; end
 
+  def will_other_order; end
+
 private
 
   def set_wizard
@@ -36,6 +38,11 @@ private
   def wizard_params
     params.require(:school_welcome_wizard).permit(
       :step,
+      :user_orders_devices,
+      :invite_user,
+      :full_name,
+      :email_address,
+      :telephone,
       :orders_devices,
     )
   end

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -10,8 +10,13 @@ class SchoolWelcomeWizard < ApplicationRecord
     order_your_own: 'order_your_own',
     will_you_order: 'will_you_order',
     techsource_account: 'techsource_account',
+    will_other_order: 'will_other_order',
     complete: 'complete',
   }
+
+  delegate :full_name, :email_address, :telephone, :orders_devices, to: :invited_user
+
+  attr_accessor :invite_user
 
   def update_step!(params = {})
     return true if complete?
@@ -32,8 +37,10 @@ class SchoolWelcomeWizard < ApplicationRecord
       end
     when 'will_you_order'
       if update_will_you_order(params)
-        if orders_devices?
+        if user_orders_devices?
           techsource_account!
+        elsif less_than_3_users_can_order?
+          will_other_order!
         else
           complete!
         end
@@ -41,26 +48,68 @@ class SchoolWelcomeWizard < ApplicationRecord
         false
       end
     when 'techsource_account'
-      complete!
+      if less_than_3_users_can_order?
+        will_other_order!
+      else
+        complete!
+      end
+    when 'will_other_order'
+      if update_will_other_order(params)
+        complete!
+      else
+        false
+      end
     else
       raise "Unknown step: #{step}"
     end
   end
 
+  def invited_user
+    @invited_user ||= find_or_build_invited_user
+  end
+
 private
 
+  def find_or_build_invited_user
+    if invited_user_id
+      User.find(invited_user_id)
+    else
+      user.school.users.build
+    end
+  end
+
   def update_will_you_order(params)
-    user_orders_devices = params.fetch(:orders_devices, nil)
+    user_orders_devices = params.fetch(:user_orders_devices, nil)
 
     if user_orders_devices.nil? || !user_orders_devices.in?(%w[1 0])
-      errors.add(:orders_devices, I18n.t('page_titles.school_user_welcome_wizard.will_you_order.errors.choose_option'))
+      errors.add(:user_orders_devices, I18n.t('will_you_order.errors.choose_option', scope: i18n_scope))
       false
     else
       SchoolWelcomeWizard.transaction do
-        update!(orders_devices: user_orders_devices)
+        update!(user_orders_devices: user_orders_devices)
         user.update!(orders_devices: user_orders_devices)
       end
       true
+    end
+  end
+
+  def update_will_other_order(params)
+    self.invite_user = params.fetch(:invite_user, nil)
+    if @invite_user.nil?
+      errors.add(:invite_user, I18n.t('will_other_order.errors.will_other_order', scope: i18n_scope))
+      false
+    elsif @invite_user == 'yes'
+      user_attrs = user_params(params)
+
+      @invited_user = user.school.users.build(user_attrs)
+      if @invited_user.valid?
+        save_and_invite_user!(@invited_user)
+      else
+        errors.copy!(@invited_user.errors)
+        false
+      end
+    else
+      update!(invite_user: 'no')
     end
   end
 
@@ -68,9 +117,31 @@ private
     @first_school_user.nil? ? set_first_user_flag! : @first_school_user
   end
 
+  def less_than_3_users_can_order?
+    user.school.users.who_can_order_devices.count < 3
+  end
+
   def set_first_user_flag!
     is_first_user_for_school = user.school.users.count == 1
     update!(first_school_user: is_first_user_for_school)
     is_first_user_for_school
+  end
+
+  def save_and_invite_user!(new_user)
+    SchoolWelcomeWizard.transaction do
+      new_user.save!
+      self.invited_user_id = new_user.id
+      save!
+      InviteSchoolUserMailer.with(user: new_user).nominated_contact_email.deliver_later
+    end
+    true
+  end
+
+  def user_params(params)
+    params.slice(:full_name, :email_address, :telephone, :orders_devices)
+  end
+
+  def i18n_scope
+    'page_titles.school_user_welcome_wizard'
   end
 end

--- a/app/views/school/users/new.html.erb
+++ b/app/views/school/users/new.html.erb
@@ -27,7 +27,9 @@
       <li>can configure devices or give technical information</li>
     </ul>
     <%= form_for @user, url: school_users_path do |f| %>
-      <%= render partial: 'form', locals: { submit_text: 'Send invite', form: f } %>
+      <%= f.govuk_error_summary %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= f.govuk_submit 'Send invite' %>
     <%- end %>
   </div>
 </div>

--- a/app/views/school/welcome_wizard/will_other_order.html.erb
+++ b/app/views/school/welcome_wizard/will_other_order.html.erb
@@ -1,0 +1,33 @@
+<%-
+  scope = 'page_titles.school_user_welcome_wizard.will_other_order'
+  title = t('title', scope: scope)
+%>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+      <%= f.hidden_field :step %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p class="govuk-body">Invite someone in your school who:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>understands what devices are needed and who will get them</li>
+        <li>can configure devices or give technical information</li>
+      </ul>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset( :invite_user, legend: { text: nil } ) do %>
+      <%= f.govuk_radio_button  :invite_user,
+                                'yes',
+                                label: { text: t(:yes_label, scope: scope) } do %>
+        <%= render partial: 'shared/school_user_form', locals: { form: f, nested: true } %>
+      <%- end %>
+      <%= f.govuk_radio_button  :invite_user,
+                                'no',
+                                label: { text: t(:no_label, scope: scope) } %>
+      <%- end %>
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/school/welcome_wizard/will_you_order.html.erb
+++ b/app/views/school/welcome_wizard/will_you_order.html.erb
@@ -10,11 +10,11 @@
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:orders_devices) do %>
-        <%= f.govuk_radio_button :orders_devices,
+      <%= f.govuk_radio_buttons_fieldset(:user_orders_devices) do %>
+        <%= f.govuk_radio_button :user_orders_devices,
                                  '1',
                                  label: { text: t(:yes_label, scope: scope) } %>
-        <%= f.govuk_radio_button :orders_devices,
+        <%= f.govuk_radio_button :user_orders_devices,
                                  '0',
                                  label: { text: t(:no_label, scope: scope) } %>
       <%- end %>

--- a/app/views/shared/_school_user_form.html.erb
+++ b/app/views/shared/_school_user_form.html.erb
@@ -1,0 +1,21 @@
+<%- label_size = local_assigns[:nested] ? 's' : 'm' %>
+
+<%= form.govuk_text_field :full_name,
+                          label: { text: 'Name', size: label_size } %>
+
+<%= form.govuk_email_field  :email_address,
+                            label: { text: 'Email address', size: label_size } %>
+
+<%= form.govuk_text_field :telephone,
+                          width: 10,
+                          label: { text: 'Telephone number', size: label_size } %>
+
+<%= form.govuk_collection_radio_buttons :orders_devices,
+        can_user_order_devices_options,
+        :value,
+        :label,
+        :hint,
+        legend: { text: t('page_titles.invite_school_user.will_they_order_devices'), size: label_size },
+        hint_text: t('page_titles.invite_school_user.will_they_order_devices_hint'),
+        classes: 'govuk-!-margin-top-3'
+      %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,12 @@
           choose_option: Tell us whether you will order devices
       techsource_account:
         title: You will get an invite to the Computacenter TechSource website
+      will_other_order:
+        title: Do you need to give someone else access?
+        yes_label: Yes, I need to add someone
+        no_label: No, not at the moment
+        errors:
+          will_other_order: Tell us whether you need to add someone
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
     get '/order-your-own', to: 'welcome_wizard#order_your_own', as: :welcome_wizard_order_your_own
     get '/will-you-order', to: 'welcome_wizard#will_you_order', as: :welcome_wizard_will_you_order
     get '/techsource-account', to: 'welcome_wizard#techsource_account', as: :welcome_wizard_techsource_account
+    get '/will-other-order', to: 'welcome_wizard#will_other_order', as: :welcome_wizard_will_other_order
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]

--- a/db/migrate/20200907103146_add_invited_user_to_school_welcome_wizards.rb
+++ b/db/migrate/20200907103146_add_invited_user_to_school_welcome_wizards.rb
@@ -1,0 +1,6 @@
+class AddInvitedUserToSchoolWelcomeWizards < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :school_welcome_wizards, :invited_user, foreign_key: { to_table: :users }
+    rename_column :school_welcome_wizards, :orders_devices, :user_orders_devices
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_04_141052) do
+ActiveRecord::Schema.define(version: 2020_09_07_103146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,8 +142,10 @@ ActiveRecord::Schema.define(version: 2020_09_04_141052) do
     t.string "step", default: "welcome", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "orders_devices"
+    t.boolean "user_orders_devices"
     t.boolean "first_school_user"
+    t.bigint "invited_user_id"
+    t.index ["invited_user_id"], name: "index_school_welcome_wizards_on_invited_user_id"
     t.index ["user_id"], name: "index_school_welcome_wizards_on_user_id"
   end
 
@@ -217,6 +219,7 @@ ActiveRecord::Schema.define(version: 2020_09_04_141052) do
   add_foreign_key "preorder_information", "school_contacts"
   add_foreign_key "responsible_bodies", "users", column: "key_contact_id"
   add_foreign_key "school_device_allocations", "schools"
+  add_foreign_key "school_welcome_wizards", "users", column: "invited_user_id"
   add_foreign_key "schools", "responsible_bodies"
   add_foreign_key "users", "schools"
 end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -24,6 +24,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_the_techsource_account_page
 
     when_i_click_continue
+    then_i_see_the_will_other_order_page
+
+    when_i_choose_yes_and_submit_the_form
     then_i_see_the_school_home_page
   end
 
@@ -110,6 +113,22 @@ RSpec.feature 'Navigate school welcome wizard' do
   def then_i_see_the_techsource_account_page
     expect(page).to have_current_path(school_welcome_wizard_techsource_account_path)
     expect(page).to have_text('You will get an invite to the Computacenter TechSource website')
+  end
+
+  def then_i_see_the_will_other_order_page
+    expect(page).to have_current_path(school_welcome_wizard_will_other_order_path)
+    expect(page).to have_text('Do you need to give someone else access?')
+  end
+
+  def when_i_choose_yes_and_submit_the_form
+    choose 'Yes, I need to add someone'
+    within('#school-welcome-wizard-invite-user-yes-conditional') do
+      fill_in 'Name', with: 'Amanda Handstand'
+      fill_in 'Email address', with: 'amanda@example.com'
+      fill_in 'Telephone number', with: '01234 567890'
+      choose 'Yes, give them access to the TechSource website'
+    end
+    click_on 'Continue'
   end
 
   def when_i_choose_yes_and_click_continue


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/EwtiVEL2/569-schools-wizard-user-wont-order-but-nominates-someone-else)
Gives the user the choice to add an additional user during the welcome wizard

### Changes proposed in this pull request
Refactored school invite form to shared partial
User can add new school user via the wizard
### Guidance to review

School user must be the only (first) user for the school in the service
Selecting 'Yes' opens the invite user form
New user will be sent the School nominated contact email on creation
I've not implemented the "Back" link and I'm not sure how we'd handle this step at all if you'd already added a user and tried to go back - it would probably need to skip the page as the user would no longer be the only user for the school in the service - but additional content may be required.
The `id` of the new user is stored in the `SchoolWelcomeWizard.invited_user_id` attribute. I ended up jumping through hoops with this and ended up not using a relation to access this user with but it is accessible via the `invited_user` method.

![image](https://user-images.githubusercontent.com/333931/92400575-08faeb00-f124-11ea-8349-791b46cc92b4.png)
