### PR TITLE
Update responsible body school details page

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -30,7 +30,9 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
       },
       {
         key: 'Can place orders?',
-        value: ['Not yet because there are no local coronavirus restrictions', govuk_link_to('Get devices early for specific circumstances', responsible_body_devices_request_devices_path)].join('<br>').html_safe,
+        value: 'Not yet because there are no local coronavirus&nbsp;restrictions'.html_safe,
+        action_path: responsible_body_devices_request_devices_path,
+        action: 'Request devices for specific circumstances',
       },
       {
         key: 'Type of school',
@@ -97,11 +99,11 @@ private
       if info.orders_managed_centrally?
         domain.merge!({
           change_path: change_path,
-          action: 'Domain',
+          action: 'domain',
         })
         recovery.merge!({
           change_path: change_path,
-          action: 'Recovery email',
+          action: 'recovery email',
         })
       end
       rows += [domain, recovery]

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -3,14 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
       <%= @school.name %>
     </h1>
-
-    <div class="govuk-!-margin-bottom-6 govuk-!-padding-top-0">
-      <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @school) %>
-    </div>
-
     <%- if @school.preorder_information.orders_managed_centrally? %>
       <%- unless @school.preorder_information.chromebook_information_complete? %>
       <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
@@ -18,12 +13,19 @@
       <%= render partial: 'shared/chromebook_information_form', locals: { url: responsible_body_devices_school_chromebooks_path(@school.urn), form_object: @chromebook_information_form } %>
       <%- end %>
     <%- end %>
-
-    <p class="govuk-body">
-      <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-      <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-        or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-      <% end %>
-    </p>
   </div>
 </div>
+
+<%- if @school.preorder_information.orders_managed_centrally? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4">School details</h2>
+<%- end %>
+<div class="govuk-!-padding-top-0 govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+  <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @school) %>
+</div>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
+  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
+    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
+  <% end %>
+</p>

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -3,23 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-8">
+    <h1 class="govuk-heading-xl">
       <%= @school.name %>
     </h1>
 
     <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-4">School details</h2>
-
-    <div class="govuk-inset-text govuk-!-padding-top-0">
-      <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @form.school) %>
-    </div>
-
-    <p class="govuk-body">
-      <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-      <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-        or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-      <% end %>
-    </p>
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">School details</h2>
   </div>
 </div>
+
+<div class="govuk-!-padding-top-0 govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+  <%= render ResponsibleBody::SchoolDetailsSummaryListComponent.new(school: @form.school) %>
+</div>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
+  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
+    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
+  <% end %>
+</p>

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -41,14 +41,14 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details without links to change it' do
-      expect(result.css('dd')[8].text).to include('Yes')
-      expect(result.css('dd')[9].text).to include('school.domain.org')
-      expect(result.css('dd')[10].text).to include('admin@recovery.org')
+      expect(result.css('dd')[9].text).to include('Yes')
+      expect(result.css('dd')[10].text).to include('school.domain.org')
+      expect(result.css('dd')[11].text).to include('admin@recovery.org')
     end
 
     context "when the school isn't under lockdown restrictions or has any shielding children" do
       it 'cannot place orders' do
-        expect(result.css('.govuk-summary-list__row')[3].text).to include('Not yet because there are no local coronavirus restrictions')
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('Not yet because there are no local coronavirus')
       end
     end
 
@@ -103,12 +103,12 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details with links to change it' do
-      expect(result.css('dd')[7].text).to include('Yes')
-      expect(result.css('dd')[8].text).to include('Change')
-      expect(result.css('dd')[9].text).to include('school.domain.org')
-      expect(result.css('dd')[10].text).to include('Change')
-      expect(result.css('dd')[11].text).to include('admin@recovery.org')
-      expect(result.css('dd')[12].text).to include('Change')
+      expect(result.css('dd')[8].text).to include('Yes')
+      expect(result.css('dd')[9].text).to include('Change')
+      expect(result.css('dd')[10].text).to include('school.domain.org')
+      expect(result.css('dd')[11].text).to include('Change')
+      expect(result.css('dd')[12].text).to include('admin@recovery.org')
+      expect(result.css('dd')[13].text).to include('Change')
     end
 
     it 'does not show the school contact even if the school contact is set' do


### PR DESCRIPTION
Bring inline with design by:

  - moving form questions to above the summary list
  - fixing spacing
  - making summary list full width
  - making "Request devices" link consistent with other rows

![Screen Shot 2020-09-09 at 08 00 00](https://user-images.githubusercontent.com/319055/92565449-8f254780-f272-11ea-9c83-69957d55b305.png)
![localhost_3000_responsible-body_devices_schools_146279_who-to-contact](https://user-images.githubusercontent.com/319055/92565473-99474600-f272-11ea-99ba-505bfc00d8e8.png)
