### PR TITLE
Fix missing flash message when an RB changes who will order

### DIFF
--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -12,7 +12,7 @@ class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::
     if @form.valid?
       @school.preorder_information.change_who_will_order_devices!(@form.who_will_order.singularize)
 
-      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update success])
+      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update])
       redirect_to responsible_body_devices_school_path(@school.urn)
     else
       render :edit, status: :unprocessable_entity


### PR DESCRIPTION
### Context

A bug that Tom noticed during user testing.

### Changes proposed in this pull request

Fix nesting on the flash message scope.

### Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/92408077-5aab7180-f134-11ea-8f11-d13c0cfff05b.png)

After:

![image](https://user-images.githubusercontent.com/23801/92408098-69922400-f134-11ea-82cc-7f19f5f6bda0.png)

