### PR TITLE
add new statuses to device perf dashsboard

### DIFF
--- a/app/models/support/devices/service_performance.rb
+++ b/app/models/support/devices/service_performance.rb
@@ -36,8 +36,9 @@ class Support::Devices::ServicePerformance
   def number_of_schools_devolved_to
     needs_contact_count = preorder_information_counts_by_status['needs_contact'] || 0
     has_contact_count = preorder_information_counts_by_status['school_will_be_contacted'] || 0
-
-    needs_contact_count + has_contact_count
+    contacted_count = preorder_information_counts_by_status['school_contacted'] || 0
+    school_ready_count = preorder_information_counts_by_status['school_ready'] || 0
+    needs_contact_count + has_contact_count + contacted_count + school_ready_count
   end
 
   def number_of_schools_managed_centrally

--- a/app/views/support/devices/service_performance/_preorder_information.html.erb
+++ b/app/views/support/devices/service_performance/_preorder_information.html.erb
@@ -47,6 +47,13 @@
       </span>
       <%= t(:needs_a_contact, scope: %i[support devices_performance], count: @stats.preorder_information_counts_by_status['needs_contact'] || 0) %>
     </div>
+
+    <div class="app-card app-card--blue">
+      <span class="app-card__secondary-count">
+        <%= number_with_delimiter(@stats.preorder_information_counts_by_status['school_contacted'] || 0) %>
+      </span>
+      <%= t(:school_contacted, scope: %i[support devices_performance], count: @stats.preorder_information_counts_by_status['school_contacted'] || 0) %>
+    </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card app-card--light-blue">
@@ -54,6 +61,13 @@
         <%= number_with_delimiter(@stats.preorder_information_counts_by_status['school_will_be_contacted'] || 0) %>
       </span>
       <%= t(:school_contacts, scope: %i[support devices_performance], count: @stats.preorder_information_counts_by_status['school_will_be_contacted'] || 0) %>
+    </div>
+
+    <div class="app-card app-card--green">
+      <span class="app-card__secondary-count">
+        <%= number_with_delimiter(@stats.preorder_information_counts_by_status['school_ready'] || 0) %>
+      </span>
+      <%= t(:school_ready, scope: %i[support devices_performance], count: @stats.preorder_information_counts_by_status['school_ready'] || 0) %>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,6 +264,12 @@
       schools_devolved_to:
         one: school will place its own orders
         other: schools will place their own orders
+      school_contacted:
+        one: has been contacted
+        other: have been contacted
+      school_ready:
+        one: is ready
+        other: are ready
     schools:
       invite:
         success: "%{name} has been invited successfully"

--- a/spec/models/support/devices/service_performance_spec.rb
+++ b/spec/models/support/devices/service_performance_spec.rb
@@ -74,22 +74,26 @@ RSpec.describe Support::Devices::ServicePerformance, type: :model do
     end
   end
 
-  describe 'preorder_information_counts_by_status' do
+  describe 'status-counting methods' do
     before do
       create_list(:preorder_information, 5, status: 'needs_info')
       create_list(:preorder_information, 2, status: 'needs_contact')
       create_list(:preorder_information, 2, status: 'school_will_be_contacted')
       create_list(:preorder_information, 2, status: 'school_contacted')
       create_list(:preorder_information, 3, status: 'ready')
+      create_list(:preorder_information, 7, status: 'school_ready')
       ResponsibleBody.update_all(in_devices_pilot: true)
     end
 
-    it 'returns the total number of preorder_information records with each status' do
-      expect(stats.preorder_information_counts_by_status['needs_info']).to eq(5)
-      expect(stats.preorder_information_counts_by_status['needs_contact']).to eq(2)
-      expect(stats.preorder_information_counts_by_status['school_will_be_contacted']).to eq(2)
-      expect(stats.preorder_information_counts_by_status['school_contacted']).to eq(2)
-      expect(stats.preorder_information_counts_by_status['ready']).to eq(3)
+    describe 'preorder_information_counts_by_status' do
+      it 'returns the total number of preorder_information records with each status' do
+        expect(stats.preorder_information_counts_by_status['needs_info']).to eq(5)
+        expect(stats.preorder_information_counts_by_status['needs_contact']).to eq(2)
+        expect(stats.preorder_information_counts_by_status['school_will_be_contacted']).to eq(2)
+        expect(stats.preorder_information_counts_by_status['school_contacted']).to eq(2)
+        expect(stats.preorder_information_counts_by_status['ready']).to eq(3)
+        expect(stats.preorder_information_counts_by_status['school_ready']).to eq(7)
+      end
     end
 
     describe '#preorder_information_by_status' do
@@ -99,19 +103,26 @@ RSpec.describe Support::Devices::ServicePerformance, type: :model do
         expect(stats.preorder_information_by_status('school_will_be_contacted')).to eq(2)
         expect(stats.preorder_information_by_status('school_contacted')).to eq(2)
         expect(stats.preorder_information_by_status('ready')).to eq(3)
+        expect(stats.preorder_information_counts_by_status['school_ready']).to eq(7)
       end
     end
 
-    it 'calculates the number of schools managed centrally' do
-      expect(stats.number_of_schools_managed_centrally).to eq(8)
+    describe '#number_of_schools_managed_centrally' do
+      it 'adds up the number of schools in status "needs_info" and "ready"' do
+        expect(stats.number_of_schools_managed_centrally).to eq(8)
+      end
     end
 
-    it 'calculates the number of schools that decisions have been devolved to' do
-      expect(stats.number_of_schools_devolved_to).to eq(4)
+    describe '#number_of_schools_devolved_to' do
+      it 'adds up the number of schools in status needs_contact, school_will_be_contacted, school_contacted and school_ready' do
+        expect(stats.number_of_schools_devolved_to).to eq(13)
+      end
     end
 
-    it 'calculates the total number of schools devolved or managed centrally' do
-      expect(stats.number_of_schools_with_a_decision_made).to eq(12)
+    describe '#number_of_schools_with_a_decision_made' do
+      it 'calculates the total number of schools devolved or managed centrally' do
+        expect(stats.number_of_schools_with_a_decision_made).to eq(21)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

See [Trello card 724](https://trello.com/c/KVzUVXwc/724-check-numbers-on-devices-performance-dashboard) 

### Changes proposed in this pull request

Include new PreorderInformation statuses in the Support / Devices / Service Performance dashboard

![Screen Shot 2020-09-23 at 15 46 03](https://user-images.githubusercontent.com/134501/94028657-efa89e80-fdb3-11ea-8256-67d3ee652d82.png)


### Guidance to review

