### PR TITLE
[594] Backfill now uses current time

### DIFF
--- a/app/models/computacenter/backfill_ledger.rb
+++ b/app/models/computacenter/backfill_ledger.rb
@@ -24,7 +24,7 @@ module Computacenter
           school: user.school&.name,
           school_urn: user.school&.urn,
           cc_ship_to_number: user.school&.computacenter_reference,
-          updated_at_timestamp: user.created_at,
+          updated_at_timestamp: Time.zone.now.utc,
           type_of_update: 'New',
           original_first_name: nil,
           original_last_name: nil,


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-user-changes-feed-for-computacenter
- Backfilled records are not appearing at the bottom of the csv therefore Computacenter will not know to apply these changes

### Changes proposed in this pull request

- When user is backfilled it takes the current time so when ordered in the ledger it appears at the bottom

### Guidance to review

- Backfill a user, `update_at_timestamp` should be the current time and not when the user was created
