### PR TITLE
Show school users in support, linked from the RB devices support page

### DIFF
--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -1,4 +1,9 @@
 class Support::Devices::SchoolsController < Support::BaseController
+  def show
+    @school = School.find_by!(urn: params[:urn])
+    @users = @school.users
+  end
+
   def invite
     school = School.find_by!(urn: params[:school_urn])
     success = school.invite_school_contact

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -57,7 +57,7 @@
       <tbody class="govuk-table__body">
         <% @schools.each do |school| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= school.name %> (<%= school.urn %>)<br><%= school.type_label %></td>
+            <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_devices_school_path(urn: school.urn) %><br><%= school.type_label %></td>
             <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
             <%- device_allocations_data = school.device_allocations.detect(&:std_device?) %>
             <td class="govuk-table__cell">

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for :title, "#{@school.name} – Support" %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { t('page_titles.support_responsible_bodies') => support_devices_responsible_bodies_path },
+    { @school.responsible_body.name => support_devices_responsible_body_path(@school.responsible_body) },
+    @school.name,
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Devices pilot</span>
+      <%= @school.name %>
+    </h1>
+
+    <h2 class="govuk-heading-l">Users</h2>
+
+    <% if @users.present? %>
+      <table id="responsible-body-users" class="govuk-table">
+        <caption class="govuk-table__caption">School users</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Email address</th>
+            <th scope="col" class="govuk-table__header">Full name</th>
+            <th scope="col" class="govuk-table__header">Sign-in count</th>
+            <th scope="col" class="govuk-table__header">Last sign in</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @users.each do |user| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= user.email_address %></td>
+              <td class="govuk-table__cell"><%= user.full_name %></td>
+              <td class="govuk-table__cell"><%= user.sign_in_count %></td>
+              <td class="govuk-table__cell"><%= user.last_signed_in_at&.to_date&.to_s(:govuk) || 'Never' %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">None</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,7 +127,7 @@ Rails.application.routes.draw do
       get '/performance', to: 'service_performance#index', as: :service_performance
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
-      resources :schools, only: [], param: :urn do
+      resources :schools, only: %i[show], param: :urn do
         post '/invite', to: 'schools#invite'
       end
     end

--- a/spec/features/support/devices/managing_schools_spec.rb
+++ b/spec/features/support/devices/managing_schools_spec.rb
@@ -1,11 +1,22 @@
 require 'rails_helper'
 
-RSpec.feature 'Inviting schools from the support area', type: :feature do
+RSpec.feature 'Managing schools from the support area', type: :feature do
   let(:local_authority) { create(:local_authority, name: 'Coventry', in_devices_pilot: true) }
   let(:responsible_bodies_page) { PageObjects::Support::Devices::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::Devices::ResponsibleBodyPage.new }
 
-  scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
+  scenario 'DfE users see school users' do
+    given_a_responsible_body
+    and_it_has_a_school_with_users
+
+    when_i_sign_in_as_a_dfe_user
+    and_i_visit_the_responsible_body_page
+    and_i_visit_the_school_page
+
+    then_i_see_the_school_users
+  end
+
+  scenario 'DfE users invite school contacts to prepare for ordering devices' do
     given_a_responsible_body
     and_it_has_a_school_that_needs_to_be_contacted
 
@@ -33,6 +44,15 @@ RSpec.feature 'Inviting schools from the support area', type: :feature do
     expect(school.preorder_information.school_will_be_contacted?).to be_truthy
   end
 
+  def and_it_has_a_school_with_users
+    school = create(:school, :with_preorder_information, :with_headteacher_contact,
+                    name: 'Alpha School',
+                    urn: '123321',
+                    responsible_body: local_authority)
+    create(:school_user, school: school, full_name: 'James P. Sullivan', email_address: 'sully@alpha.sch.uk')
+    create(:school_user, school: school, full_name: 'Mike Wazowski', email_address: 'mike@alpha.sch.uk')
+  end
+
   def when_i_sign_in_as_a_dfe_user
     sign_in_as create(:dfe_user)
   end
@@ -40,6 +60,10 @@ RSpec.feature 'Inviting schools from the support area', type: :feature do
   def and_i_visit_the_responsible_body_page
     responsible_bodies_page.load
     click_on local_authority.name
+  end
+
+  def and_i_visit_the_school_page
+    click_on 'Alpha School (123321)'
   end
 
   def then_i_can_invite_the_school
@@ -57,5 +81,13 @@ RSpec.feature 'Inviting schools from the support area', type: :feature do
 
   def and_i_can_no_longer_invite_the_school
     expect(responsible_body_page.school_rows[0]).not_to have_button('Invite')
+  end
+
+  def then_i_see_the_school_users
+    expect(page).to have_text('James P. Sullivan')
+    expect(page).to have_text('sully@alpha.sch.uk')
+
+    expect(page).to have_text('Mike Wazowski')
+    expect(page).to have_text('mike@alpha.sch.uk')
   end
 end


### PR DESCRIPTION
### Context

DfE staff need to see information about schools and their users, in order to provide the best support to user queries. This is the first step in that direction.

### Changes proposed in this pull request

Introduce a schools page in the devices support area. Display the school's users on that page.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92814673-62307c00-f3bb-11ea-8dcd-b1454bdac273.png)

![image](https://user-images.githubusercontent.com/23801/92814625-56dd5080-f3bb-11ea-8979-4d7de54dda40.png)
