### PR TITLE
[594] Add extra cols to computacenter_user_changes

### DIFF
--- a/app/models/computacenter/ledger.rb
+++ b/app/models/computacenter/ledger.rb
@@ -26,7 +26,16 @@ module Computacenter
             user_change.updated_at_timestamp.utc.strftime('%R'),
             user_change.updated_at_timestamp.utc.iso8601,
             user_change.type_of_update,
+            user_change.original_first_name,
+            user_change.original_last_name,
             user_change.original_email_address,
+            user_change.original_telephone,
+            user_change.original_responsible_body,
+            user_change.original_responsible_body_urn,
+            user_change.original_cc_sold_to_number,
+            user_change.original_school,
+            user_change.original_school_urn,
+            user_change.original_cc_ship_to_number,
           ]
         end
       end
@@ -48,7 +57,16 @@ module Computacenter
         'Time of Update', # 24 hour clock
         'Timestamp of Update', # ISO
         'Type of Update', # New / Change / Remove
+        'Original First Name',
+        'Original Last Name',
         'Original Email',
+        'Original Telephone',
+        'Original Responsible Body',
+        'Original Responsible Body URN',
+        'Original CC Sold To Number',
+        'Original School',
+        'Original School URN',
+        'Original CC Ship To Number',
       ]
     end
 
@@ -74,7 +92,16 @@ module Computacenter
           cc_ship_to_number: user.school&.computacenter_reference,
           updated_at_timestamp: user.created_at,
           type_of_update: 'New',
+          original_first_name: nil,
+          original_last_name: nil,
           original_email_address: nil,
+          original_telephone: nil,
+          original_responsible_body: nil,
+          original_responsible_body_urn: nil,
+          original_cc_sold_to_number: nil,
+          original_school: nil,
+          original_school_urn: nil,
+          original_cc_ship_to_number: nil,
         )
       end
     end

--- a/db/migrate/20200908094419_add_originals_to_computacenter_user_changes.rb
+++ b/db/migrate/20200908094419_add_originals_to_computacenter_user_changes.rb
@@ -1,0 +1,13 @@
+class AddOriginalsToComputacenterUserChanges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :computacenter_user_changes, :original_first_name, :text
+    add_column :computacenter_user_changes, :original_last_name, :text
+    add_column :computacenter_user_changes, :original_telephone, :text
+    add_column :computacenter_user_changes, :original_responsible_body, :text
+    add_column :computacenter_user_changes, :original_responsible_body_urn, :text
+    add_column :computacenter_user_changes, :original_cc_sold_to_number, :text
+    add_column :computacenter_user_changes, :original_school, :text
+    add_column :computacenter_user_changes, :original_school_urn, :text
+    add_column :computacenter_user_changes, :original_cc_ship_to_number, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,15 @@ ActiveRecord::Schema.define(version: 2020_09_08_104822) do
     t.text "original_email_address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "original_first_name"
+    t.text "original_last_name"
+    t.text "original_telephone"
+    t.text "original_responsible_body"
+    t.text "original_responsible_body_urn"
+    t.text "original_cc_sold_to_number"
+    t.text "original_school"
+    t.text "original_school_urn"
+    t.text "original_cc_ship_to_number"
     t.index ["updated_at_timestamp"], name: "index_computacenter_user_changes_on_updated_at_timestamp"
     t.index ["user_id"], name: "index_computacenter_user_changes_on_user_id"
   end

--- a/spec/models/computacenter/ledger_spec.rb
+++ b/spec/models/computacenter/ledger_spec.rb
@@ -20,7 +20,16 @@ RSpec.describe Computacenter::Ledger do
         'Time of Update',
         'Timestamp of Update',
         'Type of Update',
+        'Original First Name',
+        'Original Last Name',
         'Original Email',
+        'Original Telephone',
+        'Original Responsible Body',
+        'Original Responsible Body URN',
+        'Original CC Sold To Number',
+        'Original School',
+        'Original School URN',
+        'Original CC Ship To Number',
       ]
     end
 
@@ -52,6 +61,15 @@ RSpec.describe Computacenter::Ledger do
           user.created_at.utc.iso8601,
           'New',
           nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
         ])
       end
     end
@@ -77,6 +95,15 @@ RSpec.describe Computacenter::Ledger do
           user.created_at.utc.strftime('%R'),
           user.created_at.utc.iso8601,
           'New',
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
           nil,
         ])
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-spike-can-we-generate-the-cc-user-changes-feed-using-papertrail
- Add extra columns to `computacenter_user_changes` as specified in the `v3` spreadsheet

### Changes proposed in this pull request

- Add extra db columns to `computacenter_user_changes`
- CSV generator takes these extra columns into consideration

### Guidance to review

- Start service with users
- `service = Computacenter::Ledger.new(users: User.all)`
- Generate csv from service
- `service.to_csv`
- Should generate csv with extra columns