### PR TITLE
Remove explicit dependency on view_component gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,9 +74,6 @@ gem 'notifications-ruby-client'
 # parsing XLSX spreadsheets for bulk extra data requests
 gem 'rubyXL'
 
-# Reusable view code
-gem 'view_component'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,6 @@ DEPENDENCIES
   timecop
   travis
   tzinfo-data
-  view_component
   web-console (>= 3.3.0)
   webdrivers (~> 4.3)
   webmock


### PR DESCRIPTION
It's already pulled in by govuk-components
