### PR TITLE
Chromebook details fix

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -68,9 +68,10 @@ private
     info = @school.preorder_information
     return [] if info.nil?
 
+    detail_value = info.will_need_chromebooks.nil? ? 'Not yet known' : t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks])
     detail = {
       key: 'Ordering Chromebooks?',
-      value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
+      value: detail_value,
     }
 
     if info.orders_managed_centrally?

--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -66,35 +66,45 @@ private
 
   def chromebook_rows_if_needed
     info = @school.preorder_information
-    if info&.needs_chromebook_information?
+    return [] if info.nil?
+
+    detail = {
+      key: 'Ordering Chromebooks?',
+      value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
+    }
+
+    if info.orders_managed_centrally?
       change_path = responsible_body_devices_school_chromebooks_edit_path(school_urn: @school.urn)
-      rows = [
-        info.will_need_chromebooks && {
-          key: 'Ordering Chromebooks?',
-          value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
-          change_path: change_path,
-          action: 'whether Chromebooks are needed',
-        },
-      ]
-      if info.will_need_chromebooks?
-        rows += [
-          info.school_or_rb_domain && {
-            key: 'Domain',
-            value: info.school_or_rb_domain,
-            change_path: change_path,
-            action: 'Domain',
-          },
-          info.recovery_email_address && {
-            key: 'Recovery email',
-            value: info.recovery_email_address,
-            change_path: change_path,
-            action: 'Recovery email',
-          },
-        ]
-      end
-      rows.compact
-    else
-      []
+      detail.merge!({
+        change_path: change_path,
+        action: 'whether Chromebooks are needed',
+      })
     end
+
+    rows = [detail]
+
+    if info.will_need_chromebooks?
+      domain = {
+        key: 'Domain',
+        value: info.school_or_rb_domain,
+      }
+      recovery = {
+        key: 'Recovery email',
+        value: info.recovery_email_address,
+      }
+
+      if info.orders_managed_centrally?
+        domain.merge!({
+          change_path: change_path,
+          action: 'Domain',
+        })
+        recovery.merge!({
+          change_path: change_path,
+          action: 'Recovery email',
+        })
+      end
+      rows += [domain, recovery]
+    end
+    rows
   end
 end

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -30,30 +30,44 @@ private
 
   def chromebook_rows_if_needed
     info = @school.preorder_information
-    if info&.needs_chromebook_information?
-      rows = [
-        info.will_need_chromebooks && {
-          key: 'Will your school need to order Chromebooks?',
-          value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
-          change_path: school_chromebooks_edit_path,
-          action: 'whether Chromebooks are needed',
-        },
-      ]
-      if info.will_need_chromebooks?
-        rows += [
-          info.school_or_rb_domain && {
-            key: 'Domain',
-            value: info.school_or_rb_domain,
-          },
-          info.recovery_email_address && {
-            key: 'Recovery email',
-            value: info.recovery_email_address,
-          },
-        ]
-      end
-      rows.compact
-    else
-      []
+    return [] if info.nil?
+
+    detail = {
+      key: 'Will your school need to order Chromebooks?',
+      value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
+    }
+
+    unless info.orders_managed_centrally?
+      detail.merge!({
+        change_path: school_chromebooks_edit_path,
+        action: 'whether Chromebooks are needed',
+      })
     end
+
+    rows = [detail]
+
+    if info.will_need_chromebooks?
+      domain = {
+        key: 'Domain',
+        value: info.school_or_rb_domain,
+      }
+      recovery = {
+        key: 'Recovery email',
+        value: info.recovery_email_address,
+      }
+
+      unless info.orders_managed_centrally?
+        domain.merge!({
+          change_path: school_chromebooks_edit_path,
+          action: 'Domain',
+        })
+        recovery.merge!({
+          change_path: school_chromebooks_edit_path,
+          action: 'Recovery email',
+        })
+      end
+      rows += [domain, recovery]
+    end
+    rows
   end
 end

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -32,9 +32,10 @@ private
     info = @school.preorder_information
     return [] if info.nil?
 
+    detail_value = info.will_need_chromebooks.nil? ? 'Not yet known' : t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks])
     detail = {
       key: 'Will your school need to order Chromebooks?',
-      value: t(info.will_need_chromebooks, scope: %i[activerecord attributes preorder_information will_need_chromebooks]),
+      value: detail_value,
     }
 
     unless info.orders_managed_centrally?

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -10,7 +10,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::Devices::Ba
     @school = @responsible_body.schools.find_by!(urn: params[:urn])
     if @school.preorder_information.needs_contact?
       redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn)
-    elsif @school.preorder_information.needs_chromebook_information?
+    elsif @school.preorder_information.orders_managed_centrally?
       @chromebook_information_form = ChromebookInformationForm.new(school: @school)
     end
   end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -30,7 +30,7 @@ class PreorderInformation < ApplicationRecord
   def infer_status
     if school_will_order_devices?
       school_contact.present? ? 'school_will_be_contacted' : 'needs_contact'
-    elsif needs_chromebook_information? && chromebook_information_complete?
+    elsif orders_managed_centrally? && chromebook_information_complete?
       'ready'
     else
       'needs_info'
@@ -57,7 +57,7 @@ class PreorderInformation < ApplicationRecord
     self.status = infer_status
   end
 
-  def needs_chromebook_information?
+  def orders_managed_centrally?
     who_will_order_devices == 'responsible_body'
   end
 

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -11,7 +11,7 @@
       <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @school) %>
     </div>
 
-    <%- if @school.preorder_information.needs_chromebook_information? %>
+    <%- if @school.preorder_information.orders_managed_centrally? %>
       <%- unless @school.preorder_information.chromebook_information_complete? %>
       <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
       <%= render partial: 'shared/chromebook_information_intro' %>

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -13,7 +13,14 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
 
   context 'when the school will place device orders' do
     before do
-      create(:preorder_information, school: school, who_will_order_devices: :school)
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :school,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes',
+             school_contact: headteacher)
+
       create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
     end
 
@@ -30,7 +37,13 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school details' do
-      expect(result.css('.govuk-summary-list__row')[0].text).to include('Needs a contact')
+      expect(result.css('.govuk-summary-list__row')[0].text).to include('School will be contacted')
+    end
+
+    it 'shows the chromebook details without links to change it' do
+      expect(result.css('dd')[8].text).to include('Yes')
+      expect(result.css('dd')[9].text).to include('school.domain.org')
+      expect(result.css('dd')[10].text).to include('admin@recovery.org')
     end
 
     context "when the school isn't under lockdown restrictions or has any shielding children" do
@@ -73,18 +86,32 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
   context 'when the responsible body will place device orders' do
     let(:school) { create(:school, :primary, :academy) }
 
+    before do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :responsible_body,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes',
+             school_contact: headteacher)
+    end
+
     it 'confirms that fact' do
       create(:preorder_information, school: school, who_will_order_devices: :responsible_body)
 
       expect(result.css('.govuk-summary-list__row')[1].text).to include('The trust orders devices')
     end
 
-    it 'does not show the school contact even if the school contact is set' do
-      create(:preorder_information,
-             school: school,
-             who_will_order_devices: :responsible_body,
-             school_contact: headteacher)
+    it 'shows the chromebook details with links to change it' do
+      expect(result.css('dd')[7].text).to include('Yes')
+      expect(result.css('dd')[8].text).to include('Change')
+      expect(result.css('dd')[9].text).to include('school.domain.org')
+      expect(result.css('dd')[10].text).to include('Change')
+      expect(result.css('dd')[11].text).to include('admin@recovery.org')
+      expect(result.css('dd')[12].text).to include('Change')
+    end
 
+    it 'does not show the school contact even if the school contact is set' do
       expect(result.css('dl').text).not_to include('School contact')
     end
   end

--- a/spec/components/school/school_details_summary_list_component_spec.rb
+++ b/spec/components/school/school_details_summary_list_component_spec.rb
@@ -13,7 +13,14 @@ describe School::SchoolDetailsSummaryListComponent do
 
   context 'when the school will place device orders' do
     before do
-      create(:preorder_information, school: school, who_will_order_devices: :school)
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :school,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes',
+             school_contact: headteacher)
+
       create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
     end
 
@@ -23,6 +30,15 @@ describe School::SchoolDetailsSummaryListComponent do
 
     it 'renders the school type' do
       expect(result.css('dd')[1].text).to include('Primary school')
+    end
+
+    it 'shows the chromebook details with links to change it' do
+      expect(result.css('dd')[2].text).to include('Yes')
+      expect(result.css('dd')[3].text).to include('Change')
+      expect(result.css('dd')[4].text).to include('school.domain.org')
+      expect(result.css('dd')[5].text).to include('Change')
+      expect(result.css('dd')[6].text).to include('admin@recovery.org')
+      expect(result.css('dd')[7].text).to include('Change')
     end
   end
 
@@ -34,7 +50,7 @@ describe School::SchoolDetailsSummaryListComponent do
              school: school,
              who_will_order_devices: :responsible_body,
              school_or_rb_domain: 'school.domain.org',
-             recovery_email_address: 'admin@school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
              will_need_chromebooks: 'yes',
              school_contact: headteacher)
     end
@@ -43,11 +59,10 @@ describe School::SchoolDetailsSummaryListComponent do
       expect(result.css('dl').text).not_to include('School contact')
     end
 
-    it 'shows the chromebook details with a link to change it' do
+    it 'shows the chromebook details without links to change it' do
       expect(result.css('dd')[2].text).to include('Yes')
-      expect(result.css('dd')[3].text).to include('Change')
-      expect(result.css('dd')[4].text).to include('school.domain.org')
-      expect(result.css('dd')[5].text).to include('admin@school.domain.org')
+      expect(result.css('dd')[3].text).to include('school.domain.org')
+      expect(result.css('dd')[4].text).to include('admin@recovery.org')
     end
   end
 end

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Change school Chromebook information' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith', school: school) }
 
   before do
-    create(:preorder_information, school: school_user.school, who_will_order_devices: 'responsible_body', will_need_chromebooks: 'yes')
+    create(:preorder_information, school: school_user.school, who_will_order_devices: 'school', will_need_chromebooks: 'yes')
     create(:school_device_allocation, school: school_user.school, device_type: 'std_device', allocation: 63)
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/MTSFSrWS/622-cannot-add-chromebook-details-if-youve-said-i-dont-know)
[Trello card](https://trello.com/c/jZ0jqIW6/623-school-details-dont-show-chromebook-settings-if-youve-said-no-to-chromebooks)

### Changes proposed in this pull request
Show chromebook details for RBs and Schools
Enable `Change` link on Chromebook details depending on whether the School or RB will be managing (managing entity sees the Change links)
Added 'Not yet known' as default text when `:will_need_chromebooks` hasn't been set

### Guidance to review
![image](https://user-images.githubusercontent.com/333931/92491724-783b1280-f1ea-11ea-978a-1555766a104a.png)
![image](https://user-images.githubusercontent.com/333931/92491924-b33d4600-f1ea-11ea-8354-6f1bfa9181f5.png)
![image](https://user-images.githubusercontent.com/333931/92491974-c2bc8f00-f1ea-11ea-847a-a4fd2682bcfb.png)

![image](https://user-images.githubusercontent.com/333931/92492385-32cb1500-f1eb-11ea-8606-09a238b8485e.png)
![image](https://user-images.githubusercontent.com/333931/92492199-00211c80-f1eb-11ea-8a03-24ed2aced9be.png)
![image](https://user-images.githubusercontent.com/333931/92492249-0e6f3880-f1eb-11ea-8d87-9f08746d23af.png)

