### PR TITLE
Make the connectivity pilot RB report more useful

### DIFF
--- a/app/controllers/support/internet/responsible_bodies_controller.rb
+++ b/app/controllers/support/internet/responsible_bodies_controller.rb
@@ -1,6 +1,7 @@
 class Support::Internet::ResponsibleBodiesController < Support::BaseController
   def index
     @responsible_bodies = ResponsibleBody
+      .in_connectivity_pilot
       .includes(:bt_wifi_voucher_allocation, :bt_wifi_vouchers)
       .joins(:users)
       .distinct

--- a/spec/features/support/internet/viewing_onboarded_responsible_bodies_spec.rb
+++ b/spec/features/support/internet/viewing_onboarded_responsible_bodies_spec.rb
@@ -4,32 +4,34 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
   let(:responsible_bodies_page) { PageObjects::Support::Internet::ResponsibleBodiesPage.new }
 
   scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
-    given_there_are_responsible_bodies_that_have_users
-    and_given_there_are_responsible_bodies_that_do_not_have_any_users
+    given_there_are_pilot_responsible_bodies_that_have_users
+    and_given_there_are_responsible_bodies_that_are_outside_the_pilot
 
     when_i_sign_in_as_a_dfe_user
     and_i_visit_the_support_responsible_bodies_page
 
-    then_i_can_see_the_responsible_bodies_with_users
-    and_i_cannot_see_the_responsible_bodies_without_users
+    then_i_can_see_the_pilot_responsible_bodies_with_users
+    and_i_cannot_see_responsible_bodies_outside_the_pilot
   end
 
-  def given_there_are_responsible_bodies_that_have_users
-    la = create(:local_authority, name: 'Coventry')
+  def given_there_are_pilot_responsible_bodies_that_have_users
+    la = create(:local_authority, name: 'Coventry', in_connectivity_pilot: true)
     create(:user, responsible_body: la, sign_in_count: 0)
     create(:user, responsible_body: la, sign_in_count: 2)
     create(:bt_wifi_voucher_allocation, amount: 123, responsible_body: la)
     create_list(:bt_wifi_voucher, 123, :downloaded, responsible_body: la)
 
-    trust = create(:trust, name: 'AWESOME TRUST')
+    trust = create(:trust, name: 'AWESOME TRUST', in_connectivity_pilot: true)
     create(:user, responsible_body: trust, sign_in_count: 0)
     create(:bt_wifi_voucher_allocation, amount: 456, responsible_body: trust)
     create_list(:bt_wifi_voucher, 456, responsible_body: trust)
   end
 
-  def and_given_there_are_responsible_bodies_that_do_not_have_any_users
-    create(:local_authority, name: 'Wandsworth')
-    create(:trust, name: 'ANOTHER TRUST')
+  def and_given_there_are_responsible_bodies_that_are_outside_the_pilot
+    la = create(:local_authority, name: 'Wandsworth', in_connectivity_pilot: false)
+    create(:user, responsible_body: la, sign_in_count: 2)
+
+    create(:trust, name: 'ANOTHER TRUST', in_connectivity_pilot: false)
   end
 
   def when_i_sign_in_as_a_dfe_user
@@ -40,7 +42,7 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     responsible_bodies_page.load
   end
 
-  def then_i_can_see_the_responsible_bodies_with_users
+  def then_i_can_see_the_pilot_responsible_bodies_with_users
     expect(responsible_bodies_page.responsible_body_rows.size).to eq(2)
 
     first_row = responsible_bodies_page.responsible_body_rows[0]
@@ -60,7 +62,7 @@ RSpec.feature 'Viewing on-boarded responsible bodies in the support area', type:
     expect(second_row).to have_text('No') # hotspots downloaded?
   end
 
-  def and_i_cannot_see_the_responsible_bodies_without_users
+  def and_i_cannot_see_responsible_bodies_outside_the_pilot
     expect(page).not_to have_text('Wandsworth')
     expect(page).not_to have_text('ANOTHER TRUST')
   end

--- a/spec/features/support/internet/viewing_responsible_body_users_spec.rb
+++ b/spec/features/support/internet/viewing_responsible_body_users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing responsible body users in the support area', type: :feature do
-  let(:local_authority) { create(:local_authority, name: 'Coventry') }
+  let(:local_authority) { create(:local_authority, name: 'Coventry', in_connectivity_pilot: true) }
   let(:responsible_bodies_page) { PageObjects::Support::Internet::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::Internet::ResponsibleBodyPage.new }
 


### PR DESCRIPTION
# Context

When the connectivity pilot RB report in Support was conceived, we only had a limited number of RBs with users. Now that the devices work is also in the service, that assumption is no longer the case, so we need to filter the connectivity RB list
by participation in the connectivity pilot.

### Changes proposed in this pull request

Only show RBs in the connectivity pilot for the support > internet > responsible bodies page.

### Guidance to review

