### PR TITLE
[665] Added mail notification of cap changes to computacenter

### DIFF
--- a/app/mailers/computacenter_mailer.rb
+++ b/app/mailers/computacenter_mailer.rb
@@ -1,0 +1,48 @@
+class ComputacenterMailer < ApplicationMailer
+  def notify_of_devices_cap_change
+    setup_params
+
+    template_mail(
+      devices_cap_change_template_id,
+      to: recipient,
+      personalisation: personalisation,
+    )
+  end
+
+  def notify_of_comms_cap_change
+    setup_params
+
+    template_mail(
+      comms_cap_change_template_id,
+      to: recipient,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def setup_params
+    @school = params[:school]
+    @new_cap_value = params[:new_cap_value]
+  end
+
+  def personalisation
+    {
+      school_name: @school.name,
+      urn: @school.urn,
+      new_cap_value: @new_cap_value,
+    }
+  end
+
+  def recipient
+    Settings.computacenter.notify_email_address
+  end
+
+  def devices_cap_change_template_id
+    Settings.govuk_notify.templates.computacenter.device_cap_change
+  end
+
+  def comms_cap_change_template_id
+    Settings.govuk_notify.templates.computacenter.comms_cap_change
+  end
+end

--- a/app/services/cap_update_service.rb
+++ b/app/services/cap_update_service.rb
@@ -11,9 +11,23 @@ class CapUpdateService
     allocation = update_cap!(cap)
 
     update_cap_on_computacenter!(allocation.id)
+
+    notify_computacenter_by_email(allocation.cap)
   end
 
 private
+
+  def notify_computacenter_by_email(new_cap_value)
+    if FeatureFlag.active?(:notify_computacenter_of_cap_changes)
+      if @device_type == 'std_device'
+        ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
+          .notify_of_devices_cap_change.deliver_later
+      else
+        ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
+          .notify_of_comms_cap_change.deliver_later
+      end
+    end
+  end
 
   def update_order_state!(order_state)
     @school.update!(order_state: order_state)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -7,6 +7,7 @@ class FeatureFlag
     who_will_order_slack_notifications
     invite_slack_notifications
     rbs_can_manage_users
+    notify_computacenter_of_cap_changes
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@
 # See the file initializers/config.rb for more info on how this is configured.
 
 computacenter:
+  notify_email_address: departmentforeducation@computacenter.com
   techsource_url: https://techsource.computacenter.com/en/
   outgoing_api:
     endpoint:
@@ -35,6 +36,9 @@ govuk_notify:
       invite_responsible_body_user: '42e5cd7a-deaa-4234-bdea-db63b7c4ad90'
       nominate_contacts: 'ef964a6f-d984-4f35-a074-6f3cb79bfec7'
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
+    computacenter:
+      device_cap_change: '6e00f2bf-d373-436d-a2c0-2910f20ef521'
+      comms_cap_change: '01f1b2a3-a216-44cc-a567-704bfd0a3c56'
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000
 

--- a/spec/services/cap_update_service_spec.rb
+++ b/spec/services/cap_update_service_spec.rb
@@ -21,6 +21,26 @@ RSpec.describe CapUpdateService do
       expect { service.update!(cap: new_cap, order_state: new_order_state) }.to change(school, :order_state).from('cannot_order').to('can_order')
     end
 
+    context 'when the notify_computacenter_of_cap_changes feature flag is active' do
+      before do
+        FeatureFlag.activate(:notify_computacenter_of_cap_changes)
+      end
+
+      it 'sends an email to computacenter' do
+        expect { service.update!(cap: new_cap, order_state: new_order_state) }.to have_enqueued_mail(ComputacenterMailer, :notify_of_devices_cap_change).once
+      end
+    end
+
+    context 'when the notify_computacenter_of_cap_changes feature flag is not active' do
+      before do
+        FeatureFlag.deactivate(:notify_computacenter_of_cap_changes)
+      end
+
+      it 'does not send an email to computacenter' do
+        expect { service.update!(cap: new_cap, order_state: new_order_state) }.not_to have_enqueued_mail(ComputacenterMailer, :notify_of_devices_cap_change)
+      end
+    end
+
     context 'when a std SchoolDeviceAllocation does not exist' do
       before do
         SchoolDeviceAllocation.delete_all
@@ -37,6 +57,16 @@ RSpec.describe CapUpdateService do
 
         it 'creates a new allocation record with the given device_type' do
           expect { service.update!(cap: new_cap, order_state: new_order_state) }.to change(school.device_allocations.by_device_type('coms_device'), :count).by(1)
+        end
+
+        context 'when the notify_computacenter_of_cap_changes feature flag is active' do
+          before do
+            FeatureFlag.activate(:notify_computacenter_of_cap_changes)
+          end
+
+          it 'sends an email to computacenter' do
+            expect { service.update!(cap: new_cap, order_state: new_order_state) }.to have_enqueued_mail(ComputacenterMailer, :notify_of_comms_cap_change).once
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/SsxJkncU/665-an-email-is-sent-to-computacenter-when-a-cap-is-updated)
An email notification is sent to Computacenter when a cap changes.
This is enabled using the feature flag `:notify_computacenter_of_cap_changes`

### Changes proposed in this pull request
Addition of mailer for Computacenter with emails for devices and comms cap changes
Addition of feature flag to control whether email notification are sent

### Guidance to review
`CapUpdateService#update!` will trigger an email if the feature flag is activated.  This also attempts to send a SOAP request to computacenter (which failed on my dev environment) so may not be a safe way to test this?
