### PR TITLE
Update Google domain label

### DIFF
--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -10,7 +10,7 @@
                               'yes',
                               label: { text: t(:yes, scope: scope) } do %>
       <%= f.govuk_text_field  :school_or_rb_domain,
-                              label: { text: "School or #{local_assigns[:form_object].school.responsible_body.humanized_type} domain", size: 's' },
+                              label: { text: "School or #{local_assigns[:form_object].school.responsible_body.humanized_type} domain registered for G Suite for Education", size: 's' },
                               hint_text: "For example, ‘school.co.uk’" %>
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },


### PR DESCRIPTION
Specify that it must be the domain registered for G Suite for Education

![Screen Shot 2020-09-08 at 17 27 00](https://user-images.githubusercontent.com/319055/92503842-bd1a7580-f1f9-11ea-921a-dd3bf80e92bc.png)
