### PR TITLE
[635] ordering devices centrally

### DIFF
--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -1,0 +1,22 @@
+class ResponsibleBody::Devices::OrdersController < ResponsibleBody::Devices::BaseController
+  def show
+    if @responsible_body.has_any_schools_that_can_order_now?
+      if @responsible_body.has_centrally_managed_schools_that_can_order_now?
+        # at least 1 centrally managed school can order now
+        # or mix of centrally managed and devolved
+        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_std_devices_now
+
+        if @schools.that_are_ordering_for_lockdown.count.positive?
+          render 'order_now'
+        else
+          render 'specific_circumstances'
+        end
+      else
+        # must only be schools that order devices that can order now
+        render 'cannot_order_yet'
+      end
+    else
+      render 'cannot_order_yet'
+    end
+  end
+end

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -4,7 +4,7 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::Devices::Bas
       if @responsible_body.has_centrally_managed_schools_that_can_order_now?
         # at least 1 centrally managed school can order now
         # or mix of centrally managed and devolved
-        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_now
+        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_now.order(name: :asc)
 
         if @schools.can_order.count.positive?
           render 'order_devices'

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -4,10 +4,10 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::Devices::Bas
       if @responsible_body.has_centrally_managed_schools_that_can_order_now?
         # at least 1 centrally managed school can order now
         # or mix of centrally managed and devolved
-        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_std_devices_now
+        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_now
 
-        if @schools.that_are_ordering_for_lockdown.count.positive?
-          render 'order_now'
+        if @schools.can_order.count.positive?
+          render 'order_devices'
         else
           render 'specific_circumstances'
         end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -31,7 +31,7 @@ module ViewHelper
     }.merge(html_options.except(:class))
 
     link_to(url, options) do
-      raw(%Q(#{body}
+      raw(%(#{body}
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
         </svg>))
@@ -133,6 +133,10 @@ module ViewHelper
         label: t('cannot_order_devices', scope: scope),
       ),
     ]
+  end
+
+  def techsource_url
+    Settings.computacenter.techsource_url
   end
 
 private

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -139,6 +139,14 @@ module ViewHelper
     Settings.computacenter.techsource_url
   end
 
+  def what_to_order(device_count, specific_circumstances)
+    if device_count.zero?
+      'All devices ordered'
+    else
+      "Order #{device_count} #{'device'.pluralize(device_count)}#{' for specific circumstances' if specific_circumstances}"
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -22,6 +22,22 @@ module ViewHelper
     link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
   end
 
+  def govuk_start_button_link_to(body, url, html_options = {})
+    options = {
+      class: prepend_css_class('govuk-button govuk-button--start', html_options[:class]),
+      role: 'button',
+      data: { module: 'govuk-button' },
+      draggable: false,
+    }.merge(html_options.except(:class))
+
+    link_to(url, options) do
+      raw(%Q(#{body}
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>))
+    end
+  end
+
   def title_with_error_prefix(title, error)
     "#{t('page_titles.error_prefix') if error}#{title}"
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -90,33 +90,18 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def is_ordering_for_schools?
-    schools.that_are_centrally_managed.count.positive?
+    schools.that_are_centrally_managed.any?
   end
 
   def has_centrally_managed_schools_that_can_order_now?
-    schools.that_are_centrally_managed.that_can_order_now.count.positive?
+    schools.that_are_centrally_managed.that_can_order_now.any?
   end
 
   def has_schools_that_can_order_devices_now?
-    schools.that_will_order_devices.that_can_order_now.count.positive?
+    schools.that_will_order_devices.that_can_order_now.any?
   end
 
   def has_any_schools_that_can_order_now?
-    schools.that_can_order_now.count.positive?
-  end
-
-  def count_of_schools_we_order_for_link_text
-    count = schools.that_are_centrally_managed.count
-    "#{count} #{'school'.pluralize(count)} you will be placing orders for"
-  end
-
-  def unmanaged_schools_that_can_order_link_text
-    count = schools.that_will_order_devices.can_order.count
-    "#{count} #{'school'.pluralize(count)} #{'has'.pluralize(count)} local coronavirus restrictions"
-  end
-
-  def unmanaged_schools_that_can_order_for_specific_circumstances_text
-    count = schools.that_will_order_devices.can_order_for_specific_circumstances.count
-    "#{count} #{'school'.pluralize(count)} can order devices for specific circumstances because their #{'request'.pluralize(count)} #{'has'.pluralize(count)} been approved."
+    schools.that_can_order_now.any?
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -94,19 +94,15 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def has_centrally_managed_schools_that_can_order_now?
-    schools.that_are_centrally_managed.that_can_order_std_devices_now.count.positive?
-  end
-
-  def schools_that_can_order_devices_now
-    schools.that_order_devices.that_can_order_std_devices_now
+    schools.that_are_centrally_managed.that_can_order_now.count.positive?
   end
 
   def has_schools_that_can_order_devices_now?
-    schools_that_can_order_devices_now.count.positive?
+    schools.that_will_order_devices.that_can_order_now.count.positive?
   end
 
   def has_any_schools_that_can_order_now?
-    schools.that_can_order_std_devices_now.count.positive?
+    schools.that_can_order_now.count.positive?
   end
 
   def count_of_schools_we_order_for_link_text
@@ -114,8 +110,13 @@ class ResponsibleBody < ApplicationRecord
     "#{count} #{'school'.pluralize(count)} you will be placing orders for"
   end
 
-  def count_of_schools_that_can_order_now_link_text
-    count = schools_that_can_order_devices_now.count
+  def unmanaged_schools_that_can_order_link_text
+    count = schools.that_will_order_devices.can_order.count
     "#{count} #{'school'.pluralize(count)} #{'has'.pluralize(count)} local coronavirus restrictions"
+  end
+
+  def unmanaged_schools_that_can_order_for_specific_circumstances_text
+    count = schools.that_will_order_devices.can_order_for_specific_circumstances.count
+    "#{count} #{'school'.pluralize(count)} can order devices for specific circumstances because their #{'request'.pluralize(count)} #{'has'.pluralize(count)} been approved."
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -88,4 +88,34 @@ class ResponsibleBody < ApplicationRecord
       ",
     )
   end
+
+  def is_ordering_for_schools?
+    schools.that_are_centrally_managed.count.positive?
+  end
+
+  def has_centrally_managed_schools_that_can_order_now?
+    schools.that_are_centrally_managed.that_can_order_std_devices_now.count.positive?
+  end
+
+  def schools_that_can_order_devices_now
+    schools.that_order_devices.that_can_order_std_devices_now
+  end
+
+  def has_schools_that_can_order_devices_now?
+    schools_that_can_order_devices_now.count.positive?
+  end
+
+  def has_any_schools_that_can_order_now?
+    schools.that_can_order_std_devices_now.count.positive?
+  end
+
+  def count_of_schools_we_order_for_link_text
+    count = schools.that_are_centrally_managed.count
+    "#{count} #{'school'.pluralize(count)} you will be placing orders for"
+  end
+
+  def count_of_schools_that_can_order_now_link_text
+    count = schools_that_can_order_devices_now.count
+    "#{count} #{'school'.pluralize(count)} #{'has'.pluralize(count)} local coronavirus restrictions"
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -85,37 +85,11 @@ class School < ApplicationRecord
     responsible_body.next_school_sorted_ascending_by_name(self)
   end
 
-  def has_devices_available_to_order?(device_type = 'std_device')
-    available_devices_count(device_type).positive?
-  end
-
-  def available_devices_count(device_type = 'std_device')
-    allocation = device_allocations.by_device_type(device_type).first
-    allocation&.cap.to_i - allocation&.devices_ordered.to_i
-  end
-
   def invite_school_contact
     if preorder_information.present?
       preorder_information.invite_school_contact!
     else
       false
-    end
-  end
-
-  def what_to_order_text
-    count = available_devices_count
-    if count.zero?
-      'All devices ordered'
-    else
-      "Order #{count} #{'device'.pluralize(count)} #{order_reason_text}".rstrip
-    end
-  end
-
-  def order_reason_text
-    if can_order_for_specific_circumstances?
-      'for specific circumstances'
-    else
-      ''
     end
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -50,6 +50,11 @@ class School < ApplicationRecord
     device_allocations.find_by_device_type!(device_type)
   end
 
+  def can_order_devices?
+    (can_order? || can_order_for_specific_circumstances?) &&
+      (std_device_allocation&.has_devices_available_to_order? == true)
+  end
+
   def has_std_device_allocation?
     std_device_allocation&.allocation.to_i.positive?
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -23,6 +23,14 @@ class SchoolDeviceAllocation < ApplicationRecord
     by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type))
   end
 
+  def has_devices_available_to_order?
+    available_devices_count.positive?
+  end
+
+  def available_devices_count
+    cap.to_i - devices_ordered.to_i
+  end
+
   def computacenter_cap_type
     Computacenter::CapTypeConverter.to_computacenter_type(device_type)
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -11,6 +11,10 @@ class SchoolDeviceAllocation < ApplicationRecord
     'std_device': 'std_device',
   }
 
+  def self.can_order_std_devices_now
+    by_device_type('std_device').where('cap > devices_ordered')
+  end
+
   def self.by_device_type(device_type)
     where(device_type: device_type)
   end

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -23,6 +23,20 @@
       <li>see your list of schools and their allocations</li>
     </ul>
 
+    <% if @responsible_body.is_ordering_for_schools? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to t('page_titles.order_devices.title'), responsible_body_devices_order_devices_path %>
+      </h2>
+
+      <p class="govuk-body">Use this section to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>place orders in the event of local coronavirus restrictions</li>
+        <li>place orders for specific circumstances</li>
+        <li>access the Computacenter TechSource website</li>
+      </ul>
+    <%- end %>
+
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.responsible_body_devices_request_devices'), responsible_body_devices_request_devices_path %>
     </h2>

--- a/app/views/responsible_body/devices/orders/_get_devices_early.html.erb
+++ b/app/views/responsible_body/devices/orders/_get_devices_early.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
     
-<p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged chilren', responsible_body_devices_request_devices_path %> who:</p>
+<p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', responsible_body_devices_request_devices_path %> who:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>are extremely clinically vulnerable and must continue shielding on&nbsp;official&nbsp;advice</li>

--- a/app/views/responsible_body/devices/orders/_get_devices_early.html.erb
+++ b/app/views/responsible_body/devices/orders/_get_devices_early.html.erb
@@ -1,0 +1,8 @@
+<h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
+    
+<p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged chilren', responsible_body_devices_request_devices_path %> who:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>are extremely clinically vulnerable and must continue shielding on&nbsp;official&nbsp;advice</li>
+  <li>cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+</ul>

--- a/app/views/responsible_body/devices/orders/_heading.html.erb
+++ b/app/views/responsible_body/devices/orders/_heading.html.erb
@@ -1,0 +1,9 @@
+<%- title = t('page_titles.order_devices.title') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { 'Home' => responsible_body_home_path },
+    { "#{t('page_titles.responsible_body_devices_home')}" => responsible_body_devices_path },
+    title,
+  ]) %>
+<% end %>

--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -1,5 +1,3 @@
-
-
 <table id="schools" class="govuk-table">
   <caption class="govuk-table__caption">
     <span class="govuk-heading-m">Schools you need to place orders for</span>
@@ -14,7 +12,7 @@
     <% @schools.each do |school| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= govuk_link_to(school.name, responsible_body_devices_school_path(school.urn)) %> (<%= school.urn %>)
+          <%= govuk_link_to("#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn)) %>
         </td>
         <td class="govuk-table__cell">
           <%= school.what_to_order_text %>
@@ -31,6 +29,6 @@
 
 <p class="govuk-body">If you do not remember your password use the 'Forgotten password?' link to reset it.</p>
 
-<%= govuk_start_button_link_to('Start now', '#', class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
+<%= govuk_start_button_link_to('Start now', techsource_url, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
 
 <p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -15,7 +15,8 @@
           <%= govuk_link_to("#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn)) %>
         </td>
         <td class="govuk-table__cell">
-          <%= school.what_to_order_text %>
+          <%= what_to_order(school.std_device_allocation.available_devices_count,
+                            school.can_order_for_specific_circumstances?) %>
         </td>
       </tr>
     <%- end %>

--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -1,0 +1,36 @@
+
+
+<table id="schools" class="govuk-table">
+  <caption class="govuk-table__caption">
+    <span class="govuk-heading-m">Schools you need to place orders for</span>
+  </caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header app-schools-table__school-column">School</th>
+      <th class="govuk-table__header">What to order</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @schools.each do |school| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= govuk_link_to(school.name, responsible_body_devices_school_path(school.urn)) %> (<%= school.urn %>)
+        </td>
+        <td class="govuk-table__cell">
+          <%= school.what_to_order_text %>
+        </td>
+      </tr>
+    <%- end %>
+  </tbody>
+</table>
+
+<h2 class="govuk-heading-m">Help signing in to TechSource</h2>
+<p class="govuk-body">You need to place orders on a website called TechSource, which is run by Computacenter.</p>
+
+<p class="govuk-body">Your 'User ID' is your email address: <%= @user.email_address %></p>
+
+<p class="govuk-body">If you do not remember your password use the 'Forgotten password?' link to reset it.</p>
+
+<%= govuk_start_button_link_to('Start now', '#', class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
+
+<p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
+++ b/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
@@ -1,0 +1,4 @@
+<h2 class="govuk-heading-m">Some schools can place their own orders</h2>
+    
+<p class="govuk-body"><%= govuk_link_to @responsible_body.count_of_schools_that_can_order_now_link_text, responsible_body_devices_schools_path %>.</p>
+<p class="govuk-body">They can order their full allocation of devices.</p>

--- a/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
+++ b/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
@@ -1,4 +1,10 @@
 <h2 class="govuk-heading-m">Some schools can place their own orders</h2>
     
-<p class="govuk-body"><%= govuk_link_to @responsible_body.count_of_schools_that_can_order_now_link_text, responsible_body_devices_schools_path %>.</p>
+<% if @responsible_body.schools.that_will_order_devices.can_order.count.positive? %>
+<p class="govuk-body"><%= govuk_link_to @responsible_body.unmanaged_schools_that_can_order_link_text, responsible_body_devices_schools_path %>.</p>
 <p class="govuk-body">They can order their full allocation of devices.</p>
+<%- end %>
+
+<% if @responsible_body.schools.that_will_order_devices.can_order_for_specific_circumstances.count.positive? %>
+  <p class="govuk-body"><%= @responsible_body.unmanaged_schools_that_can_order_for_specific_circumstances_text %></p>
+<%- end %>

--- a/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
+++ b/app/views/responsible_body/devices/orders/_some_schools_can_order.html.erb
@@ -1,10 +1,15 @@
 <h2 class="govuk-heading-m">Some schools can place their own orders</h2>
     
-<% if @responsible_body.schools.that_will_order_devices.can_order.count.positive? %>
-<p class="govuk-body"><%= govuk_link_to @responsible_body.unmanaged_schools_that_can_order_link_text, responsible_body_devices_schools_path %>.</p>
-<p class="govuk-body">They can order their full allocation of devices.</p>
+<%
+  lr_school_count = @responsible_body.schools.that_will_order_devices.can_order.count
+  sc_school_count = @responsible_body.schools.that_will_order_devices.can_order_for_specific_circumstances.count
+%>
+
+<% if lr_school_count.positive? %>
+  <p class="govuk-body"><%= govuk_link_to("#{lr_school_count} #{'school'.pluralize(lr_school_count)} #{'has'.pluralize(lr_school_count)} local coronavirus restrictions", responsible_body_devices_schools_path) %>.</p>
+  <p class="govuk-body">They can order their full allocation of devices.</p>
 <%- end %>
 
-<% if @responsible_body.schools.that_will_order_devices.can_order_for_specific_circumstances.count.positive? %>
-  <p class="govuk-body"><%= @responsible_body.unmanaged_schools_that_can_order_for_specific_circumstances_text %></p>
+<% if sc_school_count.positive? %>
+  <p class="govuk-body"><%= "#{sc_school_count} #{'school'.pluralize(sc_school_count)} can order devices for specific circumstances because their #{'request'.pluralize(sc_school_count)} #{'has'.pluralize(sc_school_count)} been approved." %></p>
 <%- end %>

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -1,0 +1,21 @@
+<%= render partial: 'heading' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= t('page_titles.order_devices.title') %></span>
+      <%= t('page_titles.order_devices.you_cannot_order_yet') %>
+    </h1>
+
+    <p class="govuk-body">None of the <%= govuk_link_to @responsible_body.count_of_schools_we_order_for_link_text, responsible_body_devices_schools_path %> have local coronavirus restrictions.</p>
+
+    <p class="govuk-body">You can only place orders when local coronavirus restrictions are confirmed.</p>
+
+    <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
+    <% if @responsible_body.has_schools_that_can_order_devices_now? %>
+      <%= render partial: 'some_schools_can_order' %>
+    <%- end %>
+
+    <%= render partial: 'get_devices_early' %>
+  </div>
+</div>

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -7,7 +7,8 @@
       <%= t('page_titles.order_devices.you_cannot_order_yet') %>
     </h1>
 
-    <p class="govuk-body">None of the <%= govuk_link_to @responsible_body.count_of_schools_we_order_for_link_text, responsible_body_devices_schools_path %> have local coronavirus restrictions.</p>
+    <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
+    <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> local coronavirus restrictions.</p>
 
     <p class="govuk-body">You can only place orders when local coronavirus restrictions are confirmed.</p>
 

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'heading' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.order_devices.order_devices_now') %>
+    </h1>
+
+    <p class="govuk-body">Place an order for each school.</p>
+    <p class="govuk-body">Devices will arrive the next working day if you order before 4pm.</p>
+  </div>
+</div>
+<%= render partial: 'place_order_for_schools' %>

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.order_devices.order_for_specific_circumstances') %>
     </h1>
 
-    <p class="govuk-body">Now you’ve emailed us to <%= govuk_link_to 'request devices for specific circumstances', '#' %>, you can go ahead with your order.</p>
+    <p class="govuk-body">Now you’ve emailed us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order.</p>
 
     <p class="govuk-body">You cannot order a school’s full allocation yet because there are no local coronavirus restrictions. The number of devices you can currently place for each school is shown.</p>
 

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -1,0 +1,18 @@
+<%= render partial: 'heading' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= t('page_titles.order_devices.title') %></span>
+      <%= t('page_titles.order_devices.order_for_specific_circumstances') %>
+    </h1>
+
+    <p class="govuk-body">Now you’ve emailed us to <%= govuk_link_to 'request devices for specific circumstances', '#' %>, you can go ahead with your order.</p>
+
+    <p class="govuk-body">You cannot order a school’s full allocation yet because there are no local coronavirus restrictions. The number of devices you can currently place for each school is shown.</p>
+
+    <p class="govuk-body">Place an order for each school.</p>
+    <p class="govuk-body">Devices will arrive the next working day if you order before 4pm.</p>
+  </div>
+</div>
+<%= render partial: 'place_order_for_schools' %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,5 +16,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'DfE' # Department for Education
   inflect.acronym 'API'
   inflect.irregular 'was', 'were'
+  inflect.irregular 'has', 'have'
   inflect.irregular 'contains', 'contain'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,11 @@
     school_details: Check your school details
     school_edit_chromebooks: Will your school need to order Chromebooks?
     school_users: Manage users
+    order_devices:
+      title: Order devices
+      you_cannot_order_yet: You cannot order devices yet
+      order_for_specific_circumstances: You can order devices for specific circumstances
+      order_devices_now: Order devices now
     invite_school_user:
       title: Invite a new user
       will_they_order_devices: Will they place orders for devices?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
       get '/who-will-order', to: 'who_will_order#show'
       get '/who-will-order/edit', to: 'who_will_order#edit'
       patch '/who-will-order', to: 'who_will_order#update'
+      get 'order-devices', to: 'orders#show', as: :order_devices
 
       resources :schools, only: %i[index show update], param: :urn do
         get '/who-to-contact', to: 'who_to_contact#new'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@
 # See the file initializers/config.rb for more info on how this is configured.
 
 computacenter:
+  techsource_url: https://techsource.computacenter.com/en/
   outgoing_api:
     endpoint:
     username:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_09_13_134728) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
-    t.bigint "responsible_body_id", null: false
+    t.integer "responsible_body_id", null: false
     t.string "contract_type"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -42,5 +42,13 @@ FactoryBot.define do
     trait :with_coms_device_allocation do
       association :coms_device_allocation, factory: %i[school_device_allocation with_coms_allocation]
     end
+
+    trait :with_shielding_pupils do
+      order_state { 'can_order_for_specific_circumstances' }
+    end
+
+    trait :in_lockdown do
+      order_state { 'can_order' }
+    end
   end
 end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+RSpec.feature 'Ordering devices' do
+  let(:responsible_body) { create(:local_authority, :in_devices_pilot) }
+  let(:schools) { create_list(:school, 5, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, responsible_body: responsible_body) }
+  let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }
+
+  before do
+    given_i_am_signed_in_as_a_responsible_body_user
+    given_my_order_information_is_up_to_date
+  end
+
+  scenario 'navigate to order devices page' do
+    when_i_visit_the_responsible_body_home_page
+    and_i_follow_the_get_laptops_and_tablets_link
+    then_i_see_the_get_laptops_and_tablets_page
+
+    when_i_follow_the_order_devices_link
+    then_i_see_the_cannot_order_devices_yet_page
+  end
+
+  scenario 'a centrally managed school can order for specific circumstances' do
+    given_a_centrally_managed_school_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_for_specific_circumstances_page
+  end
+
+  scenario 'a centrally managed school can order for local restrictions' do
+    given_a_centrally_managed_school_can_order_for_local_restrictions
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_1_school_that_i_need_to_place_orders_for
+  end
+
+  scenario 'centrally managed schools that can order for local restrictions and specific circumstances' do
+    given_a_centrally_managed_school_can_order_for_local_restrictions
+    given_a_centrally_managed_school_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_2_schools_that_i_need_to_place_orders_for
+  end
+
+  scenario 'a school that orders can order for specific circumstances' do
+    given_a_school_that_will_order_devices_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_cannot_order_devices_yet_page
+    and_i_see_that_1_school_can_place_their_own_order_for_specific_circumstances
+  end
+
+  scenario 'a school that orders can order for local restrictions' do
+    given_a_school_that_will_order_devices_can_order_for_local_restrictions
+    when_i_visit_the_order_devices_page
+    then_i_see_the_cannot_order_devices_yet_page
+    and_i_see_that_1_school_can_place_their_own_order_for_local_restrictions
+  end
+
+  scenario 'schools that order can order for local restrictions and specific circumstances' do
+    given_a_school_that_will_order_devices_can_order_for_local_restrictions
+    given_a_school_that_will_order_devices_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_cannot_order_devices_yet_page
+    and_i_see_that_2_schools_can_place_their_own_orders
+  end
+
+  def given_i_am_signed_in_as_a_responsible_body_user
+    sign_in_as user
+  end
+
+  def given_my_order_information_is_up_to_date
+    responsible_body.update!(who_will_order_devices: 'responsible_body')
+    PreorderInformation.where(school_id: responsible_body.schools).update_all(will_need_chromebooks: 'no')
+    schools[0].preorder_information.responsible_body_will_order_devices!
+    schools[1].preorder_information.responsible_body_will_order_devices!
+    schools[2].preorder_information.responsible_body_will_order_devices!
+    schools[3].preorder_information.school_will_order_devices!
+    schools[4].preorder_information.school_will_order_devices!
+  end
+
+  def given_a_centrally_managed_school_can_order_for_specific_circumstances
+    schools[1].can_order_for_specific_circumstances!
+    schools[1].std_device_allocation.update!(cap: 4, allocation: 8)
+  end
+
+  def given_a_centrally_managed_school_can_order_for_local_restrictions
+    schools[2].can_order!
+    schools[2].std_device_allocation.update!(cap: 7, allocation: 7)
+  end
+
+  def given_a_school_that_will_order_devices_can_order_for_specific_circumstances
+    schools[3].can_order_for_specific_circumstances!
+    schools[3].std_device_allocation.update!(cap: 2, allocation: 23)
+  end
+
+  def given_a_school_that_will_order_devices_can_order_for_local_restrictions
+    schools[4].can_order!
+    schools[4].std_device_allocation.update!(cap: 23, allocation: 23)
+  end
+
+  def when_i_visit_the_responsible_body_home_page
+    visit responsible_body_home_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def when_i_visit_the_order_devices_page
+    visit responsible_body_devices_order_devices_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def when_i_follow_the_order_devices_link
+    click_link('Order devices')
+  end
+
+  def and_i_follow_the_get_laptops_and_tablets_link
+    click_link 'Get laptops and tablets'
+  end
+
+  def then_i_see_the_get_laptops_and_tablets_page
+    expect(page).to have_css('h1', text: 'Get laptops and tablets')
+    expect(page).to have_link('Get schools ready')
+    expect(page).to have_link('Order devices')
+    expect(page).to have_link('Request devices for specific circumstances')
+  end
+
+  def then_i_see_the_cannot_order_devices_yet_page
+    expect(page).to have_css('h1', text: 'You cannot order devices yet')
+  end
+
+  def and_i_see_that_1_school_can_place_their_own_order_for_specific_circumstances
+    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
+    expect(page).to have_text('1 school can order devices for specific circumstances because their request has been approved.')
+  end
+
+  def and_i_see_that_1_school_can_place_their_own_order_for_local_restrictions
+    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
+    expect(page).to have_text('1 school has local coronavirus restrictions')
+  end
+
+  def and_i_see_that_2_schools_can_place_their_own_orders
+    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
+    expect(page).to have_text('1 school has local coronavirus restrictions')
+    expect(page).to have_text('1 school can order devices for specific circumstances because their request has been approved.')
+  end
+
+  def then_i_see_the_order_for_specific_circumstances_page
+    expect(page).to have_css('h1', text: 'You can order devices for specific circumstances')
+    expect(page).to have_text(schools[1].name)
+    expect(page).to have_text('Order 4 devices for specific circumstances')
+  end
+
+  def then_i_see_the_order_now_page
+    expect(page).to have_css('h1', text: 'Order devices now')
+  end
+
+  def and_i_see_1_school_that_i_need_to_place_orders_for
+    expect(page).to have_text('Schools you need to place orders for')
+    expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
+    expect(page).to have_text(schools[2].what_to_order_text)
+  end
+
+  def and_i_see_2_schools_that_i_need_to_place_orders_for
+    expect(page).to have_text('Schools you need to place orders for')
+    expect(page).to have_text("#{schools[1].name} (#{schools[1].urn})")
+    expect(page).to have_text(schools[1].what_to_order_text)
+    expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
+    expect(page).to have_text(schools[2].what_to_order_text)
+  end
+end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Ordering devices' do
+  include ViewHelper
+
   let(:responsible_body) { create(:local_authority, :in_devices_pilot) }
   let(:schools) { create_list(:school, 5, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, responsible_body: responsible_body) }
   let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }
@@ -154,14 +156,19 @@ RSpec.feature 'Ordering devices' do
   def and_i_see_1_school_that_i_need_to_place_orders_for
     expect(page).to have_text('Schools you need to place orders for')
     expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
-    expect(page).to have_text(schools[2].what_to_order_text)
+    expect(page).to have_text(what_to_order_for(schools[2]))
   end
 
   def and_i_see_2_schools_that_i_need_to_place_orders_for
     expect(page).to have_text('Schools you need to place orders for')
     expect(page).to have_text("#{schools[1].name} (#{schools[1].urn})")
-    expect(page).to have_text(schools[1].what_to_order_text)
+    expect(page).to have_text(what_to_order_for(schools[1]))
     expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
-    expect(page).to have_text(schools[2].what_to_order_text)
+    expect(page).to have_text(what_to_order_for(schools[2]))
+  end
+
+  def what_to_order_for(school)
+    what_to_order(school.std_device_allocation.available_devices_count,
+                  school.can_order_for_specific_circumstances?)
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -208,11 +208,11 @@ RSpec.describe School, type: :model do
   end
 
   describe '#can_order_devices?' do
-    let(:school) { create(:school) }
+    let(:school) { create(:school, :in_lockdown) }
 
     context 'when there is no allocation of the given type' do
       it 'is false' do
-        expect(school.can_order_devices?).to eq(false)
+        expect(school.can_order_devices?).to be false
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,6 +83,7 @@ RSpec.configure do |config|
   end
 
   config.before do
+    Faker::Number.unique.clear
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/43443pu0/635-ordering-devices-centrally)
Add ordering devices for responsible body
See [https://increasing-access-history.herokuapp.com/ordering-devices-centrally/](https://increasing-access-history.herokuapp.com/ordering-devices-centrally/)

### Changes proposed in this pull request
Add 'order devices' page for RBs in devices pilot
The order devices page is different depending on:
Any schools can order
Any centrally managed schools can order
Any schools that will order devices can order

### Guidance to review
There are a couple of changes to the design that have had to be worked in.  The designs assume that we are tracking allocation amounts i.e. 'You've ordered 1 of 4 devices' which isn't a thing currently so that text is missing.
@emmajhf has provided some copy for when there are schools that will order devices that can order for specific circumstances and/or for local restrictions.
The final page in the design has not been added as it also relies on the tracking of allocation amounts - I'm also not sure at which point you'd want to switch from that page back to the 'Cannot order devices yet' page, if at all, or whether once an order has been placed you would never see the 'Cannot order devices yet' page again.
