### PR TITLE
[697] New RB users assigned to a school

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -90,10 +90,10 @@ private
   def root_url_for(user)
     if user.is_mno_user?
       mno_extra_mobile_data_requests_path
+    elsif user.hybrid?
+      school_user_start_url(user)
     elsif user.needs_to_see_privacy_notice?
       responsible_body_privacy_notice_path
-    elsif user.is_responsible_body_user? && user.is_school_user?
-      school_user_start_url(user)
     elsif user.is_responsible_body_user?
       responsible_body_home_path
     elsif user.is_school_user?

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -92,6 +92,8 @@ private
       mno_extra_mobile_data_requests_path
     elsif user.needs_to_see_privacy_notice?
       responsible_body_privacy_notice_path
+    elsif user.is_responsible_body_user? && user.is_school_user?
+      school_user_start_url(user)
     elsif user.is_responsible_body_user?
       responsible_body_home_path
     elsif user.is_school_user?

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -10,11 +10,14 @@ class Support::UsersController < Support::BaseController
                                        approved_at: Time.zone.now,
                                        orders_devices: true))
 
-    if @responsible_body.school_journey?
+    if @responsible_body.hybrid_setup?
       @user.school = @responsible_body.schools.first
     end
 
     if @user.valid?
+      if @responsible_body.hybrid_setup?
+        @responsible_body.hybrid_setup!
+      end
       @user.save!
       redirect_to return_path
     else

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -10,15 +10,9 @@ class Support::UsersController < Support::BaseController
                                        approved_at: Time.zone.now,
                                        orders_devices: true))
 
-    if @responsible_body.hybrid_setup?
-      @user.school = @responsible_body.schools.first
-    end
-
     if @user.valid?
-      if @responsible_body.hybrid_setup?
-        @responsible_body.hybrid_setup!
-      end
       @user.save!
+      @user.hybrid_setup!
       redirect_to return_path
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -10,6 +10,10 @@ class Support::UsersController < Support::BaseController
                                        approved_at: Time.zone.now,
                                        orders_devices: true))
 
+    if @responsible_body.school_journey?
+      @user.school = @responsible_body.schools.first
+    end
+
     if @user.valid?
       @user.save!
       redirect_to return_path

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -105,7 +105,11 @@ class ResponsibleBody < ApplicationRecord
     schools.that_can_order_now.any?
   end
 
-  def school_journey?
+  def hybrid_setup?
     schools.count == 1 && users.blank?
+  end
+
+  def hybrid_setup!
+    schools.first.create_preorder_information!(who_will_order_devices: 'school')
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -104,12 +104,4 @@ class ResponsibleBody < ApplicationRecord
   def has_any_schools_that_can_order_now?
     schools.that_can_order_now.any?
   end
-
-  def hybrid_setup?
-    schools.count == 1 && users.blank?
-  end
-
-  def hybrid_setup!
-    schools.first.create_preorder_information!(who_will_order_devices: 'school')
-  end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -104,4 +104,8 @@ class ResponsibleBody < ApplicationRecord
   def has_any_schools_that_can_order_now?
     schools.that_can_order_now.any?
   end
+
+  def school_journey?
+    schools.count == 1 && users.blank?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,11 @@ class User < ApplicationRecord
     school = responsible_body.schools.first
 
     update(school: school)
-    school.create_preorder_information!(who_will_order_devices: 'school')
+    contact = school.contacts.create!(email_address: email_address,
+                                      full_name: full_name,
+                                      role: :contact,
+                                      phone_number: telephone)
+    school.create_preorder_information!(who_will_order_devices: 'school', school_contact: contact)
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,10 @@ class User < ApplicationRecord
     responsible_body || school&.responsible_body
   end
 
+  def hybrid?
+    school_id && responsible_body_id
+  end
+
 private
 
   def cleansed_full_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,11 +115,11 @@ class User < ApplicationRecord
     one_school = responsible_body.schools.count == 1
     only_user = responsible_body.users == [self]
 
-    return unless (one_school && only_user)
+    return unless one_school && only_user
 
     school = responsible_body.schools.first
 
-    update(school: school)
+    update!(school: school)
     contact = school.contacts.create!(email_address: email_address,
                                       full_name: full_name,
                                       role: :contact,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,7 +124,9 @@ class User < ApplicationRecord
                                       full_name: full_name,
                                       role: :contact,
                                       phone_number: telephone)
-    school.create_preorder_information!(who_will_order_devices: 'school', school_contact: contact)
+    school.create_preorder_information!(who_will_order_devices: 'school',
+                                        school_contact: contact,
+                                        status: 'school_contacted')
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,18 @@ class User < ApplicationRecord
     school_id && responsible_body_id
   end
 
+  def hybrid_setup!
+    one_school = responsible_body.schools.count == 1
+    only_user = responsible_body.users == [self]
+
+    return unless (one_school && only_user)
+
+    school = responsible_body.schools.first
+
+    update(school: school)
+    school.create_preorder_information!(who_will_order_devices: 'school')
+  end
+
 private
 
   def cleansed_full_name

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -43,6 +43,21 @@ RSpec.describe SignInTokensController, type: :controller do
       delete :destroy, params: valid_token_params
       expect(EventNotificationsService).to have_received(:broadcast).with(mock_event)
     end
+
+    context 'when user is associated with RB and school' do
+      let(:school) { create(:school) }
+      let(:user) do
+        create(:local_authority_user,
+               :who_has_requested_a_magic_link,
+               orders_devices: true,
+               school: school)
+      end
+
+      it 'redirects them to the school journey' do
+        delete :destroy, params: valid_token_params
+        expect(response).to redirect_to('/school/privacy')
+      end
+    end
   end
 
   describe 'GET #validate' do

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SignInTokensController, type: :controller do
       expect(EventNotificationsService).to have_received(:broadcast).with(mock_event)
     end
 
-    context 'when user is associated with RB and school' do
+    context 'when hybrid user is associated with RB and school' do
       let(:school) { create(:school) }
       let(:user) do
         create(:local_authority_user,
@@ -56,6 +56,21 @@ RSpec.describe SignInTokensController, type: :controller do
       it 'redirects them to the school journey' do
         delete :destroy, params: valid_token_params
         expect(response).to redirect_to('/school/privacy')
+      end
+
+      context 'when they have not accepted privacy policies' do
+        let(:user) do
+          create(:local_authority_user,
+                 :who_has_requested_a_magic_link,
+                 orders_devices: true,
+                 privacy_notice_seen_at: nil,
+                 school: school)
+        end
+
+        it 'redirects them to the school privacy policies' do
+          delete :destroy, params: valid_token_params
+          expect(response).to redirect_to('/school/privacy')
+        end
       end
     end
   end

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Support::UsersController, type: :controller do
           user = User.last
           expect(user.school).to eql(school)
         end
+
+        it 'creates preorder on the school with school to order' do
+          perform_create!
+          school.reload
+
+          expect(school.preorder_information).to be_present
+          expect(school.preorder_information.who_will_order_devices).to eql('school')
+        end
       end
     end
 

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -27,10 +27,28 @@ RSpec.describe Support::UsersController, type: :controller do
         expect(user.orders_devices).to be_truthy
       end
 
+      it 'does not set the school on the user' do
+        perform_create!
+
+        user = User.last
+        expect(user.school).to be_blank
+      end
+
       it 'audits changes with reference to user that requested the changes' do
         perform_create!
 
         expect(User.last.versions.last.whodunnit).to eql("User:#{dfe_user.id}")
+      end
+
+      context 'if RB only has one school and this is the first user' do
+        let!(:school) { create(:school, responsible_body: responsible_body) }
+
+        it 'sets user.school to the school' do
+          perform_create!
+
+          user = User.last
+          expect(user.school).to eql(school)
+        end
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe '#hybrid_setup!' do
+    let!(:responsible_body) { create(:trust, schools: [school]) }
+    let(:school) { create(:school) }
+
+    subject(:user) do
+      create(:user,
+             orders_devices: true,
+             school: school,
+             responsible_body: responsible_body)
+    end
+
+    it 'uses this user as the school contact' do
+      user.hybrid_setup!
+      contact = user.school.preorder_information.school_contact
+
+      expect(contact).to be_present
+      expect(contact.email_address).to eql(user.email_address)
+      expect(contact.full_name).to eql(user.full_name)
+      expect(contact.role).to eql('contact')
+      expect(contact.phone_number).to eql(user.telephone)
+    end
+  end
+
   describe '#is_mno_user?' do
     it 'is true when the user is from an MNO participating in the pilot' do
       user = build(:user, mobile_network: build(:mobile_network))

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe User, type: :model do
       expect(contact.role).to eql('contact')
       expect(contact.phone_number).to eql(user.telephone)
     end
+
+    it 'marks preorder#status as school_contacted' do
+      user.hybrid_setup!
+      expect(user.school.preorder_information.status).to eql('school_contacted')
+    end
   end
 
   describe '#is_mno_user?' do


### PR DESCRIPTION
### Context

- https://trello.com/c/hlBiVAGh/697-responsible-bodies-with-only-one-school-should-see-the-school-journey
- On support adding user to RB if RB only has one school and this is the first user set them up as a hybrid user 

### Changes proposed in this pull request

- Hybrid users belongs to both an RB and a school
- Hybrid setup also orchestrates a few things to put things in the correct state 

### Guidance to review

#### User experience

- Login as support user
- Invite a new RB user - there must be no other RB users + RB must only have one school
- Logout and login as invited user
- Invited user should go thru school journey and no touch any RB screen
- Wizard should work and after sent user to school
- Logout and log back in
- Should be sent to school screens

#### Backend checks

- Preorder should be made for the school
- Preorder set `who_will_order_devices` to `school`
- Preorder should set `status` to `school_contacted`
- The school contacts should have one contact which is this hybrid user
- The preorder contact should be this school contact