### PR TITLE
[631] add button for Computacenter to Download CSV of users

### DIFF
--- a/app/controllers/computacenter/user_ledger_controller.rb
+++ b/app/controllers/computacenter/user_ledger_controller.rb
@@ -1,0 +1,13 @@
+class Computacenter::UserLedgerController < Computacenter::BaseController
+  def index
+    @users = User.who_can_order_devices
+                .who_have_seen_privacy_notice
+    @ledger = Computacenter::Ledger.new(users: @users)
+
+    respond_to do |format|
+      format.csv do
+        render csv: @ledger.to_csv, filename: "computacenter-users-#{Time.zone.now.iso8601}"
+      end
+    end
+  end
+end

--- a/app/models/computacenter/ledger.rb
+++ b/app/models/computacenter/ledger.rb
@@ -8,7 +8,7 @@ module Computacenter
 
     def to_csv
       CSV.generate do |csv|
-        csv << headers
+        csv << self.class.headers
 
         user_changes.each do |user_change|
           csv << [
@@ -32,6 +32,26 @@ module Computacenter
       end
     end
 
+    def self.headers
+      [
+        'First Name',
+        'Last Name',
+        'Email',
+        'Telephone',
+        'Responsible Body',
+        'Responsible Body URN',
+        'CC Sold To Number',
+        'School',
+        'School URN',
+        'CC Ship To Number',
+        'Date of Update', # "24/08/2020" / "dd/mm/yyyy"
+        'Time of Update', # 24 hour clock
+        'Timestamp of Update', # ISO
+        'Type of Update', # New / Change / Remove
+        'Original Email',
+      ]
+    end
+    
   private
 
     def users
@@ -59,24 +79,5 @@ module Computacenter
       end
     end
 
-    def headers
-      [
-        'First Name',
-        'Last Name',
-        'Email',
-        'Telephone',
-        'Responsible Body',
-        'Responsible Body URN',
-        'CC Sold To Number',
-        'School',
-        'School URN',
-        'CC Ship To Number',
-        'Date of Update', # "24/08/2020" / "dd/mm/yyyy"
-        'Time of Update', # 24 hour clock
-        'Timestamp of Update', # ISO
-        'Type of Update', # New / Change / Remove
-        'Original Email',
-      ]
-    end
   end
 end

--- a/app/models/computacenter/ledger.rb
+++ b/app/models/computacenter/ledger.rb
@@ -51,7 +51,7 @@ module Computacenter
         'Original Email',
       ]
     end
-    
+
   private
 
     def users
@@ -78,6 +78,5 @@ module Computacenter
         )
       end
     end
-
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   scope :from_responsible_body_in_connectivity_pilot, -> { joins(:responsible_body).where('responsible_bodies.in_connectivity_pilot = ?', true) }
   scope :mno_users, -> { where.not(mobile_network: nil) }
   scope :who_can_order_devices, -> { where(orders_devices: true) }
+  scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
 
   validates :full_name,
             presence: true,

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -7,7 +7,11 @@
     <p class="govuk-body">Use this service to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>download a CSV file of users who have permission to place orders on TechSource</li>
+      <li>
+        <span class="govuk-!-margin-bottom-4">download a CSV file of users who have permission to place orders on TechSource</span>
+        <br /><br />
+        <%= govuk_button_link_to 'Download CSV', computacenter_user_ledger_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
+      </li>
     </ul>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
 
   namespace :computacenter do
     get '/', to: 'home#show', as: :home
+    get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
     resources :api_tokens, path: '/api-tokens'
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection

--- a/spec/features/computacenter/download_user_changes_csv_spec.rb
+++ b/spec/features/computacenter/download_user_changes_csv_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'Download user changes CSV' do
+  context 'signed in as a Computacenter user' do
+    let(:user) { create(:computacenter_user) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'shows me a Download CSV link' do
+      expect(page).to have_link('Download CSV')
+    end
+
+    describe 'clicking Download CSV' do
+      let!(:user_who_has_seen_privacy_notice_and_can_order_devices) { create(:school_user, :has_seen_privacy_notice, :orders_devices) }
+      let!(:user_who_has_seen_privacy_notice_but_cant_order_devices) { create(:school_user, :has_seen_privacy_notice, orders_devices: false) }
+      let!(:user_who_has_not_seen_privacy_notice_but_can_order_devices) { create(:school_user, :orders_devices, privacy_notice_seen_at: nil) }
+
+
+      it 'downloads a CSV file' do
+        click_on 'Download CSV'
+        expect_download(content_type: 'text/csv')
+        expect(page.body).to include(Computacenter::Ledger.headers.join(','))
+      end
+
+      it 'includes only users who have seen the privacy notice and can order devices' do
+        click_on 'Download CSV'
+        expect(page.body).to include(user_who_has_seen_privacy_notice_and_can_order_devices.email_address)
+        expect(page.body).not_to include(user_who_has_seen_privacy_notice_but_cant_order_devices.email_address)
+        expect(page.body).not_to include(user_who_has_not_seen_privacy_notice_but_can_order_devices.email_address)
+      end
+    end
+  end
+
+  context 'signed in as a non-Computacenter user' do
+    let(:user) { create(:local_authority_user) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'responds with forbidden' do
+      visit computacenter_home_path
+      expect(page).to have_http_status(:forbidden)
+      visit computacenter_user_ledger_path(format: :csv)
+      expect(page).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/features/computacenter/download_user_changes_csv_spec.rb
+++ b/spec/features/computacenter/download_user_changes_csv_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'Download user changes CSV' do
       let!(:user_who_has_seen_privacy_notice_but_cant_order_devices) { create(:school_user, :has_seen_privacy_notice, orders_devices: false) }
       let!(:user_who_has_not_seen_privacy_notice_but_can_order_devices) { create(:school_user, :orders_devices, privacy_notice_seen_at: nil) }
 
-
       it 'downloads a CSV file' do
         click_on 'Download CSV'
         expect_download(content_type: 'text/csv')


### PR DESCRIPTION
### Context

[Trello card 631](https://trello.com/c/5xfhKBRT/631-add-ui-for-computacenter-to-generate-a-user-changes-csv) - first draft strawperson UI, no filtering, just a big green button. Refinements will come later.

### Changes proposed in this pull request

* Add a big green `Download CSV` button that downloads the unfiltered user ledger as CSV
* move the `Computacenter::Ledger.headers` method to a public class scope - it's going to be the same for all instances, and this also allows it to be referenced in the test.
 
### Guidance to review

![Screen Shot 2020-09-08 at 16 40 39](https://user-images.githubusercontent.com/134501/92498227-46c64500-f1f2-11ea-9c60-212469f4c358.png)
