### PR TITLE
Improvements to the 'Enable school orders' support form

### DIFF
--- a/app/views/support/devices/order_status/edit.html.erb
+++ b/app/views/support/devices/order_status/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', support_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_link_to('Back', support_devices_school_path(@school.urn), class: 'govuk-back-link') %>
 <%- title = t('page_titles.support_order_status.enable_orders') %>
 <%- content_for :title, title %>
 

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Enabling orders for a school from the support area' do
   let(:support_user) { create(:support_user) }
-  let(:school) { create(:school) }
+  let(:school) { create(:school, order_state: :cannot_order) }
   let(:school_details_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
 
   before do
@@ -30,6 +30,9 @@ RSpec.feature 'Enabling orders for a school from the support area' do
         expect(page).to have_field('No, orders cannot be placed yet')
         expect(page).to have_field('They can place orders for specific circumstances')
         expect(page).to have_field('They can order their full allocation because local coronavirus restrictions are confirmed')
+
+        # the 'no' option should be chosen
+        expect(find('#support-enable-orders-form-order-state-cannot-order-field')['checked']).to eq('checked')
       end
 
       context 'selecting They can place orders for specific circumstances' do


### PR DESCRIPTION
### Context

The back link on that form is broken. The form doesn't pre-populate existing values from the school model.

### Changes proposed in this pull request

Fix broken back link.
Populate the edit form with existing values.
