### PR TITLE
Improve heuristics for splitting first and last name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,10 @@ private
 
   def full_name_from_email_address(string)
     local_part = string.split('@').first
-    local_part.gsub('.', ' ').titleize
+    if local_part.include?('.')
+      local_part.gsub('.', ' ').titleize
+    else
+      "#{local_part[0]} #{local_part[1..-1]}".titleize
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,14 +94,22 @@ class User < ApplicationRecord
   end
 
   def first_name
-    (full_name || '').strip.split(' ').first.to_s
+    cleansed_full_name.split(' ').first.to_s
   end
 
   def last_name
-    (full_name || '').strip.split(' ').last.to_s
+    cleansed_full_name.split(' ').last.to_s
   end
 
   def effective_responsible_body
     responsible_body || school&.responsible_body
+  end
+
+private
+
+  def cleansed_full_name
+    (full_name || '')
+      .strip
+      .gsub(/^(Mr|Mrs|Ms|Miss|Dr) /, '')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,12 @@ private
   def cleansed_full_name
     (full_name || '')
       .strip
+      .then { |str| str =~ /@/ ? full_name_from_email_address(str) : str }
       .gsub(/^(Mr|Mrs|Ms|Miss|Dr) /, '')
+  end
+
+  def full_name_from_email_address(string)
+    local_part = string.split('@').first
+    local_part.gsub('.', ' ').titleize
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -201,6 +201,14 @@ RSpec.describe User, type: :model do
         expect(described_class.new(full_name: 'Dr Jane Smith').first_name).to eq('Jane')
       end
     end
+
+    context 'when the full_name is a firstname.lastname@domain email address' do
+      subject(:user) { described_class.new(full_name: 'jane.smith@school.sch.uk') }
+
+      it 'guesses the first name from the local part' do
+        expect(user.first_name).to eql('Jane')
+      end
+    end
   end
 
   describe '#last_name' do
@@ -235,6 +243,14 @@ RSpec.describe User, type: :model do
         expect(described_class.new(full_name: 'Miss Jane Smith').last_name).to eq('Smith')
         expect(described_class.new(full_name: 'Ms Jane Smith').last_name).to eq('Smith')
         expect(described_class.new(full_name: 'Dr Jane Smith').last_name).to eq('Smith')
+      end
+    end
+
+    context 'when the full_name is a firstname.lastname@domain email address' do
+      subject(:user) { described_class.new(full_name: 'jane.smith@school.sch.uk') }
+
+      it 'guesses the last name from the local part' do
+        expect(user.last_name).to eql('Smith')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,6 +209,14 @@ RSpec.describe User, type: :model do
         expect(user.first_name).to eql('Jane')
       end
     end
+
+    context 'when the full_name is a <initial>lastname@domain email address' do
+      subject(:user) { described_class.new(full_name: 'jsmith@school.sch.uk') }
+
+      it 'guesses the first name initial from the local part' do
+        expect(user.first_name).to eql('J')
+      end
+    end
   end
 
   describe '#last_name' do
@@ -250,6 +258,14 @@ RSpec.describe User, type: :model do
       subject(:user) { described_class.new(full_name: 'jane.smith@school.sch.uk') }
 
       it 'guesses the last name from the local part' do
+        expect(user.last_name).to eql('Smith')
+      end
+    end
+
+    context 'when the full_name is a <initial>lastname@domain email address' do
+      subject(:user) { described_class.new(full_name: 'jsmith@school.sch.uk') }
+
+      it 'guesses the first name initial from the local part' do
         expect(user.last_name).to eql('Smith')
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -191,6 +191,16 @@ RSpec.describe User, type: :model do
         expect(user.first_name).to eql('')
       end
     end
+
+    context 'when the full_name contains an honorific' do
+      it 'returns the first name without the honorific' do
+        expect(described_class.new(full_name: 'Mr John Smith').first_name).to eq('John')
+        expect(described_class.new(full_name: 'Ms Jane Smith').first_name).to eq('Jane')
+        expect(described_class.new(full_name: 'Miss Jane Smith').first_name).to eq('Jane')
+        expect(described_class.new(full_name: 'Ms Jane Smith').first_name).to eq('Jane')
+        expect(described_class.new(full_name: 'Dr Jane Smith').first_name).to eq('Jane')
+      end
+    end
   end
 
   describe '#last_name' do
@@ -215,6 +225,16 @@ RSpec.describe User, type: :model do
 
       it 'returns empty string' do
         expect(user.last_name).to eql('')
+      end
+    end
+
+    context 'when the full_name contains an honorific' do
+      it 'returns the last name without the honorific' do
+        expect(described_class.new(full_name: 'Mr John Smith').last_name).to eq('Smith')
+        expect(described_class.new(full_name: 'Ms Jane Smith').last_name).to eq('Smith')
+        expect(described_class.new(full_name: 'Miss Jane Smith').last_name).to eq('Smith')
+        expect(described_class.new(full_name: 'Ms Jane Smith').last_name).to eq('Smith')
+        expect(described_class.new(full_name: 'Dr Jane Smith').last_name).to eq('Smith')
       end
     end
   end


### PR DESCRIPTION
### Context

This service uses full names for users, as [per the GOV.UK Design System](https://design-system.service.gov.uk/patterns/names/). However downstream systems need this split into first and last names to work. We're working with imperfect data so the full name sometimes includes honorifics or is an email address.

### Changes proposed in this pull request

- Strip out common honorifics when deriving a user's first and last name
- guess the first and last name from emails of the form `first.last@domain`
- guess the initial and last name from emails of the form `<initial>last@domain`

### Guidance to review

Not proud of this code, but it feels like the least worst solution to data mismatches between two systems.