### PR TITLE
[594] Callback to sync Computacenter::UserChange

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,3 +133,6 @@ Style/HashTransformValues:
 Rake/Desc:
   Exclude:
     - 'lib/tasks/reset_qa.rake'
+
+RSpec/NestedGroups:
+  Max: 5

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -1,5 +1,11 @@
-class Computacenter::UserChange < ApplicationRecord
-  self.table_name = 'computacenter_user_changes'
+module Computacenter
+  class UserChange < ApplicationRecord
+    self.table_name = 'computacenter_user_changes'
 
-  enum type_of_update: { New: 0, Change: 1, Remove: 2 }
+    enum type_of_update: { New: 0, Change: 1, Remove: 2 }
+
+    def self.read_from_version(version)
+      UserChangeGenerator.new(version).call
+    end
+  end
 end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -1,0 +1,162 @@
+class Computacenter::UserChangeGenerator
+  attr_reader :version
+
+  def initialize(version)
+    @version = version
+  end
+
+  def call
+    return if version.nil?
+
+    case type_of_update
+    when 'New'
+      return unless after_user.seen_privacy_notice? && after_user.orders_devices?
+    when 'Change'
+      return unless after_user.seen_privacy_notice? && after_user.orders_devices?
+    when 'Remove'
+      return unless before_user.seen_privacy_notice? && before_user.orders_devices?
+    end
+
+    return if (version.changeset.keys & fields_to_monitor).empty?
+
+    Computacenter::UserChange.create!(user_change_attributes.merge(original_csv_fields))
+  end
+
+private
+
+  def user_change_attributes
+    {
+      user_id: version.item_id,
+      first_name: after_user.first_name,
+      last_name: after_user.last_name,
+      email_address: after_user.email_address,
+      telephone: after_user.telephone,
+      responsible_body: after_user.effective_responsible_body&.name,
+      responsible_body_urn: after_user.effective_responsible_body&.computacenter_identifier,
+      cc_sold_to_number: after_user.effective_responsible_body&.computacenter_reference,
+      school: after_user.school&.name,
+      school_urn: after_user.school&.urn,
+      cc_ship_to_number: after_user.school&.computacenter_reference,
+      updated_at_timestamp: version.created_at,
+      type_of_update: type_of_update,
+    }
+  end
+
+  def fields_to_diff
+    %w[
+      full_name
+      telephone
+      email_address
+      responsible_body_id
+      school_id
+    ]
+  end
+
+  def fields_to_monitor
+    %w[
+      full_name
+      telephone
+      email_address
+      responsible_body_id
+      school_id
+    ]
+  end
+
+  def original_attributes
+    case type_of_update
+    when 'New'
+      {}
+    when 'Change', 'Remove'
+      original = version.changeset.transform_values(&:first).to_h
+      original_filtered = original.filter { |k, _| fields_to_diff.include?(k) }.select { |_k, v| v }
+      original_filtered
+    end
+  end
+
+  def original_csv_fields
+    hash = original_attributes
+
+    expand_full_name_changes(hash)
+    expand_responsible_body_changes(hash)
+    expand_school_changes(hash)
+
+    hash.transform_keys! { |k| "original_#{k}" }
+
+    hash
+  end
+
+  def expand_full_name_changes(hash)
+    if hash.key?('full_name')
+      hash['first_name'] = before_user.first_name
+      hash['last_name'] = before_user.last_name
+
+      hash.delete('full_name')
+    end
+  end
+
+  def expand_responsible_body_changes(hash)
+    if hash.key?('responsible_body_id')
+      responsible_body = ResponsibleBody.find(hash['responsible_body_id'])
+
+      if responsible_body
+        hash['responsible_body'] = responsible_body.name
+        hash['responsible_body_urn'] = responsible_body.computacenter_identifier
+        hash['cc_sold_to_number'] = responsible_body.computacenter_reference
+      end
+
+      hash.delete('responsible_body_id')
+    end
+  end
+
+  def expand_school_changes(hash)
+    if hash.key?('school_id')
+      school = School.find(hash['school_id'])
+
+      if school
+        hash['school'] = school.name
+        hash['school_urn'] = school.urn
+        hash['cc_ship_to_number'] = school.computacenter_reference
+      end
+
+      hash.delete('school_id')
+    end
+  end
+
+  def before_user
+    @before_user ||= case version.event
+                     when 'create'
+                       User.new
+                     when 'update'
+                       User.new(version.object_deserialized)
+                     when 'destroy'
+                       User.new(version.object_deserialized)
+                     end
+  end
+
+  def after_user
+    @after_user ||= User.new(after_user_attributes)
+  end
+
+  def after_user_attributes
+    case version.event
+    when 'create'
+      version.changeset.transform_values(&:last)
+    when 'update'
+      version.object_deserialized.merge(version.changeset.transform_values(&:last))
+    when 'destroy'
+      {}
+    end
+  end
+
+  def type_of_update
+    if Computacenter::UserChange.where(user_id: (before_user.id || after_user.id)).exists?
+      if version.event == 'destroy'
+        'Remove'
+      else
+        'Change'
+      end
+    else
+      'New'
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,14 @@ class User < ApplicationRecord
 
   include SignInWithToken
 
+  after_save do |user|
+    Computacenter::UserChange.read_from_version(user.versions.last)
+  end
+
+  after_destroy do |user|
+    Computacenter::UserChange.read_from_version(user.versions.last)
+  end
+
   def is_mno_user?
     mobile_network.present?
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
       privacy_notice_seen_at { 3.days.ago }
     end
 
+    trait :has_not_seen_privacy_notice do
+      privacy_notice_seen_at { nil }
+    end
+
     trait :approved do
       approved_at { Time.zone.now.utc - 3.days }
     end
@@ -88,6 +92,16 @@ FactoryBot.define do
       email_address do
         full_name.downcase.gsub(' ', '.') + '@computacenter.com'
       end
+    end
+
+    trait :relevant_to_computacenter do
+      has_seen_privacy_notice
+      orders_devices { true }
+    end
+
+    trait :not_relevant_to_computacenter do
+      has_not_seen_privacy_notice
+      orders_devices { false }
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-spike-can-we-generate-the-cc-user-changes-feed-using-papertrail
- This change updates the Computacenter::UserChange table as users are added/updated/deleted in our system to keep Computacenter in sync

### Changes proposed in this pull request

- On creating, updating or destroy a user, write to Computacenter::UserChange table
- Only changes to certain fields will write to Computacenter::UserChange table
- User must pass a certain criteria otherwise does not write to Computacenter::UserChange table
- From Computacenter view a user is considered New if they have not seen the user before
- Association changes are attempted to be read to add to the Computercenter::UserChange table, if not found they will not be added

### Guidance to review

#### Backfilling script

- If a user has been backfilled any changes should append to the ledger
- If a user is already in the ledger and the backfill script is ran it should not cause a duplicate entry

#### Backfilling existing paper_trail versions into ComputaCenter::UserChange

- We can backfill from an existing paper_trail version
- `UserChangeForVersion.new(PaperTrail::Version.first).call` or any other version
- This should a `ComputaCenter::UserChange` if they meet the criteria. Most likely as a `New` or `Change`

#### Expected behaviour once deployed

- A user created that is Computacenter concerned will create a `Computacenter::UserChange` record of type `New`
- A user created that is not Computacenter concerned will not create a `Computacenter::UserChange` record
- A user updated that is Computacenter concerned will create a `Computacenter::UserChange` record of type `Change`
- A user updated that is not Computacenter concerned will not create a `Computacenter::UserChange` record
- A user deleted that is Computacenter concerned will create a `Computacenter::UserChange` record of type `Remove`
- A user delete that is not Computacenter concerned will not create a `Computacenter::UserChange` record
- On each new `Computacenter::UserChange` record, fields should be filled in correctly
- A `Computacenter::UserChange` is only created when certain fields are updated which are relevant to Computacenter

