### PR TITLE
Onboard single-school RBs with users who are an existing school contacts

### DIFF
--- a/app/services/onboard_single_school_responsible_body_service.rb
+++ b/app/services/onboard_single_school_responsible_body_service.rb
@@ -37,10 +37,12 @@ private
   end
 
   def set_user_as_school_contact(user_to_contact)
-    contact = school.contacts.create!(email_address: user_to_contact.email_address,
-                                      full_name: user_to_contact.full_name,
-                                      role: :contact,
-                                      phone_number: user_to_contact.telephone)
+    contact = school
+      .contacts
+      .where(email_address: user_to_contact.email_address)
+      .first_or_create!(full_name: user_to_contact.full_name,
+                        role: :contact,
+                        phone_number: user_to_contact.telephone)
     school.preorder_information.update!(school_contact: contact)
   end
 


### PR DESCRIPTION
### Context

Having onboarded a handful of single academy trusts, the onboarding service had trouble with a single academy trust where one of the trust users was the headteacher. When the service tried to create the headteacher as the school contact, it triggered the email uniqueness validation.

### Changes proposed in this pull request

Only create a new school contact if one matching the user doesn't already exist.
