### PR TITLE
Reduce the number of slack-related feature flags to just one

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event
   end
 
   def notifiable?
-    false
+    FeatureFlag.active?(:slack_notifications)
   end
 
   def message

--- a/app/models/invite_event.rb
+++ b/app/models/invite_event.rb
@@ -1,8 +1,4 @@
 class InviteEvent < Event
-  def notifiable?
-    FeatureFlag.active?(:invite_slack_notifications)
-  end
-
   def message
     I18n.t(
       :invite_event,

--- a/app/models/sign_in_event.rb
+++ b/app/models/sign_in_event.rb
@@ -1,6 +1,6 @@
 class SignInEvent < Event
   def notifiable?
-    FeatureFlag.active?(:sign_in_slack_notifications) \
+    FeatureFlag.active?(:slack_notifications) \
       && (@params[:user].is_mno_user? || @params[:user].is_responsible_body_user? || @params[:user].is_school_user?)
   end
 

--- a/app/models/who_will_order_event.rb
+++ b/app/models/who_will_order_event.rb
@@ -1,8 +1,4 @@
 class WhoWillOrderEvent < Event
-  def notifiable?
-    FeatureFlag.active?(:who_will_order_slack_notifications)
-  end
-
   def message
     I18n.t(
       message_key,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -3,9 +3,7 @@ class FeatureFlag
     show_debug_info
     rate_limiting
     public_account_creation
-    sign_in_slack_notifications
-    who_will_order_slack_notifications
-    invite_slack_notifications
+    slack_notifications
     rbs_can_manage_users
     computacenter_cap_update_api
     notify_computacenter_of_cap_changes


### PR DESCRIPTION
### Context

We have 3 separate feature flags for enabling/disabling individual types of Slack event.

It's very unlikely we'd ever want to switch individual notifications on or off in a given environment. We've been wanting it on or off globally for any given env.

### Changes proposed in this pull request

Have just one feature flag around slack notifications, delete the rest.


