### PR TITLE
[594] Add service to backfill user_changes

### DIFF
--- a/app/models/computacenter/backfill_ledger.rb
+++ b/app/models/computacenter/backfill_ledger.rb
@@ -1,0 +1,43 @@
+require 'csv'
+
+module Computacenter
+  class BackfillLedger
+    def call
+      users.each do |user|
+        next if UserChange.where(user_id: user.id).exists?
+
+        UserChange.create!(
+          user_id: user.id,
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email_address: user.email_address,
+          telephone: user.telephone,
+          responsible_body: user.effective_responsible_body.name,
+          responsible_body_urn: user.effective_responsible_body.computacenter_identifier,
+          cc_sold_to_number: user.effective_responsible_body.computacenter_reference,
+          school: user.school&.name,
+          school_urn: user.school&.urn,
+          cc_ship_to_number: user.school&.computacenter_reference,
+          updated_at_timestamp: user.created_at,
+          type_of_update: 'New',
+          original_first_name: nil,
+          original_last_name: nil,
+          original_email_address: nil,
+          original_telephone: nil,
+          original_responsible_body: nil,
+          original_responsible_body_urn: nil,
+          original_cc_sold_to_number: nil,
+          original_school: nil,
+          original_school_urn: nil,
+          original_cc_ship_to_number: nil,
+        )
+      end
+    end
+
+  private
+
+    def users
+      User.who_can_order_devices.where.not(privacy_notice_seen_at: nil)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
       privacy_notice_seen_at { 3.days.ago }
     end
 
+    trait :has_not_seen_privacy_notice do
+      privacy_notice_seen_at { nil }
+    end
+
     trait :approved do
       approved_at { Time.zone.now.utc - 3.days }
     end

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::BackfillLedger do
+  subject(:service) { described_class.new }
+
+  describe '#call' do
+    context 'happy path' do
+      let!(:user) { create(:local_authority_user, orders_devices: true) }
+
+      it 'persists user to ledger' do
+        expect { service.call }.to change(Computacenter::UserChange, :count).by(1)
+      end
+
+      it 'creates change record correctly' do
+        service.call
+        user_change = Computacenter::UserChange.last
+
+        expect(user_change.user_id).to eql(user.id)
+        expect(user_change.first_name).to eql(user.first_name)
+        expect(user_change.last_name).to eql(user.last_name)
+        expect(user_change.email_address).to eql(user.email_address)
+        expect(user_change.telephone).to eql(user.telephone)
+        expect(user_change.responsible_body).to eql(user.effective_responsible_body.name)
+        expect(user_change.responsible_body_urn).to eql(user.effective_responsible_body.computacenter_identifier)
+        expect(user_change.cc_sold_to_number).to eql(user.effective_responsible_body.computacenter_reference)
+        expect(user_change.school).to eql(user.school&.name)
+        expect(user_change.school_urn).to eql(user.school&.urn)
+        expect(user_change.cc_ship_to_number).to eql(user.school&.computacenter_reference)
+        expect(user_change.updated_at_timestamp).to eql(user.created_at)
+        expect(user_change.type_of_update).to eql('New')
+        expect(user_change.original_first_name).to be(nil)
+        expect(user_change.original_last_name).to be(nil)
+        expect(user_change.original_email_address).to be(nil)
+        expect(user_change.original_telephone).to be(nil)
+        expect(user_change.original_responsible_body).to be(nil)
+        expect(user_change.original_responsible_body_urn).to be(nil)
+        expect(user_change.original_cc_sold_to_number).to be(nil)
+        expect(user_change.original_school).to be(nil)
+        expect(user_change.original_school_urn).to be(nil)
+        expect(user_change.original_cc_ship_to_number).to be(nil)
+      end
+    end
+
+    context 'calling backfill multiple times' do
+      before do
+        create(:local_authority_user, orders_devices: true)
+      end
+
+      it 'does not persist multiple times' do
+        expect {
+          service.call
+          service.call
+        }.to change(Computacenter::UserChange, :count).by(1)
+      end
+    end
+
+    context 'when user has not read privacy policy' do
+      before do
+        create(:local_authority_user, :has_not_seen_privacy_notice)
+      end
+
+      it 'does not backfill user to ledger' do
+        expect { service.call }.not_to change(Computacenter::UserChange, :count)
+      end
+    end
+
+    context 'when user cannot order devices' do
+      before do
+        create(:local_authority_user, orders_devices: false)
+      end
+
+      it 'does not backfill user to ledger' do
+        expect { service.call }.not_to change(Computacenter::UserChange, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-spike-can-we-generate-the-cc-user-changes-feed-using-papertrail
- Add service to backfill user changes table

### Changes proposed in this pull request

- New service to backfill user changes table
- Should be idempotent so we can run multiple times to append to the table till we have a better mechanism in place
- We ignore users that have not read the privacy policy or can order devices 

### Guidance to review

- With some test users present in local database
- Call service with `Computacenter::BackfillLedger.new.call`
- Table should should ledger with new users dated in the past