### PR TITLE
[693 / 694] RB users and orders_devices

### DIFF
--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -13,8 +13,10 @@ class ResponsibleBody::UsersController < ResponsibleBody::BaseController
 
   def create
     @rb_user = @responsible_body.users.new(
-      user_params.merge(responsible_body_id: @responsible_body.id),
+      user_params.merge(responsible_body_id: @responsible_body.id,
+                        orders_devices: true),
     )
+
     if @rb_user.valid?
       @rb_user.save!
       InviteResponsibleBodyUserMailer.with(user: @rb_user).invite_user_email.deliver_later

--- a/db/migrate/20200918101304_data_rb_users_techsource_account.rb
+++ b/db/migrate/20200918101304_data_rb_users_techsource_account.rb
@@ -1,0 +1,9 @@
+class DataRbUsersTechsourceAccount < ActiveRecord::Migration[6.0]
+  def up
+    User.responsible_body_users.update(orders_devices: true)
+  end
+
+  def down
+    # this migration cannot be reversed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_13_134728) do
+ActiveRecord::Schema.define(version: 2020_09_18_101304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/responsible_body/users_controller_spec.rb
+++ b/spec/controllers/responsible_body/users_controller_spec.rb
@@ -47,4 +47,32 @@ RSpec.describe ResponsibleBody::UsersController do
       end
     end
   end
+
+  describe '#create' do
+    before do
+      sign_in_as rb_user
+    end
+
+    def perform_create!
+      post :create, params: {
+        id: local_authority.id,
+        user: {
+          full_name: 'John Doe',
+          email_address: 'john.doe@example.com',
+          phone_number: '020 1',
+        },
+      }
+    end
+
+    it 'creates a user record' do
+      expect { perform_create! }.to change(User, :count).by(1)
+    end
+
+    it 'sets user with orders_devices as true' do
+      perform_create!
+
+      user = User.last
+      expect(user.orders_devices).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/9L3IQkh4/694-adding-or-editing-rb-users-should-force-setting-whether-the-user-needs-a-techsource-account-or-not
- https://trello.com/c/upShx5aS/693-all-existing-rb-users-should-be-eligible-for-a-techsource-account

### Changes proposed in this pull request

- New RB users have `orders_devices` set to `true`
- Migration to set all existing RB users `orders_devices` to true
- Migration will fire activerecord lifecycle callbacks, ie. `PaperTrail::Version` records will be created and potentially `Computacenter::UserChange` records will be created

### Guidance to review

- Create new RB user
- New user `orders_devices` should be `true`
- All existing RB users `orders_devices` should be `true`