### PR TITLE
Prevent flaky spec failure by specifying valid initial data

### DIFF
--- a/spec/services/cap_update_service_spec.rb
+++ b/spec/services/cap_update_service_spec.rb
@@ -103,7 +103,11 @@ RSpec.describe CapUpdateService do
 
       context 'with an existing allocation' do
         before do
-          create(:school_device_allocation, :with_std_allocation, school: school, cap: 3, devices_ordered: 1)
+          create(:school_device_allocation, :with_std_allocation,
+                 school: school,
+                 allocation: 7,
+                 cap: 3,
+                 devices_ordered: 1)
         end
 
         it 'sets the new cap to equal the devices_ordered, regardless of what was given' do


### PR DESCRIPTION
### Context

This spec failed [on an unrelated change](https://github.com/DFE-Digital/get-help-with-tech/runs/1130960364?check_suite_focus=true) because:

- the factory used to set up the data assigns a random allocation
- that allocation can sometimes be less than the statically-defined cap
- this can cause the data setup to fail as the constructed object fail the validation that allocation >= cap

### Changes proposed in this pull request

Affix the allocation data so it's consistent with the cap data.

