### PR TITLE
MNO requests should always have a responsible body

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -3,7 +3,7 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network
-  belongs_to :responsible_body, optional: true
+  belongs_to :responsible_body
 
   validates :status, presence: true
   validates :account_holder_name, presence: true

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -1,7 +1,8 @@
 class FakeDataService
-  def self.generate!(extra_mobile_data_requests: 10, mobile_network_id:, created_by_user_id: nil)
+  def self.generate!(extra_mobile_data_requests: 10, mobile_network_id:, responsible_body_id:, created_by_user_id: nil)
     extra_mobile_data_requests.times do
       name = Faker::Name.name
+      responsible_body = ResponsibleBody.find(responsible_body_id)
       r = ExtraMobileDataRequest.create!(
         device_phone_number: Faker::PhoneNumber.cell_phone,
         account_holder_name: name,
@@ -9,7 +10,8 @@ class FakeDataService
         mobile_network_id: mobile_network_id,
         contract_type: ExtraMobileDataRequest.contract_types.values.sample,
         status: ExtraMobileDataRequest.statuses.values.sample,
-        created_by_user_id: created_by_user_id,
+        responsible_body: responsible_body,
+        created_by_user_id: created_by_user_id || responsible_body.users.sample&.id,
       )
       r.update!(created_at: Time.zone.now.utc - rand(500_000).seconds)
       r.update!(problem: ExtraMobileDataRequest.problems.values.sample) if r.queried?

--- a/db/migrate/20200816154413_make_extra_mobile_data_requests_responsible_body_not_null.rb
+++ b/db/migrate/20200816154413_make_extra_mobile_data_requests_responsible_body_not_null.rb
@@ -1,0 +1,12 @@
+class MakeExtraMobileDataRequestsResponsibleBodyNotNull < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :extra_mobile_data_requests, :responsible_body_id, :integer, null: false
+      end
+      dir.down do
+        change_column :extra_mobile_data_requests, :responsible_body_id, :integer, null: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_09_09_080651) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
-    t.bigint "responsible_body_id"
+    t.bigint "responsible_body_id", null: false
     t.string "contract_type"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"

--- a/spec/factories/extra_mobile_data_requests.rb
+++ b/spec/factories/extra_mobile_data_requests.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     status                            { :requested }
     problem                           { nil }
     contract_type                     { :pay_as_you_go_payg }
+    responsible_body                  { created_by_user&.responsible_body }
     association :mobile_network
     association :created_by_user, factory: :local_authority_user
 

--- a/spec/services/fake_data_service_spec.rb
+++ b/spec/services/fake_data_service_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe FakeDataService, type: :model do
   let(:mobile_network) { create(:mobile_network) }
+  let(:responsible_body) { create(:local_authority) }
 
-  let(:fake_data_call) { FakeDataService.generate!(extra_mobile_data_requests: 3, mobile_network_id: mobile_network.id) }
+  let(:fake_data_call) { FakeDataService.generate!(extra_mobile_data_requests: 3, mobile_network_id: mobile_network.id, responsible_body_id: responsible_body.id) }
 
   it 'creates the requested number of extra mobile data requests' do
     expect { fake_data_call }.to change { ExtraMobileDataRequest.count }.from(0).to(3)


### PR DESCRIPTION
### Context

Had this branch knocking about for some time and wanted to get it in.

### Changes proposed in this pull request

Enforce the existence of a responsible body on MNO requests at the DB level, for data consistency.

### Guidance to review

I've checked and there are no MNO requests without an RB on any of our environments, so no data migration is needed.