### PR TITLE
Show school details in support

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -4,7 +4,8 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
 
   delegate :school_will_order_devices?,
            :school_contact,
-           to: :preorder_information
+           to: :preorder_information,
+           allow_nil: true
 
   def initialize(school:)
     @school = school
@@ -32,12 +33,23 @@ private
   end
 
   def who_will_order_row
-    {
-      key: 'Who will order?',
-      value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
-      change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
-      action: 'who will order',
-    }
+    who = (@school.preorder_information || @school.responsible_body).who_will_order_devices_label
+
+    if who.present?
+      {
+        key: 'Who will order?',
+        value: "The #{who.downcase} orders devices",
+        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+        action: 'who will order',
+      }
+    else
+      {
+        key: 'Who will order?',
+        value: "#{@school.responsible_body.name} hasn’t decided this yet",
+        action_path: responsible_body_devices_who_will_order_edit_path,
+        action: 'Decide who will order',
+      }
+    end
   end
 
   def allocation_row

--- a/app/components/support/school_details_summary_list_component.html.erb
+++ b/app/components/support/school_details_summary_list_component.html.erb
@@ -1,0 +1,3 @@
+<div class="school-details-summary-list">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -2,7 +2,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
 private
 
   def who_will_order_row
-    super.except(:change_path, :action)
+    super.except(:change_path, :action, :action_path)
   end
 
   def allocation_row

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -1,0 +1,27 @@
+class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetailsSummaryListComponent
+private
+
+  def who_will_order_row
+    super.except(:change_path, :action)
+  end
+
+  def allocation_row
+    super.except(:action_path, :action)
+  end
+
+  def order_status_row
+    super.except(:action_path, :action)
+  end
+
+  def school_contact_row_if_contact_present
+    super
+      .tap do |rows|
+        if rows.present? && @school&.preorder_information&.school_will_be_contacted?
+          rows.first.merge!(
+            action_path: support_devices_school_invite_path(school_urn: @school.urn),
+            action: 'Invite',
+          )
+        end
+      end
+  end
+end

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -14,7 +14,9 @@
       <%= @school.name %>
     </h1>
 
-    <h2 class="govuk-heading-l">Users</h2>
+    <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school) %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-8">Users</h2>
 
     <% if @users.present? %>
       <table id="responsible-body-users" class="govuk-table">

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe ResponsibleBody::SchoolDetailsSummaryListComponent do
+  include Rails.application.routes.url_helpers
+
   let(:school) { create(:school, :primary, :la_maintained) }
   let(:headteacher) do
     create(:school_contact, :headteacher,
@@ -137,6 +139,14 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
 
     it 'does not show the school contact even if the school contact is set' do
       expect(result.css('dl').text).not_to include('School contact')
+    end
+  end
+
+  context 'when the responsible body has not made a decision about who will order' do
+    it 'confirms that fact and provides a link to make the decision' do
+      expect(result.css('.govuk-summary-list__row')[1].text).to include("#{school.responsible_body.name} hasn’t decided this yet")
+      expect(result.css('.govuk-summary-list__row')[1].text).to include('Decide who will order')
+      expect(result.css('.govuk-summary-list__row a').attr('href').value).to eq(responsible_body_devices_who_will_order_edit_path)
     end
   end
 end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -124,4 +124,11 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(result.css('dl').text).not_to include('School contact')
     end
   end
+
+  context 'when the responsible body has not made a decision about who will order' do
+    it 'confirms that fact' do
+      expect(result.css('.govuk-summary-list__row')[1].text).to include("#{school.responsible_body.name} hasn’t decided this yet")
+      expect(result.css('.govuk-summary-list__row')[1].text).not_to include('Decide who will order')
+    end
+  end
 end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+describe Support::SchoolDetailsSummaryListComponent do
+  let(:school) { create(:school, :primary, :la_maintained) }
+  let(:headteacher) do
+    create(:school_contact, :headteacher,
+           full_name: 'Davy Jones',
+           email_address: 'davy.jones@school.sch.uk',
+           phone_number: '12345')
+  end
+
+  subject(:result) { render_inline(described_class.new(school: school)) }
+
+  context 'when the school will place device orders' do
+    before do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :school,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes',
+             school_contact: headteacher)
+
+      create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+    end
+
+    it 'confirms that fact' do
+      expect(result.css('.govuk-summary-list__row')[1].text).to include('The school orders devices')
+    end
+
+    it 'renders the school allocation' do
+      expect(result.css('.govuk-summary-list__row')[2].text).to include('3 devices')
+    end
+
+    it 'renders the school type' do
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('Primary school')
+    end
+
+    it 'renders the school details' do
+      expect(result.css('.govuk-summary-list__row')[0].text).to include('School will be contacted')
+    end
+
+    it 'shows the chromebook details without links to change it' do
+      expect(result.css('.govuk-summary-list__row')[6].text).to include('Yes, they will need Chromebooks')
+      expect(result.css('.govuk-summary-list__row')[7].text).to include('school.domain.org')
+      expect(result.css('.govuk-summary-list__row')[8].text).to include('admin@recovery.org')
+    end
+
+    context "when the school isn't under lockdown restrictions or has any shielding children" do
+      it 'cannot place orders' do
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('Not yet because there are no local coronavirus')
+      end
+    end
+
+    context 'and the headteacher has been set as the school contact' do
+      it 'displays the headteacher details' do
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: headteacher)
+
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('School contact')
+        expect(result.css('.govuk-summary-list__row')[5].inner_html).to include('Headteacher: Davy Jones<br>davy.jones@school.sch.uk<br>12345')
+      end
+    end
+
+    context 'and the headteacher has been set as the school contact, the school is ready to be contacted' do
+      it 'displays an invite link' do
+        create(:preorder_information,
+               school: school,
+               status: :school_will_be_contacted,
+               who_will_order_devices: :school,
+               school_contact: headteacher)
+
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('Invite')
+      end
+    end
+
+    context 'and someone else has been set as the school contact' do
+      it "displays the new contact's details" do
+        new_contact = create(:school_contact, :contact,
+                             full_name: 'Jane Smith',
+                             email_address: 'abc@example.com',
+                             phone_number: '12345')
+        create(:preorder_information,
+               school: school,
+               who_will_order_devices: :school,
+               school_contact: new_contact)
+
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('School contact')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('Jane Smith')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('abc@example.com')
+        expect(result.css('.govuk-summary-list__row')[5].text).to include('12345')
+      end
+    end
+  end
+
+  context 'when the responsible body will place device orders' do
+    let(:school) { create(:school, :primary, :academy) }
+
+    before do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :responsible_body,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes',
+             school_contact: headteacher)
+    end
+
+    it 'confirms that fact' do
+      create(:preorder_information, school: school, who_will_order_devices: :responsible_body)
+
+      expect(result.css('.govuk-summary-list__row')[1].text).to include('The trust orders devices')
+    end
+
+    it 'shows the chromebook details with links to change it' do
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('Yes, they will need Chromebooks')
+      expect(result.css('.govuk-summary-list__row')[6].text).to include('school.domain.org')
+      expect(result.css('.govuk-summary-list__row')[7].text).to include('admin@recovery.org')
+    end
+
+    it 'does not show the school contact even if the school contact is set' do
+      expect(result.css('dl').text).not_to include('School contact')
+    end
+  end
+end


### PR DESCRIPTION
~~**This PR builds upon #457, so merge that one first and rebase this one.**~~ ✅ 

### Context

Support agents need to see how far individual schools have gotten in the pre-order journey.

### Changes proposed in this pull request

Display school details in support, but without any change links.
Provide a link to invite the school contact when that's appropriate.

### Guidance to review

Best reviewed commit-by-commit.

**When a school is ready to be invited**

![image](https://user-images.githubusercontent.com/23801/93005487-5246a280-f549-11ea-9615-603f7aa76576.png)

**When the RB hasn't even made the decision to centralise or devolve orders**

![image](https://user-images.githubusercontent.com/23801/93005476-25928b00-f549-11ea-9b3a-74309a47dbe5.png)
