### PR TITLE
Add page furniture for contact edit screen in support

### DIFF
--- a/app/views/support/devices/contacts/edit.html.erb
+++ b/app/views/support/devices/contacts/edit.html.erb
@@ -1,15 +1,28 @@
-<%= form_with model: @contact, url: support_devices_school_contact_path(school_urn: @school.urn, id: @contact.id) do |f| %>
-  <%= f.govuk_error_summary %>
+<%- content_for :before_content, govuk_link_to('Back', support_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- title = t('page_titles.support_school_contacts_edit') %>
+<%- content_for :title, title %>
 
-  <%= f.govuk_text_field :full_name,
-      label: { text: 'Name' } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
 
-  <%= f.govuk_email_field :email_address,
-      label: { text: 'Email address' } %>
+    <%= form_with model: @contact, url: support_devices_school_contact_path(school_urn: @school.urn, id: @contact.id) do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <%= f.govuk_text_field :phone_number,
-      label: { text: 'Telephone number' },
-      width: 10 %>
+      <%= f.govuk_text_field :full_name,
+          label: { text: 'Name' } %>
 
-  <%= f.govuk_submit %>
-<% end %>
+      <%= f.govuk_email_field :email_address,
+          label: { text: 'Email address' } %>
+
+      <%= f.govuk_text_field :phone_number,
+          label: { text: 'Telephone number' },
+          width: 10 %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@
     support_devices_responsible_bodies: Devices pilot on-boarded responsible bodies
     support_internet_responsible_bodies: Internet pilot on-boarded responsible bodies
     support_responsible_bodies: On-boarded responsible bodies
+    support_school_contacts_edit: Edit school contact
     support_devices: Devices
     support_order_status:
       enable_orders: Can they place orders?


### PR DESCRIPTION
### Context

I may have overzealously merged #478, since the contact edit page didn't have any titles, headings or back link.

### Changes proposed in this pull request

Add page furniture to the contact edit page.

### Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/93398145-ed55ba00-f872-11ea-997d-34ba324d887e.png)


After: 

![image](https://user-images.githubusercontent.com/23801/93398119-e169f800-f872-11ea-81af-322ef5599990.png)
