### PR TITLE
[DO NOT CLOSE] SPIKE: Mock up second level content directly from home page

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,0 +1,11 @@
+class LandingPagesController < ApplicationController
+  def get_laptops_and_tablets; end
+
+  def get_support; end
+
+  def get_internet_access; end
+
+  def digital_platforms; end
+
+  def edtech_demonstrator_programme; end
+end

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,5 +1,5 @@
 class LandingPagesController < ApplicationController
-  layout 'page_with_toc', only: :get_support
+  layout 'page_with_toc', only: [:get_support, :get_internet_access]
 
   def get_laptops_and_tablets; end
 
@@ -8,7 +8,10 @@ class LandingPagesController < ApplicationController
     render
   end
 
-  def get_internet_access; end
+  def get_internet_access
+    @title = I18n.t!('second_level_content.get_internet_access.title')
+    render
+  end
 
   def digital_platforms; end
 

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,11 +1,30 @@
 class LandingPagesController < ApplicationController
+  layout 'page_with_toc', only: :get_support
+
   def get_laptops_and_tablets; end
 
-  def get_support; end
+  def get_support;
+    @title = I18n.t!('second_level_content.get_support.title')
+    render
+  end
 
   def get_internet_access; end
 
   def digital_platforms; end
 
   def edtech_demonstrator_programme; end
+
+private
+
+  def get_page_meta_data
+    I18n.t!('second_level_content').map do |page_id, page_metadata|
+      {
+        page_id: page_id,
+        # path: devices_guidance_subpage_path(subpage_slug: page_id.to_s.dasherize),
+        title: page_metadata[:title],
+        # description: page_metadata[:description],
+        # audience: page_metadata[:audience],
+      }
+    end
+  end
 end

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,5 +1,5 @@
 class LandingPagesController < ApplicationController
-  layout 'page_with_toc', only: [:get_support, :get_internet_access]
+  layout 'page_with_toc', only: [:get_support, :get_internet_access, :edtech_demonstrator_programme]
 
   def get_laptops_and_tablets; end
 
@@ -15,7 +15,10 @@ class LandingPagesController < ApplicationController
 
   def digital_platforms; end
 
-  def edtech_demonstrator_programme; end
+  def edtech_demonstrator_programme
+    @title = I18n.t!('second_level_content.edtech_demonstrator_programme.title')
+    render
+  end
 
 private
 

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,5 +1,5 @@
 class LandingPagesController < ApplicationController
-  layout 'page_with_toc', only: [:get_support, :get_internet_access, :edtech_demonstrator_programme]
+  layout 'page_with_toc', only: [:get_support, :get_internet_access, :edtech_demonstrator_programme, :digital_platforms]
 
   def get_laptops_and_tablets; end
 
@@ -13,7 +13,10 @@ class LandingPagesController < ApplicationController
     render
   end
 
-  def digital_platforms; end
+  def digital_platforms
+    @title = I18n.t!('second_level_content.digital_platforms.title')
+    render
+  end
 
   def edtech_demonstrator_programme
     @title = I18n.t!('second_level_content.edtech_demonstrator_programme.title')

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -1,0 +1,4 @@
+# Get funding and support to set up a digital education platform
+
+
+[Visit The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/)

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -74,12 +74,32 @@ After you complete your support request form, you'll receive an email from the D
 
 Once your platform is set up, you can claim the following grant funding:
 
-Type of school | Grant funding available
-:--- | :---
-Individual primary school | £1,500
-Individual secondary school | £2,000
-Multi-academy trust | £1,000 per school
-Virtual school | £1,500
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Type of school</th>
+      <th scope="col" class="govuk-table__header">Grant funding available</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Individual primary school</th>
+        <td class="govuk-table__cell">£1,500</td>  
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Individual secondary school</th>
+        <td class="govuk-table__cell">£2,000</td>  
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Multi-academy trust</th>
+        <td class="govuk-table__cell">£1,000 per school</td>  
+      </tr>       
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Virtual school</th>
+        <td class="govuk-table__cell">£1,500</td>  
+      </tr>
+  </tbody>
+</table>
 
 ## Will platforms continue to be free to use?
 

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -1,4 +1,93 @@
-# Get funding and support to set up a digital education platform
+## About the programme
 
+Government-funded support is available for schools to get set up on one of two free-to-use digital education platforms. You can choose to use either:
 
-[Visit The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/)
+* G Suite for Education (Google Classroom)
+* Office 365 Education (Microsoft Teams)
+
+[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/feature-comparison-g-suite-education-and-office-365-education/?marker=content-body) provides feature comparison and case studies on how schools are making the most of these platforms, to help you make the most appropriate choice for your school.
+
+You have until the end of March 2021 to register with this programme and claim your grant.
+
+## What is a digital education platform?
+It's a place where teachers and pupils can continue learning through online virtual classrooms. 
+
+The platforms are purpose-built for remote learning in a way that a school website is not. 
+
+Teachers can:
+
+* communicate with pupils and deliver lessons via video calls
+* record virtual lessons 
+* set tasks
+* let pupils work together through supervised group calls
+* give personalised feedback via video or within shared documents
+* continue with formal assessment for learning
+* set up separate classrooms for smaller groups of students
+* develop structured file and folder storage for different users
+* use tools to support staff planning
+
+Using a digital education platform will allow teachers and pupils to continue education if a school closes.
+
+[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/lead-your-approach/why-every-school-should-be-using-digital-education-platform/) has information on why you should make the move to a digital education platform, if you have not already. 
+
+## Who can apply
+
+The funded support is for schools that:
+
+* do not have a digital education platform
+* have access to Office 365 Education or G Suite for Education, but are not yet set up to assign work and communicate with pupils
+
+Support is available to state funded:
+
+* primary schools
+* secondary schools
+* special schools
+* pupil referral units
+
+Virtual schools are also eligible for the programme. This is especially true for virtual schools that:
+
+* regularly coordinate and deliver elements of educational provision and curricular content 
+* engage with looked after children
+
+## How to apply
+
+You can choose to apply for support from either a Google or Microsoft partner. 
+
+To apply, complete the support request form by your chosen partner below:
+
+* [Apply for support from a Google partner](https://docs.google.com/forms/d/e/1FAIpQLSc45tWnxrk0ZPyhEE4UioGAxDF_2eYNEuE3lLzY_P6Hpo8jxg/viewform)
+* [Apply for support from a Microsoft partner](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR8OxR8KDk1BHllyTqp9sEZBUNEVJNDlRN0U1WUtQWk1KTjY5RDFCM1M3VyQlQCN0PWcu)
+
+Trusts and sponsors can apply on behalf of their schools.
+
+## What happens after you apply
+
+A member from either Google or Microsoft will receive your request. They’ll confirm if you’re eligible for the programme and if so, they’ll assign you to an IT supplier. 
+
+Your IT supplier will contact you within 2 days to agree a day and time to start the process of setting up the platform for your school. 
+
+It will take only a few days to install your platform if you respond quickly to the IT supplier’s requests to agree to the scope of work, and share user data and any other relevant information. 
+
+## How to claim your grant funding
+
+After you complete your support request form, you'll receive an email from the DfE Digital Infrastructure Payments team with details on how to claim your grant. 
+
+Once your platform is set up, you can claim the following grant funding:
+
+Type of school | Grant funding available
+:--- | :---
+Individual primary school | £1,500
+Individual secondary school | £2,000
+Multi-academy trust | £1,000 per school
+Virtual school | £1,500
+
+## Will platforms continue to be free to use?
+
+Once you have access to a platform, you and your pupils can use it for free.
+
+## How to get support
+You can find more information about the programme and how schools are using digital platforms on [The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/).
+
+[Free training and support to set up and use technology effectively](/EdTech-demonstrator-programme) is available through the EdTech Demonstrator Programme.
+
+If you have a question about this programme, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.

--- a/app/views/landing_pages/edtech_demonstrator_programme.md
+++ b/app/views/landing_pages/edtech_demonstrator_programme.md
@@ -1,5 +1,50 @@
-# Get peer-to-peer support on the effective use of technology
+## About the programme
+
+The [EdTech Demonstrator programme](https://edtech-demonstrator.lgfl.net/home) launched in 2019 to offer peer-to-peer support on the effective use of technology in education. It currently focuses on helping schools and colleges to provide remote and blended education. 
+
+The programme offer is tailored to the needs of each school or college, but will include training and support through:
+
+* live group webinars
+* peer-to-peer discussions
+* recorded content
+
+One-to-one training and support is also available if requested.
+
+Advice and training is provided on:
+
+* using devices, apps and platforms
+* how to make effective use of online learning platforms for remote education, and teaching in the classroom
+* using technology to maintain effective communication between teachers, pupils and parents
+* digital safety and safeguarding
+* supporting the needs of pupils with SEND
+* creating a digital strategy
+* promoting pupil and teacher wellbeing during remote teaching
 
 
-[Visit EdTech Demonstrator Programme site](https://edtech-demonstrator.lgfl.net/)
-      
+You can [view a list of upcoming events](https://edtech-demonstrator.lgfl.net/support-and-resources/upcoming-events) on the EdTech Demonstrator website.
+
+Demonstrators are [schools and colleges](https://edtech-demonstrator.lgfl.net/demonstrator-schools-and-colleges) with significant experience and expertise in the effective use of education technology. All demonstrators have applied to be part of the programme, and have undergone a rigorous selection process through the Department for Education (DfE).
+
+## Who the programme is for
+Any publically funded school or college in England can apply for support from an EdTech Demonstrator. Independent schools and training providers are not eligible for the scheme.
+
+The programme offers support to schools and colleges who are setting up a [new online learning platform](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/). 
+
+It can also help those that would like support to develop their approach to remote learning to improve learner outcomes, engagement and wellbeing.
+
+## How to apply for free training and support
+
+Please visit the EdTech Demonstrator website to [complete this form and register your interest](https://edtech-demonstrator.lgfl.net/register-your-interest). You’ll then be contacted to find out more about your needs. 
+
+## The long-term benefits of the programme
+
+The EdTech Demonstrator programme is funded by the DfE until the end of March 2021.
+
+Schools and colleges will receive facilitated support from demonstrators through continuous professional development (CPD). 
+
+You can [watch video testimonials](https://edtech-demonstrator.lgfl.net/about/how-it-works) from demonstrators and some of the schools and colleges they work with on the EdTech Demonstrator website.
+
+## Contact us
+To apply for free training and support, please visit the EdTech Demonstrator website to [complete this form](https://edtech-demonstrator.lgfl.net/register-your-interest). 
+
+If you have a question about the EdTech Demonstrator Programme please email EdTech.TEAM@education.gov.uk.

--- a/app/views/landing_pages/edtech_demonstrator_programme.md
+++ b/app/views/landing_pages/edtech_demonstrator_programme.md
@@ -1,0 +1,5 @@
+# Get peer-to-peer support on the effective use of technology
+
+
+[Visit EdTech Demonstrator Programme site](https://edtech-demonstrator.lgfl.net/)
+      

--- a/app/views/landing_pages/get_internet_access.md
+++ b/app/views/landing_pages/get_internet_access.md
@@ -1,0 +1,3 @@
+# Get internet access
+
+

--- a/app/views/landing_pages/get_internet_access.md
+++ b/app/views/landing_pages/get_internet_access.md
@@ -1,5 +1,3 @@
-# Get internet access
-
 ## About the scheme
 
 Internet access supports remote education, as well as virtual contact between children, their social workers and other services.
@@ -35,6 +33,6 @@ This support is available for children from early years up to 16, and care leave
 
 ## How to get support
 
-If you have a question about internet access schemes, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.
+If you have a question about internet access schemes, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk). We aim to respond within 3 working days.
 
 If you need support to manage a 4G wireless router you’ve received from us, please [see our guidance](https://get-help-with-tech.education.gov.uk/devices/preparing-4g-wireless-routers). It includes information about data, contract length and security.

--- a/app/views/landing_pages/get_internet_access.md
+++ b/app/views/landing_pages/get_internet_access.md
@@ -1,3 +1,40 @@
 # Get internet access
 
+## About the scheme
 
+Internet access supports remote education, as well as virtual contact between children, their social workers and other services.
+
+We know that many children do not have reliable internet access, and we’re acting to change this by:
+
+- [giving children free access to wifi hotspots](https://get-help-with-tech.education.gov.uk/about-bt-wifi)
+- [increasing data allowances on mobile devices](https://get-help-with-tech.education.gov.uk/about-increasing-mobile-data)
+
+We’ve also provided more than 50,000 [4G wireless routers](https://get-help-with-tech.education.gov.uk/devices/preparing-4g-wireless-routers) to local authorities and academy trusts this year.
+
+## Who can get help
+
+### [Free access to BT wifi hotspots](https://get-help-with-tech.education.gov.uk/about-bt-wifi)
+
+The Department for Education is running a pilot scheme that gives children and young people free access to BT wifi hotspots. If they live in range of a BT hotspot, their school will give them log-in details to access the network.
+
+Available for families with children from early years up to 16, and care leavers up to 25 if they:
+
+- do not have access to a [fixed broadband connection](https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics)
+- cannot afford the additional data needed to access educational resources or social care services
+- have access to a BT hotspot (coverage varies depending on where they live)
+
+### [Increasing data allowances on children’s mobile devices](https://get-help-with-tech.education.gov.uk/about-increasing-mobile-data)
+
+We’re running a pilot scheme to temporarily increase data allowances on certain mobile devices. This is so disadvantaged children and young people can continue their remote education and maintain contact with social care services without incurring extra data charges.
+
+This support is available for children from early years up to 16, and care leavers up to 25 if they:
+
+- do not have access to a [fixed broadband connection](https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics)
+- cannot afford the additional data needed to access social care services or educational resources while learning at home [cannot access a BT hotspot](https://get-help-with-tech.education.gov.uk/about-bt-wifi)
+- are an existing customer of a [participating mobile network operator](https://get-help-with-tech.education.gov.uk/about-increasing-mobile-data#whos-on-board) (for some operators, they’ll need to be on a pay monthly contract)
+
+## How to get support
+
+If you have a question about internet access schemes, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.
+
+If you need support to manage a 4G wireless router you’ve received from us, please [see our guidance](https://get-help-with-tech.education.gov.uk/devices/preparing-4g-wireless-routers). It includes information about data, contract length and security.

--- a/app/views/landing_pages/get_laptops_and_tablets.html.erb
+++ b/app/views/landing_pages/get_laptops_and_tablets.html.erb
@@ -14,7 +14,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">who can get laptops and tablets</a>. We’re also providing <a href="https://get-help-with-tech.education.gov.uk/internet-access" class="govuk-link">internet connections</a> where they're needed.
+      Find out <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">who can get laptops and tablets</a>. We’re also providing <a href="/internet-access" class="govuk-link">internet connections</a> where they're needed.
     </p>
 
     <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active">
@@ -48,7 +48,7 @@
             <p class="app-step-nav__paragraph">
               They can adapt this choice individually for each school. Additional users from within a local authority or academy trust can be invited to provide this information through the Get help with technology service.
             </p>
-            <p>This is a different process than they may have followed to order devices between May and July 2020. This step must be completed before anyone can order.</p>
+            <p class="app-step-nav__paragraph">This is a different process than they may have followed to order devices between May and July 2020. This step must be completed before anyone can order.</p>
           </div>
 
         </li>
@@ -86,10 +86,10 @@
               These contacts will have the option to invite up to 2 other people from their school to manage orders.
             </p>
             <p class="app-step-nav__paragraph">
-              If orders are to be managed centrally, we’ll ask if each school will require Chromebooks. If they do,
+              We’ll ask if each school will require Chromebooks. If they do,
               we'll ask for some technical information so they can be set up correctly when orders are placed.
             </p>
-            <p>See the ‘Choosing devices’ section below for information on what device types are available and the details we’ll ask for when ordering.</p>
+            <p class="app-step-nav__paragraph">See the <a class="govuk-link" href="#step-panel-choosing-devices-4">‘Choosing devices’</a> section below for information on what device types are available and the details we’ll ask for when ordering.</p>
           </div>
         </li>
 
@@ -142,7 +142,7 @@
             </p>
 
             <p class="app-step-nav__paragraph">
-              <%= link_to_devices_guidance_subpage 'Find out about allocations', 'device-allocations' %> and what information is required if you would like to request additional devices for a school.
+              <a class="govuk-link" href="/devices/device-allocations">Find out about allocations</a> and what information is required if you would like to request additional devices for a school.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -162,7 +162,7 @@
                 </span>
               </span>
 
-            <span class="js-step-title">
+              <span class="js-step-title">
                 Choosing devices
               </span>
             </h2>
@@ -174,21 +174,21 @@
             </p>
             <ul class="govuk-list govuk-list--bullet">
               <li>
-              Microsoft laptops
+                Microsoft laptops
               </li>
               <li>
                 Microsoft tablets
               </li>
               <li>
-              Google Chromebooks
+                Google Chromebooks
               </li>
               <li>
-              Apple iPads
+                Apple iPads
               </li>
             </ul>
 
             <p class="app-step-nav__paragraph">
-              View the <%= link_to_devices_guidance_subpage 'Find out about allocations', 'device-allocations' %> of these devices.
+              View the <a class="govuk-link" href="/devices/device-specification">full specifications</a> of these devices.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -196,12 +196,12 @@
             </p>
 
             <ul class="govuk-list govuk-list--bullet">
-              <li>not having DfE settings installed - these ‘Unsecured’ devices can be configured with preferred safeguarding software and brought into an existing device management framework</li>
-              <li>having DfE settings installed - these ‘Secured’ devices are not configurable, with limitations on downloading certain software and changing the strict content filters that may prevent some browsers and conferencing tools from functioning</li>
+              <li>not having DfE settings installed - these ‘Standard’ devices can be configured with preferred safeguarding software and brought into an existing device management framework</li>
+              <li>having DfE settings installed - these ‘DfE Restricted’ devices are not configurable, with limitations on downloading certain software and changing the strict content filters that may prevent some browsers and conferencing tools from functioning</li>
             </ul>
 
             <p class="app-step-nav__paragraph">
-              Read more information about <%= link_to_devices_guidance_subpage 'preparing Microsoft devices', 'preparing-microsoft-windows-laptops-and-tablets' %>.
+              Read more information about <a class="govuk-link" href="/devices/preparing-microsoft-windows-laptops-and-tablets">preparing Microsoft devices</a>.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -230,7 +230,7 @@
               If an education platform is not currently in use, schools, local authorities and academy trusts can apply
               for DfE-funded support to get access to either G Suite for Education or Office 365 Education. More
               information is available from
-              <a href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/" class="govuk-link">The Key for School             Leaders</a>.
+              <a href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/" class="govuk-link" target="_blank">The Key for School Leaders</a>.
             </p>
           </div>
         </li>
@@ -254,20 +254,24 @@
 
           <div class="app-step-nav__panel" id="step-panel-place-an-order-5">
             <p class="app-step-nav__paragraph">
-              If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <a href="https://form.education.gov.uk/service/educational-setting-status" class="govuk-link">Educational settings status form</a>. We’ll then email nominated contacts to inform them when device orders can be placed.
+              If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <a href="https://form.education.gov.uk/service/educational-setting-status" class="govuk-link" target="_blank">Educational settings status form</a>. We’ll then email nominated contacts to inform them when device orders can be placed.
             </p>
-              <p class="app-step-nav__paragraph">
-                As the form only captures certain circumstances, devices can also be requested by emailing COVID.TECHNOLOGY@education.gov.uk when a school:
-              </p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>
-                  has 15 or more children in years 3 to 11 who are self-isolating having each been exposed to a confirmed case outside the school community
-                </li>
-                <li>
-                  is supporting a disadvantaged child in any year group who has been advised to shield because they (or someone they live with) are clinically extremely vulnerable
-                </li>
-                <li>is supporting a disadvantaged child living in another area who is unable to attend due to local travel restrictions</li>
-              </ul>
+            <p class="app-step-nav__paragraph">
+              As the form only captures certain circumstances, devices can also be requested by emailing COVID.TECHNOLOGY@education.gov.uk when a school:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                has 15 or more children in years 3 to 11 who are self-isolating having each been exposed to a confirmed case outside the school community
+              </li>
+              <li>
+                is supporting a disadvantaged child in any year group who has been advised to shield because they (or someone they live with) are clinically extremely vulnerable
+              </li>
+              <li>is supporting a disadvantaged child living in another area who is unable to attend due to local travel restrictions</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              Please do not email any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask for it to be resent.
+            </p>
 
             <p class="app-step-nav__paragraph">
               The full allocation can be ordered in one go or made in multiple orders.
@@ -282,12 +286,12 @@
         </li>
 
         <li class="app-step-nav__step js-step" id="receive-and-distribute-laptops-and-tablets" >
-          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="5">
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="6">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
                 <span class="app-step-nav__circle-inner">
                   <span class="app-step-nav__circle-background">
-                    <span class="govuk-visually-hidden">Step</span> 5
+                    <span class="govuk-visually-hidden">Step</span> 6
                   </span>
                 </span>
               </span>
@@ -298,14 +302,14 @@
             </h2>
           </div>
 
-          <div class="app-step-nav__panel" id="step-panel-receive-and-distribute-laptops-and-tablets-5">
+          <div class="app-step-nav__panel" id="step-panel-receive-and-distribute-laptops-and-tablets-6">
             <p class="app-step-nav__paragraph">
               Devices will be delivered to schools within 2 working days of an order being confirmed, subject to stock availability.
             </p>
 
             <p class="app-step-nav__paragraph">
               All devices will be fully owned by the schools or academy trusts who receive them. It will be the
-              responsibility of the school to loan the devices to those who need them.
+              responsibility of the school to lend the devices to those who need them.
             </p>
 
             <p class="app-step-nav__paragraph">

--- a/app/views/landing_pages/get_laptops_and_tablets.html.erb
+++ b/app/views/landing_pages/get_laptops_and_tablets.html.erb
@@ -1,0 +1,337 @@
+<% content_for :devices_service, true %>
+<% content_for :title, t('page_titles.devices_guidance_how_to_order') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      How and when to order laptops and tablets during coronavirus (COVID-19)
+    </h1>
+
+    <p class="govuk-body">
+      Prepare to <%= govuk_link_to 'order laptops and tablets', start_path %>
+      for disadvantaged children in certain year groups when schools are  affected by disruption to face-to-face
+      education due to coronavirus (COVID-19).
+    </p>
+
+    <p class="govuk-body">
+      Find out <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">who can get laptops and tablets</a>. We’re also providing <a href="https://get-help-with-tech.education.gov.uk/internet-access" class="govuk-link">internet connections</a> where they're needed.
+    </p>
+
+    <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active">
+      <ol class="app-step-nav__steps">
+        <li class="app-step-nav__step" id="decide-who-will-place-orders" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="1">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 1
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Decide who will place orders
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-decide-who-will-place-orders-1">
+            <p class="app-step-nav__paragraph">
+              Representatives from local authorities and academy trusts have been contacted by email. They’ve been asked to use the <%= govuk_link_to 'Get help with technology service', start_path %> to tell us if they want to:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>let schools place their own orders</li>
+              <li>place orders centrally on behalf of schools</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              They can adapt this choice individually for each school. Additional users from within a local authority or academy trust can be invited to provide this information through the Get help with technology service.
+            </p>
+            <p>This is a different process than they may have followed to order devices between May and July 2020. This step must be completed before anyone can order.</p>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step" id="nominate-people-to-manage-orders" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="2">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 2
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Nominate people to manage orders
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-nominate-people-to-manage-orders-2">
+            <p class="app-step-nav__paragraph">
+              If local authorities and academy trusts choose to let schools place their own orders,
+              they can use the <%= govuk_link_to 'Get help with technology service', start_path %> to nominate the headteacher or give the following information for an alternative contact at each school:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>name</li>
+              <li>email address</li>
+              <li>phone number</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              These contacts will have the option to invite up to 2 other people from their school to manage orders.
+            </p>
+            <p class="app-step-nav__paragraph">
+              If orders are to be managed centrally, we’ll ask if each school will require Chromebooks. If they do,
+              we'll ask for some technical information so they can be set up correctly when orders are placed.
+            </p>
+            <p>See the ‘Choosing devices’ section below for information on what device types are available and the details we’ll ask for when ordering.</p>
+          </div>
+        </li>
+
+        <li class="app-step-nav__step" id="prepare-to-place-an-order" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="3">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 3
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Prepare to place an order
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-prepare-to-place-an-order-3">
+            <p class="app-step-nav__paragraph">
+              While devices may not be available to order immediately, we suggest all nominated contacts familiarise themselves with this process to prevent delays when ordering   does become available.
+            </p>
+            <p class="app-step-nav__paragraph">
+              When someone is nominated as responsible for placing orders, they’ll receive an email inviting
+              them to the <%= govuk_link_to 'Get help with technology service', start_path %> where they can:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>amend existing contact information</li>
+              <li>add additional contacts to place orders</li>
+              <li>find out a school’s device allocation</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              The device allocation is the number of laptops and tablets we estimate are needed based on:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>the number of children in years 3 to 11</li>
+              <li>free school meals data</li>
+              <li>an estimate of the number of devices a school already has</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              This allocation can be used as part of preparing to deliver remote education. However, the exact
+              number and type of devices available will be confirmed at the time of ordering based on stock
+              availability and the extent of coronavirus restrictions.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              <%= link_to_devices_guidance_subpage 'Find out about allocations', 'device-allocations' %> and what information is required if you would like to request additional devices for a school.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              Local authorities and trusts managing the process on behalf of schools should contact them with details about the offer.
+            </p>
+          </div>
+        </li>
+
+        <li class="app-step-nav__step" id="choosing-devices" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="4">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 4
+                  </span>
+                </span>
+              </span>
+
+            <span class="js-step-title">
+                Choosing devices
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-choosing-devices-4">
+            <p class="app-step-nav__paragraph">
+              The available device types will be:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+              Microsoft laptops
+              </li>
+              <li>
+                Microsoft tablets
+              </li>
+              <li>
+              Google Chromebooks
+              </li>
+              <li>
+              Apple iPads
+              </li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              View the <%= link_to_devices_guidance_subpage 'Find out about allocations', 'device-allocations' %> of these devices.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              When ordering Microsoft devices, a selection can be made between:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>not having DfE settings installed - these ‘Unsecured’ devices can be configured with preferred safeguarding software and brought into an existing device management framework</li>
+              <li>having DfE settings installed - these ‘Secured’ devices are not configurable, with limitations on downloading certain software and changing the strict content filters that may prevent some browsers and conferencing tools from functioning</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              Read more information about <%= link_to_devices_guidance_subpage 'preparing Microsoft devices', 'preparing-microsoft-windows-laptops-and-tablets' %>.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              When ordering Chromebooks, the following information needs to be added to the
+              <%= govuk_link_to 'Get help with technology service', start_path %>
+              before orders can be placed:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>a school’s Google domain</li>
+              <li>a recovery email address</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              When ordering Apple devices, we'll require:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                an Apple School Manager (ASM) Organisation ID. This is a 7-8 digit number available when logged
+                in to ASM. We recommend knowing this ID in advance to avoid any delay in the ordering process.
+              </li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              If an education platform is not currently in use, schools, local authorities and academy trusts can apply
+              for DfE-funded support to get access to either G Suite for Education or Office 365 Education. More
+              information is available from
+              <a href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/" class="govuk-link">The Key for School             Leaders</a>.
+            </p>
+          </div>
+        </li>
+
+        <li class="app-step-nav__step" id="place-an-order" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="5">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle  app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 5
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Place an order
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-place-an-order-5">
+            <p class="app-step-nav__paragraph">
+              If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <a href="https://form.education.gov.uk/service/educational-setting-status" class="govuk-link">Educational settings status form</a>. We’ll then email nominated contacts to inform them when device orders can be placed.
+            </p>
+              <p class="app-step-nav__paragraph">
+                As the form only captures certain circumstances, devices can also be requested by emailing COVID.TECHNOLOGY@education.gov.uk when a school:
+              </p>
+              <ul class="govuk-list govuk-list--bullet">
+                <li>
+                  has 15 or more children in years 3 to 11 who are self-isolating having each been exposed to a confirmed case outside the school community
+                </li>
+                <li>
+                  is supporting a disadvantaged child in any year group who has been advised to shield because they (or someone they live with) are clinically extremely vulnerable
+                </li>
+                <li>is supporting a disadvantaged child living in another area who is unable to attend due to local travel restrictions</li>
+              </ul>
+
+            <p class="app-step-nav__paragraph">
+              The full allocation can be ordered in one go or made in multiple orders.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              Once a device selection has been made, the person placing the order will be asked to confirm delivery and contact details during the checkout process.
+            </p>
+
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="receive-and-distribute-laptops-and-tablets" >
+          <div class="app-step-nav__header app-step-nav__header--non-clickable" data-position="5">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 5
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Receive and distribute laptops and tablets
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel" id="step-panel-receive-and-distribute-laptops-and-tablets-5">
+            <p class="app-step-nav__paragraph">
+              Devices will be delivered to schools within 2 working days of an order being confirmed, subject to stock availability.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              All devices will be fully owned by the schools or academy trusts who receive them. It will be the
+              responsibility of the school to loan the devices to those who need them.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              After receiving devices and preparing them for use by children, schools can:
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>arrange for them to be collected by families from school, or</li>
+              <li>organise for them to be delivered to children’s homes</li>
+            </ul>
+
+            <p class="app-step-nav__paragraph">
+              All distribution and return of loan devices should be done in accordance with the <a href="https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19" class="govuk-link"> social distancing guidelines relevant to your local area</a>.
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              The <a href="https://computacenterprod.service-now.com/dfe" class="govuk-link">Computacenter Support Portal</a>
+              provides information on how to request admin passwords, report device
+              faults and arrange a repair or replacement under warranty terms.
+            </p>
+
+          </div>
+
+        </li>
+
+      </ol>
+    </div>
+  </div>
+</div>

--- a/app/views/landing_pages/get_laptops_and_tablets.md
+++ b/app/views/landing_pages/get_laptops_and_tablets.md
@@ -1,0 +1,1 @@
+# Get laptops and tablets

--- a/app/views/landing_pages/get_laptops_and_tablets.md
+++ b/app/views/landing_pages/get_laptops_and_tablets.md
@@ -1,3 +1,0 @@
-# Get laptops and tablets
-
-[View previously linked page](/start)

--- a/app/views/landing_pages/get_laptops_and_tablets.md
+++ b/app/views/landing_pages/get_laptops_and_tablets.md
@@ -1,1 +1,3 @@
 # Get laptops and tablets
+
+[View previously linked page](/start)

--- a/app/views/landing_pages/get_support.md
+++ b/app/views/landing_pages/get_support.md
@@ -1,0 +1,1 @@
+# Get support to order and manage devices

--- a/app/views/landing_pages/get_support.md
+++ b/app/views/landing_pages/get_support.md
@@ -1,7 +1,9 @@
 ## About the scheme
 
 Many vulnerable and disadvantaged children and young people in England do not have access to a laptop, tablet or internet connection. The Department for Education (DfE) is offering support to help children, young people and families access remote education and social care during coronavirus (COVID-19).
+
 The DfE is working with a delivery partner to supply local authorities, academy trusts and schools with laptops, tablets and connectivity packages. 
+
 We also offer guidance and a support team to help you order, distribute and manage these devices.
 ## How to get support
 

--- a/app/views/landing_pages/get_support.md
+++ b/app/views/landing_pages/get_support.md
@@ -2,57 +2,72 @@
 
 Many vulnerable and disadvantaged children and young people in England do not have access to a laptop, tablet or internet connection. The Department for Education (DfE) is offering support to help children, young people and families access remote education and social care during coronavirus (COVID-19).
 
-The DfE is working with a delivery partner to supply local authorities, academy trusts and schools with laptops, tablets and connectivity packages. 
+The DfE is working with a delivery partner to supply local authorities, academy trusts and schools with [laptops, tablets and connectivity packages](https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19). 
 
 We also offer guidance and a support team to help you order, distribute and manage these devices.
+
 ## How to get support
 
-If you need help to [order laptops and tablets](https://get-help-with-tech.education.gov.uk/start), please [see our guidance section below](#allocation-and-ordering-devices). 
+If you need help to [order laptops and tablets](/start), please [see our guidance section below](#allocation-and-ordering-devices). 
 
 If you need help with a laptop, tablet or 4G wireless router you’ve already received from us, please see our guidance below on [setting devices up](#setting-devices-up), or [managing devices and safeguarding](#managing-devices-and-safeguarding).
 
 If you cannot find the information you need here, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk). We aim to respond within 3 working days.
+
 ## Allocation and ordering devices
 
-### [Who devices are available for](https://get-help-with-tech.education.gov.uk/devices/about-the-offer)
+### [Who devices are available for](/devices/about-the-offer)
+
 Find out who is eligible for devices and why the DfE is providing them.
 
-### [Device allocations](https://get-help-with-tech.education.gov.uk/devices/device-allocations)
+### [Device allocations](/devices/device-allocations)
+
 Find out how we estimated device requirements for each school and how to query an allocation.
 
-### [How and when to order laptops and tablets](https://get-help-with-tech.education.gov.uk/devices/how-to-order)
+### [How and when to order laptops and tablets](/devices/how-to-order)
+
 Prepare to order laptops and tablets for disadvantaged children in certain year groups when schools are affected by disruption to face-to-face education due to coronavirus.
 
-### [Device options and specifications](https://get-help-with-tech.education.gov.uk/devices/device-specification)
+### [Device options and specifications](/devices/device-specification)
+
 See what device types are available and technical details for the various options.
 
 ## Setting devices up
 
-### [Microsoft Windows laptops and tablets](https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets)
+### [Microsoft Windows laptops and tablets](/devices/preparing-microsoft-windows-laptops-and-tablets)
 
 Guidance on how to set up Microsoft Windows devices provided with safeguarding and mobile device management software, and how to install your own.
-Guidance to share with children, young people and families: How to get started with your Microsoft Windows laptop or tablet
+
+Guidance to share with children, young people and families:  
+[How to get started with your Microsoft Windows laptop or tablet](/devices/getting-started-with-your-microsoft-windows-device)
 
 ### [Google Chromebooks](https://get-help-with-tech.education.gov.uk/devices/preparing-chromebooks)
 
 Guidance on how to enrol Google Chromebooks on your domain, how to install Cisco Umbrella content filtering, and set up instructions for local authorities, trusts and schools.
-Guidance to share with children, young people and families: How to get started with your Google Chromebook
+
+Guidance to share with children, young people and families:   
+[How to get started with your Google Chromebook](/devices/getting-started-with-your-google-chromebook)
+
 
 ### [4G routers](https://get-help-with-tech.education.gov.uk/devices/preparing-4g-wireless-routers)
 
 Find out how 4G wireless routers are secured, how much data users get, the length of contract and what records you should keep.
-Guidance to share with children, young people and families: How to get started with your 4G wireless router
+
+Guidance to share with children, young people and families:  
+[How to get started with your 4G wireless router](/devices/getting-started-with-your-google-chromebook)
  
 ## Managing devices and safeguarding
  
 ### [Device ownership and distribution](https://get-help-with-tech.education.gov.uk/devices/device-distribution-and-ownership)
 
 Advice on how to get devices to children and young people via schools, social workers and deliveries to their homes. Information on insuring devices, asset management and loan agreements.
+
 ### [Support and maintenance](https://get-help-with-tech.education.gov.uk/devices/support-and-maintenance)
 
 Find out how to support your users, access additional support, and deal with a faulty device.
 
 ### [Safeguarding for device users](https://get-help-with-tech.education.gov.uk/devices/safeguarding-for-device-users)
+
 Information on content filtering, privacy policies and mobile device management to ensure devices are used appropriately by young people and families.
  
 

--- a/app/views/landing_pages/get_support.md
+++ b/app/views/landing_pages/get_support.md
@@ -11,7 +11,7 @@ If you need help to [order laptops and tablets](https://get-help-with-tech.educa
 
 If you need help with a laptop, tablet or 4G wireless router you’ve already received from us, please see our guidance below on [setting devices up](#setting-devices-up), or [managing devices and safeguarding](#managing-devices-and-safeguarding).
 
-If you cannot find the information you need here, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.
+If you cannot find the information you need here, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk). We aim to respond within 3 working days.
 ## Allocation and ordering devices
 
 ### [Who devices are available for](https://get-help-with-tech.education.gov.uk/devices/about-the-offer)

--- a/app/views/landing_pages/get_support.md
+++ b/app/views/landing_pages/get_support.md
@@ -1,1 +1,58 @@
-# Get support to order and manage devices
+## About the scheme
+
+Many vulnerable and disadvantaged children and young people in England do not have access to a laptop, tablet or internet connection. The Department for Education (DfE) is offering support to help children, young people and families access remote education and social care during coronavirus (COVID-19).
+The DfE is working with a delivery partner to supply local authorities, academy trusts and schools with laptops, tablets and connectivity packages. 
+We also offer guidance and a support team to help you order, distribute and manage these devices.
+## How to get support
+
+If you need help to [order laptops and tablets](https://get-help-with-tech.education.gov.uk/start), please [see our guidance section below](#allocation-and-ordering-devices). 
+
+If you need help with a laptop, tablet or 4G wireless router you’ve already received from us, please see our guidance below on [setting devices up](#setting-devices-up), or [managing devices and safeguarding](#managing-devices-and-safeguarding).
+
+If you cannot find the information you need here, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.
+## Allocation and ordering devices
+
+### [Who devices are available for](https://get-help-with-tech.education.gov.uk/devices/about-the-offer)
+Find out who is eligible for devices and why the DfE is providing them.
+
+### [Device allocations](https://get-help-with-tech.education.gov.uk/devices/device-allocations)
+Find out how we estimated device requirements for each school and how to query an allocation.
+
+### [How and when to order laptops and tablets](https://get-help-with-tech.education.gov.uk/devices/how-to-order)
+Prepare to order laptops and tablets for disadvantaged children in certain year groups when schools are affected by disruption to face-to-face education due to coronavirus.
+
+### [Device options and specifications](https://get-help-with-tech.education.gov.uk/devices/device-specification)
+See what device types are available and technical details for the various options.
+
+## Setting devices up
+
+### [Microsoft Windows laptops and tablets](https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets)
+
+Guidance on how to set up Microsoft Windows devices provided with safeguarding and mobile device management software, and how to install your own.
+Guidance to share with children, young people and families: How to get started with your Microsoft Windows laptop or tablet
+
+### [Google Chromebooks](https://get-help-with-tech.education.gov.uk/devices/preparing-chromebooks)
+
+Guidance on how to enrol Google Chromebooks on your domain, how to install Cisco Umbrella content filtering, and set up instructions for local authorities, trusts and schools.
+Guidance to share with children, young people and families: How to get started with your Google Chromebook
+
+### [4G routers](https://get-help-with-tech.education.gov.uk/devices/preparing-4g-wireless-routers)
+
+Find out how 4G wireless routers are secured, how much data users get, the length of contract and what records you should keep.
+Guidance to share with children, young people and families: How to get started with your 4G wireless router
+ 
+## Managing devices and safeguarding
+ 
+### [Device ownership and distribution](https://get-help-with-tech.education.gov.uk/devices/device-distribution-and-ownership)
+
+Advice on how to get devices to children and young people via schools, social workers and deliveries to their homes. Information on insuring devices, asset management and loan agreements.
+### [Support and maintenance](https://get-help-with-tech.education.gov.uk/devices/support-and-maintenance)
+
+Find out how to support your users, access additional support, and deal with a faulty device.
+
+### [Safeguarding for device users](https://get-help-with-tech.education.gov.uk/devices/safeguarding-for-device-users)
+Information on content filtering, privacy policies and mobile device management to ensure devices are used appropriately by young people and families.
+ 
+
+
+

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to t('page_titles.devices_guidance_index'), devices_guidance_index_path, class: 'govuk-breadcrumbs__link' %>
+      <%= link_to "Home", guidance_page_path, class: 'govuk-breadcrumbs__link' %>
     </li>
     <li class="govuk-breadcrumbs__list-item">
       <%= @title %>

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -1,0 +1,35 @@
+<%- content_for :before_content do %>
+  <div class="govuk-breadcrumbs ">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to t('page_titles.devices_guidance_index'), devices_guidance_index_path, class: 'govuk-breadcrumbs__link' %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= @title %>
+    </li>
+  </ol>
+  </div>
+<% end %>
+
+<% content_for :content do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= @title %></h1>
+
+<!--      <p class="govuk-body-l"><%#= @page.description %></p>-->
+
+      <% if content_for(:html_list_of_headings_links).present? %>
+        <h2 class="govuk-heading-s">Contents</h2>
+
+        <%= content_for :html_list_of_headings_links %>
+      <% end %>
+
+      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+      <%= yield %>
+
+    </div>
+  </div>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -6,8 +6,7 @@
 
     <p class="govuk-body">
       Information for local authorities, academy trusts and schools about the devices, internet access
-      and support available to provide remote education and access to children’s social care during the
-      coronavirus (COVID-19).
+      and support available to provide remote education and access to children’s social care during coronavirus (COVID-19).
     </p>
     <p class="govuk-body govuk-!-margin-bottom-9">
       Find out more about the Department for Education’s <br>
@@ -30,7 +29,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get support to order and manage devices", get_support_landing_page_path %>
+      <%= govuk_link_to "Get support with laptops, tablets and 4G wireless routers", get_support_landing_page_path %>
     </h2>
 
     <p class="govuk-body">
@@ -65,7 +64,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get peer-to-peer support on the effective use of technology" , edtech_demonstrator_programme_landing_page_path %>
+      <%= govuk_link_to "Get free training and support to set up and use technology effectively" , edtech_demonstrator_programme_landing_page_path %>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -67,9 +67,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/">
-        Get peer-to-peer support on the effective use of technology
-      </a>
+      <%= govuk_link_to "Get peer-to-peer support on the effective use of technology" , edtech_demonstrator_programme_landing_page_path %>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -54,9 +54,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/">
-        Get funding and support to set up a digital education platform
-      </a>
+      <%= govuk_link_to("Get funding and support to set up a digital education platform", digital_platforms_landing_page_path) %>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get laptops and tablets", start_path %>
+      <%= govuk_link_to "Get laptops and tablets", get_devices_landing_page_path %>
     </h2>
     <p class="govuk-body">
       Find out how to prepare to order <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">
@@ -30,7 +30,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get support to order and manage devices", devices_guidance_index_path %>
+      <%= govuk_link_to "Get support to order and manage devices", get_support_landing_page_path %>
     </h2>
 
     <p class="govuk-body">
@@ -42,7 +42,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get internet access", connectivity_home_path %>
+      <%= govuk_link_to "Get internet access", get_internet_access_landing_page_path  %>
     </h2>
 
     <p class="govuk-body">
@@ -54,9 +54,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/">
-        Get funding and support to set up a digital education platform
-      </a>
+      <%= govuk_link_to "Get funding and support to set up a digital education platform", digital_platforms_landing_page_path %>
     </h2>
 
     <p class="govuk-body">
@@ -67,9 +65,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/">
-        Get peer-to-peer support on the effective use of technology
-      </a>
+      <%= govuk_link_to "Get peer-to-peer support on the effective use of technology", edtech_demonstrator_programme_landing_page_path  %>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get laptops and tablets", get_devices_landing_page_path %>
+      <%= govuk_link_to "Get laptops and tablets", start_path %>
     </h2>
     <p class="govuk-body">
       Find out how to prepare to order <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">
@@ -65,7 +65,9 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get peer-to-peer support on the effective use of technology", edtech_demonstrator_programme_landing_page_path  %>
+      <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/">
+        Get peer-to-peer support on the effective use of technology
+      </a>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get laptops and tablets", start_path %>
+      <%= govuk_link_to "Get laptops and tablets", get_devices_landing_page_path %>
     </h2>
     <p class="govuk-body">
       Find out how to prepare to order <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19" class="govuk-link">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -54,7 +54,9 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Get funding and support to set up a digital education platform", digital_platforms_landing_page_path %>
+      <a class="govuk-link" href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/">
+        Get funding and support to set up a digital education platform
+      </a>
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -30,12 +30,13 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Manage devices", devices_guidance_index_path %>
+      <%= govuk_link_to "Get support to order and manage devices", devices_guidance_index_path %>
     </h2>
 
     <p class="govuk-body">
-      Get information about setting up, distributing and managing the laptops, tablets and 4G wireless routers
-      you’ve received. You can also find guides to share with children and young people to help them use the devices.
+      Get information about choosing, ordering, setting up, distributing and managing the laptops, tablets and 4G
+      wireless routers you’ve received. You can also find guides to share with children and young people to help them
+      use the devices.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -59,8 +60,8 @@
     </h2>
 
     <p class="govuk-body">
-      Find out how to apply for government-funded support through The Key for School Leaders and access one of two
-      free-to-use digital education platforms: G Suite for Education or Office 365 Education.
+      Visit The Key for School Leaders website to find out how to apply for government-funded support to access one of
+      two free-to-use digital education platforms: G Suite for Education or Office 365 Education.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -72,14 +73,14 @@
     </h2>
 
     <p class="govuk-body">
-      Learn how you can use the EdTech Demonstrator Programme to contact a network of schools and colleges who are
-      already using remote education technology resources for help and support.
+      The EdTech Demonstrator Programme website has information on how to contact a network of schools and colleges who
+      are already using remote education technology resources for help and support. You can also access CPD training resources.
     </p>
   </div>
 
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      Get support
+      Contact us
     </h2>
     <p class="govuk-body-s">
       If you work for a local authority, academy trust or school and you need help with any of the devices or services

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -1,15 +1,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Get help with technology
+      <%= t('service_name') %>
     </h1>
 
     <p class="govuk-body">
       Information for local authorities, academy trusts and schools about the devices, internet access
-      and support available to provide remote education and access to children’s social care during coronavirus (COVID-19).
+      and support available to provide remote education and access to children&rsquo;s social care during coronavirus (COVID-19).
     </p>
     <p class="govuk-body govuk-!-margin-bottom-9">
-      Find out more about the Department for Education’s <br>
+      Find out more about the Department for Education&rsquo;s <br>
       <a href="https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19" class="govuk-link">Get help with technology programme on GOV.UK.</a>
     </p>
   </div>
@@ -33,9 +33,8 @@
     </h2>
 
     <p class="govuk-body">
-      Get information about choosing, ordering, setting up, distributing and managing the laptops, tablets and 4G
-      wireless routers you’ve received. You can also find guides to share with children and young people to help them
-      use the devices.
+      Get information about setting up, distributing and managing the laptops, tablets and 4G wireless routers
+      you’ve received. You can also find guides to share with children and young people to help them use the devices.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -57,8 +56,8 @@
     </h2>
 
     <p class="govuk-body">
-      Visit The Key for School Leaders website to find out how to apply for government-funded support to access one of
-      two free-to-use digital education platforms: G Suite for Education or Office 365 Education.
+      Find out how to apply for government-funded support to access one of two free-to-use digital education platforms:
+      G Suite for Education or Office 365 Education.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -68,43 +67,22 @@
     </h2>
 
     <p class="govuk-body">
-      The EdTech Demonstrator Programme website has information on how to contact a network of schools and colleges who
-      are already using remote education technology resources for help and support. You can also access CPD training resources.
+      Access funded advice, guidance and training from the EdTech demonstrators, a network of schools and colleges expert in their use of technology.
+      This may be helpful if you&rsquo;ve received devices or support to set up a new digital platform through the Get help with technology programme,
+      or if you&rsquo;re developing your approach to remote education, reducing teacher workloads and improving pupil outcomes.
     </p>
   </div>
 
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      Guidance you might find useful
-    </h2>
-
-    <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
-      <li>
-        <%= govuk_link_to 'Request local admin and BIOS passwords to install your own software', '/devices/preparing-microsoft-windows-laptops-and-tablets#requesting-local-admin-and-bios-passwords-and-installing-your-own-software-and-settings' %>
-      </li>
-
-      <li>
-        <%= govuk_link_to 'How devices are allocated', '/devices/device-allocations' %>
-      </li>
-
-      <li>
-        <%= govuk_link_to 'Internet access through free BT hotspots', '/about-bt-wifi' %>
-      </li>
-
-      <li>
-        <%= govuk_link_to 'Increasing data allowances on mobile devices', '/about-increasing-mobile-data' %>
-      </li>
-    </ul>
-
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       Contact us
     </h2>
     <p class="govuk-body-s">
       If you work for a local authority, academy trust or school and you need help with any of the devices or services
-      offered by this programme, please email <%= ghwt_contact_mailto %>. We aim to respond within 3 working days.
+      offered by this programme, please email <%= ghwt_contact_mailto(subject: nil) %>. We aim to respond within 3 working days.
     </p>
     <p class="govuk-body-s">
-      If you’ve been given a laptop, tablet or 4G wireless router by your local authority or school and need some help,
+      If you&rsquo;ve been given a laptop, tablet or 4G wireless router by your local authority or school and need some help,
       please contact the person or school who gave it to you.
     </p>
   </div>

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -75,6 +75,28 @@
 
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      Guidance you might find useful
+    </h2>
+
+    <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
+      <li>
+        <%= govuk_link_to 'Request local admin and BIOS passwords to install your own software', '/devices/preparing-microsoft-windows-laptops-and-tablets#requesting-local-admin-and-bios-passwords-and-installing-your-own-software-and-settings' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'How devices are allocated', '/devices/device-allocations' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'Internet access through free BT hotspots', '/about-bt-wifi' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'Increasing data allowances on mobile devices', '/about-increasing-mobile-data' %>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       Contact us
     </h2>
     <p class="govuk-body-s">

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -80,6 +80,28 @@
 
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      Guidance you might find useful
+    </h2>
+
+    <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
+      <li>
+        <%= govuk_link_to 'Request local admin and BIOS passwords to install your own software', '/devices/preparing-microsoft-windows-laptops-and-tablets#requesting-local-admin-and-bios-passwords-and-installing-your-own-software-and-settings' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'How devices are allocated', '/devices/device-allocations' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'Internet access through free BT hotspots', '/about-bt-wifi' %>
+      </li>
+
+      <li>
+        <%= govuk_link_to 'Increasing data allowances on mobile devices', '/about-increasing-mobile-data' %>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       Contact us
     </h2>
     <p class="govuk-body-s">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,10 +555,10 @@ en:
     get_support:
       title: "Get support to order and manage devices"
       description:
-    get_internet:
-      title:
+    get_internet_access:
+      title: "Get internet access"
       description:
-    digital_platform:
+    digital_platforms:
       title:
       description:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -559,7 +559,7 @@ en:
       title: "Get internet access"
       description:
     digital_platforms:
-      title:
+      title: "Get funding and support to set up a digital education platform"
       description:
     edtech_demonstrator_programme:
       title: "Get free training and support to set up and use technology effectively"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -561,6 +561,9 @@ en:
     digital_platforms:
       title:
       description:
+    edtech_demonstrator_programme:
+      title: "Get free training and support to set up and use technology effectively"
+      description:
 
   events:
     default: An event just happened

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,6 +548,20 @@ en:
         name: Name
         name_hint: Must be unique, and between 2 and 64 characters long
         create: Generate
+  second_level_content:
+    get_laptops_and_tablets:
+      title:
+      description:
+    get_support:
+      title: "Get support to order and manage devices"
+      description:
+    get_internet:
+      title:
+      description:
+    digital_platform:
+      title:
+      description:
+
   events:
     default: An event just happened
     sign_in_event: A user from %{organisation} just signed in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,13 @@ Rails.application.routes.draw do
 
   get '/start', to: 'pages#start'
 
+  get '/get-laptops-and-tablets', to: 'landing_pages#get_laptops_and_tablets', as: :get_devices_landing_page
+  get '/get-support', to:  'landing_pages#get_support', as: :get_support_landing_page
+  get '/get-internet-access', to:  'landing_pages#get_internet_access', as: :get_internet_access_landing_page
+  get '/digital-platforms', to:  'landing_pages#digital_platforms', as: :digital_platforms_landing_page
+  get '/EdTech-demonstrator-programme', to:  'landing_pages#edtech_demonstrator_programme', as: :edtech_demonstrator_programme_landing_page
+
+
   get '/about-bt-wifi', to: 'pages#about_bt_wifi'
   get '/about-increasing-mobile-data', to: 'pages#about_increasing_mobile_data'
   get '/bt-wifi/privacy-notice', to: 'pages#bt_wifi_privacy_notice'


### PR DESCRIPTION
### Context
Off the back of #505, this PR mocks up second-level content pages. It's a very rough mock-up of the pages and will be used for user research.

# ⚠️ If you want to close PR/delete branch please contact ghwt_centeral_services team first (@Lloyd-K)

### TODO
- Reconsider either refactoring the existing multipage guidance template/en.yml etc or continue with a completely new simplified second level structure.

### Changes proposed in this pull request
- Add second level landing pages templates (markdown format)
- complete overhaul of the devices guidance page
- complete overhaul of the get internet page 

### Guidance to review



### converting to production-ready code
 
- [x] Get laptops and tablets #722 
- [x] Get support with laptops, tablets, and routers #722
- [x] Get internet access **NO CHANGES NEEDED**
- [x] Get funding and support to set up a digital education platform #713 
- [x] Get free training and support to set up and use technology effectively #710 
- [ ] Add "Guidance" section to home page sidebar #714 

