### PR TITLE
Show no allocation guidance when 0 devices allocated

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -31,6 +31,10 @@ class School < ApplicationRecord
     device_allocations.find_by_device_type!(device_type)
   end
 
+  def has_std_device_allocation?
+    std_device_allocation&.allocation.to_i.positive?
+  end
+
   def type_label
     if special_establishment_type?
       'Special school'

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -6,6 +6,11 @@
     <h1 class="govuk-heading-xl">
       <%= @school.name %>
     </h1>
+
+    <%- unless @school.has_std_device_allocation? %>
+      <%= render partial: 'shared/school_without_allocation' %>
+    <%- end %>
+
     <%- if @school.preorder_information.orders_managed_centrally? %>
       <%- unless @school.preorder_information.chromebook_information_complete? %>
       <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
@@ -16,7 +21,7 @@
   </div>
 </div>
 
-<%- if @school.preorder_information.orders_managed_centrally? %>
+<%- if @school.preorder_information.orders_managed_centrally? || !@school.has_std_device_allocation? %>
   <h2 class="govuk-heading-l govuk-!-margin-top-4">School details</h2>
 <%- end %>
 <div class="govuk-!-padding-top-0 govuk-!-margin-top-0 govuk-!-margin-bottom-6">

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -7,7 +7,13 @@
       <%= @school.name %>
     </h1>
 
-    <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
+    <%- unless @school.has_std_device_allocation? %>
+      <%= render partial: 'shared/school_without_allocation' %>
+    <%- end %>
+
+    <div class="govuk-!-margin-top-8">
+      <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
+    </div>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-6">School details</h2>
   </div>

--- a/app/views/shared/_school_without_allocation.html.erb
+++ b/app/views/shared/_school_without_allocation.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-l">This school has no allocation</h2>
+
+<p class="govuk-body">They can still <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>.</p>
+
+<p class="govuk-body">Reasons for a 0 allocation include:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>the school has no children in the eligible year groups, years 3 to 11</li>
+  <li>there are very few children on free school meals according to the most recent census data</li>
+  <li>there was not enough data to calculate an allocation – for example it’s a new school</li>
+</ul>
+
+<%- if @school.preorder_information.needs_contact? || (@school.preorder_information.orders_managed_centrally? && !@school.preorder_information.chromebook_information_complete?) %>
+  <h3 class="govuk-heading-m">We still need some information</h3>
+
+  <p class="govuk-body">If the school will request and order their own devices, we need to know who to contact.</p>
+  <p class="govuk-body">If you are managing their requests centrally, we need to know if they will want Google Chromebooks.</p>
+<%- end %>
+
+<h3 class="govuk-heading-m">Tell us if this school needs an allocation</h3>
+
+<p class="govuk-body">Send details to <%= ghwt_contact_mailto(subject: 'A school needs an allocation') %></p>

--- a/app/views/shared/_school_without_allocation.html.erb
+++ b/app/views/shared/_school_without_allocation.html.erb
@@ -18,4 +18,4 @@
 
 <h3 class="govuk-heading-m">Tell us if this school needs an allocation</h3>
 
-<p class="govuk-body">Send details to <%= ghwt_contact_mailto(subject: 'A school needs an allocation') %></p>
+<p class="govuk-body">Send details to <%= ghwt_contact_mailto(subject: "A school (#{@school.name} #{@school.urn}) needs an allocation") %></p>

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -128,6 +128,27 @@ RSpec.feature 'Setting up the devices ordering' do
       and_the_status_reflects_that_the_school_will_be_contacted_shortly
     end
 
+    scenario 'when the school has no standard device allocation' do
+      given_there_is_a_school_with_no_standard_device_allocation
+      when_i_follow_the_get_devices_link
+      and_i_continue_through_the_guidance
+      and_i_choose_ordering_through_schools_which_is_recommended
+      and_i_continue_after_choosing_ordering_through_schools
+      when_i_click_on_the_name_of_a_school_which_has_no_standard_device_allocation
+      then_i_see_guidance_about_why_there_is_no_allocation
+      and_in_the_allocation_guidance_we_ask_for_information
+      when_i_select_to_contact_someone_else_and_save_their_details
+      then_i_see_the_allocation_guidance_without_the_we_need_information_section
+
+      when_i_follow_the_change_who_will_order_link
+      when_i_select_orders_will_be_placed_centrally
+      then_i_see_guidance_about_why_there_is_no_allocation
+      and_in_the_allocation_guidance_we_ask_for_information
+
+      when_i_choose_no_they_will_not_need_chromebooks
+      then_i_see_the_allocation_guidance_without_the_we_need_information_section
+    end
+
     scenario 'learning about requesting devices for specific circumstances' do
       # the page is only visible when the responsible body has completed the 'who will order' wizard
       responsible_body.update!(who_will_order_devices: :responsible_body)
@@ -385,5 +406,31 @@ RSpec.feature 'Setting up the devices ordering' do
   def when_i_select_orders_will_be_placed_centrally
     choose('Orders will be placed centrally')
     click_on 'Continue'
+  end
+
+  def given_there_is_a_school_with_no_standard_device_allocation
+    expect(@zebra_school.has_std_device_allocation?).to be false
+  end
+
+  def when_i_click_on_the_name_of_a_school_which_has_no_standard_device_allocation
+    click_on @zebra_school.name
+  end
+
+  def then_i_see_guidance_about_why_there_is_no_allocation
+    expect(responsible_body_school_page).to have_content('This school has no allocation')
+  end
+
+  def and_in_the_allocation_guidance_we_ask_for_information
+    expect(responsible_body_school_page).to have_content('We still need some information')
+  end
+
+  def then_i_see_the_allocation_guidance_without_the_we_need_information_section
+    expect(responsible_body_school_page).to have_content('This school has no allocation')
+    expect(responsible_body_school_page).not_to have_content('We still need some information')
+  end
+
+  def when_i_choose_no_they_will_not_need_chromebooks
+    choose 'No, they will not need Chromebooks'
+    click_on 'Save'
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -167,6 +167,46 @@ RSpec.describe School, type: :model do
     end
   end
 
+  describe '#has_std_device_allocation?' do
+    let(:school) { create(:school) }
+
+    context 'when there is no standard device allocation' do
+      it 'is false' do
+        expect(school.has_std_device_allocation?).to eq(false)
+      end
+    end
+
+    context 'when there is a standard device allocation of the given type but the value is 0' do
+      before do
+        school.device_allocations << build(:school_device_allocation, device_type: 'std_device', allocation: 0)
+      end
+
+      it 'is false' do
+        expect(school.has_std_device_allocation?).to eq(false)
+      end
+    end
+
+    context 'when there is a standard device allocation' do
+      before do
+        school.device_allocations << build(:school_device_allocation, device_type: 'std_device', allocation: 1)
+      end
+
+      it 'is true' do
+        expect(school.has_std_device_allocation?).to eq(true)
+      end
+    end
+
+    context 'when there is a comms device allocation' do
+      before do
+        school.device_allocations << build(:school_device_allocation, device_type: 'coms_device', allocation: 1)
+      end
+
+      it 'is false' do
+        expect(school.has_std_device_allocation?).to eq(false)
+      end
+    end
+  end
+
   describe '#can_order_devices?' do
     let(:school) { create(:school) }
 


### PR DESCRIPTION
Add guidance to match designs in https://increasing-access-history.herokuapp.com/schools-with-no-allocation/

![localhost_3000_responsible-body_devices_schools_140214](https://user-images.githubusercontent.com/319055/92591526-f30d3780-f295-11ea-830f-3829cc260b8c.png)
