### PR TITLE
Fix flaky unit test

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe User, type: :model do
       end
 
       context 'already computacenter relevant' do
-        let!(:user) { create(:trust_user, :relevant_to_computacenter) }
+        let!(:user) { create(:trust_user, :relevant_to_computacenter, full_name: 'Jane Smith') }
 
         context 'single field is changed' do
           let!(:original_email) { user.email_address }


### PR DESCRIPTION
This spec failed in the build:

https://github.com/DFE-Digital/get-help-with-tech/runs/1148408135

The spec makes assumptions about how the full name is split, but the name
is generated by faker and doesn't split nicely into first_name and last_name in all
cases.

By specifying an easy name to split, this should ensure that the spec doesn't flake.
