### PR TITLE
Inviting schools onto the service via support

### DIFF
--- a/app/components/school_preorder_status_tag_component.rb
+++ b/app/components/school_preorder_status_tag_component.rb
@@ -15,7 +15,7 @@ class SchoolPreorderStatusTagComponent < ViewComponent::Base
       :grey
     when 'school_contacted', 'school_will_be_contacted'
       :yellow
-    when 'ready'
+    when 'school_ready', 'ready'
       :blue
     else
       :default

--- a/app/controllers/support/devices/responsible_bodies_controller.rb
+++ b/app/controllers/support/devices/responsible_bodies_controller.rb
@@ -12,6 +12,9 @@ class Support::Devices::ResponsibleBodiesController < Support::BaseController
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
     @users = @responsible_body.users.order('last_signed_in_at desc nulls last, updated_at desc')
-    @schools = @responsible_body.schools.includes(:device_allocations).order(name: :asc)
+    @schools = @responsible_body
+      .schools
+      .includes(:device_allocations, :preorder_information)
+      .order(name: :asc)
   end
 end

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -1,0 +1,12 @@
+class Support::Devices::SchoolsController < Support::BaseController
+  def invite
+    school = School.find_by!(urn: params[:school_urn])
+    success = school.invite_school_contact_if_possible!
+    if success
+      flash[:success] = I18n.t('support.schools.invite.success', name: school.name)
+    else
+      flash[:warning] = I18n.t('support.schools.invite.failure', name: school.name)
+    end
+    redirect_to support_devices_responsible_body_path(school.responsible_body)
+  end
+end

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -1,7 +1,7 @@
 class Support::Devices::SchoolsController < Support::BaseController
   def invite
     school = School.find_by!(urn: params[:school_urn])
-    success = school.invite_school_contact_if_possible!
+    success = school.invite_school_contact
     if success
       flash[:success] = I18n.t('support.schools.invite.success', name: school.name)
     else

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -24,13 +24,15 @@ class PreorderInformation < ApplicationRecord
     set_defaults
   end
 
-  # Update this method as we add more fields (e.g. chromebook info)
-  # with reference to the prototype:
-  # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html
+  # If this method is added, we may need to update School::SchoolDetailsSummaryListComponent
   def infer_status
-    if school_will_order_devices?
-      school_contact.present? ? 'school_will_be_contacted' : 'needs_contact'
-    elsif orders_managed_centrally? && chromebook_information_complete?
+    if school_will_order_devices? && school_contact.nil?
+      'needs_contact'
+    elsif school_will_order_devices? && school_contacted_at.nil?
+      'school_will_be_contacted'
+    elsif school_will_order_devices? && school_contacted_at.present? && !chromebook_information_complete?
+      'school_contacted'
+    elsif chromebook_information_complete?
       'ready'
     else
       'needs_info'

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -86,6 +86,19 @@ class PreorderInformation < ApplicationRecord
     joins(school: :responsible_body).merge(ResponsibleBody.in_devices_pilot)
   end
 
+  def invite_school_contact!
+    new_user = school_contact&.to_user
+
+    if new_user&.valid?
+      transaction do
+        new_user.save!
+        InviteSchoolUserMailer.with(user: new_user).nominated_contact_email.deliver_later
+        update!(school_contacted_at: Time.zone.now)
+        update!(status: infer_status)
+      end
+    end
+  end
+
 private
 
   def set_defaults

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -96,6 +96,9 @@ class PreorderInformation < ApplicationRecord
         update!(school_contacted_at: Time.zone.now)
         update!(status: infer_status)
       end
+      true
+    else
+      false
     end
   end
 

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -12,6 +12,7 @@ class PreorderInformation < ApplicationRecord
     ready: 'ready',
     school_will_be_contacted: 'school_will_be_contacted',
     school_contacted: 'school_contacted',
+    school_ready: 'school_ready',
   }
 
   enum who_will_order_devices: {
@@ -32,6 +33,8 @@ class PreorderInformation < ApplicationRecord
       'school_will_be_contacted'
     elsif school_will_order_devices? && school_contacted_at.present? && !chromebook_information_complete?
       'school_contacted'
+    elsif school_will_order_devices? && school_contacted_at.present? && chromebook_information_complete?
+      'school_ready'
     elsif chromebook_information_complete?
       'ready'
     else

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -69,6 +69,10 @@ class School < ApplicationRecord
   end
 
   def invite_school_contact_if_possible!
-    preorder_information.invite_school_contact! unless preorder_information.nil?
+    if preorder_information.present?
+      preorder_information.invite_school_contact!
+    else
+      false
+    end
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -67,4 +67,8 @@ class School < ApplicationRecord
     allocation = device_allocations.by_device_type(device_type).first
     allocation&.cap.to_i > allocation&.devices_ordered.to_i
   end
+
+  def invite_school_contact_if_possible!
+    preorder_information.invite_school_contact! unless preorder_information.nil?
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -68,7 +68,7 @@ class School < ApplicationRecord
     allocation&.cap.to_i > allocation&.devices_ordered.to_i
   end
 
-  def invite_school_contact_if_possible!
+  def invite_school_contact
     if preorder_information.present?
       preorder_information.invite_school_contact!
     else

--- a/app/models/school_contact.rb
+++ b/app/models/school_contact.rb
@@ -13,4 +13,14 @@ class SchoolContact < ApplicationRecord
 
   validates :full_name, presence: true
   validates :role, presence: true
+
+  def to_user
+    User.new(
+      school: school,
+      full_name: full_name,
+      email_address: email_address,
+      telephone: phone_number,
+      orders_devices: false, # TODO: is this right?
+    )
+  end
 end

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -51,6 +51,7 @@
           <th scope="col" class="govuk-table__header">Status</th>
           <th scope="col" class="govuk-table__header">Devices</th>
           <th scope="col" class="govuk-table__header">Dongles</th>
+          <th scope="col" class="govuk-table__header">Actions</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -69,6 +70,13 @@
               <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
               <%= dongles_allocations_data&.cap || 0 %> caps<br>
               <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+            </td>
+            <td class="govuk-table__cell">
+              <% if school&.preorder_information&.school_will_be_contacted? %>
+                <%= form_with url: support_devices_school_invite_path(school_urn: school.urn), method: 'post' do |f| %>
+                  <%= f.govuk_submit 'Invite' %>
+                <% end %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,10 @@
       schools_devolved_to:
         one: school will place its own orders
         other: schools will place their own orders
+    schools:
+      invite:
+        success: "%{name} has been invited successfully"
+        failure: "Could not invite %{name}"
   errors:
     format:
       "'%{attribute}' %{message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@
           ready: Ready
           school_contacted: School contacted
           school_will_be_contacted: School will be contacted
+          school_ready: School ready
       school_device_allocation:
         device_type:
           std_device: 'Standard device (laptop etc)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,9 @@ Rails.application.routes.draw do
       get '/performance', to: 'service_performance#index', as: :service_performance
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
+      resources :schools, only: [], param: :urn do
+        post '/invite', to: 'schools#invite'
+      end
     end
     resources :responsible_bodies, only: %i[], path: '/:pilot/responsible-bodies' do
       resources :users, only: %i[new create]

--- a/db/migrate/20200907224535_add_preorder_information_school_contacted_at.rb
+++ b/db/migrate/20200907224535_add_preorder_information_school_contacted_at.rb
@@ -1,0 +1,5 @@
+class AddPreorderInformationSchoolContactedAt < ActiveRecord::Migration[6.0]
+  def change
+    add_column :preorder_information, :school_contacted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_09_08_104822) do
     t.string "will_need_chromebooks"
     t.string "school_or_rb_domain"
     t.string "recovery_email_address"
+    t.datetime "school_contacted_at"
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/spec/features/support/devices/inviting_schools_spec.rb
+++ b/spec/features/support/devices/inviting_schools_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.feature 'Inviting schools from the support area', type: :feature do
+  let(:local_authority) { create(:local_authority, name: 'Coventry', in_devices_pilot: true) }
+  let(:responsible_bodies_page) { PageObjects::Support::Devices::ResponsibleBodiesPage.new }
+  let(:responsible_body_page) { PageObjects::Support::Devices::ResponsibleBodyPage.new }
+
+  scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
+    given_a_responsible_body
+    and_it_has_a_school_that_needs_to_be_contacted
+
+    when_i_sign_in_as_a_dfe_user
+    and_i_visit_the_responsible_body_page
+    then_i_can_invite_the_school
+
+    when_i_invite_the_school
+    then_the_school_is_contacted
+    and_i_can_no_longer_invite_the_school
+  end
+
+  def given_a_responsible_body
+    local_authority
+  end
+
+  def and_it_has_a_school_that_needs_to_be_contacted
+    school = create(:school, :with_preorder_information, :with_headteacher_contact,
+                    name: 'Alpha School',
+                    responsible_body: local_authority)
+    school.preorder_information.change_who_will_order_devices!(:school)
+    school.preorder_information.school_contact = school.headteacher_contact
+    school.preorder_information.save!
+
+    expect(school.preorder_information.school_will_be_contacted?).to be_truthy
+  end
+
+  def when_i_sign_in_as_a_dfe_user
+    sign_in_as create(:dfe_user)
+  end
+
+  def and_i_visit_the_responsible_body_page
+    responsible_bodies_page.load
+    click_on local_authority.name
+  end
+
+  def then_i_can_invite_the_school
+    expect(responsible_body_page.school_rows[0]).to have_button('Invite')
+  end
+
+  def when_i_invite_the_school
+    responsible_body_page.school_rows[0].click_on 'Invite'
+  end
+
+  def then_the_school_is_contacted
+    expect(page).to have_text('Alpha School has been invited successfully')
+    expect(responsible_body_page.school_rows[0]).to have_text('School contacted')
+  end
+
+  def and_i_can_no_longer_invite_the_school
+    expect(responsible_body_page.school_rows[0]).not_to have_button('Invite')
+  end
+end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe PreorderInformation, type: :model do
+  describe 'status' do
+    context 'when the school orders devices and the school contact is missing' do
+      subject do
+        build(:preorder_information,
+              who_will_order_devices: :school,
+              school_contact: nil,
+              school_contacted_at: nil).infer_status
+      end
+
+      it { is_expected.to eq('needs_contact') }
+    end
+
+    context "when the school orders devices, the school contact is present but hasn't been contacted yet" do
+      subject do
+        build(:preorder_information,
+              who_will_order_devices: :school,
+              school_contact: build(:school_contact),
+              school_contacted_at: nil).infer_status
+      end
+
+      it { is_expected.to eq('school_will_be_contacted') }
+    end
+
+    context "when the school orders devices, it's been contacted but hasn't logged in to input the Chromebook details" do
+      subject do
+        build(:preorder_information,
+              who_will_order_devices: :school,
+              school_contact: build(:school_contact),
+              school_contacted_at: Time.zone.now,
+              will_need_chromebooks: nil).infer_status
+      end
+
+      it { is_expected.to eq('school_contacted') }
+    end
+
+    context "when the school orders devices, it has logged in and doesn't plan to order Chromebooks" do
+      subject do
+        build(:preorder_information,
+              :does_not_need_chromebooks,
+              who_will_order_devices: :school,
+              school_contact: build(:school_contact),
+              school_contacted_at: Time.zone.now).infer_status
+      end
+
+      it { is_expected.to eq('ready') }
+    end
+
+    context 'when the school orders devices, it has logged in and plans to order Chromebooks' do
+      subject do
+        build(:preorder_information,
+              :needs_chromebooks,
+              who_will_order_devices: :school,
+              school_contact: build(:school_contact),
+              school_contacted_at: Time.zone.now).infer_status
+      end
+
+      it { is_expected.to eq('ready') }
+    end
+
+    context 'when the orders are placed centrally and the responsible body has not provided Chromebook details' do
+      subject do
+        build(:preorder_information,
+              who_will_order_devices: :responsible_body,
+              will_need_chromebooks: nil).infer_status
+      end
+
+      it { is_expected.to eq('needs_info') }
+    end
+
+    context "when the orders are placed centrally and the responsible body doesn't plan to order Chromebooks" do
+      subject do
+        build(:preorder_information,
+              :does_not_need_chromebooks,
+              who_will_order_devices: :responsible_body).infer_status
+      end
+
+      it { is_expected.to eq('ready') }
+    end
+
+    context 'when the orders are placed centrally and the school has logged in and plans to order Chromebooks' do
+      subject do
+        build(:preorder_information,
+              :needs_chromebooks,
+              who_will_order_devices: :responsible_body).infer_status
+      end
+
+      it { is_expected.to eq('ready') }
+    end
+  end
+end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe PreorderInformation, type: :model do
               school_contacted_at: Time.zone.now).infer_status
       end
 
-      it { is_expected.to eq('ready') }
+      it { is_expected.to eq('school_ready') }
     end
 
     context 'when the school orders devices, it has logged in and plans to order Chromebooks' do
@@ -57,7 +57,7 @@ RSpec.describe PreorderInformation, type: :model do
               school_contacted_at: Time.zone.now).infer_status
       end
 
-      it { is_expected.to eq('ready') }
+      it { is_expected.to eq('school_ready') }
     end
 
     context 'when the orders are placed centrally and the responsible body has not provided Chromebook details' do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe '#invite_school_contact_if_possible!' do
+  describe '#invite_school_contact' do
     context "when the school contact isn't a user on the system" do
       let(:school_contact) do
         create(:school_contact,
@@ -235,7 +235,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'creates a new user from the contact details' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .to change { User.count }.from(0).to(1)
 
         invited_user = User.last
@@ -247,7 +247,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'sends an invitation email to the school user' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .to(have_enqueued_job(ActionMailer::MailDeliveryJob)
           .once
           .with do |mailer_name, mailer_action, _, params|
@@ -258,7 +258,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'updates the status' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .to change { school.preorder_information.status }.from('school_will_be_contacted').to('school_contacted')
       end
     end
@@ -267,7 +267,7 @@ RSpec.describe School, type: :model do
       subject(:school) { build(:school, preorder_information: nil) }
 
       it 'does nothing' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .not_to change { User.count }.from(0)
       end
     end
@@ -279,7 +279,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'does nothing' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .not_to change { User.count }.from(0)
       end
     end
@@ -297,7 +297,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'does nothing' do
-        expect { school.invite_school_contact_if_possible! }
+        expect { school.invite_school_contact }
           .not_to change { User.count }.from(1)
       end
     end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -215,4 +215,91 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe '#invite_school_contact_if_possible!' do
+    context "when the school contact isn't a user on the system" do
+      let(:school_contact) do
+        create(:school_contact,
+               email_address: 'jsmith@school.sch.gov.uk',
+               full_name: 'Jane Smith',
+               school: school)
+      end
+
+      subject(:school) do
+        create(:school, preorder_information: create(:preorder_information,
+                                                     who_will_order_devices: :school))
+      end
+
+      before do
+        school.preorder_information.update(school_contact: school_contact)
+      end
+
+      it 'creates a new user from the contact details' do
+        expect { school.invite_school_contact_if_possible! }
+          .to change { User.count }.from(0).to(1)
+
+        invited_user = User.last
+        expect(invited_user.email_address).to eq('jsmith@school.sch.gov.uk')
+        expect(invited_user.full_name).to eq('Jane Smith')
+        expect(invited_user.orders_devices).to be_falsey
+        expect(invited_user.is_school_user?).to be_truthy
+        expect(invited_user.school).to eq(school)
+      end
+
+      it 'sends an invitation email to the school user' do
+        expect { school.invite_school_contact_if_possible! }
+          .to(have_enqueued_job(ActionMailer::MailDeliveryJob)
+          .once
+          .with do |mailer_name, mailer_action, _, params|
+            expect(mailer_name).to eq('InviteSchoolUserMailer')
+            expect(mailer_action).to eq('nominated_contact_email')
+            expect(params[:params][:user].email_address).to eq('jsmith@school.sch.gov.uk')
+          end)
+      end
+
+      it 'updates the status' do
+        expect { school.invite_school_contact_if_possible! }
+          .to change { school.preorder_information.status }.from('school_will_be_contacted').to('school_contacted')
+      end
+    end
+
+    context 'when the school has no preorder information' do
+      subject(:school) { build(:school, preorder_information: nil) }
+
+      it 'does nothing' do
+        expect { school.invite_school_contact_if_possible! }
+          .not_to change { User.count }.from(0)
+      end
+    end
+
+    context "when there isn't any contact specified yet" do
+      subject(:school) do
+        build(:school,
+              preorder_information: build(:preorder_information, school_contact: nil))
+      end
+
+      it 'does nothing' do
+        expect { school.invite_school_contact_if_possible! }
+          .not_to change { User.count }.from(0)
+      end
+    end
+
+    context 'when the school contact matches an existing user' do
+      let(:school_contact) { build(:school_contact, email_address: 'jsmith@school.sch.gov.uk') }
+
+      subject(:school) do
+        build(:school,
+              preorder_information: build(:preorder_information, school_contact: school_contact))
+      end
+
+      before do
+        create(:user, email_address: 'jsmith@school.sch.gov.uk')
+      end
+
+      it 'does nothing' do
+        expect { school.invite_school_contact_if_possible! }
+          .not_to change { User.count }.from(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
~**Includes #428, rebase once that PR is merged.**~ Done

### Context

We want to start bringing schools (who will be responsible for ordering devices) onto the service. We will initially do this via the support interface.

### Changes proposed in this pull request

Add an 'invite' button for schools that are ready to be contacted. This button:

- adds the school contact as a user into the system
- emails them an invite
- updates the school's status
- only does something if it's possible to add the user (e.g. the user isn't already on the system for whatever reason)

Additionally, this PR updates the school statuses for the RBs so they're correct as the school users go through the welcome wizard.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92535989-7300b680-f230-11ea-876e-c78635028e64.png)

![image](https://user-images.githubusercontent.com/23801/92536014-801da580-f230-11ea-987a-7b1bc6eb1c1a.png)

![image](https://user-images.githubusercontent.com/23801/92536029-8a3fa400-f230-11ea-9214-2e2b98f2ea9d.png)

