### PR TITLE
[664] Cap and Allocation validations

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -3,6 +3,9 @@ class SchoolDeviceAllocation < ApplicationRecord
   belongs_to  :created_by_user, class_name: 'User', optional: true
   belongs_to  :last_updated_by_user, class_name: 'User', optional: true
 
+  validate :validate_cap_gte_devices_ordered
+  validate :validate_cap_lte_allocation
+
   enum device_type: {
     'coms_device': 'coms_device',
     'std_device': 'std_device',
@@ -28,6 +31,20 @@ class SchoolDeviceAllocation < ApplicationRecord
       self.cap = allocation.to_i
     else # specific circumstances
       given_cap
+    end
+  end
+
+private
+
+  def validate_cap_lte_allocation
+    if cap > allocation
+      errors.add(:cap, :lte_allocation)
+    end
+  end
+
+  def validate_cap_gte_devices_ordered
+    if cap < devices_ordered
+      errors.add(:cap, :gte_devices_ordered)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,11 @@
               blank: Select whether the contract is pay monthly or pay as you go (PAYG)
             agrees_with_privacy_statement:
               inclusion: The privacy statement must be shared with the account holder
+        school_device_allocation:
+          attributes:
+            cap:
+              lte_allocation: can’t be greater than allocation
+              gte_devices_ordered: can’t be less than devices ordered
         user:
           attributes:
             full_name:

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -23,7 +23,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
              will_need_chromebooks: 'yes',
              school_contact: headteacher)
 
-      create(:school_device_allocation, school: school, device_type: 'std_device', allocation: 3)
+      create(:school_device_allocation, school: school, device_type: 'std_device', cap: 1, allocation: 100)
     end
 
     it 'confirms that fact' do
@@ -31,7 +31,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school allocation' do
-      expect(result.css('.govuk-summary-list__row')[2].text).to include('3 devices')
+      expect(result.css('.govuk-summary-list__row')[2].text).to include('100 devices')
     end
 
     it 'renders the school type' do

--- a/spec/controllers/computacenter/api/cap_usage_controller_spec.rb
+++ b/spec/controllers/computacenter/api/cap_usage_controller_spec.rb
@@ -127,11 +127,11 @@ RSpec.describe Computacenter::API::CapUsageController do
         @school1 = create(:school, computacenter_reference: '81060874')
         @school2 = create(:school, computacenter_reference: '81060875')
 
-        create(:school_device_allocation, school: @school1, device_type: 'std_device', allocation: 100)
-        create(:school_device_allocation, school: @school1, device_type: 'coms_device', allocation: 100)
+        create(:school_device_allocation, school: @school1, device_type: 'std_device', cap: 100, allocation: 100)
+        create(:school_device_allocation, school: @school1, device_type: 'coms_device', cap: 100, allocation: 100)
 
-        create(:school_device_allocation, school: @school2, device_type: 'std_device', allocation: 300)
-        create(:school_device_allocation, school: @school2, device_type: 'coms_device', allocation: 400)
+        create(:school_device_allocation, school: @school2, device_type: 'std_device', cap: 100, allocation: 300)
+        create(:school_device_allocation, school: @school2, device_type: 'coms_device', cap: 100, allocation: 400)
       end
 
       it 'responds with :ok status and updates the records' do
@@ -180,8 +180,8 @@ RSpec.describe Computacenter::API::CapUsageController do
       before do
         # only 1 of 2 schools there so partial failure
         school1 = create(:school, computacenter_reference: '81060874')
-        create(:school_device_allocation, school: school1, device_type: 'std_device', allocation: 100)
-        create(:school_device_allocation, school: school1, device_type: 'coms_device', allocation: 100)
+        create(:school_device_allocation, school: school1, device_type: 'std_device', cap: 100, allocation: 100)
+        create(:school_device_allocation, school: school1, device_type: 'coms_device', cap: 100, allocation: 100)
       end
 
       it 'responds with :multi_status status' do
@@ -201,7 +201,7 @@ RSpec.describe Computacenter::API::CapUsageController do
 
       before do
         @school = create(:school, computacenter_reference: '81060874')
-        create(:school_device_allocation, school: @school, device_type: 'std_device', allocation: 100)
+        create(:school_device_allocation, school: @school, device_type: 'std_device', cap: 100, allocation: 100)
       end
 
       it 'responds with :multi_status status' do

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Enabling orders for a school from the support area' do
   let(:school_details_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
 
   before do
-    create(:school_device_allocation, :with_std_allocation, allocation: 50)
+    create(:school_device_allocation, :with_std_allocation, allocation: 50, school: school)
     sign_in_as support_user
   end
 

--- a/spec/models/computacenter/api/cap_usage_update_spec.rb
+++ b/spec/models/computacenter/api/cap_usage_update_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
 
   describe '#apply!' do
     let!(:school) { create(:school, computacenter_reference: '123456') }
-    let!(:allocation) { create(:school_device_allocation, school: school, device_type: 'std_device') }
+    let!(:allocation) { create(:school_device_allocation, school: school, device_type: 'std_device', cap: 30, allocation: 100) }
 
     it 'updates the correct allocation with the given usedCap' do
       expect { cap_usage_update.apply! }.to change { allocation.reload.devices_ordered }.from(0).to(20)

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -22,4 +22,54 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       end
     end
   end
+
+  describe 'validations' do
+    let(:school) { build(:school) }
+
+    context 'cap exceeds allocation' do
+      subject(:allocation) { described_class.new(cap: 11, allocation: 10, school: school) }
+
+      it 'fails validation' do
+        expect(allocation.valid?).to be_falsey
+        expect(allocation.errors).to have_key(:cap)
+        expect(allocation.errors[:cap]).to include('can’t be greater than allocation')
+      end
+    end
+
+    context 'cap equals allocation' do
+      subject(:allocation) { described_class.new(cap: 10, allocation: 10, school: school) }
+
+      it 'passes validation' do
+        expect(allocation.valid?).to be_truthy
+      end
+    end
+
+    context 'cap less than devices_ordered' do
+      subject(:allocation) do
+        described_class.new(cap: 9,
+                            devices_ordered: 10,
+                            allocation: 100,
+                            school: school)
+      end
+
+      it 'fails validation' do
+        expect(allocation.valid?).to be_falsey
+        expect(allocation.errors).to have_key(:cap)
+        expect(allocation.errors[:cap]).to include('can’t be less than devices ordered')
+      end
+    end
+
+    context 'cap equals devices_ordered' do
+      subject(:allocation) do
+        described_class.new(cap: 10,
+                            devices_ordered: 10,
+                            allocation: 100,
+                            school: school)
+      end
+
+      it 'passes validation' do
+        expect(allocation.valid?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -232,9 +232,14 @@ RSpec.describe School, type: :model do
     context 'when there is an allocation of the given type with cap > devices_ordered' do
       let(:cap) { 2 }
       let(:devices_ordered) { 1 }
+      let(:allocation) { 3 }
 
       before do
-        school.device_allocations << build(:school_device_allocation, device_type: 'std_device', cap: cap, devices_ordered: devices_ordered)
+        school.device_allocations << build(:school_device_allocation,
+                                           device_type: 'std_device',
+                                           cap: cap,
+                                           allocation: allocation,
+                                           devices_ordered: devices_ordered)
       end
 
       it 'is true' do
@@ -242,12 +247,18 @@ RSpec.describe School, type: :model do
       end
     end
 
-    context 'when there is an allocation of the given type with cap < devices_ordered' do
-      let(:cap) { 1 }
+    context 'when there is an allocation of the given type with cap equals devices_ordered' do
+      let(:cap) { 2 }
       let(:devices_ordered) { 2 }
+      let(:allocation) { 3 }
 
       before do
-        school.device_allocations << create(:school_device_allocation, school: school, device_type: 'std_device', cap: cap, devices_ordered: devices_ordered)
+        school.device_allocations << create(:school_device_allocation,
+                                            school: school,
+                                            device_type: 'std_device',
+                                            cap: cap,
+                                            allocation: allocation,
+                                            devices_ordered: devices_ordered)
       end
 
       it 'is false' do


### PR DESCRIPTION
### Context

- https://trello.com/c/xUIUD6em/664-allow-cap-changes-via-support
- Add backend validations to ensure caps, allocations and order_state are kept in valid states

### Changes proposed in this pull request

- Validations ensure that devices_ordered <= cap <= allocation
- Changing order_state we check the cap and allocation values

### Guidance to review

- `SchoolDeviceAllocation.devices_ordered` must be lte `SchoolDeviceAllocation.cap`
- `SchoolDeviceAllocation.cap` must be lte `SchoolDeviceAllocation.allocation`
- Changing `School.order_state` to `can_order` can only happen if there is a non-zero cap
- Changing `School.order_state` to `can_order_for_specific_circumstances` can only happen if there is a non-zero allocation

