### PR TITLE
[571] schools wizard chromebooks

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -27,6 +27,8 @@ class School::WelcomeWizardController < School::BaseController
 
   def devices_you_can_order; end
 
+  def chromebooks; end
+
 private
 
   def set_wizard

--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -48,6 +48,9 @@ private
       :email_address,
       :telephone,
       :orders_devices,
+      :will_need_chromebooks,
+      :school_or_rb_domain,
+      :recovery_email_address,
     )
   end
 

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -12,11 +12,13 @@ class SchoolWelcomeWizard < ApplicationRecord
     techsource_account: 'techsource_account',
     will_other_order: 'will_other_order',
     devices_you_can_order: 'devices_you_can_order',
+    chromebooks: 'chromebooks',
     complete: 'complete',
   }
 
+  delegate :school, to: :user
   delegate :full_name, :email_address, :telephone, :orders_devices, to: :invited_user
-
+  delegate :will_need_chromebooks, :school_or_rb_domain, :recovery_email_address, :to: :chrombook_information
   attr_accessor :invite_user
 
   def update_step!(params = {})
@@ -61,6 +63,8 @@ class SchoolWelcomeWizard < ApplicationRecord
         false
       end
     when 'devices_you_can_order'
+      chromebooks!
+    when 'chromebooks'
       complete!
     else
       raise "Unknown step: #{step}"
@@ -69,6 +73,15 @@ class SchoolWelcomeWizard < ApplicationRecord
 
   def invited_user
     @invited_user ||= find_or_build_invited_user
+  end
+
+  def chromebook_information
+    @chromebook_information ||= ChromebookInformationForm.new(
+      school: school,
+      will_need_chromebooks: school.preorder_information&.will_need_chromebooks,
+      school_or_rb_domain: school.preorder_information&.school_or_rb_domain,
+      recovery_email_address: school.preorder_information&.recovery_email_address,
+    )
   end
 
 private

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -18,7 +18,7 @@ class SchoolWelcomeWizard < ApplicationRecord
 
   delegate :school, to: :user
   delegate :full_name, :email_address, :telephone, :orders_devices, to: :invited_user
-  delegate :will_need_chromebooks, :school_or_rb_domain, :recovery_email_address, :to: :chrombook_information
+  delegate :will_need_chromebooks, :school_or_rb_domain, :recovery_email_address, to: :chromebook_information
   attr_accessor :invite_user
 
   def update_step!(params = {})
@@ -63,9 +63,17 @@ class SchoolWelcomeWizard < ApplicationRecord
         false
       end
     when 'devices_you_can_order'
-      chromebooks!
+      if will_need_chromebooks.nil?
+        chromebooks!
+      else
+        complete!
+      end
     when 'chromebooks'
-      complete!
+      if update_chromebooks(params)
+        complete!
+      else
+        false
+      end
     else
       raise "Unknown step: #{step}"
     end
@@ -90,7 +98,7 @@ private
     if invited_user_id
       User.find(invited_user_id)
     else
-      user.school.users.build
+      school.users.build
     end
   end
 
@@ -117,7 +125,7 @@ private
     elsif @invite_user == 'yes'
       user_attrs = user_params(params)
 
-      @invited_user = user.school.users.build(user_attrs)
+      @invited_user = school.users.build(user_attrs)
       if @invited_user.valid?
         save_and_invite_user!(@invited_user)
       else
@@ -129,16 +137,31 @@ private
     end
   end
 
+  def update_chromebooks(params)
+    cb_params = chromebook_params(params)
+    chromebook_information.assign_attributes(cb_params)
+
+    if will_need_chromebooks.nil?
+      errors.add(:will_need_chromebooks, I18n.t('chromebooks.errors.choice', scope: i18n_scope))
+      false
+    elsif chromebook_information.invalid?
+      errors.copy!(chromebook_information.errors)
+      false
+    else
+      update_preorder_information!(cb_params)
+    end
+  end
+
   def show_will_you_order_section?
     @first_school_user.nil? ? set_first_user_flag! : @first_school_user
   end
 
   def less_than_3_users_can_order?
-    user.school.users.who_can_order_devices.count < 3
+    school.users.who_can_order_devices.count < 3
   end
 
   def set_first_user_flag!
-    is_first_user_for_school = user.school.users.count == 1
+    is_first_user_for_school = school.users.count == 1
     update!(first_school_user: is_first_user_for_school)
     is_first_user_for_school
   end
@@ -146,15 +169,23 @@ private
   def save_and_invite_user!(new_user)
     SchoolWelcomeWizard.transaction do
       new_user.save!
-      self.invited_user_id = new_user.id
-      save!
+      update!(invited_user_id: new_user.id)
       InviteSchoolUserMailer.with(user: new_user).nominated_contact_email.deliver_later
     end
     true
   end
 
+  def update_preorder_information!(params)
+    params[:will_need_chromebooks] = nil if params[:will_need_chromebooks] == 'i_dont_know'
+    school.preorder_information.update_chromebook_information_and_status!(params)
+  end
+
   def user_params(params)
     params.slice(:full_name, :email_address, :telephone, :orders_devices)
+  end
+
+  def chromebook_params(params)
+    params.slice(:will_need_chromebooks, :school_or_rb_domain, :recovery_email_address)
   end
 
   def i18n_scope

--- a/app/views/school/welcome_wizard/chromebooks.html.erb
+++ b/app/views/school/welcome_wizard/chromebooks.html.erb
@@ -1,0 +1,13 @@
+<%-
+  scope = 'page_titles.school_user_welcome_wizard.chromebooks'
+  title = t('title', scope: scope)
+%>
+<%- content_for :title, title %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= render partial: 'shared/chromebook_information_intro' %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path, form_object: @wizard, show_i_dont_know: true, submit_label: 'Continue' } %>
+  </div>
+</div>

--- a/app/views/school/welcome_wizard/chromebooks.html.erb
+++ b/app/views/school/welcome_wizard/chromebooks.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/chromebook_information_intro' %>
-    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path, form_object: @wizard, show_i_dont_know: true, submit_label: 'Continue' } %>
+    <%= render partial: 'shared/chromebook_information_intro', locals: { show_different_devices_text: true } %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path, form_object: @wizard, show_i_dont_know_option: true, submit_label: 'Continue', scope: scope } %>
   </div>
 </div>

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -1,3 +1,4 @@
+<%- submit_label = local_assigns[:submit_label] || 'Save' %>
 <%= form_for local_assigns[:form_object], url: local_assigns[:url], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
@@ -15,7 +16,11 @@
     <%= f.govuk_radio_button  :will_need_chromebooks,
                               'no',
                               label: { text: t(:no, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
-
+    <% if local_assigns[:show_i_dont_know_option] %>
+      <%= f.govuk_radio_button :will_need_chromebooks,
+                              'i_dont_know',
+                              label: { text: t(:i_dont_know, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
+    <%- end %>
   <%- end %>
-  <%= f.govuk_submit 'Save' %>
+  <%= f.govuk_submit submit_label %>
 <%- end %>

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -1,11 +1,14 @@
-<%- submit_label = local_assigns[:submit_label] || 'Save' %>
+<%-
+  submit_label = local_assigns[:submit_label] || 'Save'
+  scope = local_assigns[:scope] || 'activerecord.attributes.preorder_information.will_need_chromebooks'
+%>
 <%= form_for local_assigns[:form_object], url: local_assigns[:url], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: nil } ) do %>
     <%= f.govuk_radio_button  :will_need_chromebooks,
                               'yes',
-                              label: { text: t(:yes, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } do %>
+                              label: { text: t(:yes, scope: scope) } do %>
       <%= f.govuk_text_field  :school_or_rb_domain,
                               label: { text: "School or #{local_assigns[:form_object].school.responsible_body.humanized_type} domain", size: 's' },
                               hint_text: "For example, ‘school.co.uk’" %>
@@ -15,11 +18,11 @@
     <%- end %>
     <%= f.govuk_radio_button  :will_need_chromebooks,
                               'no',
-                              label: { text: t(:no, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
+                              label: { text: t(:no, scope: scope) } %>
     <% if local_assigns[:show_i_dont_know_option] %>
       <%= f.govuk_radio_button :will_need_chromebooks,
                               'i_dont_know',
-                              label: { text: t(:i_dont_know, scope: %i[activerecord attributes preorder_information will_need_chromebooks]) } %>
+                              label: { text: t(:i_dont_know, scope: scope) } %>
     <%- end %>
   <%- end %>
   <%= f.govuk_submit submit_label %>

--- a/app/views/shared/_chromebook_information_intro.html.erb
+++ b/app/views/shared/_chromebook_information_intro.html.erb
@@ -1,4 +1,7 @@
 <p class="govuk-body">
+<% if local_assigns[:show_different_devices_text] %>
+  It’s possible to order a range of different devices (laptops, tablets, Chromebooks).
+<%- end %>
   If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
 </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,13 @@
           will_other_order: Tell us whether you need to add someone
       devices_you_can_order:
         title: You can order a range of laptops and tablets
+      chromebooks:
+        title: Will your school’s order include a request for Chromebooks?
+        'yes': Yes, we will need Chromebooks
+        'no': No, we do not need Chromebooks
+        i_dont_know: I don’t know
+        errors:
+          choice: Tell us whether your school will need Chromebooks
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
     get '/techsource-account', to: 'welcome_wizard#techsource_account', as: :welcome_wizard_techsource_account
     get '/will-other-order', to: 'welcome_wizard#will_other_order', as: :welcome_wizard_will_other_order
     get '/devices-you-can-order', to: 'welcome_wizard#devices_you_can_order', as: :welcome_wizard_devices_you_can_order
+    get '/chromebooks', to: 'welcome_wizard#chromebooks', as: :welcome_wizard_chromebooks
     patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]

--- a/spec/factories/preorder_information.rb
+++ b/spec/factories/preorder_information.rb
@@ -3,5 +3,15 @@ FactoryBot.define do
     school
     who_will_order_devices { %w[school responsible_body].sample }
     status { infer_status }
+
+    trait :needs_chromebooks do
+      will_need_chromebooks { 'yes' }
+      school_or_rb_domain { Faker::Internet.domain_name }
+      recovery_email_address { Faker::Internet.email }
+    end
+
+    trait :does_not_need_chromebooks do
+      will_need_chromebooks { 'no' }
+    end
   end
 end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Navigate school welcome wizard' do
-  let(:school) { create(:school, :with_std_device_allocation) }
+  let(:school) { create(:school, :with_preorder_information, :with_std_device_allocation) }
 
   scenario 'step through the wizard as the first user for a school' do
     as_a_new_school_user
@@ -30,6 +30,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_information_about_devices_i_can_order
 
     when_i_click_continue
+    then_im_asked_whether_my_school_will_order_chromebooks
+
+    when_i_choose_yes_and_submit_the_chromebooks_form
     then_i_see_the_school_home_page
   end
 
@@ -51,6 +54,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_information_about_devices_i_can_order
 
     when_i_click_continue
+    then_im_asked_whether_my_school_will_order_chromebooks
+
+    when_i_choose_yes_and_submit_the_chromebooks_form
     then_i_see_the_school_home_page
   end
 
@@ -140,6 +146,20 @@ RSpec.feature 'Navigate school welcome wizard' do
   def then_i_see_information_about_devices_i_can_order
     expect(page).to have_current_path(school_welcome_wizard_devices_you_can_order_path)
     expect(page).to have_text('You can order a range of laptops and tablets')
+  end
+
+  def then_im_asked_whether_my_school_will_order_chromebooks
+    expect(page).to have_current_path(school_welcome_wizard_chromebooks_path)
+    expect(page).to have_text('Will your school’s order include a request for Chromebooks?')
+  end
+
+  def when_i_choose_yes_and_submit_the_chromebooks_form
+    choose 'Yes, we will need Chromebooks'
+    within('#school-welcome-wizard-will-need-chromebooks-yes-conditional') do
+      fill_in 'School or trust domain', with: 'example.com'
+      fill_in 'Recovery email address', with: 'admin@trust.com'
+    end
+    click_on 'Continue'
   end
 
   def when_i_choose_yes_and_click_continue


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/5L2CpbJX/571-schools-wizard-chromebooks)
Ask if school needs Chromebooks

### Changes proposed in this pull request
Adds page to wizard to ask if school needs Chromebooks
Assumes that if a school gets here that a `preorder_information`model has already been created - **I don't know if this is the case?**
Refactor of chromebook form object partials to conditionally add extra options and wording to cater for this view.

### Guidance to review
This page is only shown if `:will_need_chromebooks` is `nil` in the school's `preorder_information` model

![image](https://user-images.githubusercontent.com/333931/92415587-8b4dd400-f151-11ea-848f-66a4d6307be7.png)
