### PR TITLE
Added fix for orders devices validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,8 +79,10 @@ class User < ApplicationRecord
   end
 
   def orders_devices_user_limit
-    if orders_devices? && school.users.who_can_order_devices.count >= 3
-      errors.add(:orders_devices, I18n.t('activerecord.errors.models.user.attributes.orders_devices.user_limit'))
+    if orders_devices?
+      if (new_record? || orders_devices_changed?) && school.users.who_can_order_devices.count >= 3
+        errors.add(:orders_devices, I18n.t('activerecord.errors.models.user.attributes.orders_devices.user_limit'))
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,8 +99,10 @@ RSpec.describe User, type: :model do
         expect { new_user.save! }.to change(new_user, :email_address).to('mr.mixed.case@somedomain.org')
       end
     end
+  end
 
-    context 'school user' do
+  describe 'orders devices validation' do
+    context 'for a school user' do
       let(:school) { create(:school) }
       let(:user) { build(:school_user, :orders_devices, school: school) }
 
@@ -111,6 +113,12 @@ RSpec.describe User, type: :model do
       it 'validates that only 3 users can order devices for a school' do
         expect(user.valid?).to be false
         expect(user.errors.keys).to include(:orders_devices)
+      end
+
+      it 'does not fail to update a user when there are 3 users that can order' do
+        existing_user = school.users.last
+        existing_user.sign_in_token = '1234'
+        expect(existing_user.valid?).to be true
       end
     end
   end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/j8FB0QnK/695-investigate-invalid-school-user-records-on-production)
A school user on production cannot sign-in. He is getting a 422 on sign-in.
The school has 3 people that can order devices.
It appears that the validation for `orders_devices` is assuming that the validation applies to a new user being added.  When a user signs in their record is updated and this if failing in the validation for `orders_devices`.

### Changes proposed in this pull request
Add extra condition logic to only apply the 3 user check when the record is new or if the `orders_devices` attribute has just been changed to true.

### Guidance to review
A school should have a limit of 3 users that can order devices but updating one of the attributes on those users should not cause it to fail the `:orders_devices_user_limit` validation.
