### PR TITLE
[672] add first-draft UI for support users to enable orders

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -10,7 +10,7 @@ private
   end
 
   def order_status_row
-    super.except(:action_path, :action)
+    super.except(:action_path, :action).merge(change_path: support_devices_school_enable_orders_path(school_urn: @school.urn))
   end
 
   def school_contact_row_if_contact_present

--- a/app/controllers/support/devices/order_status_controller.rb
+++ b/app/controllers/support/devices/order_status_controller.rb
@@ -1,0 +1,35 @@
+class Support::Devices::OrderStatusController < Support::BaseController
+  before_action :set_school
+
+  def edit
+    @form = Support::EnableOrdersForm.new(enable_orders_form_params)
+  end
+
+  def update
+    @form = Support::EnableOrdersForm.new(enable_orders_form_params)
+    if @form.valid?
+      ActiveRecord::Base.transaction do
+        allocation = SchoolDeviceAllocation.find_or_initialize_by(school_id: @school.id, device_type: 'std_device')
+        # we only take the cap from the user if they chose specific circumstances
+        # for both other states, we need to infer a new cap from the chosen state
+        allocation.cap = allocation.cap_implied_by_order_state(order_state: @form.order_state, given_cap: @form.cap)
+        allocation.save!
+        @school.update!(order_state: @form.order_state)
+      end
+      flash[:success] = t(:success, scope: %i[support order_status update])
+      redirect_to support_devices_school_path(urn: @school.urn)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_school
+    @school = School.find_by_urn(params[:school_urn])
+  end
+
+  def enable_orders_form_params(opts = params)
+    opts.fetch(:support_enable_orders_form, {}).permit(:order_state, :cap)
+  end
+end

--- a/app/form_objects/support/enable_orders_form.rb
+++ b/app/form_objects/support/enable_orders_form.rb
@@ -1,0 +1,12 @@
+class Support::EnableOrdersForm
+  include ActiveModel::Model
+
+  attr_accessor :order_state, :cap
+
+  validates :order_state, inclusion: { in: School.order_states }
+  validates :cap, numericality: { only_integer: true, greater_than: 0 }, if: :cap_required?
+
+  def cap_required?
+    order_state.to_s == 'can_order_for_specific_circumstances'
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,10 @@ class ApplicationRecord < ActiveRecord::Base
       end
     end
 
+    def translate_enum_value(enum, value)
+      I18n.t(value.to_sym, scope: enum_i18n_scope(enum))
+    end
+
     def enum_i18n_scope(enum)
       [:activerecord, :attributes, name.underscore.to_sym, enum.to_sym]
     end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -19,4 +19,15 @@ class SchoolDeviceAllocation < ApplicationRecord
   def computacenter_cap_type
     Computacenter::CapTypeConverter.to_computacenter_type(device_type)
   end
+
+  def cap_implied_by_order_state(order_state:, given_cap: nil)
+    case order_state.to_sym
+    when :cannot_order
+      self.cap = devices_ordered.to_i
+    when :can_order
+      self.cap = allocation.to_i
+    else # specific circumstances
+      given_cap
+    end
+  end
 end

--- a/app/views/support/devices/order_status/edit.html.erb
+++ b/app/views/support/devices/order_status/edit.html.erb
@@ -1,0 +1,26 @@
+<%- content_for :before_content, govuk_link_to('Back', support_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- title = t('page_titles.support_order_status.enable_orders') %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: support_devices_school_enable_orders_path(@school.urn), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :order_state  do %>
+        <%= f.govuk_radio_button :order_state, 'cannot_order', label: { text: School.translate_enum_value(:order_states, "cannot_order") }, link_errors: true %>
+        <%= f.govuk_radio_button :order_state, 'can_order_for_specific_circumstances', label: { text: School.translate_enum_value(:order_states, "can_order_for_specific_circumstances") } do %>
+          <%= f.govuk_number_field :cap, width: 3 %>
+        <%- end %>
+        <%= f.govuk_radio_button :order_state, 'can_order', label: { text: School.translate_enum_value(:order_states, "can_order") }, link_errors: true %>
+      <%- end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@
     support_internet_responsible_bodies: Internet pilot on-boarded responsible bodies
     support_responsible_bodies: On-boarded responsible bodies
     support_devices: Devices
+    support_order_status:
+      enable_orders: Can they place orders?
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter_home: Users with permission to place orders and receive support through Computacenter
@@ -191,6 +193,9 @@
         one: "%{count} device"
         other: "%{count} devices"
   support:
+    order_status:
+      update:
+        success: We've saved your choices
     service_performance:
       mobile_network_operators:
         one: mobile network operator
@@ -284,6 +289,11 @@
               blank: Enter an email address in the correct format, like name@example.com
               invalid: Enter an email address in the correct format, like name@example.com
               cannot_be_same_domain_as_school_or_rb: Recovery email address must be on a different domain to the school domain
+        support/enable_orders_form:
+          attributes:
+            cap:
+              greater_than: Enter a whole number greater than zero
+              not_a_number: Enter a whole number greater than zero
   activerecord:
     attributes:
       api_token:
@@ -326,6 +336,11 @@
           school_contacted: School contacted
           school_will_be_contacted: School will be contacted
           school_ready: School ready
+      school:
+        order_states:
+          cannot_order: No, orders cannot be placed yet
+          can_order_for_specific_circumstances: They can place orders for specific circumstances
+          can_order: They can order their full allocation because local coronavirus restrictions are confirmed
       school_device_allocation:
         device_type:
           std_device: 'Standard device (laptop etc)'
@@ -420,3 +435,7 @@
     invite_event: "A user from %{organisation} has invited someone to the service"
     responsible_body_will_order_event: "%{responsible_body} will manage orders centrally"
     schools_will_order_event: "%{responsible_body} has devolved ordering to schools"
+  helpers:
+    label:
+      support_enable_orders_form:
+        cap: How many devices can they order?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,8 @@ Rails.application.routes.draw do
       resources :schools, only: %i[show], param: :urn do
         get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
         post '/invite', to: 'schools#invite'
+        get '/enable-orders', to: 'order_status#edit', as: :enable_orders
+        patch '/enable-orders', to: 'order_status#update'
       end
     end
     resources :responsible_bodies, only: %i[], path: '/:pilot/responsible-bodies' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -87,6 +87,13 @@ FactoryBot.define do
       end
     end
 
+    factory :support_user do
+      is_support { true }
+      email_address do
+        full_name.downcase.gsub(' ', '.') + ['@digital.education.gov.uk', '@education.gov.uk'].sample
+      end
+    end
+
     factory :computacenter_user do
       is_computacenter { true }
       email_address do

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe SchoolDeviceAllocation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#cap_implied_by_order_state' do
+    subject(:allocation) { described_class.new(allocation: 27, cap: nil, devices_ordered: 13) }
+
+    context 'given cannot_order' do
+      it 'returns the value of devices_ordered' do
+        expect(allocation.cap_implied_by_order_state(order_state: 'cannot_order')).to eq(13)
+      end
+    end
+
+    context 'given can_order' do
+      it 'returns the value of allocation' do
+        expect(allocation.cap_implied_by_order_state(order_state: 'can_order')).to eq(27)
+      end
+    end
+
+    context 'given can_order_for_specific_circumstances' do
+      it 'returns the given cap' do
+        expect(allocation.cap_implied_by_order_state(order_state: 'can_order_for_specific_circumstances', given_cap: 17)).to eq(17)
+      end
+    end
+  end
 end

--- a/spec/page_objects/support/devices/school_details_page.rb
+++ b/spec/page_objects/support/devices/school_details_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Support
+    module Devices
+      class SchoolDetailsPage < PageObjects::BasePage
+        elements :school_details_rows, '.school-details-summary-list .govuk-summary-list__row'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Trello card [672](https://trello.com/c/jcmxnwR1/672-support-users-can-set-the-order-state-cannot-order-can-order-specific-circumstances), as part of the larger ticket [664](https://trello.com/c/xUIUD6em/664-allow-disallow-ordering-and-set-caps-via-support)
 
### Changes proposed in this pull request

Add just the initial user interface to allow support users to enable ordering of devices for schools.
This first version applies the updates from the form and redirects back to the school page - a subsequent PR will introduce the "Check and confirm" page.

Screenshots:

Change link and success message:
![Screen Shot 2020-09-15 at 12 12 16](https://user-images.githubusercontent.com/134501/93203681-c1d8af80-f74c-11ea-933c-bc992ac891f0.png)

Form and validation errors:
![Screen Shot 2020-09-15 at 12 12 58](https://user-images.githubusercontent.com/134501/93203745-d2892580-f74c-11ea-9e69-16ef50f94253.png)


### Guidance to review

