### PR TITLE
[667] add a first-draft UI to allow support users to adjust allocations

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -6,7 +6,7 @@ private
   end
 
   def allocation_row
-    super.except(:action_path, :action)
+    super.except(:action_path, :action).merge(change_path: support_devices_school_allocation_edit_path(school_urn: @school.urn))
   end
 
   def order_status_row

--- a/app/controllers/support/devices/allocation_controller.rb
+++ b/app/controllers/support/devices/allocation_controller.rb
@@ -1,0 +1,32 @@
+class Support::Devices::AllocationController < Support::BaseController
+  before_action :set_school_and_allocation
+
+  def edit
+    @form = Support::AllocationForm.new(allocation: @allocation.allocation, school_device_allocation: @allocation)
+  end
+
+  def update
+    # we need this to be able to show the allocation description based on the
+    # values as they were *before* the failed update
+    @current_allocation = @allocation.dup
+    @form = Support::AllocationForm.new(allocation_params.merge(school_device_allocation: @allocation))
+    if @form.valid?
+      @allocation.update!(allocation: @form.allocation)
+      flash[:success] = t(:success, scope: %i[support allocation update])
+      redirect_to support_devices_school_path(urn: @school.urn)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_school_and_allocation
+    @school = School.find_by_urn(params[:school_urn])
+    @allocation = SchoolDeviceAllocation.find_or_initialize_by(school: @school, device_type: 'std_device')
+  end
+
+  def allocation_params
+    params.fetch(:support_allocation_form, {}).permit(:allocation)
+  end
+end

--- a/app/form_objects/support/allocation_form.rb
+++ b/app/form_objects/support/allocation_form.rb
@@ -1,0 +1,19 @@
+class Support::AllocationForm
+  include ActiveModel::Model
+
+  attr_accessor :allocation, :current_allocation, :school_device_allocation
+
+  delegate :cap, :devices_ordered, to: :school_device_allocation
+
+  validates :allocation, numericality: { only_integer: true, greater_than: -1 }
+  validates_with OrderStateAndCapValidator
+
+  def initialize(params = {})
+    super(params)
+    @current_allocation = @school_device_allocation.dup
+  end
+
+  def order_state
+    school_device_allocation&.school&.order_state
+  end
+end

--- a/app/views/support/devices/allocation/edit.html.erb
+++ b/app/views/support/devices/allocation/edit.html.erb
@@ -1,0 +1,27 @@
+<%- content_for :before_content, govuk_link_to('Back', support_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- title = t('page_titles.support_edit_allocation') %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: support_devices_school_allocation_path(@school.urn), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p class="govuk-body">
+        <%= t(@form.order_state, scope: %i[support allocation edit order_states], cap: @form.current_allocation.cap, allocation: @form.current_allocation.allocation) %>
+      </p>
+
+      <%= f.govuk_number_field :allocation,
+                              only_integer: true,
+                              label: {text: 'New allocation'},
+                              width: 3 %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@
     support_order_status:
       enable_orders: Can they place orders?
       confirm_enable_orders: Check your answers and confirm
+    support_edit_allocation: Change device allocation
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter_home: Users with permission to place orders and receive support through Computacenter
@@ -209,6 +210,14 @@
           cannot_order: cannot place orders yet
           can_order_for_specific_circumstances: can place orders for specific circumstances
           can_order: can order their full allocation because local coronavirus restrictions are confirmed
+    allocation:
+      edit:
+        order_states:
+          cannot_order: They cannot place orders yet. When they can, their total allocation is %{allocation} devices.
+          can_order_for_specific_circumstances: They can place orders for specific circumstances, up to %{cap} devices from their total allocation of %{allocation}.
+          can_order: They can order their full allocation of %{allocation} because local coronavirus restrictions are confirmed.
+      update:
+        success: We’ve saved the new allocation
     service_performance:
       mobile_network_operators:
         one: mobile network operator
@@ -309,6 +318,12 @@
               not_a_number: Enter a whole number greater than zero
               lte_allocation: Cap cannot be more than their current allocation of %{allocation}
               gte_devices_ordered: Cap cannot be less than the number they have already ordered (%{devices_ordered})
+        support/allocation_form:
+          attributes:
+            cap:
+              lte_allocation: Enter an allocation that’s greater than, or the same as, the current cap
+            allocation:
+              greater_than: Enter an allocation that’s non-negative
   activerecord:
     attributes:
       api_token:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,8 @@ Rails.application.routes.draw do
         get '/enable-orders', to: 'order_status#edit', as: :enable_orders
         get '/enable-orders/confirm', to: 'order_status#confirm', as: :confirm_enable_orders
         patch '/enable-orders', to: 'order_status#update'
+        get '/allocation/edit', to: 'allocation#edit'
+        patch '/allocation', to: 'allocation#update'
       end
     end
     resources :responsible_bodies, only: %i[], path: '/:pilot/responsible-bodies' do

--- a/spec/features/support/devices/adjusting_a_schools_allocation_spec.rb
+++ b/spec/features/support/devices/adjusting_a_schools_allocation_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Adjusting a schools allocation' do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school, order_state: :cannot_order) }
+  let(:school_details_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
+  let(:enable_orders_confirm_page) { PageObjects::Support::Devices::EnableOrdersConfirmPage.new }
+
+  before do
+    create(:school_device_allocation, :with_std_allocation, allocation: 50, school: school)
+    sign_in_as support_user
+  end
+
+  describe 'visiting a school details page' do
+    before do
+      visit support_devices_school_path(school.urn)
+    end
+
+    it 'shows a link to Change whether they can order devices' do
+      expect(school_details_page.school_details_rows[2]).to have_text 'Provisional allocation'
+      expect(school_details_page.school_details_rows[2]).to have_link 'Change'
+    end
+
+    describe 'clicking Change' do
+      before do
+        within(school_details_page.school_details_rows[2]) do
+          click_on 'Change'
+        end
+      end
+
+      it 'shows me a form to change the allocation' do
+        expect(page).to have_field('New allocation')
+      end
+
+      context 'filling in an invalid value and clicking Save' do
+        before do
+          fill_in 'New allocation', with: '-1'
+          click_on 'Save'
+        end
+
+        it 'shows me an error' do
+          expect(page).to have_http_status(:unprocessable_entity)
+          expect(page).to have_text('Enter an allocation that’s non-negative')
+        end
+      end
+
+      context 'filling in an valid value and clicking Save' do
+        before do
+          fill_in 'New allocation', with: '51'
+          click_on 'Save'
+        end
+
+        it 'takes me back to the school details page' do
+          expect(page).to have_current_path(support_devices_school_path(school.urn))
+          expect(page).to have_http_status(:ok)
+          expect(page).to have_text('We’ve saved the new allocation')
+          expect(school_details_page.school_details_rows[2]).to have_text(51)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -23,7 +23,9 @@ RSpec.feature 'Enabling orders for a school from the support area' do
 
     describe 'clicking Change' do
       before do
-        click_on 'Change'
+        within(school_details_page.school_details_rows[3]) do
+          click_on 'Change'
+        end
       end
 
       it 'shows the order status form' do


### PR DESCRIPTION
### Context

[Trello card 667](https://trello.com/c/IdY4UmgF/667-support-users-can-set-allocations-for-devices)

### Changes proposed in this pull request

Add first-draft UI for adjusting device allocations. There was no design or prototype to work off, so all design suggestions very welcome.

Screens:

<img width="600" alt="Screen Shot 2020-09-17 at 17 19 33" src="https://user-images.githubusercontent.com/134501/93500641-47568e00-f90c-11ea-9c0d-1f6040c10f1a.png">

<img width="563" alt="Screen Shot 2020-09-17 at 17 19 53" src="https://user-images.githubusercontent.com/134501/93500209-ed55c880-f90b-11ea-986a-2df7d6965213.png">


### Guidance to review

