### PR TITLE
[683] Who to contact form updates existing contact

### DIFF
--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -18,7 +18,7 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
       render :new, status: :unprocessable_entity
     else
       chosen_contact = @form.chosen_contact
-      chosen_contact.save! unless chosen_contact.persisted?
+      chosen_contact.save!
       @school.preorder_information.update!(school_contact: chosen_contact)
       flash[:success] = I18n.t(:success, scope: %i[responsible_body devices schools who_to_contact create], email_address: chosen_contact.email_address)
       redirect_to responsible_body_devices_school_path(@school.urn)

--- a/app/form_objects/responsible_body/devices/who_to_contact_form.rb
+++ b/app/form_objects/responsible_body/devices/who_to_contact_form.rb
@@ -33,13 +33,11 @@ class ResponsibleBody::Devices::WhoToContactForm
     if headteacher_chosen?
       headteacher_contact
     elsif someone_else_chosen?
-      SchoolContact.new(
-        school: school,
-        role: :contact,
-        full_name: full_name,
-        email_address: email_address,
-        phone_number: phone_number,
-      )
+      school.contacts.find_or_initialize_by(email_address: email_address).tap do |contact|
+        contact.role = :contact
+        contact.full_name = full_name
+        contact.phone_number = phone_number
+      end
     end
   end
 

--- a/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ResponsibleBody::Devices::WhoToContactController do
-  let(:school) { create(:school, :with_headteacher_contact) }
+  let(:school) { create(:school, :with_headteacher_contact, :with_preorder_information) }
   let(:local_authority) { create(:local_authority, schools: [school], in_devices_pilot: true) }
   let(:rb_user) { create(:local_authority_user, responsible_body: local_authority) }
 
@@ -12,13 +12,52 @@ RSpec.describe ResponsibleBody::Devices::WhoToContactController do
   end
 
   describe '#create' do
-    it "displays errors if the user doesn't select anything" do
-      post :create, params: {
-        responsible_body_devices_who_to_contact_form: { full_name: '', email_address: '', phone_number: '' },
-        school_urn: school.urn,
-      }
+    context "when user doesn't select anything" do
+      before do
+        post :create, params: {
+          responsible_body_devices_who_to_contact_form: {
+            full_name: '',
+            email_address: '',
+            phone_number: '',
+          },
+          school_urn: school.urn,
+        }
+      end
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      it 'displays errors' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when contact exists and updating the same email' do
+      let(:existing_contact) { school.contacts.first }
+
+      before do
+        post :create, params: {
+          responsible_body_devices_who_to_contact_form: {
+            who_to_contact: 'someone_else',
+            full_name: 'different name',
+            email_address: existing_contact.email_address,
+            phone_number: '020 1',
+          },
+          school_urn: school.urn,
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { response }.not_to raise_error
+      end
+
+      it 'does not create a new contact' do
+        expect { response }.not_to change(SchoolContact, :count)
+      end
+
+      it 'updates the existing contact' do
+        existing_contact.reload
+
+        expect(existing_contact.full_name).to eql('different name')
+        expect(existing_contact.phone_number).to eql('020 1')
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/w2vkKQQu/683-rbs-cant-update-a-headteacher-contact
- Users are trying to update contacts but the implementation tries to create a new record with duplicated data which fires a uniqueness constraint therefore raising an error

### Changes proposed in this pull request

- On this form if another contact is added but uses an email of an existing contact it will update the existing contact

### Guidance to review

- I'm not sure how to actually navigate to the concerned page. This http://localhost:3000/responsible-body/devices/schools/100000/who-to-contact worked for me though
- Ensure a contact already exists
- Enter email address of existing contact
- All other inputs should be something else
- Existing contact should now be updated with the just entered data