### PR TITLE
Single school journey fixes and improvements

### DIFF
--- a/app/controllers/responsible_body/devices/who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/who_will_order_controller.rb
@@ -9,11 +9,7 @@ class ResponsibleBody::Devices::WhoWillOrderController < ResponsibleBody::Device
     @form = ResponsibleBody::Devices::WhoWillOrderForm.new(who_will_order_params)
     if @form.valid?
       ResponsibleBody.transaction do
-        @responsible_body.update!(who_will_order_devices: @form.who_will_order)
-        @responsible_body.schools.each do |school|
-          school.preorder_information&.destroy!
-          school.create_preorder_information!(who_will_order_devices: @form.who_will_order.singularize)
-        end
+        @responsible_body.update_who_will_order_devices(@form.who_will_order)
       end
 
       event = WhoWillOrderEvent.new(responsible_body: @responsible_body)

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -30,6 +30,14 @@ class ResponsibleBody < ApplicationRecord
       .first
   end
 
+  def update_who_will_order_devices(who_will_order)
+    update!(who_will_order_devices: who_will_order)
+    schools.each do |school|
+      school.preorder_information&.destroy!
+      school.create_preorder_information!(who_will_order_devices: who_will_order.singularize)
+    end
+  end
+
   def who_will_order_devices_label
     case who_will_order_devices
     when 'school'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,12 +126,12 @@ class User < ApplicationRecord
     school = responsible_body.schools.first
 
     update!(school: school)
+    responsible_body.update_who_will_order_devices('schools')
     contact = school.contacts.create!(email_address: email_address,
                                       full_name: full_name,
                                       role: :contact,
                                       phone_number: telephone)
-    school.create_preorder_information!(who_will_order_devices: 'school',
-                                        school_contact: contact,
+    school.preorder_information.update!(school_contact: contact,
                                         status: 'school_contacted')
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,8 +131,7 @@ class User < ApplicationRecord
                                       full_name: full_name,
                                       role: :contact,
                                       phone_number: telephone)
-    school.preorder_information.update!(school_contact: contact,
-                                        status: 'school_contacted')
+    school.preorder_information.update!(school_contact: contact)
   end
 
 private

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe Support::UsersController, type: :controller do
           expect(school.preorder_information).to be_present
           expect(school.preorder_information.who_will_order_devices).to eql('school')
         end
+
+        it 'devolves ordering to the school' do
+          perform_create!
+          responsible_body.reload
+
+          expect(responsible_body.who_will_order_devices).to eq('schools')
+        end
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe User, type: :model do
       expect(contact.phone_number).to eql(user.telephone)
     end
 
-    it 'marks preorder#status as school_contacted' do
+    it 'marks preorder#status as school_will_be_contacted' do
       user.hybrid_setup!
-      expect(user.school.preorder_information.status).to eql('school_contacted')
+      expect(user.school.preorder_information.status).to eql('school_will_be_contacted')
     end
   end
 


### PR DESCRIPTION
### Context

The data for single-school responsible bodies should be consistent with the other RBs.

### Changes proposed in this pull request

- set 'who will order devices' for single-school RBs
- don't explicitly override the PreorderInformation status, let it be derived automatically

### Guidance to review

Review each commit separately.