### PR TITLE
Invited school contacts should be TechSource users by default

### DIFF
--- a/app/models/school_contact.rb
+++ b/app/models/school_contact.rb
@@ -20,7 +20,7 @@ class SchoolContact < ApplicationRecord
       full_name: full_name,
       email_address: email_address,
       telephone: phone_number,
-      orders_devices: false, # TODO: is this right?
+      orders_devices: true,
     )
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe School, type: :model do
         invited_user = User.last
         expect(invited_user.email_address).to eq('jsmith@school.sch.gov.uk')
         expect(invited_user.full_name).to eq('Jane Smith')
-        expect(invited_user.orders_devices).to be_falsey
+        expect(invited_user.orders_devices).to be_truthy
         expect(invited_user.is_school_user?).to be_truthy
         expect(invited_user.school).to eq(school)
       end


### PR DESCRIPTION
### Context

This was incorrectly done in #429. There's a follow-up change to remove the techsource question from the school welcome wizard, but that's not in scope of this PR.

### Changes proposed in this pull request

Change the default "orders_devices" setting for invited school users to 'true'.

