### PR TITLE
[712] Deny hybrid user access to /responsible-body

### DIFF
--- a/app/controllers/responsible_body/base_controller.rb
+++ b/app/controllers/responsible_body/base_controller.rb
@@ -1,13 +1,22 @@
 class ResponsibleBody::BaseController < ApplicationController
-  before_action :require_rb_user!, :set_responsible_body
+  before_action :require_signed_in!,
+                :deny_hybrid_user!,
+                :require_rb_user!,
+                :set_responsible_body
 
 private
 
+  def require_signed_in!
+    redirect_to_sign_in unless SessionService.is_signed_in?(session)
+  end
+
+  def deny_hybrid_user!
+    render 'errors/forbidden', status: :forbidden if @user.hybrid?
+  end
+
   def require_rb_user!
-    if SessionService.is_signed_in?(session)
-      render 'errors/forbidden', status: :forbidden unless @user.is_responsible_body_user?
-    else
-      redirect_to_sign_in
+    unless @user.is_responsible_body_user?
+      render 'errors/forbidden', status: :forbidden
     end
   end
 

--- a/spec/controllers/responsible_body/base_controller_spec.rb
+++ b/spec/controllers/responsible_body/base_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::BaseController do
+  controller do
+    def index
+      render plain: 'hello'
+    end
+  end
+
+  context 'when user is a hybrid user' do
+    let(:user) { create(:hybrid_user) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'returns forbidden' do
+      get :index
+      expect(response).to be_forbidden
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
       approved
     end
 
+    factory :hybrid_user do
+      association :responsible_body, factory: %i[trust in_connectivity_pilot]
+      school
+      orders_devices { true }
+    end
+
     factory :school_user do
       school
       orders_devices { false }


### PR DESCRIPTION
### Context

- https://trello.com/c/dohUsCM7/712-hybrid-users-should-not-be-able-to-access-responsible-body

### Changes proposed in this pull request

- Hybrid users are shown forbidden page if they attempt to access `/responsible/body` 

### Guidance to review

- Login as a hybrid user
- Navigate to `/responsible-body`
- Should be shown 403 forbidden page