### PR TITLE
Remove the 'update_computacenter_user_change' feature flag

### DIFF
--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -5,9 +5,7 @@ module Computacenter
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }
 
     def self.read_from_version(version)
-      if FeatureFlag.active?(:update_computacenter_user_change)
-        UserChangeGenerator.new(version).call
-      end
+      UserChangeGenerator.new(version).call
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -11,9 +11,7 @@ class FeatureFlag
     notify_computacenter_of_cap_changes
   ].freeze
 
-  TEMPORARY_FEATURE_FLAGS = %i[
-    update_computacenter_user_change
-  ].freeze
+  TEMPORARY_FEATURE_FLAGS = %i[].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -272,10 +272,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'paper_trail', versioning: true do
-    before do
-      allow(ENV).to receive(:[]).with('FEATURES_update_computacenter_user_change').and_return('active')
-    end
-
     context 'creating user' do
       context 'computacenter relevant' do
         it 'creates a Computacenter::UserChange of type new' do


### PR DESCRIPTION
### Context

This feature has been running fine on production for a while, we won't be wanting to switch it off.

### Changes proposed in this pull request

Remove the feature flag and guard around the functionality.
