### PR TITLE
Enable moving backwards in wizard

### DIFF
--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -3,8 +3,10 @@ class School::WelcomeWizardController < School::BaseController
   before_action :resume_wizard, except: :next_step
 
   def next_step
-    clear_user_sign_in_token!
-    if @wizard.update_step!(wizard_params)
+    current_step = params.fetch(:step, @wizard.step)
+
+    # clear_user_sign_in_token!
+    if @wizard.update_step!(wizard_params, current_step)
       redirect_to next_step_path
     else
       render @wizard.step, status: :unprocessable_entity

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -157,7 +157,7 @@ private
   end
 
   def show_chromebooks_form?
-    user_is_first_school_user?
+    show_chromebooks.nil? ? set_show_chromebooks_flag! : show_chromebooks
   end
 
   def less_than_3_users_can_order?
@@ -168,6 +168,12 @@ private
     is_first_user_for_school = school.users.count == 1
     update!(first_school_user: is_first_user_for_school)
     is_first_user_for_school
+  end
+
+  def set_show_chromebooks_flag!
+    show_page = will_need_chromebooks.nil?
+    update!(show_chromebooks: show_page)
+    show_page
   end
 
   def save_and_invite_user!(new_user)

--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/chromebooks.html.erb
+++ b/app/views/school/welcome_wizard/chromebooks.html.erb
@@ -8,6 +8,6 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render partial: 'shared/chromebook_information_intro', locals: { show_different_devices_text: true } %>
-    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path, form_object: @wizard, show_i_dont_know_option: true, submit_label: 'Continue', scope: scope } %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path(step: @wizard.step), form_object: @wizard, show_i_dont_know_option: true, submit_label: 'Continue', scope: scope } %>
   </div>
 </div>

--- a/app/views/school/welcome_wizard/devices_you_can_order.html.erb
+++ b/app/views/school/welcome_wizard/devices_you_can_order.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/order_your_own.html.erb
+++ b/app/views/school/welcome_wizard/order_your_own.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-l"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/privacy.html.erb
+++ b/app/views/school/welcome_wizard/privacy.html.erb
@@ -5,7 +5,7 @@
 
     <%= render partial: 'shared/privacy_notice' %>
 
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <%= f.govuk_submit 'Continue' %>
     <%- end %>

--- a/app/views/school/welcome_wizard/techsource_account.html.erb
+++ b/app/views/school/welcome_wizard/techsource_account.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/will_other_order.html.erb
+++ b/app/views/school/welcome_wizard/will_other_order.html.erb
@@ -5,7 +5,8 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step),
+      html: { autocomplete: 'off' } do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/school/welcome_wizard/will_you_order.html.erb
+++ b/app/views/school/welcome_wizard/will_you_order.html.erb
@@ -5,7 +5,7 @@
 <%- content_for :title, title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @wizard, url: school_welcome_wizard_path do |f| %>
+    <%= form_for @wizard, url: school_welcome_wizard_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= title %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,7 +114,7 @@ Rails.application.routes.draw do
     get '/devices-you-can-order', to: 'welcome_wizard#devices_you_can_order', as: :welcome_wizard_devices_you_can_order
     get '/chromebooks', to: 'welcome_wizard#chromebooks', as: :welcome_wizard_chromebooks
     get '/what-happens-next', to: 'welcome_wizard#what_happens_next', as: :welcome_wizard_what_happens_next
-    patch '/next', to: 'welcome_wizard#next_step', as: :welcome_wizard
+    patch '/next(/:step)', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create]
   end

--- a/db/migrate/20200909080651_add_show_chromebooks_to_school_welcome_wizard.rb
+++ b/db/migrate/20200909080651_add_show_chromebooks_to_school_welcome_wizard.rb
@@ -1,0 +1,5 @@
+class AddShowChromebooksToSchoolWelcomeWizard < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_welcome_wizards, :show_chromebooks, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_08_104822) do
+ActiveRecord::Schema.define(version: 2020_09_09_080651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 2020_09_08_104822) do
     t.boolean "user_orders_devices"
     t.boolean "first_school_user"
     t.bigint "invited_user_id"
+    t.boolean "show_chromebooks"
     t.index ["invited_user_id"], name: "index_school_welcome_wizards_on_invited_user_id"
     t.index ["user_id"], name: "index_school_welcome_wizards_on_user_id"
   end

--- a/spec/factories/school_welcome_wizards.rb
+++ b/spec/factories/school_welcome_wizards.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     trait :completed do
       step { 'complete' }
     end
+
+    trait :first_user do
+      first_school_user { true }
+    end
+
+    trait :subsequent_user do
+      first_school_user { false }
+    end
   end
 end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -39,7 +39,32 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_the_school_home_page
   end
 
-  scenario 'step through wizard as subsequent user' do
+  scenario 'step through wizard as subsequent user when the chromebooks question has been answered yes/no' do
+    as_a_subsequent_school_user
+    when_the_chromebooks_question_has_already_been_answered
+    when_i_sign_in_for_the_first_time
+    then_i_see_a_welcome_page_for_my_school
+
+    when_i_click_continue
+    then_i_see_a_privacy_notice
+
+    when_i_click_continue
+    then_i_see_the_allocation_for_my_school
+
+    when_i_click_continue
+    then_i_see_the_order_your_own_page
+
+    when_i_click_continue
+    then_i_see_information_about_devices_i_can_order
+
+    when_i_click_continue
+    then_i_see_information_about_what_happens_next
+
+    when_i_click_to_finish_and_go_to_homepage
+    then_i_see_the_school_home_page
+  end
+
+  scenario 'step through wizard as subsequent user when the chromebooks question has not been answered yes/no' do
     as_a_subsequent_school_user
     when_i_sign_in_for_the_first_time
     then_i_see_a_welcome_page_for_my_school
@@ -57,6 +82,9 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_information_about_devices_i_can_order
 
     when_i_click_continue
+    then_im_asked_whether_my_school_will_order_chromebooks
+
+    when_i_choose_no_and_submit_the_chromebooks_form
     then_i_see_information_about_what_happens_next
 
     when_i_click_to_finish_and_go_to_homepage
@@ -82,6 +110,10 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def as_a_subsequent_school_user
     @user = create_list(:school_user, 2, :new_visitor, school: school).last
+  end
+
+  def when_the_chromebooks_question_has_already_been_answered
+    school.preorder_information.update!(will_need_chromebooks: 'no')
   end
 
   def when_i_sign_in_for_the_first_time
@@ -164,6 +196,11 @@ RSpec.feature 'Navigate school welcome wizard' do
       fill_in "School or #{school.responsible_body.humanized_type} domain", with: 'example.com'
       fill_in 'Recovery email address', with: 'admin@trust.com'
     end
+    click_on 'Continue'
+  end
+
+  def when_i_choose_no_and_submit_the_chromebooks_form
+    choose 'No, we do not need Chromebooks'
     click_on 'Continue'
   end
 

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -57,9 +57,6 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_information_about_devices_i_can_order
 
     when_i_click_continue
-    then_im_asked_whether_my_school_will_order_chromebooks
-
-    when_i_choose_yes_and_submit_the_chromebooks_form
     then_i_see_information_about_what_happens_next
 
     when_i_click_to_finish_and_go_to_homepage

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         school.preorder_information.update!(will_need_chromebooks: 'yes')
       end
 
-      it 'moves to the what_happens_next step' do
+      it 'moves to the chromebooks step' do
         wizard.update_step!
-        expect(wizard.what_happens_next?).to be true
+        expect(wizard.chromebooks?).to be true
       end
     end
 

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         school.preorder_information.update!(will_need_chromebooks: 'yes')
       end
 
-      it 'moves to the chromebooks step' do
+      it 'skips the chromebook step and moves to the what_happens_next step' do
         wizard.update_step!
-        expect(wizard.chromebooks?).to be true
+        expect(wizard.what_happens_next?).to be true
       end
     end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/oB609ypc/629-allow-users-to-use-the-browsers-back-button-in-the-school-wizard)

### Changes proposed in this pull request
Pass wizard step to update method to enable back button to work as expected
Invite additional user only available to "first" school user
Chromebooks page only shown to "first" school user

### Guidance to review
Will need a good check of the flows through the wizard and using the back button to repeat steps.  Check that the user journey still makes sense.

