### PR TITLE
Introduce school order state

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -12,36 +12,58 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
 
   def rows
     [
-      {
-        key: 'Status',
-        value: render(SchoolPreorderStatusTagComponent.new(school: @school)),
-      },
-      {
-        key: 'Who will order?',
-        value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
-        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
-        action: 'who will order',
-      },
-      {
-        key: 'Provisional allocation',
-        value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
-        action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
-        action: 'Query allocation',
-      },
-      {
-        key: 'Can place orders?',
-        value: 'Not yet because there are no local coronavirus&nbsp;restrictions'.html_safe,
-        action_path: responsible_body_devices_request_devices_path,
-        action: 'Request devices for specific circumstances',
-      },
-      {
-        key: 'Type of school',
-        value: @school.type_label,
-      },
-    ] + school_contact_row_if_contact_present + chromebook_rows_if_needed
+      preorder_status_row,
+      who_will_order_row,
+      allocation_row,
+      order_status_row,
+      school_type_row,
+    ] +
+      school_contact_row_if_contact_present +
+      chromebook_rows_if_needed
   end
 
 private
+
+  def preorder_status_row
+    {
+      key: 'Status',
+      value: render(SchoolPreorderStatusTagComponent.new(school: @school)),
+    }
+  end
+
+  def who_will_order_row
+    {
+      key: 'Who will order?',
+      value: "The #{(@school.preorder_information || @school.responsible_body).who_will_order_devices_label.downcase} orders devices",
+      change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+      action: 'who will order',
+    }
+  end
+
+  def allocation_row
+    {
+      key: 'Provisional allocation',
+      value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
+      action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
+      action: 'Query allocation',
+    }
+  end
+
+  def order_status_row
+    {
+      key: 'Can place orders?',
+      value: 'Not yet because there are no local coronavirus&nbsp;restrictions'.html_safe,
+      action_path: responsible_body_devices_request_devices_path,
+      action: 'Request devices for specific circumstances',
+    }
+  end
+
+  def school_type_row
+    {
+      key: 'Type of school',
+      value: @school.type_label,
+    }
+  end
 
   def school_contact_row_if_contact_present
     if school_will_order_devices? && school_contact.present?

--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -55,6 +55,11 @@ private
         key: 'Can place orders?',
         value: 'Yes, local coronavirus restrictions have been confirmed',
       }
+    elsif @school.can_order_for_specific_circumstances?
+      {
+        key: 'Can place orders?',
+        value: 'Yes, for specific circumstances',
+      }
     else
       {
         key: 'Can place orders?',

--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -50,12 +50,19 @@ private
   end
 
   def order_status_row
-    {
-      key: 'Can place orders?',
-      value: 'Not yet because there are no local coronavirus&nbsp;restrictions'.html_safe,
-      action_path: responsible_body_devices_request_devices_path,
-      action: 'Request devices for specific circumstances',
-    }
+    if @school.can_order?
+      {
+        key: 'Can place orders?',
+        value: 'Yes, local coronavirus restrictions have been confirmed',
+      }
+    else
+      {
+        key: 'Can place orders?',
+        value: 'Not yet because there are no local coronavirus&nbsp;restrictions'.html_safe,
+        action_path: responsible_body_devices_request_devices_path,
+        action: 'Request devices for specific circumstances',
+      }
+    end
   end
 
   def school_type_row

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -30,6 +30,7 @@ class School < ApplicationRecord
 
   enum order_state: {
     cannot_order: 'cannot_order',
+    can_order_for_specific_circumstances: 'can_order_for_specific_circumstances',
     can_order: 'can_order',
   }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -28,6 +28,11 @@ class School < ApplicationRecord
     other_type: 'other_type',
   }, _suffix: true
 
+  enum order_state: {
+    cannot_order: 'cannot_order',
+    can_order: 'can_order',
+  }
+
   def allocation_for_type!(device_type)
     device_allocations.find_by_device_type!(device_type)
   end

--- a/db/migrate/20200913134728_add_school_order_state_to_schools.rb
+++ b/db/migrate/20200913134728_add_school_order_state_to_schools.rb
@@ -1,0 +1,5 @@
+class AddSchoolOrderStateToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :order_state, :string, null: false, default: :cannot_order
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_09_214548) do
+ActiveRecord::Schema.define(version: 2020_09_13_134728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2020_09_09_214548) do
     t.string "phase"
     t.string "establishment_type"
     t.string "phone_number"
+    t.string "order_state", default: "cannot_order", null: false
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -47,8 +47,22 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     context "when the school isn't under lockdown restrictions or has any shielding children" do
+      before do
+        school.cannot_order!
+      end
+
       it 'cannot place orders' do
         expect(result.css('.govuk-summary-list__row')[3].text).to include('Not yet because there are no local coronavirus')
+      end
+    end
+
+    context 'when the school is under lockdown restrictions' do
+      before do
+        school.can_order!
+      end
+
+      it 'can place orders' do
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('Yes, local coronavirus restrictions have been confirmed')
       end
     end
 

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -66,6 +66,16 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       end
     end
 
+    context 'when the school can order devices for specific circumstances' do
+      before do
+        school.can_order_for_specific_circumstances!
+      end
+
+      it 'can place orders' do
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('Yes, for specific circumstances')
+      end
+    end
+
     context 'and the headteacher has been set as the school contact' do
       it 'displays the headteacher details' do
         create(:preorder_information,


### PR DESCRIPTION
**Depends on #458, rebase this PR after that one is merged.**

### Context

Schools and responsible bodies need to know when they can start ordering devices, and whether that's for specific circumstances or local coronavirus restrictions. This will be tracked on a per-school basis.

### Changes proposed in this pull request

- Introduce an order state on the school's pre-order information.
- Update the responsible body's school details summary table to show appropriate guidance in the "Can place orders?" section.

### Guidance to review

It's awkward having the order state on the **pre**order information, but it feels like that's the right place for the information. It's worth considering whether we want to rename `PreorderInformation`, to reflect its increased scope, as a subsequent change.

#### Screenshots

Is the microcopy correct? cc @emmajhf

**Cannot order**

![image](https://user-images.githubusercontent.com/23801/93020906-bf087e00-f5d7-11ea-8ca2-15637e5df53a.png)

**Can order under local lockdown**

![image](https://user-images.githubusercontent.com/23801/93020915-cdef3080-f5d7-11ea-8254-c13e79228bdd.png)

** Can order for specific circumstances**

![image](https://user-images.githubusercontent.com/23801/93020924-de071000-f5d7-11ea-89a7-356aa4380bc5.png)
