### PR TITLE
[594] Add feature flag for adding to user change

### DIFF
--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -5,7 +5,9 @@ module Computacenter
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }
 
     def self.read_from_version(version)
-      UserChangeGenerator.new(version).call
+      if FeatureFlag.active?(:update_computacenter_user_change)
+        UserChangeGenerator.new(version).call
+      end
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,7 +9,9 @@ class FeatureFlag
     rbs_can_manage_users
   ].freeze
 
-  TEMPORARY_FEATURE_FLAGS = %i[].freeze
+  TEMPORARY_FEATURE_FLAGS = %i[
+    update_computacenter_user_change
+  ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -220,6 +220,10 @@ RSpec.describe User, type: :model do
   end
 
   describe 'paper_trail', versioning: true do
+    before do
+      allow(ENV).to receive(:[]).with('FEATURES_update_computacenter_user_change').and_return('active')
+    end
+
     context 'creating user' do
       context 'computacenter relevant' do
         it 'creates a Computacenter::UserChange of type new' do


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-user-changes-feed-for-computacenter

### Changes proposed in this pull request

- Add feature flag to only append to user change table when enabled

### Guidance to review

- With feature off should never write to `Computacenter::UserChange`
- With feature on should write to `Computacenter::UserChange` when applicable