### PR TITLE
[694] Support new RB users have order_devices true

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -6,7 +6,9 @@ class Support::UsersController < Support::BaseController
 
   def create
     @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
-    @user = User.new(user_params.merge(responsible_body: @responsible_body, approved_at: Time.zone.now))
+    @user = User.new(user_params.merge(responsible_body: @responsible_body,
+                                       approved_at: Time.zone.now,
+                                       orders_devices: true))
 
     if @user.valid?
       @user.save!

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -10,18 +10,25 @@ RSpec.describe Support::UsersController, type: :controller do
         sign_in_as dfe_user
       end
 
-      it 'creates users' do
-        expect {
-          post :create, params: { responsible_body_id: responsible_body.id,
-                                  user: attributes_for(:user),
-                                  pilot: 'devices' }
-        }.to change(User, :count).by(1)
-      end
-
-      it 'audits changes with reference to user that requested the changes' do
+      def perform_create!
         post :create, params: { responsible_body_id: responsible_body.id,
                                 user: attributes_for(:user),
                                 pilot: 'devices' }
+      end
+
+      it 'creates users' do
+        expect { perform_create! }.to change(User, :count).by(1)
+      end
+
+      it 'sets orders_devices to true' do
+        perform_create!
+
+        user = User.last
+        expect(user.orders_devices).to be_truthy
+      end
+
+      it 'audits changes with reference to user that requested the changes' do
+        perform_create!
 
         expect(User.last.versions.last.whodunnit).to eql("User:#{dfe_user.id}")
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/9L3IQkh4/694-adding-or-editing-rb-users-should-force-setting-whether-the-user-needs-a-techsource-account-or-not

### Changes proposed in this pull request

- Support users creating RB users sets `orders_devices` to `true`

### Guidance to review

- Login as support agent
- Create a new RB user
- New user should have `order_devices` set to `true`
