### PR TITLE
[711] Fix hybrid user post login screen

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,8 +89,8 @@ class User < ApplicationRecord
   def organisation_name
     mobile_network&.brand || \
       responsible_body&.local_authority_official_name || \
-      responsible_body&.name || \
       school&.name || \
+      responsible_body&.name || \
       (is_computacenter? && 'Computacenter') || \
       (is_support? && 'DfE Support')
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
       approved
     end
 
+    factory :hybrid_user do
+      association :responsible_body, factory: %i[trust in_connectivity_pilot]
+      school
+      orders_devices { true }
+    end
+
     factory :school_user do
       school
       orders_devices { false }

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -103,6 +103,19 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
+  context 'as a hybrid user' do
+    let(:user) { create(:hybrid_user) }
+
+    scenario 'logging in for the first time' do
+      visit validate_token_url_for(user)
+      expect(page).to have_text("You’re signed in as #{user.school.name}")
+      click_on 'Continue'
+      expect(page).to have_text('Before you continue, please read the privacy notice.')
+      click_on 'Continue'
+      expect(page).to have_text('You’ve been allocated 0 laptops and tablets')
+    end
+  end
+
   context 'as a support user' do
     let(:user) { create(:dfe_user) }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/w7jJ7Z4B/711-hybrid-user-post-login-screen

### Changes proposed in this pull request

- When a hybrid user logs in show the school name and not the responsible body name

### Guidance to review

- Login as a hybrid user
- Should see school name on next page and not the responsible body name
