### PR TITLE
Support: show who will be invited from the school

### DIFF
--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -4,6 +4,11 @@ class Support::Devices::SchoolsController < Support::BaseController
     @users = @school.users
   end
 
+  def confirm_invitation
+    @school = School.find_by!(urn: params[:school_urn])
+    @school_contact = @school.preorder_information&.school_contact
+  end
+
   def invite
     school = School.find_by!(urn: params[:school_urn])
     success = school.invite_school_contact

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -7,6 +7,10 @@ class Support::Devices::SchoolsController < Support::BaseController
   def confirm_invitation
     @school = School.find_by!(urn: params[:school_urn])
     @school_contact = @school.preorder_information&.school_contact
+    if @school_contact.nil?
+      flash[:warning] = I18n.t('support.schools.invite.no_school_contact', name: @school.name)
+      redirect_to support_devices_school_path(@school)
+    end
   end
 
   def invite

--- a/app/views/support/devices/responsible_bodies/show.html.erb
+++ b/app/views/support/devices/responsible_bodies/show.html.erb
@@ -73,9 +73,7 @@
             </td>
             <td class="govuk-table__cell">
               <% if school&.preorder_information&.school_will_be_contacted? %>
-                <%= form_with url: support_devices_school_invite_path(school_urn: school.urn), method: 'post' do |f| %>
-                  <%= f.govuk_submit 'Invite' %>
-                <% end %>
+                <%= govuk_link_to 'Invite', support_devices_school_confirm_invitation_path(school_urn: school.urn) %>
               <% end %>
             </td>
           </tr>

--- a/app/views/support/devices/schools/confirm_invitation.html.erb
+++ b/app/views/support/devices/schools/confirm_invitation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Invite #{@school.name} – Support" %>
+<%- content_for :before_content, govuk_link_to('Back', support_devices_responsible_body_path(@school.responsible_body), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Devices pilot</span>
+      Invite <%= @school.name %>
+    </h1>
+
+    <p class="govuk-body">
+      <% school_contact_lines = [
+          @school_contact.title.present? ? "#{@school_contact.title.upcase_first}: #{@school_contact.full_name}" : @school_contact.full_name,
+          @school_contact.email_address,
+          @school_contact.phone_number,
+        ].reject(&:blank?) %>
+      <%= safe_join(school_contact_lines, '<br>'.html_safe) %>
+    </p>
+
+    <%= form_with url: support_devices_school_invite_path(school_urn: @school.urn), method: 'post' do |f| %>
+      <%= f.govuk_submit 'Invite' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,7 @@
       invite:
         success: "%{name} has been invited successfully"
         failure: "Could not invite %{name}"
+        no_school_contact: "Could not invite %{name} because the school does not have a contact"
   errors:
     format:
       "'%{attribute}' %{message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
       resources :schools, only: %i[show], param: :urn do
+        get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
         post '/invite', to: 'schools#invite'
       end
     end

--- a/spec/controllers/support/devices/schools_controller_spec.rb
+++ b/spec/controllers/support/devices/schools_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Support::Devices::SchoolsController, type: :controller do
+  let(:school) { create(:school) }
+
+  describe 'show' do
+    it 'is forbidden for MNO users' do
+      sign_in_as create(:mno_user)
+
+      get :show, params: { urn: school.urn }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'is forbidden for responsible body users' do
+      sign_in_as create(:trust_user)
+
+      get :show, params: { urn: school.urn }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'redirects to / for unauthenticated users' do
+      get :show, params: { urn: school.urn }
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+end

--- a/spec/controllers/support/devices/schools_controller_spec.rb
+++ b/spec/controllers/support/devices/schools_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Support::Devices::SchoolsController, type: :controller do
-  let(:school) { create(:school) }
+  let(:school) { create(:school, name: 'Alpha School') }
 
   describe 'show' do
     it 'is forbidden for MNO users' do
@@ -24,6 +24,22 @@ RSpec.describe Support::Devices::SchoolsController, type: :controller do
       get :show, params: { urn: school.urn }
 
       expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  describe 'confirm_invitation' do
+    before do
+      create(:preorder_information, school: school, school_contact: nil)
+      sign_in_as create(:dfe_user)
+    end
+
+    context 'when the school has no school contact' do
+      it 'redirects back to the school page with an error' do
+        get :confirm_invitation, params: { school_urn: school.urn }
+
+        expect(response).to redirect_to(support_devices_school_path(school))
+        expect(request.flash[:warning]).to eq('Could not invite Alpha School because the school does not have a contact')
+      end
     end
   end
 end

--- a/spec/features/support/devices/managing_schools_spec.rb
+++ b/spec/features/support/devices/managing_schools_spec.rb
@@ -67,11 +67,12 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
   end
 
   def then_i_can_invite_the_school
-    expect(responsible_body_page.school_rows[0]).to have_button('Invite')
+    expect(responsible_body_page.school_rows[0]).to have_link('Invite')
   end
 
   def when_i_invite_the_school
     responsible_body_page.school_rows[0].click_on 'Invite'
+    click_on 'Invite'
   end
 
   def then_the_school_is_contacted


### PR DESCRIPTION
### Context

Currently, when inviting a school, there's no way to see who you are inviting, in case you need to follow up with them for research.

### Changes proposed in this pull request

- change the invite button to a link
- show an invitation confirmation page, which shows who will be invited

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/92992076-ff84d080-f4df-11ea-8342-ef06ffb2057a.png)

![image](https://user-images.githubusercontent.com/23801/92992071-f136b480-f4df-11ea-9931-0e290a09b366.png)
