### PR TITLE
Display the school URN to RBs

### DIFF
--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -46,7 +46,7 @@
 <table id="schools" class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header app-schools-table__school-column">School</th>
+      <th class="govuk-table__header app-schools-table__school-column">School and URN</th>
       <th class="govuk-table__header">Allocation</th>
       <th class="govuk-table__header">Who will order?</th>
       <th class="govuk-table__header">Status</th>
@@ -56,7 +56,7 @@
     <% @schools.each do |school| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= govuk_link_to school.name, responsible_body_devices_school_path(school.urn) %>
+          <%= govuk_link_to "#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn) %>
           <br>
           <%= school.type_label %>
         </td>

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -12,9 +12,11 @@ RSpec.feature 'Setting up the devices ordering' do
     before do
       @zebra_school = create(:school, :la_maintained, :secondary,
                              responsible_body: responsible_body,
+                             urn: '123321',
                              name: 'Zebra Secondary School')
       @aardvark_school = create(:school, :la_maintained, :primary,
                                 responsible_body: responsible_body,
+                                urn: '456654',
                                 name: 'Aardvark Primary School')
 
       create(:school_device_allocation, school: @aardvark_school, device_type: 'std_device', allocation: 42)
@@ -245,9 +247,9 @@ RSpec.feature 'Setting up the devices ordering' do
   def then_i_see_a_list_of_the_schools_i_am_responsible_for
     expect(page).to have_content('2 schools')
     expect(responsible_body_schools_page.school_rows[0].title)
-      .to have_content('Aardvark Primary School Primary school')
+      .to have_content('Aardvark Primary School (456654) Primary school')
     expect(responsible_body_schools_page.school_rows[1].title)
-      .to have_content('Zebra Secondary School Secondary school')
+      .to have_content('Zebra Secondary School (123321) Secondary school')
   end
 
   def then_i_see_a_list_of_the_academies_i_am_responsible_for


### PR DESCRIPTION
### Context

Display the school URN to RBs to avoid confusion around similar-sounding schools.

There are lots of St Joseph's schools.

### Changes proposed in this pull request

Show school URN alongside the name.

### Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/92775433-4ff01700-f396-11ea-805d-d486af505ed0.png)

After:

![image](https://user-images.githubusercontent.com/23801/92775394-436bbe80-f396-11ea-83b6-08d522f9b92e.png)
