### PR TITLE
[684] Support can set current school contact

### DIFF
--- a/app/controllers/support/devices/contacts_controller.rb
+++ b/app/controllers/support/devices/contacts_controller.rb
@@ -16,6 +16,15 @@ class Support::Devices::ContactsController < Support::BaseController
     end
   end
 
+  def set_as_school_contact
+    @school = School.find_by(urn: params[:school_urn])
+    @contact = @school.contacts.find(params[:id])
+
+    if @school.preorder_information&.update(school_contact: @contact)
+      redirect_to support_devices_school_path(urn: @school.urn)
+    end
+  end
+
 private
 
   def school_contact_params

--- a/app/models/school_contact.rb
+++ b/app/models/school_contact.rb
@@ -14,6 +14,10 @@ class SchoolContact < ApplicationRecord
   validates :full_name, presence: true
   validates :role, presence: true
 
+  def current_school_contact?
+    school&.preorder_information&.school_contact == self
+  end
+
   def to_user
     User.new(
       school: school,

--- a/app/views/support/devices/contacts/edit.html.erb
+++ b/app/views/support/devices/contacts/edit.html.erb
@@ -24,5 +24,9 @@
 
       <%= f.govuk_submit %>
     <% end %>
+
+    <% unless @contact.current_school_contact? %>
+      <%= button_to('Set as the school contact', set_as_school_contact_support_devices_school_contact_path(school_urn: @school.urn, id: @contact), { method: :put, class: 'govuk-button govuk-button--secondary' }) %>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,7 +129,11 @@ Rails.application.routes.draw do
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
       resources :schools, only: %i[show], param: :urn do
-        resources :contacts, only: %i[edit update]
+        resources :contacts, only: %i[edit update] do
+          member do
+            put :set_as_school_contact, path: 'set-as-school-contact'
+          end
+        end
         get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
         post '/invite', to: 'schools#invite'
         get '/enable-orders', to: 'order_status#edit', as: :enable_orders

--- a/spec/controllers/support/devices/contacts_controller_spec.rb
+++ b/spec/controllers/support/devices/contacts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Support::Devices::ContactsController do
   include Rails.application.routes.url_helpers
 
-  let(:school) { create(:school, :with_headteacher_contact) }
+  let(:school) { create(:school, :with_headteacher_contact, :with_preorder_information) }
   let(:contact) { school.contacts.first }
   let(:support_user) { create(:support_user) }
 
@@ -55,6 +55,21 @@ RSpec.describe Support::Devices::ContactsController do
       it 'renders form again' do
         expect(contact).to render_template('support/devices/contacts/edit')
       end
+    end
+  end
+
+  describe '#set_as_school_contact' do
+    let(:other_contact) { create(:school_contact, school: school) }
+
+    before do
+      put :set_as_school_contact, params: {
+        school_urn: school.urn,
+        id: other_contact.id,
+      }
+    end
+
+    it 'updates current school contact' do
+      expect(school.preorder_information.reload.school_contact).to eql(other_contact)
     end
   end
 end

--- a/spec/models/school_contact_spec.rb
+++ b/spec/models/school_contact_spec.rb
@@ -18,4 +18,26 @@ RSpec.describe SchoolContact, type: :model do
     it { is_expected.to validate_presence_of(:role) }
     it { is_expected.not_to allow_value('invalid.email').for(:email_address) }
   end
+
+  describe '#current_school_contact?' do
+    let(:school) { build(:school) }
+
+    subject(:contact) { build(:school_contact, school: school) }
+
+    context 'when current school contact' do
+      before do
+        school.build_preorder_information(school_contact: contact)
+      end
+
+      it 'returns true' do
+        expect(contact.current_school_contact?).to be_truthy
+      end
+    end
+
+    context 'when not current school contact' do
+      it 'returns false' do
+        expect(contact.current_school_contact?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/mQs5Q3Jl/684-no-ability-to-edit-school-contacts-for-support-users
- Allow support to be able to select a contact and set the as the current contact

### Changes proposed in this pull request

- In support added a secondary button to be able to set the contact on the page as the current contact. Only visible if the contact is not the current contact

![image](https://user-images.githubusercontent.com/92580/93452723-ac8c8e00-f8d0-11ea-9cb2-d2ece96cf8f5.png)

### Guidance to review

- Find school with multiple contacts
- Go go edit contact of the current contact, should not see the `Set as current contact` button as they are already the current contact
- Go to another contact
- Set them as the current contact
- They should now be the current contact, visible on school show page