### PR TITLE
Swap out govuk_link_to with govuk-component version

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,12 +1,4 @@
 module ViewHelper
-  def govuk_link_to(body, url, html_options = {}, &_block)
-    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
-
-    return link_to(url, html_options) { yield } if block_given?
-
-    link_to(body, url, html_options)
-  end
-
   def ghwt_contact_mailto(subject: 'Increasing%20internet%20access', label: 'COVID.TECHNOLOGY@education.gov.uk')
     mail_to_url = [
       'mailto:COVID.TECHNOLOGY@education.gov.uk',

--- a/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
@@ -14,9 +14,9 @@
           <%= @extra_mobile_data_request.account_holder_name %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-account-holder-name-field') ) do %>
-            Change<span class="govuk-visually-hidden"> Account holder name</span>
-          <%- end %>
+          <%= govuk_link_to('Change<span class="govuk-visually-hidden"> Account holder name</span>'.html_safe,
+                            new_responsible_body_internet_mobile_manual_request_path(
+                              anchor: 'extra-mobile-data-request-account-holder-name-field') ) %>
         </dd>
       </div>
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- replaces custom govuk_link_to with govuk-component govuk_link_to helper method ([source](https://github.com/DFE-Digital/govuk-components/blob/master/app/helpers/govuk_link_helper.rb#L2-L4))

There is only one major difference between govuk-component helper method implementation and the one in the service. The difference is that govuk-component helper method does not support passing in a block. I don't see this as a blocker as I could only see one instance where a block was used and I assume the reason it was a block was because it was using html markup and rails would have been escaping it. This could have been overcome by using html_safe.


### Guidance to review

