### PR TITLE
[594] Add ChangeUser if relevant to Computacenter

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -59,6 +59,8 @@ private
       email_address
       responsible_body_id
       school_id
+      privacy_notice_seen_at
+      orders_devices
     ]
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe User, type: :model do
         let!(:user) { create(:user, :not_relevant_to_computacenter) }
 
         def perform_change!
-          user.update(privacy_notice_seen_at: 1.second.ago, orders_devices: true, email_address: 'change@example.com')
+          user.update(privacy_notice_seen_at: 1.second.ago, orders_devices: true)
         end
 
         it 'creates a Computacenter::UserChange of type New' do
@@ -287,7 +287,7 @@ RSpec.describe User, type: :model do
           perform_change!
 
           user_change = Computacenter::UserChange.last
-          expect(user_change.email_address).to eql('change@example.com')
+          expect(user_change.email_address).to eql(user.email_address)
         end
 
         it 'does not set original fields' do


### PR DESCRIPTION
### Context

- https://trello.com/c/n9stv3jD/594-user-changes-feed-for-computacenter
- Previously if a User was relevant to computer it would only be appended as New if they changed a monitored field too

### Changes proposed in this pull request

- If a user is made Computacenter relevant they are immediately added as a new user to `Computacenter::ChangeUser`

### Guidance to review

- Find a user not relevant to Computacenter
- Update their `privacy_notice_seen_at` and `orders_devices` fields ONLY so they are now Computacenter relevant
- Should create `New` entry in `Computacenter::ChangeUser`