### PR TITLE
Add school order devices page

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,9 +1,5 @@
 class School::DevicesController < School::BaseController
   def order
-    # replace with if conditon below when we've developed the other
-    # branch of the user journey
-    # if false && @school.can_order_devices?
-    # else
     if @school.can_order_devices?
       render :order
     else

--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -4,8 +4,11 @@ class School::DevicesController < School::BaseController
     # branch of the user journey
     # if false && @school.can_order_devices?
     # else
-    render :cannot_order
-    # end
+    if @school.can_order_devices?
+      render :order
+    else
+      render :cannot_order
+    end
   end
 
   def request_devices

--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -26,10 +26,4 @@
 <h2 class="govuk-heading-m">Help signing in to TechSource</h2>
 <p class="govuk-body">You need to place orders on a website called TechSource, which is run by Computacenter.</p>
 
-<p class="govuk-body">Your 'User ID' is your email address: <%= @user.email_address %></p>
-
-<p class="govuk-body">If you do not remember your password use the 'Forgotten password?' link to reset it.</p>
-
-<%= govuk_start_button_link_to('Start now', techsource_url, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
-
-<p class="govuk-body-s">on TechSource in a new window</p>
+<%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address } %>

--- a/app/views/school/devices/order.html.erb
+++ b/app/views/school/devices/order.html.erb
@@ -1,0 +1,37 @@
+<%- title = t('page_titles.school_order_devices') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { t('page_titles.school_home') => school_home_path },
+    title,
+  ]) %>
+<%- end %>
+
+<%-
+  device_count = @school.std_device_allocation.available_devices_count
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <div class="app-card app-card__order">
+      <h2 class="govuk-panel__title govuk-!-font-size-36 govuk-!-margin-bottom-2">
+        <%= "#{device_count} #{'device'.pluralize(device_count)} available" -%>
+      </h2>
+      <div class="govuk-panel__body govuk-!-font-size-24">
+        You’ve ordered <%= @school.std_device_allocation.devices_ordered %> of
+        <%= @school.std_device_allocation.cap %> devices
+      </div>
+    </div>
+
+    <p class="govuk-body">Order your devices now. Do not delay.</p>
+    <p class="govuk-body">They will arrive on the next working day if you order before 4pm.</p>
+    <p class="govuk-body">You need to place orders on a website called TechSource.</p>
+
+    <h2 class="govuk-heading-m">Before you start</h2>
+    <p class="govuk-body">It’s important to know your device allocation before you sign in. If you try to order more devices that you’ve been allocated, the order will be cancelled.</p>
+
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address } %>
+  </div>
+</div>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">Your ‘User ID’ is your email address: <%= local_assigns[:email_address] %></p>
+
+<p class="govuk-body">If you do not remember your password use the ‘Forgotten password?’ link to reset it.</p>
+
+<%= govuk_start_button_link_to('Start now', techsource_url, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
+
+<p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/webpacker/styles/_card.scss
+++ b/app/webpacker/styles/_card.scss
@@ -37,6 +37,16 @@
   background-color: govuk-colour("white");
 }
 
+.app-card__order {
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
+  }
+}
+
 .app-card__count {
   @include govuk-font($size: 80, $weight: bold);
   display: block;

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -1,18 +1,56 @@
 require 'rails_helper'
 
-RSpec.feature 'Order devices (outside lockdown)' do
-  let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
+RSpec.feature 'Order devices' do
+  include ViewHelper
 
-  context 'logged in as a school user' do
-    before do
-      sign_in_as school_user
-    end
+  let(:school) { create(:school, :with_std_device_allocation) }
+  let(:school_user) { create(:school_user, school: school, full_name: 'AAA Smith') }
 
-    scenario 'Finding out about ordering devices' do
-      click_on 'Order devices'
+  before do
+    given_i_am_signed_in_as_a_school_user
+  end
 
-      expect(page).to have_content('You cannot order devices yet')
-      expect(page).to have_link('request devices for disadvantaged children')
-    end
+  scenario 'when my school can order devices' do
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_the_amount_of_devices_i_can_order
+    and_i_see_a_link_to_techsource
+  end
+
+  scenario 'when my school cannot order devices' do
+    given_i_cannot_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_that_i_cannot_order_devices_yet
+  end
+
+  def given_i_am_signed_in_as_a_school_user
+    sign_in_as school_user
+  end
+
+  def given_i_can_order_devices
+    school.std_device_allocation.update!(cap: 50, allocation: 100, devices_ordered: 20)
+    school.can_order!
+  end
+
+  def given_i_cannot_order_devices
+    school.cannot_order!
+  end
+
+  def when_i_visit_the_order_devices_page
+    visit school_order_devices_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def then_i_see_the_amount_of_devices_i_can_order
+    expect(page).to have_text('30 devices available')
+  end
+
+  def and_i_see_a_link_to_techsource
+    expect(page).to have_link('Start now', href: techsource_url)
+  end
+
+  def then_i_see_that_i_cannot_order_devices_yet
+    expect(page).to have_content('You cannot order devices yet')
+    expect(page).to have_link('request devices for disadvantaged children')
   end
 end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/6SoAV292/562-schools-order-devices-in-lockdown)
Order devices page for schools

### Changes proposed in this pull request
Add order devices page with link to TechSource

### Guidance to review
The trigger for displaying the order devices page is `School#can_order_devices?` which takes the `order_state` and whether there are any devices available to order into account - should this only consider the `order_state` so a school can see when they've used their allocation rather than see the 'You can't order devices yet' page once they've ordered their devices?

Currently kept the `You’ve ordered 0 of 2 devices` text although we don't track it and we decided not to show it on the RB order devices pages. We can only show "`devices_ordered` of `cap`" which may end up being confusing.
I extracted the text around the tech source link from the RB journey into a partial for re-use here - the wording is slightly different maybe a content review to make it consistent across the journeys is needed at some point.

![image](https://user-images.githubusercontent.com/333931/93481359-60544480-f8f6-11ea-8aed-e405c9a71c11.png)

