### PR TITLE
[502] Handle computacenter error on cap update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'http'
 # GovUK Notify
 gem 'mail-notify'
 
+gem 'nokogiri'
+
 # pagination
 gem 'pagy'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,6 +479,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.3)
   logstash-logger (~> 0.26.1)
   mail-notify
+  nokogiri
   notifications-ruby-client
   pagy
   paper_trail

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -87,5 +87,35 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
         expect { request.post! }.to raise_error(Computacenter::OutgoingAPI::Error)
       end
     end
+
+    context 'when the response contains an error' do
+      let(:response_body) do
+        '<CapAdjustmentResponse dateTime="2020-08-21T12:30:40Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult errorDetails="Non of the records are processed" piMessageID="11111111111111111111111111111111" status="Failed"/><FailedRecords><Record capAmount="9" capType="DfE_RemainThresholdQty|Std_Device" errorDetails="New cap must be greater than or equal to used quantity" shipTO="11111111" status="Failed"/></FailedRecords></CapAdjustmentResponse>'
+      end
+
+      before do
+        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+        allow(HTTP).to receive(:post).and_return(mock_response)
+      end
+
+      it 'raises an error' do
+        expect { request.post! }.to raise_error(Computacenter::OutgoingAPI::Error)
+      end
+    end
+
+    context 'when the response does not contain an error' do
+      let(:response_body) do
+        '<CapAdjustmentResponse dateTime="2020-09-14T21:55:37Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult piMessageID="11111111111111111111111111111111" status="Success"/><FailedRecords/></CapAdjustmentResponse>'
+      end
+
+      before do
+        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+        allow(HTTP).to receive(:post).and_return(mock_response)
+      end
+
+      it 'does not raise an error' do
+        expect { request.post! }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/FBZnVdwk/502-handle-computacenter-returning-200-response-on-failed-capupdates
- For cap updates the computacenter response can return a 200 when there is an error

### Changes proposed in this pull request

- To ensure there is no error we also parse the response body
- If there is an error it will be raised

### Guidance to review

- n/a