### PR TITLE
720 record cap update request timestamp and payload

### DIFF
--- a/app/models/computacenter/outgoing_api/cap_update_request.rb
+++ b/app/models/computacenter/outgoing_api/cap_update_request.rb
@@ -36,7 +36,6 @@ class Computacenter::OutgoingAPI::CapUpdateRequest
       )
     end
 
-    SchoolDeviceAllocation.where(id: @allocation_ids).update_all(cap_update_request_timestamp: @timestamp, cap_update_request_payload_id: @payload_id)
     @response
   end
 

--- a/app/models/computacenter/outgoing_api/cap_update_request.rb
+++ b/app/models/computacenter/outgoing_api/cap_update_request.rb
@@ -36,6 +36,7 @@ class Computacenter::OutgoingAPI::CapUpdateRequest
       )
     end
 
+    SchoolDeviceAllocation.where(id: @allocation_ids).update_all(cap_update_request_timestamp: @timestamp, cap_update_request_payload_id: @payload_id)
     @response
   end
 

--- a/app/services/cap_update_service.rb
+++ b/app/services/cap_update_service.rb
@@ -44,6 +44,11 @@ private
 
   def update_cap_on_computacenter!(allocation_id)
     api_request = Computacenter::OutgoingAPI::CapUpdateRequest.new(allocation_ids: [allocation_id])
-    api_request.post!
+    response = api_request.post!
+    SchoolDeviceAllocation.where(id: allocation_id).update_all(
+      cap_update_request_timestamp: api_request.timestamp,
+      cap_update_request_payload_id: api_request.payload_id,
+    )
+    response
   end
 end

--- a/db/migrate/20200923093949_add_cap_update_request_timestamp_and_payload_id_to_school_device_allocation.rb
+++ b/db/migrate/20200923093949_add_cap_update_request_timestamp_and_payload_id_to_school_device_allocation.rb
@@ -1,0 +1,9 @@
+class AddCapUpdateRequestTimestampAndPayloadIdToSchoolDeviceAllocation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_device_allocations, :cap_update_request_timestamp, :datetime, null: true
+    add_column :school_device_allocations, :cap_update_request_payload_id, :string, null: true
+
+    add_index :school_device_allocations, :cap_update_request_timestamp, name: 'ix_allocations_cap_update_timestamp'
+    add_index :school_device_allocations, :cap_update_request_payload_id, name: 'ix_allocations_cap_update_payload_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_101304) do
+ActiveRecord::Schema.define(version: 2020_09_23_093949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,7 +162,11 @@ ActiveRecord::Schema.define(version: 2020_09_18_101304) do
     t.bigint "last_updated_by_user_id"
     t.bigint "created_by_user_id"
     t.integer "cap", default: 0, null: false
+    t.datetime "cap_update_request_timestamp"
+    t.string "cap_update_request_payload_id"
     t.index ["cap"], name: "index_school_device_allocations_on_cap"
+    t.index ["cap_update_request_payload_id"], name: "ix_allocations_cap_update_payload_id"
+    t.index ["cap_update_request_timestamp"], name: "ix_allocations_cap_update_timestamp"
     t.index ["created_by_user_id"], name: "index_school_device_allocations_on_created_by_user_id"
     t.index ["last_updated_by_user_id"], name: "index_school_device_allocations_on_last_updated_by_user_id"
     t.index ["school_id"], name: "index_school_device_allocations_on_school_id"

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Enabling orders for a school from the support area' do
         end
 
         context 'filling in a valid number and clicking Continue' do
-          let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, payload_id: 'abc123') }
+          let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, payload_id: 'abc123', timestamp: Time.zone.now) }
           let!(:api_already_active) { FeatureFlag.active?(:computacenter_cap_update_api) }
 
           before do

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       it 'returns the response ' do
         expect(request.post!).to be_a(HTTP::Response)
       end
+
+      it 'records timestamp and payload_id on each of the allocations' do
+        request.payload_id = '123456789'
+        request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
+        request.post!
+        allocation_1.reload
+        allocation_2.reload
+        expect(allocation_1.cap_update_request_timestamp).not_to be_nil
+        expect(allocation_1.cap_update_request_payload_id).to eq('123456789')
+        expect(allocation_2.cap_update_request_timestamp).not_to be_nil
+        expect(allocation_2.cap_update_request_payload_id).to eq('123456789')
+      end
     end
 
     context 'when the response status is not a success' do
@@ -85,6 +97,16 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
 
       it 'raises an error' do
         expect { request.post! }.to raise_error(Computacenter::OutgoingAPI::Error)
+      end
+
+      it 'does not change the timestamp and payload_id on the allocations' do
+        expect { request.post! }.to raise_error(Computacenter::OutgoingAPI::Error)
+        allocation_1.reload
+        allocation_2.reload
+        expect(allocation_1.cap_update_request_timestamp).to be_nil
+        expect(allocation_1.cap_update_request_payload_id).to be_nil
+        expect(allocation_2.cap_update_request_timestamp).to be_nil
+        expect(allocation_2.cap_update_request_payload_id).to be_nil
       end
     end
 

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -73,18 +73,6 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       it 'returns the response ' do
         expect(request.post!).to be_a(HTTP::Response)
       end
-
-      it 'records timestamp and payload_id on each of the allocations' do
-        request.payload_id = '123456789'
-        request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
-        request.post!
-        allocation_1.reload
-        allocation_2.reload
-        expect(allocation_1.cap_update_request_timestamp).not_to be_nil
-        expect(allocation_1.cap_update_request_payload_id).to eq('123456789')
-        expect(allocation_2.cap_update_request_timestamp).not_to be_nil
-        expect(allocation_2.cap_update_request_payload_id).to eq('123456789')
-      end
     end
 
     context 'when the response status is not a success' do

--- a/spec/services/bulk_allocation_service_spec.rb
+++ b/spec/services/bulk_allocation_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BulkAllocationService do
   subject(:service) { described_class.new }
 
   describe '#unlock!' do
-    let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest) }
+    let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789') }
 
     before do
       allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)


### PR DESCRIPTION
### Context

See [Trello card 720](https://trello.com/c/Fd0q7j4m/720-investigate-missing-cap-updates) - this will help us diagnose any future Cap Update issues

### Changes proposed in this pull request

* When a successful CapUpdateRequest is made, record the timestamp & payload ID on each of its allocations

### Guidance to review

