### PR TITLE
Single school RB onboarding: iteration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,25 +115,6 @@ class User < ApplicationRecord
     school_id && responsible_body_id
   end
 
-  def hybrid_setup!
-    return if responsible_body.blank?
-
-    one_school = responsible_body.schools.count == 1
-    only_user = responsible_body.users == [self]
-
-    return unless one_school && only_user
-
-    school = responsible_body.schools.first
-
-    update!(school: school)
-    responsible_body.update_who_will_order_devices('schools')
-    contact = school.contacts.create!(email_address: email_address,
-                                      full_name: full_name,
-                                      role: :contact,
-                                      phone_number: telephone)
-    school.preorder_information.update!(school_contact: contact)
-  end
-
 private
 
   def cleansed_full_name

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -2,7 +2,6 @@ class CreateUserService
   def self.invite_responsible_body_user(user_params = {})
     user = User.new(user_params.merge(override_params))
     if user.save
-      user.hybrid_setup!
       InviteResponsibleBodyUserMailer.with(user: user).invite_user_email.deliver_later
     end
     user
@@ -11,7 +10,6 @@ class CreateUserService
   def self.invite_school_user(user_params = {})
     user = User.new(user_params.merge(override_params))
     if user.save
-      user.hybrid_setup!
       InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
     end
     user

--- a/app/services/onboard_single_school_responsible_body_service.rb
+++ b/app/services/onboard_single_school_responsible_body_service.rb
@@ -1,0 +1,94 @@
+class OnboardSingleSchoolResponsibleBodyService
+  def initialize(urn:)
+    @urn = urn
+  end
+
+  def call
+    return unless single_school_responsible_body?
+
+    responsible_body.update!(in_devices_pilot: true)
+    devolve_ordering_to_the_school
+
+    ensure_both_responsible_body_and_school_have_users
+  end
+
+private
+
+  def ensure_both_responsible_body_and_school_have_users
+    if responsible_body.users.present?
+      add_responsible_body_users_to_school
+      mark_school_as_invited
+    elsif school_has_headteacher_contact?
+      invite_school_headteacher
+      add_school_headteacher_to_responsible_body
+    else
+      raise 'Cannot continue without RB users or a school headteacher'
+    end
+  end
+
+  def add_responsible_body_users_to_school
+    first_rb_user = responsible_body.users.first
+    set_user_as_school_contact(first_rb_user)
+    make_school_user(first_rb_user)
+
+    (responsible_body.users - [first_rb_user]).each do |user|
+      make_school_user(user)
+    end
+  end
+
+  def set_user_as_school_contact(user_to_contact)
+    contact = school.contacts.create!(email_address: user_to_contact.email_address,
+                                      full_name: user_to_contact.full_name,
+                                      role: :contact,
+                                      phone_number: user_to_contact.telephone)
+    school.preorder_information.update!(school_contact: contact)
+  end
+
+  def mark_school_as_invited
+    PreorderInformation.transaction do
+      school.preorder_information.update!(school_contacted_at: Time.zone.now)
+      school.preorder_information.update!(status: school.preorder_information.infer_status)
+    end
+  end
+
+  def make_school_user(user)
+    # we can't have more than 3 school users who order devices!
+    user.update!(orders_devices: false) if school.users.count >= 3
+    school.users << user
+    InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
+  end
+
+  def add_school_headteacher_to_responsible_body
+    headteacher_user = school.users.find_by!(email_address: school.headteacher_contact.email_address)
+    headteacher_user.update!(responsible_body: responsible_body)
+  end
+
+  def school_has_headteacher_contact?
+    school.headteacher_contact.present?
+  end
+
+  def invite_school_headteacher
+    choose_headteacher_as_school_contact
+    school.invite_school_contact
+  end
+
+  def choose_headteacher_as_school_contact
+    school.preorder_information.update!(school_contact: school.headteacher_contact)
+  end
+
+  def devolve_ordering_to_the_school
+    responsible_body.update_who_will_order_devices('schools')
+  end
+
+  def single_school_responsible_body?
+    responsible_body&.schools&.size == 1
+  end
+
+  def school
+    @school ||= School.find_by!(urn: @urn)
+  end
+
+  def responsible_body
+    school.responsible_body
+  end
+end

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -39,32 +39,6 @@ RSpec.describe Support::UsersController, type: :controller do
 
         expect(User.last.versions.last.whodunnit).to eql("User:#{dfe_user.id}")
       end
-
-      context 'if RB only has one school and this is the first user' do
-        let!(:school) { create(:school, responsible_body: responsible_body) }
-
-        it 'sets user.school to the school' do
-          perform_create!
-
-          user = User.last
-          expect(user.school).to eql(school)
-        end
-
-        it 'creates preorder on the school with school to order' do
-          perform_create!
-          school.reload
-
-          expect(school.preorder_information).to be_present
-          expect(school.preorder_information.who_will_order_devices).to eql('school')
-        end
-
-        it 'devolves ordering to the school' do
-          perform_create!
-          responsible_body.reload
-
-          expect(responsible_body.who_will_order_devices).to eq('schools')
-        end
-      end
     end
 
     it 'is forbidden for MNO users' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,34 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe '#hybrid_setup!' do
-    let!(:responsible_body) { create(:trust, schools: [school]) }
-    let(:school) { create(:school) }
-
-    subject(:user) do
-      create(:user,
-             orders_devices: true,
-             school: school,
-             responsible_body: responsible_body)
-    end
-
-    it 'uses this user as the school contact' do
-      user.hybrid_setup!
-      contact = user.school.preorder_information.school_contact
-
-      expect(contact).to be_present
-      expect(contact.email_address).to eql(user.email_address)
-      expect(contact.full_name).to eql(user.full_name)
-      expect(contact.role).to eql('contact')
-      expect(contact.phone_number).to eql(user.telephone)
-    end
-
-    it 'marks preorder#status as school_will_be_contacted' do
-      user.hybrid_setup!
-      expect(user.school.preorder_information.status).to eql('school_will_be_contacted')
-    end
-  end
-
   describe '#is_mno_user?' do
     it 'is true when the user is from an MNO participating in the pilot' do
       user = build(:user, mobile_network: build(:mobile_network))

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
+  after do
+    clear_enqueued_jobs
+  end
+
+  let(:responsible_body) { create(:trust, :single_academy_trust, in_devices_pilot: false) }
+  let(:school) { create(:school, responsible_body: responsible_body) }
+
+  context 'when the responsible body has no users and the school has no headteacher' do
+    it 'raises an error' do
+      expect {
+        described_class.new(urn: school.urn).call
+      }.to raise_error(/Cannot continue without RB users or a school headteacher/)
+    end
+  end
+
+  context 'when the responsible body has users' do
+    before do
+      create_list(:trust_user, 4, responsible_body: responsible_body, orders_devices: true)
+
+      described_class.new(urn: school.urn).call
+      responsible_body.reload
+      school.reload
+    end
+
+    it 'brings the responsible body into the devices pilot' do
+      expect(responsible_body.in_devices_pilot?).to be_truthy
+    end
+
+    it 'marks the responsible body as having devolved ordering to schools' do
+      expect(responsible_body.who_will_order_devices).to eq('schools')
+    end
+
+    it 'sets one of the users as a school contact' do
+      expect(school.preorder_information.school_contact).to be_present
+
+      contact_email_address = school.preorder_information.school_contact.email_address
+      expect(responsible_body.users.find_by(email_address: contact_email_address)).to be_present
+    end
+
+    it 'contacts the school contact and marks the school as contacted' do
+      perform_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.first.to.first).to eq(school.preorder_information.school_contact.email_address)
+      expect(school.preorder_information.status).to eq('school_contacted')
+    end
+
+    it 'contacts all RB users' do
+      perform_enqueued_jobs
+
+      contacted_emails = ActionMailer::Base.deliveries.flat_map(&:to)
+      expect(contacted_emails).to match_array(responsible_body.users.map(&:email_address))
+    end
+
+    it 'ensures that only 3 of the RB users are going to order devices' do
+      # it's a bit strange that some users have their ability to order randomly switched off,
+      # but there's no other obvious way to decide who to ensure the '3 Techsource users' constraint
+      expect(responsible_body.users.who_can_order_devices.count).to eq(3)
+    end
+
+    it 'adds all the RB users as school users' do
+      User.all.each do |user|
+        expect(user).to be_hybrid
+        expect(user.school).to eq(school)
+        expect(user.responsible_body).to eq(responsible_body)
+      end
+    end
+  end
+
+  context 'when the responsible body has no users but the school has a headteacher contact' do
+    before do
+      @headteacher = create(:school_contact, :headteacher, school: school)
+
+      described_class.new(urn: school.urn).call
+      responsible_body.reload
+      school.reload
+    end
+
+    it 'brings the responsible body into the devices pilot' do
+      expect(responsible_body.in_devices_pilot?).to be_truthy
+    end
+
+    it 'marks the responsible body as having devolved ordering to schools' do
+      expect(responsible_body.who_will_order_devices).to eq('schools')
+    end
+
+    it 'sets the headteacher as a school contact' do
+      expect(school.preorder_information.school_contact).to eq(@headteacher)
+    end
+
+    it 'contacts the headteacher and marks the school as contacted' do
+      perform_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.first.to.first).to eq(@headteacher.email_address)
+      expect(school.preorder_information.status).to eq('school_contacted')
+    end
+
+    it 'adds the headteacher as a hybrid user who can order' do
+      user = User.find_by!(email_address: @headteacher.email_address)
+
+      expect(user).to be_hybrid
+      expect(user.school).to eq(school)
+      expect(user.responsible_body).to eq(responsible_body)
+    end
+  end
+end


### PR DESCRIPTION
### Context

#499 was a first pass at allowing single-school responsible bodies onto the service. When trying to run it on production, I realised that the assumptions in that change we'd made were incorrect, namely many single-school RBs already have existing users from wave 1.

### Changes proposed in this pull request
Iterate logic for onboarding single-school responsible bodies:

- Handle the case where an RB already has users
- Handle the case where the RB has no users but the school has a headteacher
- Remove the v1 logic as it's superseded
