### PR TITLE
[SPIKE 649] remodel user -> school/rb link as has_many through organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,3 @@
+class Organisation < ApplicationRecord
+  self.abstract_class = true # remove this line for STI
+end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -1,13 +1,14 @@
 require 'computacenter/responsible_body_urns'
 
-class ResponsibleBody < ApplicationRecord
+class ResponsibleBody < Organisation
   has_one :bt_wifi_voucher_allocation
   belongs_to :key_contact, class_name: 'User', optional: true
   has_many :bt_wifi_vouchers
-  has_many :users
   has_many :extra_mobile_data_requests
   has_many :schools
-
+  has_many :user_organisations, as: :organisation
+  has_many :users, through: :user_organisations
+  
   extend Computacenter::ResponsibleBodyUrns::ClassMethods
   include Computacenter::ResponsibleBodyUrns::InstanceMethods
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,11 +1,12 @@
-class School < ApplicationRecord
+class School < Organisation
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
   has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
   has_one    :coms_device_allocation, -> { where device_type: 'coms_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
-  has_many :users
+  has_many :user_organisations, as: :organisation
+  has_many :users, through: :user_organisations
   has_one :preorder_information
 
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,12 @@ class User < ApplicationRecord
 
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
+  has_many :user_organisations
+  has_many :schools, through: :user_organisations, source: :organisation, source_type: "School"
+  has_many :responsible_bodies, through: :user_organisations, source: :organisation, source_type: "ResponsibleBody"
   has_one :school_welcome_wizard, dependent: :destroy
 
   belongs_to :mobile_network, optional: true
-  belongs_to :responsible_body, optional: true
-  belongs_to :school, optional: true
 
   scope :approved, -> { where.not(approved_at: nil) }
   scope :signed_in_at_least_once, -> { where('sign_in_count > 0') }
@@ -43,11 +44,11 @@ class User < ApplicationRecord
   end
 
   def is_responsible_body_user?
-    responsible_body.present?
+    responsible_bodies.exists?
   end
 
   def is_school_user?
-    school.present?
+    schools.exists?
   end
 
   def update_sign_in_count_and_timestamp!

--- a/app/models/user_organisation.rb
+++ b/app/models/user_organisation.rb
@@ -1,0 +1,4 @@
+class UserOrganisation < ApplicationRecord
+  belongs_to :user
+  belongs_to :organisation, polymorphic: true
+end

--- a/db/migrate/20200910135754_add_user_organisations.rb
+++ b/db/migrate/20200910135754_add_user_organisations.rb
@@ -1,0 +1,40 @@
+class AddUserOrganisations < ActiveRecord::Migration[6.0]
+  def up
+    create_table :user_organisations do |t|
+      t.references  :user
+      t.references  :organisation, polymorphic: true, index: { name: 'ix_user_orgs_org_type_org_id' }
+      t.timestamps
+    end
+
+    add_index :user_organisations, [:organisation_type, :organisation_id, :user_id], unique: true, name: 'ix_user_orgs_org_type_org_id_user_id'
+    add_index :user_organisations, [:user_id, :organisation_type, :organisation_id], unique: true, name: 'ix_user_orgs_user_id_org_type_org_id'
+    add_index :user_organisations, :created_at
+    add_index :user_organisations, :updated_at
+
+    User.where.not(school_id: nil).each do |user|
+      UserOrganisation.create!(user: user, organisation: user.school)
+    end
+    User.where.not(responsible_body_id: nil).each do |user|
+      UserOrganisation.create!(user: user, organisation: user.responsible_body)
+    end
+
+    remove_column :users, :school_id
+    remove_column :users, :responsible_body_id
+  end
+
+  def down
+    add_reference :users, :responsible_body, foreign_key: true
+    UserOrganisation.where(organisation_type: 'ResponsibleBody').each do |user_org|
+      user_org.user.update!(responsible_body_id: user_org.organisation_id)
+    end
+    add_index :users, :responsible_body_id
+
+    add_reference :users, :school, foreign_key: true
+    UserOrganisation.where(organisation_type: 'School').each do |user_org|
+      user_org.user.update!(school_id: user_org.organisation_id)
+    end
+    add_index :users, :school_id
+
+    drop_table :user_organisations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_09_214548) do
+ActiveRecord::Schema.define(version: 2020_09_10_135754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_09_09_214548) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
-    t.bigint "responsible_body_id", null: false
+    t.integer "responsible_body_id", null: false
     t.string "contract_type"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"
@@ -207,6 +207,20 @@ ActiveRecord::Schema.define(version: 2020_09_09_214548) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "user_organisations", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "organisation_type"
+    t.bigint "organisation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_user_organisations_on_created_at"
+    t.index ["organisation_type", "organisation_id", "user_id"], name: "ix_user_orgs_org_type_org_id_user_id", unique: true
+    t.index ["organisation_type", "organisation_id"], name: "ix_user_orgs_org_type_org_id"
+    t.index ["updated_at"], name: "index_user_organisations_on_updated_at"
+    t.index ["user_id", "organisation_type", "organisation_id"], name: "ix_user_orgs_user_id_org_type_org_id", unique: true
+    t.index ["user_id"], name: "index_user_organisations_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "full_name"
     t.string "email_address"
@@ -216,21 +230,17 @@ ActiveRecord::Schema.define(version: 2020_09_09_214548) do
     t.integer "mobile_network_id"
     t.datetime "sign_in_token_expires_at"
     t.datetime "approved_at"
-    t.bigint "responsible_body_id"
     t.integer "sign_in_count", default: 0
     t.datetime "last_signed_in_at"
     t.string "telephone"
     t.boolean "is_support", default: false, null: false
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
-    t.bigint "school_id"
     t.boolean "orders_devices"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
-    t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
-    t.index ["school_id"], name: "index_users_on_school_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true
   end
 
@@ -253,5 +263,4 @@ ActiveRecord::Schema.define(version: 2020_09_09_214548) do
   add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "school_welcome_wizards", "users", column: "invited_user_id"
   add_foreign_key "schools", "responsible_bodies"
-  add_foreign_key "users", "schools"
 end


### PR DESCRIPTION
### Context

A technical spike to see if there's a sensible way to allow a user to be associated with many schools and/or responsible bodies

### Changes proposed in this pull request

* Introduce `Organisation` as an abstract base class for `School` / `ResponsibleBody`
* Remodel the relationship from `user belongs_to :school / :responsible_body` to `user has_many :organisations`


### Guidance to review

