### PR TITLE
[688] Add devices ordered count to school table

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -12,13 +12,15 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
   end
 
   def rows
-    [
-      preorder_status_row,
-      who_will_order_row,
-      allocation_row,
-      order_status_row,
-      school_type_row,
-    ] +
+    array = []
+    array << preorder_status_row
+    array << who_will_order_row
+    array << allocation_row
+    array << devices_ordered_row if display_devices_ordered_row?
+    array << order_status_row
+    array << school_type_row
+
+    array +
       school_contact_row_if_contact_present +
       chromebook_rows_if_needed
   end
@@ -59,6 +61,17 @@ private
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query allocation',
     }
+  end
+
+  def devices_ordered_row
+    {
+      key: 'Devices ordered',
+      value: pluralize(@school.std_device_allocation&.devices_ordered.to_i, 'device'),
+    }
+  end
+
+  def display_devices_ordered_row?
+    @school.std_device_allocation&.devices_ordered.to_i.positive?
   end
 
   def order_status_row

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -149,4 +149,24 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       expect(result.css('.govuk-summary-list__row a').attr('href').value).to eq(responsible_body_devices_who_will_order_edit_path)
     end
   end
+
+  describe 'devices ordered count' do
+    context 'when no devices ordered' do
+      it 'does not show devices ordered row' do
+        expect(result.text).not_to include('Devices ordered')
+      end
+    end
+
+    context 'when devices orders' do
+      before do
+        alloc = school.build_std_device_allocation(devices_ordered: 3, cap: 100, allocation: 100)
+        alloc.save!
+      end
+
+      it 'shows devices ordered row with count' do
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('Devices ordered')
+        expect(result.css('.govuk-summary-list__row')[3].text).to include('3 devices')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/rOdSg6WL/688-show-how-many-devices-a-school-has-already-ordered-to-rbs-and-in-support

### Changes proposed in this pull request

- Add devices ordered count to the school table

![image](https://user-images.githubusercontent.com/92580/93598493-a40d8380-f9b4-11ea-9ab3-7cdcab536704.png)

### Guidance to review

- Find a school without an allocation or allocation with `devices_order` set to `0`
- Login as support user
- View the school eg http://localhost:3000/responsible-body/devices/schools/100000
- Should not see the row with `Devices ordered`
- Update the allocation with `devices_ordered` to any number
- Should now see new row with `Devices ordered` with whatever count you used
- Same behaviour should be exhibited for an RB user viewing the school