### PR TITLE
Fix page title on Get internet access page

### DIFF
--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('service_name') %>
+      <%= t('page_titles.internet_access') %>
     </h1>
 
     <p class="govuk-body">Internet access supports remote education, as well as virtual contact between children, their social workers and other services.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@
     guide_to_collecting_mobile_information: Guide to collecting mobile information
     guide_for_distributing_bt_vouchers: A guide for distributing vouchers to families
     start: Get help with technology
+    internet_access: Get internet access
     who_needs_the_data: Who needs the extra mobile data?
     report_a_problem: Report a problem
     devices_guidance_index: "Get help with technology: devices"


### PR DESCRIPTION
Page title should be "Get internet access" rather than "Get help with technology"

