### PR TITLE
[682] RBs can update the school contact

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -94,6 +94,8 @@ private
       [{
         key: 'School contact',
         value: contact_lines.map { |line| h(line) }.join('<br>').html_safe,
+        change_path: responsible_body_devices_school_who_to_contact_edit_path(school_urn: @school.urn),
+        action: 'Change',
       }]
     else
       []

--- a/app/form_objects/responsible_body/devices/who_to_contact_form.rb
+++ b/app/form_objects/responsible_body/devices/who_to_contact_form.rb
@@ -39,11 +39,10 @@ class ResponsibleBody::Devices::WhoToContactForm
     elsif someone_else_chosen?
       existing_contact = school.contacts.find_by(email_address: email_address)
       second_contact = school.contacts.contact.first
-      new_contact = school.contacts.build
+      new_contact = school.contacts.build(role: :contact)
 
       (existing_contact || second_contact || new_contact).tap do |contact|
         contact.email_address = email_address
-        contact.role = :contact
         contact.full_name = full_name
         contact.phone_number = phone_number
       end

--- a/app/form_objects/responsible_body/devices/who_to_contact_form.rb
+++ b/app/form_objects/responsible_body/devices/who_to_contact_form.rb
@@ -1,7 +1,11 @@
 class ResponsibleBody::Devices::WhoToContactForm
   include ActiveModel::Model
 
-  attr_accessor :school, :who_to_contact, :headteacher_contact, :full_name, :email_address, :phone_number
+  attr_accessor :school,
+                :who_to_contact,
+                :full_name,
+                :email_address,
+                :phone_number
 
   validates :who_to_contact, inclusion: %w[headteacher someone_else]
 
@@ -22,18 +26,23 @@ class ResponsibleBody::Devices::WhoToContactForm
             if: :someone_else_chosen?
 
   def headteacher_option_label
-    @headteacher_contact.title.upcase_first
+    headteacher_contact.title.upcase_first
   end
 
   def headteacher_option_hint_text
-    "#{@headteacher_contact.full_name} (#{@headteacher_contact.email_address})"
+    "#{headteacher_contact.full_name} (#{headteacher_contact.email_address})"
   end
 
   def chosen_contact
     if headteacher_chosen?
       headteacher_contact
     elsif someone_else_chosen?
-      school.contacts.find_or_initialize_by(email_address: email_address).tap do |contact|
+      existing_contact = school.contacts.find_by(email_address: email_address)
+      second_contact = school.contacts.contact.first
+      new_contact = school.contacts.build
+
+      (existing_contact || second_contact || new_contact).tap do |contact|
+        contact.email_address = email_address
         contact.role = :contact
         contact.full_name = full_name
         contact.phone_number = phone_number
@@ -41,7 +50,34 @@ class ResponsibleBody::Devices::WhoToContactForm
     end
   end
 
+  def headteacher_contact
+    @headteacher_contact ||= school.headteacher_contact
+  end
+
+  def populate_details_from_second_contact
+    self.full_name = second_contact.full_name
+    self.email_address = second_contact.email_address
+    self.phone_number = second_contact.phone_number
+  end
+
+  def preselect_who_to_contact
+    case current_contact&.role
+    when 'headteacher'
+      self.who_to_contact = 'headteacher'
+    when 'contact'
+      self.who_to_contact = 'someone_else'
+    end
+  end
+
 private
+
+  def current_contact
+    school.current_contact || SchoolContact.new
+  end
+
+  def second_contact
+    school.contacts.contact.first || SchoolContact.new
+  end
 
   def headteacher_chosen?
     who_to_contact&.to_sym == :headteacher

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -73,6 +73,10 @@ class School < ApplicationRecord
     contacts.find_by(role: :headteacher)
   end
 
+  def current_contact
+    preorder_information&.school_contact
+  end
+
   # TODO: update this method as preorder_information gets more fields
   # as per the prototype at
   # https://github.com/DFE-Digital/increasing-internet-access-prototype/blob/master/app/views/responsible-body/devices/school/_status-tag.html

--- a/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/_who_to_contact_form.html.erb
@@ -14,5 +14,4 @@
   <% end %>
 
   <%= f.govuk_submit 'Save' %>
-
 <%- end %>

--- a/app/views/responsible_body/devices/who_to_contact/edit.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/edit.html.erb
@@ -1,0 +1,14 @@
+<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- content_for :title, @school.name %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @school.name %>
+    </h1>
+
+    <div class="govuk-!-margin-top-8">
+      <%= render partial: 'who_to_contact_form', locals: { form: @form } %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
       resources :schools, only: %i[index show update], param: :urn do
         get '/who-to-contact', to: 'who_to_contact#new'
         post '/who-to-contact', to: 'who_to_contact#create'
+        put '/who-to-contact', to: 'who_to_contact#update'
+        get '/who-to-contact/edit', to: 'who_to_contact#edit'
         get '/change-who-will-order', to: 'change_who_will_order#edit'
         patch '/change-who-will-order', to: 'change_who_will_order#update'
       end

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -43,9 +43,9 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details without links to change it' do
-      expect(result.css('dd')[9].text).to include('Yes')
-      expect(result.css('dd')[10].text).to include('school.domain.org')
-      expect(result.css('dd')[11].text).to include('admin@recovery.org')
+      expect(result.css('dd')[10].text).to include('Yes')
+      expect(result.css('dd')[11].text).to include('school.domain.org')
+      expect(result.css('dd')[12].text).to include('admin@recovery.org')
     end
 
     context "when the school isn't under lockdown restrictions or has any shielding children" do

--- a/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ResponsibleBody::Devices::WhoToContactController do
 
         expect(existing_contact.full_name).to eql('different name')
         expect(existing_contact.phone_number).to eql('020 1')
+        expect(existing_contact.role).to eql('headteacher')
       end
     end
   end

--- a/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
@@ -60,4 +60,35 @@ RSpec.describe ResponsibleBody::Devices::WhoToContactController do
       end
     end
   end
+
+  describe '#update' do
+    context 'when 2 contacts exist' do
+      let!(:second_contact) { create(:school_contact, :contact, school: school) }
+
+      def perform_update!
+        put :update, params: {
+          responsible_body_devices_who_to_contact_form: {
+            who_to_contact: 'someone_else', # hidden field
+            full_name: 'totally new',
+            email_address: 'unique@example.com',
+            phone_number: '020 1',
+          },
+          school_urn: school.urn,
+        }
+      end
+
+      it 'does not create another contact' do
+        expect { perform_update! }.not_to change(SchoolContact, :count)
+      end
+
+      it 'updates the second contact' do
+        perform_update!
+        second_contact.reload
+
+        expect(second_contact.full_name).to eql('totally new')
+        expect(second_contact.email_address).to eql('unique@example.com')
+        expect(second_contact.phone_number).to eql('020 1')
+      end
+    end
+  end
 end

--- a/spec/form_objects/responsible_body/devices/who_to_contact_form_spec.rb
+++ b/spec/form_objects/responsible_body/devices/who_to_contact_form_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::WhoToContactForm do
+  let(:school) { build(:school) }
+
+  subject(:form) { described_class.new(school: school) }
+
+  describe '#populate_details_from_second_contact' do
+    context 'when there is no second contact' do
+      let(:school) { build(:school) }
+
+      it 'does not populate contact details' do
+        form.populate_details_from_second_contact
+
+        expect(form.full_name).to be_blank
+        expect(form.email_address).to be_blank
+        expect(form.phone_number).to be_blank
+      end
+    end
+
+    context 'when there is a second contact' do
+      let(:contact) { build(:school_contact, :contact, school: school) }
+      let(:preorder_info) { create(:preorder_information, school_contact: contact) }
+      let(:school) { create(:school) }
+
+      before do
+        school.preorder_information = preorder_info
+      end
+
+      it 'populates contact details' do
+        form.populate_details_from_second_contact
+
+        expect(form.full_name).to eql(contact.full_name)
+        expect(form.email_address).to eql(contact.email_address)
+        expect(form.phone_number).to eql(contact.phone_number)
+      end
+    end
+  end
+
+  describe '#preselect_who_to_contact' do
+    context 'no current contact' do
+      it 'leaves who_to_contact as nil' do
+        form.preselect_who_to_contact
+        expect(form.who_to_contact).to be_nil
+      end
+    end
+
+    context 'when headteacher is current_contact' do
+      let(:contact) { school.headteacher_contact }
+      let(:preorder_info) { create(:preorder_information, school_contact: contact) }
+      let(:school) { create(:school, :with_headteacher_contact) }
+
+      before do
+        school.preorder_information = preorder_info
+      end
+
+      it 'sets who_to_contact as headteacher' do
+        form.preselect_who_to_contact
+        expect(form.who_to_contact).to eql('headteacher')
+      end
+    end
+
+    context 'when other contact is current_contact' do
+      let(:contact) { create(:school_contact, :contact) }
+      let(:preorder_info) { create(:preorder_information, school_contact: contact) }
+      let(:school) { create(:school, :with_headteacher_contact) }
+
+      before do
+        school.preorder_information = preorder_info
+      end
+
+      it 'sets who_to_contact as someone_else' do
+        form.preselect_who_to_contact
+        expect(form.who_to_contact).to eql('someone_else')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/afX5ZJbs/682-no-ability-to-edit-school-contacts-rb-user
- Allow RBs to update the school contact

### Changes proposed in this pull request

- Adds change link to edit contact on school show page
- If headteacher contact present radios will be visible, otherwise no radios will be visible
- It will preselect headteacher contact or someone else radio depending on the current contact on the preorder info record
- It will populate the someone else fields if an existing contact for the school exists
- Changing the radio will point the preorder info record to the correct contact

#### Add change link
![image](https://user-images.githubusercontent.com/92580/93486365-05255080-f8fc-11ea-9a6f-7c0cf48a9a83.png)

#### Edit contact page
![image](https://user-images.githubusercontent.com/92580/93486662-5df4e900-f8fc-11ea-9c50-85aa398575a4.png)

### Guidance to review

There are quite a few scenarios to play with

- A school with and without a headteacher contact
- A school with and without a preorder info record
- A school with and without a contact record set on the preorder record
- The preorder record set as the headteacher contact or another contact
- Updating the record between headteacher and other contact
- Updating the record on the second contact
- Updating with the someone else contact with the headteacher email address should update headteacher contact