### PR TITLE
Stop trusts from adding school users in wrong place

### DIFF
--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -12,6 +12,7 @@
 
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
+        <li>add school contacts</li>
         <li>tell us who will place orders for schools</li>
         <li>give schools access to the services they need</li>
       </ul>
@@ -30,7 +31,11 @@
     <%- end %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to "Manage #{@responsible_body.humanized_type} users", responsible_body_users_path %>
+      <% if @responsible_body.is_a_trust? %>
+        <%= govuk_link_to t('page_titles.responsible_body_trust_users_index'), responsible_body_users_path %>
+      <% else %>
+        <%= govuk_link_to t('page_titles.responsible_body_users_index', rb_type: @responsible_body.humanized_type), responsible_body_users_path %>
+      <% end %>
     </h2>
 
     <p class="govuk-body">Use this section to:</p>

--- a/app/views/responsible_body/users/index.html.erb
+++ b/app/views/responsible_body/users/index.html.erb
@@ -1,4 +1,9 @@
-<%- title = t('page_titles.responsible_body_users_index', rb_type: @responsible_body.humanized_type) -%>
+<% if @responsible_body.is_a_trust? %>
+  <%- title = t('page_titles.responsible_body_trust_users_index') -%>
+<% else %>
+  <%- title = t('page_titles.responsible_body_users_index', rb_type: @responsible_body.humanized_type) -%>
+<% end %>
+
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <div class="govuk-breadcrumbs ">
@@ -33,6 +38,10 @@
         <li>make requests for mobile data</li>
       <%- end %>
     </ul>
+
+    <div class="govuk-inset-text">
+      <p class="govuk-body">Do not add school contacts here. <%= govuk_link_to 'Use the schools list instead', responsible_body_devices_path %>.</p>
+    </div>
 
     <%= govuk_button_link_to 'Invite a new user', new_responsible_body_user_path %>
 

--- a/app/views/responsible_body/users/new.html.erb
+++ b/app/views/responsible_body/users/new.html.erb
@@ -10,6 +10,14 @@
       <%= title %>
     </h1>
 
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        Do not add school contacts here. <%= govuk_link_to 'Use the schools list instead', responsible_body_devices_path %>.
+      </strong>
+    </div>
+
     <%= form_for @rb_user, url: responsible_body_users_path do |f| %>
       <%= render partial: 'form', locals: { submit_text: 'Send invite', form: f } %>
     <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@
     responsible_body_devices_request_devices: Request devices for specific circumstances
     responsible_body_internet_home: Get the internet
     responsible_body_users_index: Manage %{rb_type} users
+    responsible_body_trust_users_index: Manage trust administrators
     responsible_body_devices_chromebooks: Will the school need Chromebooks?
     new_responsible_body_user: Invite a new user
     edit_responsible_body_user: Edit user

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -104,12 +104,12 @@ RSpec.feature ResponsibleBody do
     context 'when the RB is a trust' do
       let(:rb_user) { create(:trust_user) }
 
-      it 'shows link to Manage trust users' do
+      it 'shows link to Manage trust administrators' do
         visit responsible_body_home_path
 
         expect(responsible_body_home_page).to be_displayed
         expect(page.status_code).to eq 200
-        expect(page).to have_link('Manage trust users')
+        expect(page).to have_link('Manage trust administrators')
       end
     end
   end


### PR DESCRIPTION
- Explicitly call out "add school contacts' in the Get devices section
- Change "Manage trust users" (trust users sound like people in schools) to "Manage trust administrators", so it sounds more central
- Add warnings about adding schools in the wrong place

![Screen Shot 2020-09-08 at 16 39 54](https://user-images.githubusercontent.com/319055/92498880-1337ea80-f1f3-11ea-8b8b-1abca6b64102.png)
![Screen Shot 2020-09-08 at 16 39 41](https://user-images.githubusercontent.com/319055/92498885-14691780-f1f3-11ea-8155-958dfd839891.png)
![Screen Shot 2020-09-08 at 16 39 47](https://user-images.githubusercontent.com/319055/92498887-159a4480-f1f3-11ea-80a1-55b1b0eb350f.png)
