### PR TITLE
Fix broken links in support

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -104,15 +104,19 @@ private
 
   def school_contact_row_if_contact_present
     if school_will_order_devices? && school_contact.present?
-      [{
-        key: 'School contact',
-        value: contact_lines.map { |line| h(line) }.join('<br>').html_safe,
-        change_path: responsible_body_devices_school_who_to_contact_edit_path(school_urn: @school.urn),
-        action: 'Change',
-      }]
+      [school_contact_row]
     else
       []
     end
+  end
+
+  def school_contact_row
+    {
+      key: 'School contact',
+      value: contact_lines.map { |line| h(line) }.join('<br>').html_safe,
+      change_path: responsible_body_devices_school_who_to_contact_edit_path(school_urn: @school.urn),
+      action: 'Change',
+    }
   end
 
   def contact_lines

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -24,4 +24,8 @@ private
         end
       end
   end
+
+  def chromebook_rows_if_needed
+    super.map { |row| row.except(:change_path, :action, :action_path) }
+  end
 end

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -13,11 +13,11 @@ private
     super.except(:action_path, :action).merge(change_path: support_devices_school_enable_orders_path(school_urn: @school.urn))
   end
 
-  def school_contact_row_if_contact_present
-    super
-      .tap do |rows|
-        if rows.present? && @school&.preorder_information&.school_will_be_contacted?
-          rows.first.merge!(
+  def school_contact_row
+    super.except(:change_path, :action)
+      .tap do |row|
+        if @school&.preorder_information&.school_will_be_contacted?
+          row.merge!(
             action_path: support_devices_school_invite_path(school_urn: @school.urn),
             action: 'Invite',
           )

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -59,8 +59,11 @@ describe Support::SchoolDetailsSummaryListComponent do
                who_will_order_devices: :school,
                school_contact: headteacher)
 
+        school.preorder_information.school_contacted!
+
         expect(result.css('.govuk-summary-list__row')[5].text).to include('School contact')
         expect(result.css('.govuk-summary-list__row')[5].inner_html).to include('Headteacher: Davy Jones<br>davy.jones@school.sch.uk<br>12345')
+        expect(result.css('.govuk-summary-list__row')[5].css('a')).not_to be_present
       end
     end
 

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -117,10 +117,14 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(result.css('.govuk-summary-list__row')[1].text).to include('The trust orders devices')
     end
 
-    it 'shows the chromebook details with links to change it' do
+    it 'shows the chromebook details' do
       expect(result.css('.govuk-summary-list__row')[5].text).to include('Yes, they will need Chromebooks')
       expect(result.css('.govuk-summary-list__row')[6].text).to include('school.domain.org')
       expect(result.css('.govuk-summary-list__row')[7].text).to include('admin@recovery.org')
+
+      expect(result.css('.govuk-summary-list__row')[5].css('a')).not_to be_present
+      expect(result.css('.govuk-summary-list__row')[6].css('a')).not_to be_present
+      expect(result.css('.govuk-summary-list__row')[7].css('a')).not_to be_present
     end
 
     it 'does not show the school contact even if the school contact is set' do


### PR DESCRIPTION
### Context

Because the school details table in support inherits from the responsible body school details table, a few broken links have snuck in.

### Changes proposed in this pull request

Remove the broken links that point to the RB interface.

