### PR TITLE
make backfill_ledger accept users as a param

### DIFF
--- a/app/models/computacenter/backfill_ledger.rb
+++ b/app/models/computacenter/backfill_ledger.rb
@@ -2,6 +2,12 @@ require 'csv'
 
 module Computacenter
   class BackfillLedger
+    attr_accessor :users
+
+    def initialize(users: nil)
+      self.users = users || default_users
+    end
+
     def call
       users.each do |user|
         next if UserChange.where(user_id: user.id).exists?
@@ -36,7 +42,7 @@ module Computacenter
 
   private
 
-    def users
+    def default_users
       User.who_can_order_devices.where.not(privacy_notice_seen_at: nil)
     end
   end

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Computacenter::BackfillLedger do
   subject(:service) { described_class.new }
 
-  describe '#call' do
+  describe '#call when not initalized with given users' do
     context 'happy path' do
       let!(:user) { create(:local_authority_user, orders_devices: true) }
 
@@ -72,6 +72,26 @@ RSpec.describe Computacenter::BackfillLedger do
       it 'does not backfill user to ledger' do
         expect { service.call }.not_to change(Computacenter::UserChange, :count)
       end
+    end
+  end
+
+  describe '#call when initialized with a set of users' do
+    let(:responsible_body) { create(:local_authority) }
+    let(:school) { create(:school) }
+    let(:school_users) { create_list(:user, 5, school: school) }
+    let(:given_users) { responsible_body.users }
+
+    subject(:service) { described_class.new(users: given_users) }
+
+    before do
+      create_list(:user, 3, responsible_body: responsible_body)
+      other_responsible_body = create(:local_authority)
+      create_list(:user, 5, :has_seen_privacy_notice, orders_devices: true, responsible_body: other_responsible_body)
+    end
+
+    it 'backfills the ledger with just the given users' do
+      expect {service.call}.to change(Computacenter::UserChange, :count).by(3)
+      expect(Computacenter::UserChange.pluck(:email_address).sort).to eq(given_users.pluck(:email_address).sort)
     end
   end
 end

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Computacenter::BackfillLedger do
     end
 
     it 'backfills the ledger with just the given users' do
-      expect {service.call}.to change(Computacenter::UserChange, :count).by(3)
+      expect { service.call }.to change(Computacenter::UserChange, :count).by(3)
       expect(Computacenter::UserChange.pluck(:email_address).sort).to eq(given_users.pluck(:email_address).sort)
     end
   end

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe Computacenter::BackfillLedger do
 
   describe '#call when initialized with a set of users' do
     let(:responsible_body) { create(:local_authority) }
-    let(:school) { create(:school) }
-    let(:school_users) { create_list(:user, 5, school: school) }
     let(:given_users) { responsible_body.users }
 
     subject(:service) { described_class.new(users: given_users) }
 
     before do
       create_list(:user, 3, responsible_body: responsible_body)
+      school = create(:school)
+      create_list(:user, 2, school: school, orders_devices: true)
       other_responsible_body = create(:local_authority)
       create_list(:user, 5, :has_seen_privacy_notice, orders_devices: true, responsible_body: other_responsible_body)
     end


### PR DESCRIPTION
### Context

[Trello card 652](https://trello.com/c/owCzbO0A/652-make-computacenterbackfillledger-accept-a-users-param-so-that-we-can-backfill-one-set-of-users-at-a-time) - this will allow us to backfill the ledger one set of users at a time, avoiding a single big-bang rollout and testing as we go

### Changes proposed in this pull request

* make the `Computacenter::BackfillLedger` optionally accept users as a parameter

### Guidance to review

