### PR TITLE
make Computacenter::Ledger read from UserChanges rather than Users

### DIFF
--- a/app/controllers/computacenter/user_ledger_controller.rb
+++ b/app/controllers/computacenter/user_ledger_controller.rb
@@ -1,8 +1,7 @@
 class Computacenter::UserLedgerController < Computacenter::BaseController
   def index
-    @users = User.who_can_order_devices
-                .who_have_seen_privacy_notice
-    @ledger = Computacenter::Ledger.new(users: @users)
+    @user_changes = Computacenter::UserChange.all.order(:updated_at_timestamp)
+    @ledger = Computacenter::Ledger.new(user_changes: @user_changes)
 
     respond_to do |format|
       format.csv do

--- a/app/models/computacenter/ledger.rb
+++ b/app/models/computacenter/ledger.rb
@@ -2,8 +2,10 @@ require 'csv'
 
 module Computacenter
   class Ledger
-    def initialize(users: nil)
-      @users = users
+    attr_accessor :user_changes
+
+    def initialize(user_changes: nil)
+      @user_changes = user_changes || default_user_changes
     end
 
     def to_csv
@@ -11,32 +13,7 @@ module Computacenter
         csv << self.class.headers
 
         user_changes.each do |user_change|
-          csv << [
-            user_change.first_name,
-            user_change.last_name,
-            user_change.email_address,
-            user_change.telephone,
-            user_change.responsible_body,
-            user_change.responsible_body_urn,
-            user_change.cc_sold_to_number,
-            user_change.school,
-            user_change.school_urn,
-            user_change.cc_ship_to_number,
-            user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
-            user_change.updated_at_timestamp.utc.strftime('%R'),
-            user_change.updated_at_timestamp.utc.iso8601,
-            user_change.type_of_update,
-            user_change.original_first_name,
-            user_change.original_last_name,
-            user_change.original_email_address,
-            user_change.original_telephone,
-            user_change.original_responsible_body,
-            user_change.original_responsible_body_urn,
-            user_change.original_cc_sold_to_number,
-            user_change.original_school,
-            user_change.original_school_urn,
-            user_change.original_cc_ship_to_number,
-          ]
+          csv << csv_row(user_change)
         end
       end
     end
@@ -72,38 +49,37 @@ module Computacenter
 
   private
 
-    def users
-      @users ||= User.who_can_order_devices.where('privacy_notice_seen_at IS NOT NULL').limit(1)
+    def default_user_changes
+      @user_changes ||= UserChange.all.order(:updated_at_timestamp)
     end
 
-    def user_changes
-      users.map do |user|
-        UserChange.new(
-          user_id: user.id,
-          first_name: user.first_name,
-          last_name: user.last_name,
-          email_address: user.email_address,
-          telephone: user.telephone,
-          responsible_body: user.effective_responsible_body.name,
-          responsible_body_urn: user.effective_responsible_body.computacenter_identifier,
-          cc_sold_to_number: user.effective_responsible_body.computacenter_reference,
-          school: user.school&.name,
-          school_urn: user.school&.urn,
-          cc_ship_to_number: user.school&.computacenter_reference,
-          updated_at_timestamp: user.created_at,
-          type_of_update: 'New',
-          original_first_name: nil,
-          original_last_name: nil,
-          original_email_address: nil,
-          original_telephone: nil,
-          original_responsible_body: nil,
-          original_responsible_body_urn: nil,
-          original_cc_sold_to_number: nil,
-          original_school: nil,
-          original_school_urn: nil,
-          original_cc_ship_to_number: nil,
-        )
-      end
+    def csv_row(user_change)
+      [
+        user_change.first_name,
+        user_change.last_name,
+        user_change.email_address,
+        user_change.telephone,
+        user_change.responsible_body,
+        user_change.responsible_body_urn,
+        user_change.cc_sold_to_number,
+        user_change.school,
+        user_change.school_urn,
+        user_change.cc_ship_to_number,
+        user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+        user_change.updated_at_timestamp.utc.strftime('%R'),
+        user_change.updated_at_timestamp.utc.iso8601,
+        user_change.type_of_update,
+        user_change.original_first_name,
+        user_change.original_last_name,
+        user_change.original_email_address,
+        user_change.original_telephone,
+        user_change.original_responsible_body,
+        user_change.original_responsible_body_urn,
+        user_change.original_cc_sold_to_number,
+        user_change.original_school,
+        user_change.original_school_urn,
+        user_change.original_cc_ship_to_number,
+      ]
     end
   end
 end

--- a/spec/factories/user_changes.rb
+++ b/spec/factories/user_changes.rb
@@ -1,0 +1,69 @@
+FactoryBot.define do
+  factory :user_change, class: 'Computacenter::UserChange' do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email_address { Faker::Internet.unique.email }
+    telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
+    responsible_body { [Faker::Address.county, LocalAuthority.organisation_types.values.sample].join(' ') }
+    responsible_body_urn { "LEA#{Faker::Number.number(digits: 3)}" }
+    cc_sold_to_number { Faker::Number.number(digits: 8) }
+    school { Faker::Educator.secondary_school }
+    school_urn { Faker::Number.number(digits: 6) }
+    cc_ship_to_number { Faker::Number.number(digits: 8) }
+    updated_at_timestamp { Time.zone.now.utc }
+    type_of_update { 'Change' }
+    # these fields may or may not be populated depending on the change
+    original_first_name { nil }
+    original_last_name { nil }
+    original_email_address { nil }
+    original_telephone { nil }
+    original_responsible_body { nil }
+    original_responsible_body_urn { nil }
+    original_cc_sold_to_number { nil }
+    original_school { nil }
+    original_school_urn { nil }
+    original_cc_ship_to_number { nil }
+
+    trait :new_local_authority_user do
+      responsible_body { [Faker::Address.county, LocalAuthority.organisation_types.values.sample].join(' ') }
+      responsible_body_urn { "LEA#{Faker::Number.number(digits: 3)}" }
+      cc_sold_to_number { Faker::Number.number(digits: 8) }
+      school { nil }
+      school_urn { nil }
+      cc_ship_to_number { nil }
+      updated_at_timestamp { Time.zone.now.utc }
+      type_of_update { 'New' }
+    end
+
+    trait :school_user do
+      school { Faker::Educator.secondary_school }
+      school_urn { Faker::Number.number(digits: 6) }
+      cc_ship_to_number { Faker::Number.number(digits: 8) }
+      responsible_body { [Faker::Address.county, LocalAuthority.organisation_types.values.sample].join(' ') }
+      responsible_body_urn { "LEA#{Faker::Number.number(digits: 3)}" }
+      cc_sold_to_number { Faker::Number.number(digits: 8) }
+    end
+
+    trait :school_unchanged do
+      original_school { nil }
+      original_school_urn { nil }
+      original_cc_ship_to_number { nil }
+    end
+
+    trait :school_changed do
+      original_school { Faker::Educator.secondary_school }
+      original_school_urn { Faker::Number.number(digits: 6) }
+      original_cc_ship_to_number { Faker::Number.number(digits: 8) }
+    end
+
+    trait :changed_telephone do
+      telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
+      original_telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
+    end
+
+    trait :changed_email_address do
+      email_address { Faker::Internet.unique.email }
+      original_email_address { Faker::Internet.unique.email }
+    end
+  end
+end

--- a/spec/features/computacenter/download_user_changes_csv_spec.rb
+++ b/spec/features/computacenter/download_user_changes_csv_spec.rb
@@ -14,9 +14,9 @@ RSpec.feature 'Download user changes CSV' do
     end
 
     describe 'clicking Download CSV' do
-      let!(:user_who_has_seen_privacy_notice_and_can_order_devices) { create(:school_user, :has_seen_privacy_notice, :orders_devices) }
-      let!(:user_who_has_seen_privacy_notice_but_cant_order_devices) { create(:school_user, :has_seen_privacy_notice, orders_devices: false) }
-      let!(:user_who_has_not_seen_privacy_notice_but_can_order_devices) { create(:school_user, :orders_devices, privacy_notice_seen_at: nil) }
+      let!(:user_change_1) { create(:user_change, :new_local_authority_user, updated_at_timestamp: Time.zone.now.utc - 2.seconds) }
+      let!(:user_change_2) { create(:user_change, :school_user, :changed_telephone, updated_at_timestamp: Time.zone.now.utc - 1.second) }
+      let!(:user_change_3) { create(:user_change, :school_user, :school_changed, updated_at_timestamp: Time.zone.now.utc) }
 
       it 'downloads a CSV file' do
         click_on 'Download CSV'
@@ -24,11 +24,19 @@ RSpec.feature 'Download user changes CSV' do
         expect(page.body).to include(Computacenter::Ledger.headers.join(','))
       end
 
-      it 'includes only users who have seen the privacy notice and can order devices' do
+      it 'includes all Computacenter::UserChanges in timestamp order' do
         click_on 'Download CSV'
-        expect(page.body).to include(user_who_has_seen_privacy_notice_and_can_order_devices.email_address)
-        expect(page.body).not_to include(user_who_has_seen_privacy_notice_but_cant_order_devices.email_address)
-        expect(page.body).not_to include(user_who_has_not_seen_privacy_notice_but_can_order_devices.email_address)
+        csv = CSV.parse(page.body, headers: true)
+        expect(csv[0]['Email']).to eq(user_change_1.email_address)
+        expect(csv[0]['Responsible Body']).to eq(user_change_1.responsible_body)
+
+        expect(csv[1]['Email']).to eq(user_change_2.email_address)
+        expect(csv[1]['Telephone']).to eq(user_change_2.telephone)
+        expect(csv[1]['Original Telephone']).to eq(user_change_2.original_telephone)
+
+        expect(csv[2]['Email']).to eq(user_change_3.email_address)
+        expect(csv[2]['School']).to eq(user_change_3.school)
+        expect(csv[2]['Original School']).to eq(user_change_3.original_school)
       end
     end
   end

--- a/spec/models/computacenter/ledger_spec.rb
+++ b/spec/models/computacenter/ledger_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Computacenter::Ledger do
+RSpec.describe Computacenter::Ledger, versioning: true do
   subject(:service) { described_class.new }
 
   describe '#to_csv' do
@@ -39,26 +39,26 @@ RSpec.describe Computacenter::Ledger do
       expect(rows[0]).to eql(expected_headers)
     end
 
-    context 'when trust user' do
-      let!(:user) { create(:trust_user, orders_devices: true) }
+    context 'a new local authority user' do
+      let!(:user_change) { create(:user_change, :new_local_authority_user) }
 
       it 'has correct data' do
         rows = CSV.parse(service.to_csv)
 
         expect(rows[1]).to eql([
-          user.first_name,
-          user.last_name,
-          user.email_address,
-          user.telephone,
-          user.responsible_body.name,
-          user.responsible_body.computacenter_identifier,
-          user.responsible_body.computacenter_reference,
+          user_change.first_name,
+          user_change.last_name,
+          user_change.email_address,
+          user_change.telephone,
+          user_change.responsible_body,
+          user_change.responsible_body_urn,
+          user_change.cc_sold_to_number,
           nil,
           nil,
           nil,
-          user.created_at.utc.strftime('%d/%m/%Y'),
-          user.created_at.utc.strftime('%R'),
-          user.created_at.utc.iso8601,
+          user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+          user_change.updated_at_timestamp.utc.strftime('%R'),
+          user_change.updated_at_timestamp.utc.iso8601,
           'New',
           nil,
           nil,
@@ -74,27 +74,60 @@ RSpec.describe Computacenter::Ledger do
       end
     end
 
-    context 'when school user' do
-      let!(:user) { create(:school_user, orders_devices: true) }
+    context 'when a school user changes telephone but not school' do
+      let!(:user_change) { create(:user_change, :school_user, :school_unchanged, :changed_telephone) }
 
       it 'has correct data' do
         rows = CSV.parse(service.to_csv)
-
         expect(rows[1]).to eql([
-          user.first_name,
-          user.last_name,
-          user.email_address,
-          user.telephone,
-          user.school.responsible_body.name,
-          user.school.responsible_body.computacenter_identifier,
-          user.school.responsible_body.computacenter_reference,
-          user.school.name,
-          user.school.urn.to_s,
-          user.school.computacenter_reference,
-          user.created_at.utc.strftime('%d/%m/%Y'),
-          user.created_at.utc.strftime('%R'),
-          user.created_at.utc.iso8601,
-          'New',
+          user_change.first_name,
+          user_change.last_name,
+          user_change.email_address,
+          user_change.telephone,
+          user_change.responsible_body,
+          user_change.responsible_body_urn,
+          user_change.cc_sold_to_number,
+          user_change.school,
+          user_change.school_urn,
+          user_change.cc_ship_to_number,
+          user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+          user_change.updated_at_timestamp.utc.strftime('%R'),
+          user_change.updated_at_timestamp.utc.iso8601,
+          'Change',
+          nil,
+          nil,
+          nil,
+          user_change.original_telephone,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+        ])
+      end
+    end
+
+    context 'when a school user changes school' do
+      let!(:user_change) { create(:user_change, :school_user, :school_changed) }
+
+      it 'has correct data' do
+        rows = CSV.parse(service.to_csv)
+        expect(rows[1]).to eql([
+          user_change.first_name,
+          user_change.last_name,
+          user_change.email_address,
+          user_change.telephone,
+          user_change.responsible_body,
+          user_change.responsible_body_urn,
+          user_change.cc_sold_to_number,
+          user_change.school,
+          user_change.school_urn,
+          user_change.cc_ship_to_number,
+          user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+          user_change.updated_at_timestamp.utc.strftime('%R'),
+          user_change.updated_at_timestamp.utc.iso8601,
+          'Change',
           nil,
           nil,
           nil,
@@ -102,9 +135,9 @@ RSpec.describe Computacenter::Ledger do
           nil,
           nil,
           nil,
-          nil,
-          nil,
-          nil,
+          user_change.original_school,
+          user_change.original_school_urn,
+          user_change.original_cc_ship_to_number,
         ])
       end
     end

--- a/spec/models/computacenter/ledger_spec.rb
+++ b/spec/models/computacenter/ledger_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Computacenter::Ledger, versioning: true do
+RSpec.describe Computacenter::Ledger do
   subject(:service) { described_class.new }
 
   describe '#to_csv' do


### PR DESCRIPTION
### Context

[Trello card 644](https://trello.com/c/P0H2S7zf/644-update-csv-generator-to-take-feed-from-userchange-table) and (now archived) [645](https://trello.com/c/gYuHk1qK/645-change-the-computacenter-download-csv-ui-to-read-from-the-userchanges-table-al) - part of [larger ticket 594](https://trello.com/c/n9stv3jD/594-user-changes-feed-for-computacenter)

### Changes proposed in this pull request

* make the `Computacenter::Ledger` class take its data from the `UserChanges` table rather than `Users`
* update the `Computacenter::UserLedgerController` to pass in `UserChanges`
* update the relevant specs to set up test data in the form of `UserChanges` rather than `Users`
* add factories for some anticipated `UserChanges` scenarios

### Guidance to review

