### PR TITLE
stop Google indexing content

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', defer: true %>
+    <meta name="robots" content="noindex" />
   </head>
 
   <body class="govuk-template__body ">


### PR DESCRIPTION
### Context

[Trello card 633](https://trello.com/c/PSJxsRIX/633-hide-the-service-content-from-google)

### Changes proposed in this pull request

Add a `noindex` meta tag, as described on [Google webmasters question 93710](https://support.google.com/webmasters/answer/93710)

### Guidance to review

