### PR TITLE
702 bulk put schools into lockdown

### DIFF
--- a/app/components/nav_component.rb
+++ b/app/components/nav_component.rb
@@ -37,6 +37,7 @@ class NavComponent < ViewComponent::Base
     [
       NavLinkComponent.new(title: 'Performance', url: support_devices_service_performance_path),
       NavLinkComponent.new(title: 'RBs', url: support_devices_responsible_bodies_path),
+      NavLinkComponent.new(title: 'Full allocations', url: new_support_devices_school_bulk_allocation_path),
     ]
   end
 

--- a/app/controllers/support/devices/school_bulk_allocations_controller.rb
+++ b/app/controllers/support/devices/school_bulk_allocations_controller.rb
@@ -1,0 +1,26 @@
+class Support::Devices::SchoolBulkAllocationsController < Support::BaseController
+  def new
+    @form = Support::BulkAllocationForm.new
+  end
+
+  def create
+    @form = Support::BulkAllocationForm.new(restriction_params)
+
+    if @form.valid?
+      @summary = allocation_service.unlock!(@form.urn_list)
+      render 'summary'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def restriction_params
+    params.require(:support_bulk_allocation_form).permit(:school_urns)
+  end
+
+  def allocation_service
+    @allocation_service ||= BulkAllocationService.new
+  end
+end

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -1,4 +1,6 @@
 class Support::Devices::SchoolsController < Support::BaseController
+  def index; end
+
   def show
     @school = School.find_by!(urn: params[:urn])
     @users = @school.users

--- a/app/form_objects/support/bulk_allocation_form.rb
+++ b/app/form_objects/support/bulk_allocation_form.rb
@@ -1,0 +1,13 @@
+class Support::BulkAllocationForm
+  include ActiveModel::Model
+
+  attr_accessor :school_urns
+
+  validates :school_urns, presence: { message: 'Tell us the schools with confirmed coronvirus restrictions' }
+
+  def urn_list
+    return [] if school_urns.empty?
+
+    school_urns.split("\r\n").reject(&:blank?)
+  end
+end

--- a/app/form_objects/support/bulk_allocation_form.rb
+++ b/app/form_objects/support/bulk_allocation_form.rb
@@ -8,6 +8,6 @@ class Support::BulkAllocationForm
   def urn_list
     return [] if school_urns.empty?
 
-    school_urns.split("\r\n").reject(&:blank?)
+    school_urns.split("\r\n").map(&:strip).reject(&:blank?)
   end
 end

--- a/app/services/bulk_allocation_service.rb
+++ b/app/services/bulk_allocation_service.rb
@@ -1,0 +1,50 @@
+class BulkAllocationService
+  attr_reader :success, :failures, :urn_count
+  def initialize
+    @success = []
+    @failures = []
+    @urn_count = 0
+  end
+
+  def unlock!(urn_list)
+    @urn_count = urn_list.count
+
+    urn_list.each do |urn|
+      begin
+        school = School.find_by(urn: urn)
+        if school
+          update_cap_to_full_allocation!(school)
+          add_success(school)
+        else
+          add_failure(urn, 'URN not found')
+        end
+      rescue => e
+        add_failure(urn, e.message)
+      end
+    end
+    self
+  end
+
+  def success_count
+    @success.count
+  end
+
+  def failure_count
+    @failures.count
+  end
+
+private
+
+  def update_cap_to_full_allocation!(school)
+    cus = CapUpdateService.new(school: school, device_type: 'std_device')
+    cus.update!(order_state: 'can_order', cap: nil)
+  end
+
+  def add_success(school)
+    @success << { urn: school.urn, message: school.name }
+  end
+
+  def add_failure(urn, message)
+    @failures << { urn: urn, message: message }
+  end
+end

--- a/app/services/bulk_allocation_service.rb
+++ b/app/services/bulk_allocation_service.rb
@@ -10,17 +10,15 @@ class BulkAllocationService
     @urn_count = urn_list.count
 
     urn_list.each do |urn|
-      begin
-        school = School.find_by(urn: urn)
-        if school
-          update_cap_to_full_allocation!(school)
-          add_success(school)
-        else
-          add_failure(urn, 'URN not found')
-        end
-      rescue => e
-        add_failure(urn, e.message)
+      school = School.find_by(urn: urn)
+      if school
+        update_cap_to_full_allocation!(school)
+        add_success(school)
+      else
+        add_failure(urn, 'URN not found')
       end
+    rescue StandardError => e
+      add_failure(urn, e.message)
     end
     self
   end

--- a/app/views/support/devices/school_bulk_allocations/new.html.erb
+++ b/app/views/support/devices/school_bulk_allocations/new.html.erb
@@ -1,0 +1,21 @@
+<%- title = t('page_titles.support_bulk_allocation') %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= form_for @form, url: support_devices_school_bulk_allocations_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p class="govuk-body">These schools can place orders because local coronavirus restrictions are confirmed.</p>
+
+      <%= f.govuk_text_area :school_urns,
+                            label: { text: 'Enter one school URN per line' },
+                            rows: 15 %>
+
+      <%= f.govuk_submit 'Enable full allocations' %>
+    <%- end %>
+
+  </div>
+</div>

--- a/app/views/support/devices/school_bulk_allocations/summary.html.erb
+++ b/app/views/support/devices/school_bulk_allocations/summary.html.erb
@@ -1,0 +1,74 @@
+<%-
+  title = t('page_titles.support_bulk_allocation_result')
+%>
+<% content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_link_to('Back', new_support_devices_school_bulk_allocation_path, class: 'govuk-back-link') %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <p class="govuk-body">We found <%= @summary.urn_count %> <%= 'URN'.pluralize(@summary.urn_count) %> in your request:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= @summary.failure_count %> <%= 'error'.pluralize(@summary.failure_count) %></li>
+      <li><%= @summary.success_count %> allocated successfully</li>
+    </ul>
+  </div>
+</div>
+
+<% if @summary.failures.any? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= "#{@summary.failure_count} #{'error'.pluralize(@summary.failure_count)} found" %></h2>
+  <div class="govuk-form-group--error">
+    <p class="govuk-error-message">Fix the errors in your request and try again</p>
+
+    <table class="govuk-table requests-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">School URN</th>
+          <th class="govuk-table__header">Error</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @summary.failures.each do |row| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= row[:urn] %>
+            </td>
+            <td class="govuk-table__cell">
+              <span class="govuk-error-message govuk-!-margin-bottom-0"><%= row[:message] %></span>
+            </td>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+  </div>
+<%- end %>
+
+<% if @summary.success.any? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4">
+    <%= "#{@summary.success_count} #{'allocation'.pluralize(@summary.success_count)} completed" %>
+  </h2>
+  <table class="govuk-table requests-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">School URN</th>
+        <th class="govuk-table__header">School Name</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @summary.success.each do |row| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= row[:urn] %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= row[:message] %>
+          </td>
+        </tr>
+      <%- end %>
+    </tbody>
+  </table>
+<%- end %>
+<%= govuk_button_link_to('Finish', new_support_devices_school_bulk_allocation_path) %>

--- a/app/views/support/devices/school_bulk_allocations/summary.html.erb
+++ b/app/views/support/devices/school_bulk_allocations/summary.html.erb
@@ -26,7 +26,7 @@
     <table class="govuk-table requests-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header">School URN</th>
+          <th class="govuk-table__header">URN</th>
           <th class="govuk-table__header">Error</th>
         </tr>
       </thead>

--- a/app/views/support/devices/school_bulk_allocations/summary.html.erb
+++ b/app/views/support/devices/school_bulk_allocations/summary.html.erb
@@ -53,8 +53,8 @@
   <table class="govuk-table requests-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header">School URN</th>
-        <th class="govuk-table__header">School Name</th>
+        <th class="govuk-table__header">URN</th>
+        <th class="govuk-table__header">Name</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@
       confirm_enable_orders: Check your answers and confirm
     support_edit_allocation: Change device allocation
     support_bulk_allocation: Allow schools to order their full allocation
-    support_bulk_allocation_result: Bulk allocation result
+    support_bulk_allocation_result: Bulk allocation summary
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter_home: Users with permission to place orders and receive support through Computacenter

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,8 @@
       enable_orders: Can they place orders?
       confirm_enable_orders: Check your answers and confirm
     support_edit_allocation: Change device allocation
+    support_bulk_allocation: Allow schools to order their full allocation
+    support_bulk_allocation_result: Bulk allocation result
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter_home: Users with permission to place orders and receive support through Computacenter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
         get '/allocation/edit', to: 'allocation#edit'
         patch '/allocation', to: 'allocation#update'
       end
+      resources :school_bulk_allocations, only: %i[new create]
     end
     resources :responsible_bodies, only: %i[], path: '/:pilot/responsible-bodies' do
       resources :users, only: %i[new create]

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   def and_i_click_the_enable_full_allocations_button
     click_on 'Enable full allocations'
   end
-  
+
   def then_i_see_a_summary_page
     expect(page).to have_selector('h1', text: 'Bulk allocation summary')
     expect(page).to have_text("#{schools.count} allocated successfully")
@@ -68,7 +68,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   def then_i_see_a_summary_page_with_error_messages
     expect(page).to have_selector('h1', text: 'Bulk allocation summary')
     expect(page).to have_text("#{schools.count} allocated successfully")
-    expect(page).to have_text("1 error")
+    expect(page).to have_text('1 error')
     schools.each do |school|
       expect(page).to have_selector('td', text: school.urn)
       expect(page).to have_selector('td', text: school.name)

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
     then_i_see_the_full_allocations_page
   end
 
-  scenario 'submitting urns for schools that need their full allocation' do
+  scenario 'submitting URNs for schools that need their full allocation' do
     given_i_am_signed_in_as_a_support_user
     when_i_navigate_to_the_full_allocations_page
     and_i_enter_my_school_urns
@@ -19,7 +19,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
     then_i_see_a_summary_page
   end
 
-  scenario 'submitting urns for schools that includes bad data' do
+  scenario 'submitting URNs for schools that includes bad data' do
     given_i_am_signed_in_as_a_support_user
     when_i_navigate_to_the_full_allocations_page
     and_i_enter_my_school_urns_with_bad_data

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.feature 'Allowing multiple schools to order their full allocation' do
+  let(:support_user) { create(:support_user) }
+  let(:schools) { create_list(:school, 3, :with_std_device_allocation, order_state: :cannot_order) }
+  let(:bad_urn) { '12492903' }
+
+  scenario 'visiting the full allocations page' do
+    given_i_am_signed_in_as_a_support_user
+    when_i_click_on_the_full_allocations_nav_menu_link
+    then_i_see_the_full_allocations_page
+  end
+
+  scenario 'submitting urns for schools that need their full allocation' do
+    given_i_am_signed_in_as_a_support_user
+    when_i_navigate_to_the_full_allocations_page
+    and_i_enter_my_school_urns
+    and_i_click_the_enable_full_allocations_button
+    then_i_see_a_summary_page
+  end
+
+  scenario 'submitting urns for schools that includes bad data' do
+    given_i_am_signed_in_as_a_support_user
+    when_i_navigate_to_the_full_allocations_page
+    and_i_enter_my_school_urns_with_bad_data
+    and_i_click_the_enable_full_allocations_button
+    then_i_see_a_summary_page_with_error_messages
+  end
+
+  def given_i_am_signed_in_as_a_support_user
+    sign_in_as support_user
+  end
+
+  def when_i_click_on_the_full_allocations_nav_menu_link
+    click_link 'Full allocations'
+  end
+
+  def then_i_see_the_full_allocations_page
+    expect(page).to have_selector('h1', text: 'Allow schools to order their full allocation')
+  end
+
+  def when_i_navigate_to_the_full_allocations_page
+    visit new_support_devices_school_bulk_allocation_path
+  end
+
+  def and_i_enter_my_school_urns
+    fill_in 'Enter one school URN per line', with: schools.map(&:urn).join("\r\n")
+  end
+
+  def and_i_enter_my_school_urns_with_bad_data
+    data = schools.map(&:urn).append(bad_urn).join("\r\n")
+    fill_in 'Enter one school URN per line', with: data
+  end
+
+  def and_i_click_the_enable_full_allocations_button
+    click_on 'Enable full allocations'
+  end
+  
+  def then_i_see_a_summary_page
+    expect(page).to have_selector('h1', text: 'Bulk allocation summary')
+    expect(page).to have_text("#{schools.count} allocated successfully")
+    schools.each do |school|
+      expect(page).to have_selector('td', text: school.urn)
+      expect(page).to have_selector('td', text: school.name)
+    end
+  end
+
+  def then_i_see_a_summary_page_with_error_messages
+    expect(page).to have_selector('h1', text: 'Bulk allocation summary')
+    expect(page).to have_text("#{schools.count} allocated successfully")
+    expect(page).to have_text("1 error")
+    schools.each do |school|
+      expect(page).to have_selector('td', text: school.urn)
+      expect(page).to have_selector('td', text: school.name)
+    end
+    expect(page).to have_selector('td', text: bad_urn)
+    expect(page).to have_selector('td', text: 'URN not found')
+  end
+end

--- a/spec/services/bulk_allocation_service_spec.rb
+++ b/spec/services/bulk_allocation_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BulkAllocationService do
     end
 
     it 'enables the schools to order their full allocation' do
-      service.unlock!(schools.map { |s| s.urn })
+      service.unlock!(schools.map(&:urn))
       schools.each do |school|
         school.reload
         expect(school.std_device_allocation.cap).to eq(school.std_device_allocation.allocation)
@@ -23,11 +23,11 @@ RSpec.describe BulkAllocationService do
     end
 
     it 'keeps track of successes and failures' do
-      service.unlock!(schools.map { |s| s.urn }.append('32ew'))
+      service.unlock!(schools.map(&:urn).append('32ew'))
       expect(service.success_count).to eq(schools.count)
       expect(service.failure_count).to eq(1)
-      expect(service.success.map { |s| s[:urn] }).to eq(schools.map { |s| s.urn })
-      expect(service.failures).to eq [ { urn: '32ew', message: 'URN not found' } ]
+      expect(service.success.map { |s| s[:urn] }).to eq(schools.map(&:urn))
+      expect(service.failures).to eq [{ urn: '32ew', message: 'URN not found' }]
     end
   end
 end

--- a/spec/services/bulk_allocation_service_spec.rb
+++ b/spec/services/bulk_allocation_service_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe BulkAllocationService do
+  let(:schools) { create_list(:school, 3, :with_std_device_allocation, order_state: 'cannot_order') }
+
+  subject(:service) { described_class.new }
+
+  describe '#unlock!' do
+    let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest) }
+
+    before do
+      allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
+      allow(mock_request).to receive(:post!)
+    end
+
+    it 'enables the schools to order their full allocation' do
+      service.unlock!(schools.map { |s| s.urn })
+      schools.each do |school|
+        school.reload
+        expect(school.std_device_allocation.cap).to eq(school.std_device_allocation.allocation)
+        expect(school.can_order?).to be true
+      end
+    end
+
+    it 'keeps track of successes and failures' do
+      service.unlock!(schools.map { |s| s.urn }.append('32ew'))
+      expect(service.success_count).to eq(schools.count)
+      expect(service.failure_count).to eq(1)
+      expect(service.success.map { |s| s[:urn] }).to eq(schools.map { |s| s.urn })
+      expect(service.failures).to eq [ { urn: '32ew', message: 'URN not found' } ]
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/00jc11yP/702-bulk-put-schools-into-lockdown)
Give multiple schools their full allocation and enable them to order devices

### Changes proposed in this pull request
Add support nav menu item 'Full allocations'
Add support page for entering and submitting school urns
Add service to handle request and call `CapUpdateService#update!` for each school found
Add summary page with results of request

### Guidance to review
As a support user you should see a 'Full allocations' nav menu item
This link takes you to the page where you can enter school urns, one per row
Submitting your urns will result in the schools being granted their full allocation and ability to order by the `CapUpdateService`
A summary page shows which schools were successfully given their allocation and displays any errors.

![image](https://user-images.githubusercontent.com/333931/93893503-9a05c080-fce5-11ea-9ded-077abfa2c89e.png)


![image](https://user-images.githubusercontent.com/333931/93893437-88241d80-fce5-11ea-9714-e908636be785.png)
