### PR TITLE
remove both FeatureFlags governing Cap update notifications

### DIFF
--- a/app/services/cap_update_service.rb
+++ b/app/services/cap_update_service.rb
@@ -10,22 +10,24 @@ class CapUpdateService
     update_order_state!(order_state)
     allocation = update_cap!(cap)
 
-    update_cap_on_computacenter!(allocation.id) if FeatureFlag.active?(:computacenter_cap_update_api)
-
-    notify_computacenter_by_email(allocation.cap)
+    if notify_computacenter_of_cap_changes?
+      update_cap_on_computacenter!(allocation.id)
+      notify_computacenter_by_email(allocation.cap)
+    end
   end
 
 private
 
+  def notify_computacenter_of_cap_changes?
+    Settings.computacenter.outgoing_api.endpoint.present?
+  end
+
   def notify_computacenter_by_email(new_cap_value)
-    if FeatureFlag.active?(:notify_computacenter_of_cap_changes)
-      if @device_type == 'std_device'
-        ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
-          .notify_of_devices_cap_change.deliver_later
-      else
-        ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
-          .notify_of_comms_cap_change.deliver_later
-      end
+    mailer = ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
+    if @device_type == 'std_device'
+      mailer.notify_of_devices_cap_change.deliver_later
+    else
+      mailer.notify_of_comms_cap_change.deliver_later
     end
   end
 

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -5,6 +5,11 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   let(:schools) { create_list(:school, 3, :with_std_device_allocation, order_state: :cannot_order) }
   let(:bad_urn) { '12492903' }
 
+  # disable the sending of cap update requests & emails
+  before do
+    Settings.computacenter.outgoing_api.endpoint = nil
+  end
+
   scenario 'visiting the full allocations page' do
     given_i_am_signed_in_as_a_support_user
     when_i_click_on_the_full_allocations_nav_menu_link

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -61,17 +61,12 @@ RSpec.feature 'Enabling orders for a school from the support area' do
 
         context 'filling in a valid number and clicking Continue' do
           let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, payload_id: 'abc123') }
-          let!(:api_already_active) { FeatureFlag.active?(:computacenter_cap_update_api) }
 
           before do
             allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
             allow(mock_request).to receive(:post!)
             fill_in('How many devices can they order?', with: 2)
-            FeatureFlag.activate(:computacenter_cap_update_api)
-          end
-
-          after do
-            FeatureFlag.deactivate(:computacenter_cap_update_api) unless api_already_active
+            Settings.computacenter.outgoing_api.endpoint = 'https://example.com/'
           end
 
           it 'takes me to the Check your answers page' do


### PR DESCRIPTION
### Context

See [Trello card 720](https://trello.com/c/Fd0q7j4m/720-investigate-missing-cap-updates)

### Changes proposed in this pull request

* Remove both FeatureFlags governing the behaviour of the CapUpdateService (one for whether to hit Computacenter's API, one for whether to send an email)
* Govern both behaviours based on whether the endpoint URL is present in Settings
* Minor tidy-up of the logic around it to be more DRY

### Guidance to review

