### PR TITLE
698 refactor user creation to a service

### DIFF
--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -8,10 +8,8 @@ class School::UsersController < School::BaseController
   end
 
   def create
-    @user = @school.users.new(user_params)
-    if @user.valid?
-      @user.save!
-      InviteSchoolUserMailer.with(user: @user).nominated_contact_email.deliver_later
+    @user = CreateUserService.invite_school_user(user_params.merge(school_id: @school.id))
+    if @user.persisted?
       redirect_to school_users_path
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -5,6 +5,7 @@ class Support::UsersController < Support::BaseController
   end
 
   def create
+    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = CreateUserService.invite_responsible_body_user(
       user_params.merge(responsible_body_id: params[:responsible_body_id]),
     )

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -5,14 +5,12 @@ class Support::UsersController < Support::BaseController
   end
 
   def create
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
-    @user = User.new(user_params.merge(responsible_body: @responsible_body,
-                                       approved_at: Time.zone.now,
-                                       orders_devices: true))
-
-    if @user.valid?
-      @user.save!
-      @user.hybrid_setup!
+    @user = CreateUserService.invite_responsible_body_user(
+      user_params.merge(responsible_body_id: params[:responsible_body_id]),
+    )
+    # If anything goes wrong, the service will return a non-persisted user
+    # object so that we can inspect the errors
+    if @user.persisted?
       redirect_to return_path
     else
       render :new, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,7 +112,8 @@ class User < ApplicationRecord
   end
 
   def hybrid_setup!
-    return unless responsible_body.present?
+    return if responsible_body.blank?
+
     one_school = responsible_body.schools.count == 1
     only_user = responsible_body.users == [self]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,7 @@ class User < ApplicationRecord
   end
 
   def hybrid_setup!
+    return unless responsible_body.present?
     one_school = responsible_body.schools.count == 1
     only_user = responsible_body.users == [self]
 

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -1,0 +1,25 @@
+class CreateUserService
+  def self.invite_responsible_body_user(user_params = {})
+    user = User.new(user_params.merge(override_params))
+    if user.save
+      user.hybrid_setup!
+      InviteResponsibleBodyUserMailer.with(user: user).invite_user_email.deliver_later
+    end
+    user
+  end
+
+  def self.invite_school_user(user_params = {})
+    user = User.new(user_params.merge(override_params))
+    if user.save
+      user.hybrid_setup!
+      InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
+    end
+    user
+  end
+
+  def self.override_params
+    { approved_at: Time.zone.now, orders_devices: true }
+  end
+
+  private_class_method :override_params
+end

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe CreateUserService do
+  let(:last_email) { ActionMailer::Base.deliveries.last }
+
+  describe 'invite_responsible_body_user' do
+    let(:trust) { create(:trust) }
+
+    context 'given valid user params' do
+      let(:valid_params) do
+        {
+          full_name: 'Vlad Valid',
+          email_address: 'vlad@example.com',
+          telephone: '01234 567890',
+          responsible_body_id: trust.id,
+        }
+      end
+      let(:result) { CreateUserService.invite_responsible_body_user(valid_params) }
+
+      it 'creates a user with the given params' do
+        expect { result }.to change(User, :count).by(1)
+        expect(User.last).to have_attributes(valid_params)
+      end
+
+      it 'sends the correct email' do
+        expect { perform_enqueued_jobs { result } }.to change(ActionMailer::Base.deliveries, :size).by(1)
+        expect(last_email.to[0]).to eq(valid_params[:email_address])
+        expect(last_email.header['template-id'].value).to eq(Settings.govuk_notify.templates.devices.invite_responsible_body_user)
+      end
+
+      it 'returns the user' do
+        expect(result).to be_a(User)
+        expect(result).to have_attributes(valid_params)
+      end
+    end
+
+    context 'given invalid user params' do
+      let(:invalid_params) do
+        {
+          full_name: '.',
+          email_address: 'dunno',
+          responsible_body_id: nil,
+        }
+      end
+      let(:result) { CreateUserService.invite_responsible_body_user(invalid_params) }
+
+      it 'does not create a user with the given params' do
+        expect { result }.not_to change(User, :count)
+      end
+
+      it 'does not send any email' do
+        expect { perform_enqueued_jobs { result } }.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+
+      it 'returns the user unpersisted, with errors' do
+        expect(result).to be_a(User)
+        expect(result).to have_attributes(invalid_params)
+        expect(result.errors.full_messages).not_to be_empty
+      end
+    end
+  end
+
+  describe 'invite_school_user' do
+    let(:school) { create(:school) }
+
+    context 'given valid user params' do
+      let(:valid_params) do
+        {
+          full_name: 'Vlad Valid',
+          email_address: 'vlad@example.com',
+          telephone: '01234 567890',
+          school_id: school.id,
+        }
+      end
+      let(:result) { CreateUserService.invite_school_user(valid_params) }
+
+      it 'creates a user with the given params' do
+        expect { result }.to change(User, :count).by(1)
+        expect(User.last).to have_attributes(valid_params)
+      end
+
+      it 'sends the correct email' do
+        expect { perform_enqueued_jobs { result } }.to change(ActionMailer::Base.deliveries, :size).by(1)
+        expect(last_email.to[0]).to eq(valid_params[:email_address])
+        expect(last_email.header['template-id'].value).to eq(Settings.govuk_notify.templates.devices.school_nominated_contact)
+      end
+
+      it 'returns the user' do
+        expect(result).to be_a(User)
+        expect(result).to have_attributes(valid_params)
+      end
+    end
+
+    context 'given invalid user params' do
+      let(:invalid_params) do
+        {
+          full_name: '.',
+          email_address: 'dunno',
+          school_id: nil,
+        }
+      end
+      let(:result) { CreateUserService.invite_school_user(invalid_params) }
+
+      it 'does not create a user with the given params' do
+        expect { result }.not_to change(User, :count)
+      end
+
+      it 'does not send any email' do
+        expect { perform_enqueued_jobs { result } }.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+
+      it 'returns the user unpersisted, with errors' do
+        expect(result).to be_a(User)
+        expect(result).to have_attributes(invalid_params)
+        expect(result.errors.full_messages).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

See [Trello card 698](https://trello.com/c/Yn0xKhWJ/698-refactor-user-creation-to-a-service)

### Changes proposed in this pull request

* Add a separate `CreateUser` service, with methods `invite_responsible_body_user` and `invite_school_user`

### Guidance to review

All behaviour should be unchanged 
