### PR TITLE
Show 4G dongle allocations/caps/order counts in support

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -2,6 +2,7 @@ class School < ApplicationRecord
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
   has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
+  has_one    :coms_device_allocation, -> { where device_type: 'coms_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
   has_many :users

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -47,11 +47,10 @@
       <caption class="govuk-table__caption">Schools managed by <%= @responsible_body.name %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Name and URN</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
           <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header">Device allocation</th>
-          <th scope="col" class="govuk-table__header">Device cap</th>
-          <th scope="col" class="govuk-table__header">Devices ordered</th>
+          <th scope="col" class="govuk-table__header">Devices</th>
+          <th scope="col" class="govuk-table__header">Dongles</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -60,9 +59,17 @@
             <td class="govuk-table__cell"><%= school.name %> (<%= school.urn %>)<br><%= school.type_label %></td>
             <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
             <%- device_allocations_data = school.device_allocations.detect(&:std_device?) %>
-            <td class="govuk-table__cell"><%= device_allocations_data&.allocation || 0 %></td>
-            <td class="govuk-table__cell"><%= device_allocations_data&.cap || 0 %></td>
-            <td class="govuk-table__cell"><%= device_allocations_data&.devices_ordered || 0 %></td>
+            <td class="govuk-table__cell">
+              <%= device_allocations_data&.allocation || 0 %> allocated<br>
+              <%= device_allocations_data&.cap || 0 %> caps<br>
+              <%= device_allocations_data&.devices_ordered || 0 %> ordered
+            </td>
+            <%- dongles_allocations_data = school.device_allocations.detect(&:coms_device?) %>
+            <td class="govuk-table__cell">
+              <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
+              <%= dongles_allocations_data&.cap || 0 %> caps<br>
+              <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -4,8 +4,15 @@ FactoryBot.define do
     association :created_by_user, factory: :dfe_user
     association :last_updated_by_user, factory: :dfe_user
     device_type { SchoolDeviceAllocation.device_types.keys.sample }
+
     trait :with_std_allocation do
       device_type { 'std_device' }
+      allocation { Faker::Number.within(range: 1..100) }
+      cap { 0 }
+    end
+
+    trait :with_coms_allocation do
+      device_type { 'coms_device' }
       allocation { Faker::Number.within(range: 1..100) }
       cap { 0 }
     end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -38,5 +38,9 @@ FactoryBot.define do
     trait :with_std_device_allocation do
       association :std_device_allocation, factory: %i[school_device_allocation with_std_allocation]
     end
+
+    trait :with_coms_device_allocation do
+      association :coms_device_allocation, factory: %i[school_device_allocation with_coms_allocation]
+    end
   end
 end

--- a/spec/features/support/devices/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/devices/viewing_responsible_body_info_spec.rb
@@ -34,7 +34,8 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
   end
 
   def and_it_has_some_schools
-    alpha = create(:school, :primary, :with_std_device_allocation,
+    alpha = create(:school, :primary,
+                   :with_std_device_allocation, :with_coms_device_allocation,
                    urn: 567_890,
                    name: 'Alpha Primary School',
                    responsible_body: local_authority)
@@ -42,6 +43,11 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
       allocation: 5,
       cap: 3,
       devices_ordered: 1,
+    )
+    alpha.coms_device_allocation.update!(
+      allocation: 4,
+      cap: 2,
+      devices_ordered: 0,
     )
 
     create(:school, :secondary, :with_std_device_allocation,
@@ -84,13 +90,20 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     first_row = responsible_body_page.school_rows[0]
     expect(first_row).to have_text('Alpha Primary School (567890)')
     expect(first_row).to have_text('Needs a contact')
-    expect(first_row).to have_text('5') # allocations
-    expect(first_row).to have_text('3') # caps
-    expect(first_row).to have_text('1') # device orders
+    # devices
+    expect(first_row).to have_text('5 allocated')
+    expect(first_row).to have_text('3 caps')
+    expect(first_row).to have_text('1 ordered')
+    # dongles
+    expect(first_row).to have_text('4 allocated')
+    expect(first_row).to have_text('2 caps')
+    expect(first_row).to have_text('0 ordered')
 
     second_row = responsible_body_page.school_rows[1]
     expect(second_row).to have_text('Needs a contact')
     expect(second_row).to have_text('Beta Secondary School (123456)')
-    expect(second_row).to have_text('0') # allocations or caps or device orders
+    expect(second_row).to have_text('0 allocated')
+    expect(second_row).to have_text('0 caps')
+    expect(second_row).to have_text('0 ordered')
   end
 end


### PR DESCRIPTION
### Context

The support interface needs to soon support the ability to manage allocations, caps and order counts for both devices and dongles. We start this process by displaying the current settings for these bits.

### Changes proposed in this pull request

- display the device allocations/caps/order counts in one column
- display the 4G dongle allocations/caps/order counts as well
- set a column width on the 'Name and URN' column

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92530588-96256900-f224-11ea-97c0-95c1f67ed80e.png)
