### PR TITLE
Invite school contacts as soon as they're picked by the RB

### DIFF
--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -6,24 +6,7 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
   end
 
   def create
-    @form = ResponsibleBody::Devices::WhoToContactForm.new({
-      school: @school,
-    }.merge(who_to_contact_form_params))
-
-    if @form.invalid?
-      render :new, status: :unprocessable_entity
-    else
-      chosen_contact = @form.chosen_contact
-      chosen_contact.save!
-      @school.preorder_information.update!(school_contact: chosen_contact)
-      is_success = @school.invite_school_contact
-      flash[:success] = I18n.t(
-        is_success ? :success : :failure,
-        scope: %i[responsible_body devices schools who_to_contact create],
-        email_address: chosen_contact.email_address,
-      )
-      redirect_to responsible_body_devices_school_path(@school.urn)
-    end
+    create_or_update
   end
 
   def edit
@@ -33,6 +16,12 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
   end
 
   def update
+    create_or_update
+  end
+
+private
+
+  def create_or_update
     @form = ResponsibleBody::Devices::WhoToContactForm.new({
       school: @school,
     }.merge(who_to_contact_form_params))
@@ -52,8 +41,6 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
       redirect_to responsible_body_devices_school_path(@school.urn)
     end
   end
-
-private
 
   def find_school!
     @school = @responsible_body.schools.find_by!(urn: params[:school_urn])

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -16,7 +16,12 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
       chosen_contact = @form.chosen_contact
       chosen_contact.save!
       @school.preorder_information.update!(school_contact: chosen_contact)
-      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices schools who_to_contact create], email_address: chosen_contact.email_address)
+      is_success = @school.invite_school_contact
+      flash[:success] = I18n.t(
+        is_success ? :success : :failure,
+        scope: %i[responsible_body devices schools who_to_contact create],
+        email_address: chosen_contact.email_address,
+      )
       redirect_to responsible_body_devices_school_path(@school.urn)
     end
   end
@@ -38,7 +43,12 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::Device
       chosen_contact = @form.chosen_contact
       chosen_contact.save!
       @school.preorder_information.update!(school_contact: chosen_contact)
-      flash[:success] = I18n.t(:success, scope: %i[responsible_body devices schools who_to_contact create], email_address: chosen_contact.email_address)
+      is_success = @school.invite_school_contact
+      flash[:success] = I18n.t(
+        is_success ? :success : :failure,
+        scope: %i[responsible_body devices schools who_to_contact create],
+        email_address: chosen_contact.email_address,
+      )
       redirect_to responsible_body_devices_school_path(@school.urn)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,7 +436,8 @@
       schools:
         who_to_contact:
           create:
-            success: "Saved. We will email %{email_address} shortly"
+            failure: "Saved. We will email %{email_address} shortly"
+            success: "Saved. We’ve emailed %{email_address}"
     users:
       create:
         success: "We’ve sent an invitation to %{email_address}"

--- a/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_to_contact_controller_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe ResponsibleBody::Devices::WhoToContactController do
         expect(existing_contact.role).to eql('headteacher')
       end
     end
+
+    context 'when the contact already exists as a user (this is hopefully a temporary system limitation)' do
+      let(:existing_user) { create(:school_user) }
+
+      before do
+        post :create, params: {
+          responsible_body_devices_who_to_contact_form: {
+            who_to_contact: 'someone_else',
+            full_name: 'different name',
+            email_address: existing_user.email_address,
+            phone_number: '020 1',
+          },
+          school_urn: school.urn,
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { response }.not_to raise_error
+      end
+
+      it 'displays that the school user will be contacted in future, not now' do
+        expect(request.flash[:success]).to eq("Saved. We will email #{existing_user.email_address} shortly")
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
### Context

While we were gaining confidence in the school journey, we didn't send out the school invites automatically after responsible bodies picked school contacts. Instead, they were waiting to be transitioned as a dev task/through support. We now have enough confidence in the school journey to start sending these out automatically.

There is still an edge case when inviting the school contact fails: when the school contact is an existing user in the system (because we can't handle multi-org yet). Those schools will remain in the 'school will be contacted' state.

### Changes proposed in this pull request

- Invite the school contact as soon as they're picked by the RB
- Leave schools that can't be invited in the 'school will be contacted' state
- Make it really explicit that in `WhoToContactController`, the `create` and `edit` actions do the same thing.
