### PR TITLE
586 add validation for chromebook settings

### DIFF
--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -16,8 +16,6 @@ class ChromebookInformationForm
     condition.validate :recovery_email_address_cannot_be_same_domain_as_school_or_rb
   end
 
-  # validate  :recovery_email_address_cannot_be_same_domain_as_school_or_rb, if: :will_need_chromebooks?
-
   def will_need_chromebooks?
     will_need_chromebooks == 'yes'
   end

--- a/app/services/gsuite.rb
+++ b/app/services/gsuite.rb
@@ -24,7 +24,7 @@ module Gsuite
     if response.status.success?
       body = response.body.to_s
       logger.debug body if logger
-      body =~ /Sign in - Google Accounts/
+      !(body =~ /Sign in - Google Accounts/).nil?
     elsif response.status.redirect?
       # the redirects all seem to be to SAML providers for logins
       logger.debug response.body.to_s if logger

--- a/app/services/gsuite.rb
+++ b/app/services/gsuite.rb
@@ -3,11 +3,13 @@ require 'http'
 module Gsuite
   class DomainLookupError < StandardError; end
 
-  def self.is_gsuite_domain?(domain)
+  def self.is_gsuite_domain?(domain, logger = nil)
     response = HTTP.get("https://dns.google.com/resolve?name=#{domain}&type=MX")
     if response.status.success?
       payload = JSON.parse(response.body)
-      payload['Answer']&.any? { |h| h['data'] =~ /\.google\.com/i }
+      logger.debug(payload) if logger
+
+      payload['Answer']&.any? { |h| h['data'] =~ /\.google(mail)?\.com/i }
     else
       raise Gsuite::DomainLookupError "Domain lookup failed: #{response.status}"
     end

--- a/app/services/gsuite.rb
+++ b/app/services/gsuite.rb
@@ -1,0 +1,15 @@
+require 'http'
+
+module Gsuite
+  class DomainLookupError < StandardError; end
+
+  def self.is_gsuite_domain?(domain)
+    response = HTTP.get("https://dns.google.com/resolve?name=#{domain}&type=MX")
+    if response.status.success?
+      payload = JSON.parse(response.body)
+      payload['Answer']&.any? { |h| h['data'] =~ /\.google\.com/i }
+    else
+      raise Gsuite::DomainLookupError "Domain lookup failed: #{response.status}"
+    end
+  end
+end

--- a/app/services/gsuite.rb
+++ b/app/services/gsuite.rb
@@ -4,6 +4,10 @@ module Gsuite
   class DomainLookupError < StandardError; end
 
   def self.is_gsuite_domain?(domain, logger = nil)
+    has_service_login?(domain, logger)
+  end
+
+  def self.has_google_mx_record?(domain, logger = nil)
     response = HTTP.get("https://dns.google.com/resolve?name=#{domain}&type=MX")
     if response.status.success?
       payload = JSON.parse(response.body)
@@ -11,19 +15,20 @@ module Gsuite
 
       payload['Answer']&.any? { |h| h['data'] =~ /\.google(mail)?\.com/i }
     else
-      raise Gsuite::DomainLookupError.new("Domain lookup failed: #{response.status}")
+      raise DomainLookupError, "Domain lookup failed: #{response.status}"
     end
   end
 
   def self.has_service_login?(domain, logger = nil)
     response = HTTP.get("https://www.google.com/a/#{domain}/ServiceLogin")
     if response.status.success?
-      if response.body.to_s =~ /Sign in - Google Accounts/
+      body = response.body.to_s
+      logger.debug body if logger
+      if body =~ /Sign in - Google Accounts/
         true
-      elsif response.body.to_s =~ /Sorry, you've reached a login page for a domain that isn't using G Suite/
+      elsif body =~ /Sorry, you've reached a login page for a domain that isn't using G Suite/
         false
       else
-        logger.debug response.body.to_s if logger
         false
       end
     elsif response.status.redirect?
@@ -31,7 +36,7 @@ module Gsuite
       logger.debug response.body.to_s if logger
       true
     else
-      raise Gsuite::DomainLookupError.new("Service lookup failed: #{response.status}")
+      raise DomainLookupError, "Service lookup failed: #{response.status}"
     end
   end
 end

--- a/app/services/gsuite.rb
+++ b/app/services/gsuite.rb
@@ -24,13 +24,7 @@ module Gsuite
     if response.status.success?
       body = response.body.to_s
       logger.debug body if logger
-      if body =~ /Sign in - Google Accounts/
-        true
-      elsif body =~ /Sorry, you've reached a login page for a domain that isn't using G Suite/
-        false
-      else
-        false
-      end
+      body =~ /Sign in - Google Accounts/
     elsif response.status.redirect?
       # the redirects all seem to be to SAML providers for logins
       logger.debug response.body.to_s if logger

--- a/app/validators/gsuite_domain_validator.rb
+++ b/app/validators/gsuite_domain_validator.rb
@@ -1,0 +1,7 @@
+class GsuiteDomainValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.blank? || !Gsuite.is_gsuite_domain?(value)
+      record.errors[attribute] << (options[:message] || 'is not a valid G Suite domain')
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,6 +310,7 @@
             school_or_rb_domain:
               blank: Enter a domain in the right format, like myschool.org.uk
               invalid: Enter a domain in the right format, like myschool.org.uk
+              invalid_domain: Enter a domain registered for G Suite for Education
             recovery_email_address:
               blank: Enter an email address in the correct format, like name@example.com
               invalid: Enter an email address in the correct format, like name@example.com
@@ -427,6 +428,10 @@
               invalid: The URN must be 6 digits
             name:
               blank: Enter the name of the establishment
+        preorder_information:
+          attributes:
+            school_or_rb_domain:
+              invalid_domain: 'Enter a GSuite domain'
   time:
     formats:
       time_only: "%l:%M%P"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,10 +428,6 @@
               invalid: The URN must be 6 digits
             name:
               blank: Enter the name of the establishment
-        preorder_information:
-          attributes:
-            school_or_rb_domain:
-              invalid_domain: 'Enter a GSuite domain'
   time:
     formats:
       time_only: "%l:%M%P"

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Setting up the devices ordering' do
   let!(:school) { create(:school, :la_maintained, :with_preorder_information, responsible_body: responsible_body) }
 
   before do
+    allow(Gsuite).to receive(:is_gsuite_domain?).and_return(true)
     school.preorder_information.update!(who_will_order_devices: 'responsible_body', status: 'needs_info')
     sign_in_as rb_user
     visit responsible_body_devices_schools_path

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Change school Chromebook information' do
 
     context 'when I visit the school details and click on the Chromebook information "Change" link' do
       before do
+        allow(Gsuite).to receive(:is_gsuite_domain?).and_return(true)
         click_on 'Check your school details'
         first('a', text: 'Change').click
       end

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Navigate school welcome wizard' do
   let(:school) { create(:school, :with_preorder_information, :with_std_device_allocation) }
 
+  before do
+    allow(Gsuite).to receive(:is_gsuite_domain?).and_return(true)
+  end
+
   scenario 'step through the wizard as the first user for a school' do
     as_a_new_school_user
     when_i_sign_in_for_the_first_time

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
 
       before do
         wizard.chromebooks!
+        allow(Gsuite).to receive(:is_gsuite_domain?).and_return(true)
       end
 
       it 'updates the preorder_information with the form details' do


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/r20L12bz/586-add-validation-for-chromebook-settings)

### Changes proposed in this pull request
Added G Suite domain validator
Added validations for Chromebook details in the`ChromebookInformationForm` model.
Validate `:school_or_rb_domain` with G Suite domain validator
Use EmailAddressValidator for `:recovery_email_address`
Added method to check for a service login which catches all of the domains that the MX check does and more. I've switched to using this for the validator.

### Guidance to review
The domain and email address validations are triggered when `:will_need_chromebooks` is set to 'yes'.
The domain must now be a valid G Suite domain.

Domains can be checked from the rails console with `Gsuite.is_gsuite_domain?('some-domain.com')` which returns `true` or `false` - this uses the service login check.

You can check if a domain has a google MX DNS record with `Gsuite.has_google_mx_record?('some-domain.com')`
You can check if a domain has a service login with `Gsuite.has_service_login?('some-domain.com')`