### PR TITLE
[684] Add contacts to school support page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,7 @@ group :test do
   gem 'timecop'
   gem 'webdrivers', '~> 4.3'
   gem 'shoulda-matchers', '~> 4.4'
+  gem 'rails-controller-testing'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 6.0.3.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -489,6 +493,7 @@ DEPENDENCIES
   puma (~> 4.3)
   rack-throttle
   rails (>= 6.0.3.1)
+  rails-controller-testing
   rails_semantic_logger
   redcarpet
   rspec-rails (~> 4.0.1)

--- a/app/controllers/support/devices/contacts_controller.rb
+++ b/app/controllers/support/devices/contacts_controller.rb
@@ -1,0 +1,24 @@
+class Support::Devices::ContactsController < Support::BaseController
+  def edit
+    @school = School.find_by(urn: params[:school_urn])
+    @contact = @school.contacts.find(params[:id])
+  end
+
+  def update
+    @school = School.find_by(urn: params[:school_urn])
+    @contact = @school.contacts.find(params[:id])
+
+    if @contact.update(school_contact_params)
+      flash[:success] = 'School contact has been updated'
+      redirect_to support_devices_school_path(urn: @school.urn)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def school_contact_params
+    params.require(:school_contact).permit(:full_name, :email_address, :phone_number)
+  end
+end

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -2,6 +2,7 @@ class Support::Devices::SchoolsController < Support::BaseController
   def show
     @school = School.find_by!(urn: params[:urn])
     @users = @school.users
+    @contacts = @school.contacts
   end
 
   def confirm_invitation

--- a/app/views/support/devices/contacts/edit.html.erb
+++ b/app/views/support/devices/contacts/edit.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: @contact, url: support_devices_school_contact_path(school_urn: @school.urn, id: @contact.id) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_field :full_name,
+      label: { text: 'Name' } %>
+
+  <%= f.govuk_email_field :email_address,
+      label: { text: 'Email address' } %>
+
+  <%= f.govuk_text_field :phone_number,
+      label: { text: 'Telephone number' },
+      width: 10 %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -43,5 +43,34 @@
     <% else %>
       <p class="govuk-body">None</p>
     <% end %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-8">Contacts</h2>
+
+    <% if @contacts.present? %>
+      <table id="contacts" class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Email address</th>
+            <th scope="col" class="govuk-table__header">Full name</th>
+            <th scope="col" class="govuk-table__header">Role</th>
+            <th scope="col" class="govuk-table__header">Title</th>
+            <th scope="col" class="govuk-table__header">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @contacts.each do |contact| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= contact.email_address %></td>
+              <td class="govuk-table__cell"><%= contact.full_name %></td>
+              <td class="govuk-table__cell"><%= contact.role %></td>
+              <td class="govuk-table__cell"><%= contact.title %></td>
+              <td class="govuk-table__cell"><%= link_to 'Change', edit_support_devices_school_contact_path(school_urn: @school.urn, id: contact.id) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">None</p>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
       resources :schools, only: %i[show], param: :urn do
+        resources :contacts, only: %i[edit update]
         get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
         post '/invite', to: 'schools#invite'
         get '/enable-orders', to: 'order_status#edit', as: :enable_orders

--- a/spec/controllers/support/devices/contacts_controller_spec.rb
+++ b/spec/controllers/support/devices/contacts_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Support::Devices::ContactsController do
+  include Rails.application.routes.url_helpers
+
+  let(:school) { create(:school, :with_headteacher_contact) }
+  let(:contact) { school.contacts.first }
+  let(:support_user) { create(:support_user) }
+
+  before do
+    sign_in_as support_user
+  end
+
+  describe '#edit' do
+    it 'responds successfully' do
+      get :edit, params: { school_urn: school.urn, id: contact.id }
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    let(:full_name) { 'new name' }
+
+    before do
+      put :update, params: {
+        school_urn: school.urn,
+        id: contact.id,
+        school_contact: {
+          full_name: full_name,
+          email_address: 'new.email@example.com',
+          phone_number: '020 07275930',
+        },
+      }
+    end
+
+    it 'updates contact details' do
+      contact.reload
+
+      expect(contact.full_name).to eql('new name')
+      expect(contact.email_address).to eql('new.email@example.com')
+      expect(contact.phone_number).to eql('020 07275930')
+    end
+
+    it 'redirects user back to school' do
+      expect(response).to redirect_to(support_devices_school_path(school.urn))
+    end
+
+    it 'populates success flash message' do
+      expect(flash[:success]).to be_present
+    end
+
+    context 'sad path' do
+      let(:full_name) { '' }
+
+      it 'renders form again' do
+        expect(contact).to render_template('support/devices/contacts/edit')
+      end
+    end
+  end
+end

--- a/spec/features/support/devices/contacts_management_spec.rb
+++ b/spec/features/support/devices/contacts_management_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing contacts', type: :feature do
+  let(:school_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
+  let(:contact_page) { PageObjects::Support::Devices::ContactPage.new }
+
+  let(:school) { create(:school, :with_headteacher_contact) }
+  let(:contact) { school.contacts.first }
+
+  scenario 'support user updates contact' do
+    given_a_school_with_a_contact
+    when_i_sign_in_as_a_dfe_user
+    and_i_visit_the_school_page
+    then_i_see_the_school_contacts
+
+    when_i_change_contact_info
+    then_i_see_updated_contact_info
+  end
+
+  def given_a_school_with_a_contact
+    school
+  end
+
+  def when_i_sign_in_as_a_dfe_user
+    sign_in_as create(:dfe_user)
+  end
+
+  def and_i_visit_the_school_page
+    school_page.load(urn: school.urn)
+  end
+
+  def then_i_see_the_school_contacts
+    expect(school_page.contacts).to have_content(contact.full_name)
+  end
+
+  def when_i_change_contact_info
+    school_page.contacts.click_link 'Change'
+    contact_page.full_name.fill_in with: 'Other Name'
+    contact_page.submit.click
+  end
+
+  def then_i_see_updated_contact_info
+    expect(school_page).to have_content('School contact has been updated')
+    expect(school_page.contacts).to have_content('Other Name')
+  end
+end

--- a/spec/page_objects/support/devices/contact_page.rb
+++ b/spec/page_objects/support/devices/contact_page.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Support
+    module Devices
+      class ContactPage < PageObjects::BasePage
+        element :full_name, 'input#school-contact-full-name-field'
+        element :submit, 'input[value=Continue]'
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/devices/school_details_page.rb
+++ b/spec/page_objects/support/devices/school_details_page.rb
@@ -2,7 +2,11 @@ module PageObjects
   module Support
     module Devices
       class SchoolDetailsPage < PageObjects::BasePage
+        set_url '/support/devices/schools/{urn}'
+
         elements :school_details_rows, '.school-details-summary-list .govuk-summary-list__row'
+
+        element :contacts, 'table#contacts'
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/mQs5Q3Jl/684-no-ability-to-edit-school-contacts-for-support-users
- Support agents are not able to update contacts

### Changes proposed in this pull request

- Support can now see contacts on the school show page in support
- There is a link to a form to then update the contact

### Guidance to review

- Log in as support agent
- Find a school
- Should see contacts
- Click change link and update contact info
- Contact should now be updated