### PR TITLE
692 computacenter users can download a spreadsheet with google chromebook details

### DIFF
--- a/app/controllers/computacenter/chromebooks_controller.rb
+++ b/app/controllers/computacenter/chromebooks_controller.rb
@@ -2,7 +2,7 @@ class Computacenter::ChromebooksController < Computacenter::BaseController
   def index
     respond_to do |format|
       format.csv do
-        render csv: Computacenter::ChromebookDetails.export_to_csv, filename: "computacenter-chromebooks-#{Time.zone.now.iso8601}"
+        render csv: Computacenter::ChromebookDetails.to_csv, filename: "computacenter-chromebooks-#{Time.zone.now.iso8601}"
       end
     end
   end

--- a/app/controllers/computacenter/chromebooks_controller.rb
+++ b/app/controllers/computacenter/chromebooks_controller.rb
@@ -1,0 +1,9 @@
+class Computacenter::ChromebooksController < Computacenter::BaseController
+  def index
+    respond_to do |format|
+      format.csv do
+        render csv: Computacenter::ChromebookDetails.export_to_csv, filename: "computacenter-chromebooks-#{Time.zone.now.iso8601}"
+      end
+    end
+  end
+end

--- a/app/models/computacenter/chromebook_details.rb
+++ b/app/models/computacenter/chromebook_details.rb
@@ -2,7 +2,7 @@ require 'csv'
 
 module Computacenter
   class ChromebookDetails
-    def self.export_to_csv
+    def self.to_csv
       CSV.generate do |csv|
         csv << [
           'Responsible Body URN',

--- a/app/models/computacenter/chromebook_details.rb
+++ b/app/models/computacenter/chromebook_details.rb
@@ -2,33 +2,36 @@ require 'csv'
 
 module Computacenter
   class ChromebookDetails
+    HEADERS = [
+      'Responsible Body URN',
+      'Responsible Body Name',
+      'School Name',
+      'School URN',
+      'Google Domain',
+      'Valid Recovery Off Domain Email Address',
+      'Date',
+      'Time',
+    ].freeze
+
     def self.to_csv
       CSV.generate do |csv|
-        csv << [
-          'Responsible Body URN',
-          'Responsible Body Name',
-          'School Name',
-          'School URN',
-          'Google Domain',
-          'Valid Recovery Off Domain Email Address',
-          'Date',
-          'Time'
-        ]
+        csv << HEADERS
+
         PreorderInformation
           .includes(school: :responsible_body)
           .where(will_need_chromebooks: 'yes')
           .order(updated_at: :asc)
           .each do |i|
-            csv << [
-              i.school.responsible_body.computacenter_identifier,
-              i.school.responsible_body.name,
-              i.school.name,
-              i.school.urn,
-              i.school_or_rb_domain,
-              i.recovery_email_address,
-              i.updated_at.utc.strftime('%d/%m/%Y'),
-              i.updated_at.utc.strftime('%R')
-            ]
+          csv << [
+            i.school.responsible_body.computacenter_identifier,
+            i.school.responsible_body.name,
+            i.school.name,
+            i.school.urn,
+            i.school_or_rb_domain,
+            i.recovery_email_address,
+            i.updated_at.utc.strftime('%d/%m/%Y'),
+            i.updated_at.utc.strftime('%R'),
+          ]
         end
       end
     end

--- a/app/models/computacenter/chromebook_details.rb
+++ b/app/models/computacenter/chromebook_details.rb
@@ -1,0 +1,36 @@
+require 'csv'
+
+module Computacenter
+  class ChromebookDetails
+    def self.export_to_csv
+      CSV.generate do |csv|
+        csv << [
+          'Responsible Body URN',
+          'Responsible Body Name',
+          'School Name',
+          'School URN',
+          'Google Domain',
+          'Valid Recovery Off Domain Email Address',
+          'Date',
+          'Time'
+        ]
+        PreorderInformation
+          .includes(school: :responsible_body)
+          .where(will_need_chromebooks: 'yes')
+          .order(updated_at: :asc)
+          .each do |i|
+            csv << [
+              i.school.responsible_body.computacenter_identifier,
+              i.school.responsible_body.name,
+              i.school.name,
+              i.school.urn,
+              i.school_or_rb_domain,
+              i.recovery_email_address,
+              i.updated_at.utc.strftime('%d/%m/%Y'),
+              i.updated_at.utc.strftime('%R')
+            ]
+        end
+      end
+    end
+  end
+end

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -10,9 +10,15 @@
       <li>
         <span class="govuk-!-margin-bottom-4">download a CSV file of users who have permission to place orders on TechSource</span>
         <br /><br />
-        <%= govuk_button_link_to 'Download CSV', computacenter_user_ledger_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
+        <%= govuk_button_link_to 'Download TechSource users', computacenter_user_ledger_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
       </li>
     </ul>
-
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <span class="govuk-!-margin-bottom-4">download a CSV file of Google Chromebook details for schools</span>
+        <br /><br />
+        <%= govuk_button_link_to 'Download Chromebook details', computacenter_chromebooks_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
+      </li>
+    </ul>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Rails.application.routes.draw do
   namespace :computacenter do
     get '/', to: 'home#show', as: :home
     get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
+    get '/chromebooks', to: 'chromebooks#index', as: :chromebooks
     resources :api_tokens, path: '/api-tokens'
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection

--- a/spec/features/computacenter/download_csv_files_spec.rb
+++ b/spec/features/computacenter/download_csv_files_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 require 'shared/expect_download'
 
-RSpec.feature 'Download user changes CSV' do
+RSpec.feature 'Download CSV files' do
+  let(:user) { create(:computacenter_user) }
+
   context 'signed in as a Computacenter user' do
     let(:user) { create(:computacenter_user) }
 
@@ -9,23 +11,39 @@ RSpec.feature 'Download user changes CSV' do
       sign_in_as user
     end
 
-    it 'shows me a Download CSV link' do
-      expect(page).to have_link('Download CSV')
+    it 'shows me a Download TechSource users link' do
+      expect(page).to have_link('Download TechSource users')
     end
 
-    describe 'clicking Download CSV' do
+    it 'shows me a Download Chromebook details link' do
+      expect(page).to have_link('Download Chromebook details')
+    end
+
+    describe 'clicking Download Chromebook details' do
+      before do
+        create_list(:preorder_information, 4, :needs_chromebooks)
+      end
+
+      it 'downloads a CSV file' do
+        click_on 'Download Chromebook details'
+        expect_download(content_type: 'text/csv')
+        expect(page.body).to include(Computacenter::ChromebookDetails::HEADERS.join(','))
+      end
+    end
+
+    describe 'clicking Download TechSource users' do
       let!(:user_change_1) { create(:user_change, :new_local_authority_user, updated_at_timestamp: Time.zone.now.utc - 2.seconds) }
       let!(:user_change_2) { create(:user_change, :school_user, :changed_telephone, updated_at_timestamp: Time.zone.now.utc - 1.second) }
       let!(:user_change_3) { create(:user_change, :school_user, :school_changed, updated_at_timestamp: Time.zone.now.utc) }
 
       it 'downloads a CSV file' do
-        click_on 'Download CSV'
+        click_on 'Download TechSource users'
         expect_download(content_type: 'text/csv')
         expect(page.body).to include(Computacenter::Ledger.headers.join(','))
       end
 
       it 'includes all Computacenter::UserChanges in timestamp order' do
-        click_on 'Download CSV'
+        click_on 'Download TechSource users'
         csv = CSV.parse(page.body, headers: true)
         expect(csv[0]['Email']).to eq(user_change_1.email_address)
         expect(csv[0]['Responsible Body']).to eq(user_change_1.responsible_body)

--- a/spec/models/computacenter/chromebook_details_spec.rb
+++ b/spec/models/computacenter/chromebook_details_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ChromebookDetails do
+  subject(:service) { described_class }
+
+  describe '.to_csv' do
+    let(:expected_headers) do
+      [
+        'Responsible Body URN',
+        'Responsible Body Name',
+        'School Name',
+        'School URN',
+        'Google Domain',
+        'Valid Recovery Off Domain Email Address',
+        'Date',
+        'Time'
+      ]
+    end
+    let(:chromebook_details) { create_list(:preorder_information, 5, :needs_chromebooks) }
+
+    it 'has correct headers set' do
+      rows = CSV.parse(service.to_csv)
+
+      expect(rows[0]).to eql(expected_headers)
+    end
+
+    it 'includes all the chromebook details' do
+      details = details_to_array
+      rows = CSV.parse(service.to_csv)
+      (1..5).each do |n|
+        expect(rows[n]).to eql(details[n - 1])
+      end
+    end
+
+    def details_to_array
+      details = []
+      chromebook_details.each do |cb| 
+        details << [
+          cb.school.responsible_body.computacenter_identifier,
+          cb.school.responsible_body.name,
+          cb.school.name,
+          cb.school.urn.to_s,
+          cb.school_or_rb_domain,
+          cb.recovery_email_address,
+          cb.updated_at.utc.strftime('%d/%m/%Y'),
+          cb.updated_at.utc.strftime('%R')
+        ]
+      end
+      details
+    end
+  end
+end

--- a/spec/models/computacenter/chromebook_details_spec.rb
+++ b/spec/models/computacenter/chromebook_details_spec.rb
@@ -5,18 +5,6 @@ RSpec.describe Computacenter::ChromebookDetails do
 
   describe '.to_csv' do
     let(:chromebook_details) { create_list(:preorder_information, 5, :needs_chromebooks) }
-    # let(:expected_headers) do
-    #   [
-    #     'Responsible Body URN',
-    #     'Responsible Body Name',
-    #     'School Name',
-    #     'School URN',
-    #     'Google Domain',
-    #     'Valid Recovery Off Domain Email Address',
-    #     'Date',
-    #     'Time',
-    #   ]
-    # end
 
     it 'has correct headers set' do
       rows = CSV.parse(service.to_csv)

--- a/spec/models/computacenter/chromebook_details_spec.rb
+++ b/spec/models/computacenter/chromebook_details_spec.rb
@@ -4,24 +4,24 @@ RSpec.describe Computacenter::ChromebookDetails do
   subject(:service) { described_class }
 
   describe '.to_csv' do
-    let(:expected_headers) do
-      [
-        'Responsible Body URN',
-        'Responsible Body Name',
-        'School Name',
-        'School URN',
-        'Google Domain',
-        'Valid Recovery Off Domain Email Address',
-        'Date',
-        'Time'
-      ]
-    end
     let(:chromebook_details) { create_list(:preorder_information, 5, :needs_chromebooks) }
+    # let(:expected_headers) do
+    #   [
+    #     'Responsible Body URN',
+    #     'Responsible Body Name',
+    #     'School Name',
+    #     'School URN',
+    #     'Google Domain',
+    #     'Valid Recovery Off Domain Email Address',
+    #     'Date',
+    #     'Time',
+    #   ]
+    # end
 
     it 'has correct headers set' do
       rows = CSV.parse(service.to_csv)
 
-      expect(rows[0]).to eql(expected_headers)
+      expect(rows[0]).to eql(Computacenter::ChromebookDetails::HEADERS)
     end
 
     it 'includes all the chromebook details' do
@@ -34,7 +34,7 @@ RSpec.describe Computacenter::ChromebookDetails do
 
     def details_to_array
       details = []
-      chromebook_details.each do |cb| 
+      chromebook_details.sort_by(&:id).each do |cb|
         details << [
           cb.school.responsible_body.computacenter_identifier,
           cb.school.responsible_body.name,
@@ -43,7 +43,7 @@ RSpec.describe Computacenter::ChromebookDetails do
           cb.school_or_rb_domain,
           cb.recovery_email_address,
           cb.updated_at.utc.strftime('%d/%m/%Y'),
-          cb.updated_at.utc.strftime('%R')
+          cb.updated_at.utc.strftime('%R'),
         ]
       end
       details


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/XMPFSbaA/692-computacenter-users-can-download-a-spreadsheet-with-google-chromebook-details)
Add downloading of chromebook details as CSV

### Changes proposed in this pull request
Additional button to Computacenter home screen to download Chromebook details
Export of Chromebook details from `PreorderInformation`

### Guidance to review
I have adjusted some of the text on the Computacenter home page as there are now 2 files to download not a single CSV.
I have not changed the page title but that should be changed as it is for downloading TechSource users

![image](https://user-images.githubusercontent.com/333931/93597412-ec2ba680-f9b2-11ea-978e-25ff00e13806.png)
