### PR TITLE
[721] CC can bulk update users with TechSource accounts

### DIFF
--- a/app/controllers/computacenter/techsource_controller.rb
+++ b/app/controllers/computacenter/techsource_controller.rb
@@ -1,0 +1,26 @@
+class Computacenter::TechsourceController < Computacenter::BaseController
+  def new
+    @form = BulkTechsourceForm.new
+  end
+
+  def create
+    if form.valid?
+      @service = ConfirmTechsourceAccountCreatedService.new(emails: form.array_of_emails)
+      @service.call
+
+      render :summary
+    else
+      render :new
+    end
+  end
+
+private
+
+  def form
+    @form ||= BulkTechsourceForm.new(form_params)
+  end
+
+  def form_params
+    params.require(:bulk_techsource_form).permit(:emails)
+  end
+end

--- a/app/form_objects/bulk_techsource_form.rb
+++ b/app/form_objects/bulk_techsource_form.rb
@@ -1,0 +1,27 @@
+class BulkTechsourceForm
+  include ActiveModel::Model
+
+  attr_accessor :emails
+
+  validates :emails, presence: true
+  validate :validate_one_email_per_line
+  validate :validate_valid_emails
+
+  def array_of_emails
+    emails.split("\r\n").map(&:strip).reject(&:blank?).map(&:downcase)
+  end
+
+private
+
+  def validate_one_email_per_line
+    unless array_of_emails.all? { |line| !line.match(/,| /) }
+      errors.add(:emails, 'Enter no more than one email address per line')
+    end
+  end
+
+  def validate_valid_emails
+    unless array_of_emails.all? { |line| line.match(/.*@.*\..*/) }
+      errors.add(:emails, 'Ensure all email addresses are valid')
+    end
+  end
+end

--- a/app/services/confirm_techsource_account_created_service.rb
+++ b/app/services/confirm_techsource_account_created_service.rb
@@ -1,0 +1,34 @@
+class ConfirmTechsourceAccountCreatedService
+  attr_reader :processed, :unprocessed
+
+  def initialize(emails: [])
+    @emails = emails
+    @processed = []
+    @unprocessed = []
+  end
+
+  def call
+    emails.each do |email|
+      user = User.find_by(email_address: email)
+
+      if user
+        if user.update(has_techsource_account: true)
+          processed << { email: email }
+        else
+          unprocessed << { email: email, message: 'User could not be updated' }
+        end
+      else
+        unprocessed << { email: email, message: 'No user with this email found' }
+      end
+    end
+  end
+
+  def email_count
+    processed.size + unprocessed.size
+  end
+
+private
+
+  attr_reader :emails
+  attr_writer :processed, :unprocessed
+end

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -4,30 +4,22 @@
       <%= t('page_titles.computacenter.home') %>
     </h1>
 
-    <p class="govuk-body">Use this service to:</p>
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Download TechSource users', computacenter_user_ledger_path(format: :csv) %>
+    </h2>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <span class="govuk-!-margin-bottom-4">download a CSV file of users who have permission to place orders on TechSource</span>
-        <br /><br />
-        <%= govuk_button_link_to 'Download TechSource users', computacenter_user_ledger_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
-      </li>
-    </ul>
+    <p class="govuk-body">Download a CSV file of all users with permission to place orders on TechSource.</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <span class="govuk-!-margin-bottom-4">download a CSV file of Google Chromebook details for schools</span>
-        <br /><br />
-        <%= govuk_button_link_to 'Download Chromebook details', computacenter_chromebooks_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
-      </li>
-    </ul>
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Update TechSource users', computacenter_techsource_path %>
+    </h2>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <span class="govuk-!-margin-bottom-4">update users that have TechSource accounts</span>
-        <br /><br />
-        <%= govuk_button_link_to 'Update TechSource users', computacenter_techsource_path, classes: 'govuk-!-margin-top-4' %>
-      </li>
-    </ul>
+    <p class="govuk-body">Tell us which email addresses have had TechSource accounts created for them.</p>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Download Chromebook details', computacenter_chromebooks_path(format: :csv) %>
+    </h2>
+
+    <p class="govuk-body">Download a CSV file of Google Chromebook details for schools.</p>
   </div>
 </div>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.computacenter_home') %>
+      <%= t('page_titles.computacenter.home') %>
     </h1>
 
     <p class="govuk-body">Use this service to:</p>
@@ -13,11 +13,20 @@
         <%= govuk_button_link_to 'Download TechSource users', computacenter_user_ledger_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
       </li>
     </ul>
+
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <span class="govuk-!-margin-bottom-4">download a CSV file of Google Chromebook details for schools</span>
         <br /><br />
         <%= govuk_button_link_to 'Download Chromebook details', computacenter_chromebooks_path(format: :csv), classes: 'govuk-!-margin-top-4' %>
+      </li>
+    </ul>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <span class="govuk-!-margin-bottom-4">update users that have TechSource accounts</span>
+        <br /><br />
+        <%= govuk_button_link_to 'Update TechSource users', computacenter_techsource_path, classes: 'govuk-!-margin-top-4' %>
       </li>
     </ul>
   </div>

--- a/app/views/computacenter/techsource/new.html.erb
+++ b/app/views/computacenter/techsource/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.computacenter.techsource') %>
+<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.computacenter.techsource') %>
+    </h1>
+
+    <p class="govuk-body">Enter email addresses for users who have TechSource accounts. Use one line per address.</p>
+
+    <%= form_with model: @form, url: computacenter_techsource_path do |f| %>
+      <%= f.govuk_text_area :emails,
+                            label: { text: 'Email addresses', size: 'm' },
+                            rows: 12 %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/computacenter/techsource/summary.html.erb
+++ b/app/views/computacenter/techsource/summary.html.erb
@@ -1,0 +1,70 @@
+<% content_for :title, t('page_titles.computacenter.techsource') %>
+<% content_for :before_content, govuk_link_to('Back', computacenter_techsource_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">Summary of updated TechSource users</h1>
+
+    <p class="govuk-body">We found <%= @service.email_count %> <%= 'email'.pluralize(@service.email_count) %> in your request:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= @service.unprocessed.size %> <%= 'error'.pluralize(@service.unprocessed.size) %></li>
+      <li><%= @service.processed.size %> <%= 'user'.pluralize(@service.processed.size) %> updated successfully</li>
+    </ul>
+  </div>
+</div>
+
+<% if @service.unprocessed.any? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= "#{@service.unprocessed.size} #{'error'.pluralize(@service.unprocessed.size)} found" %></h2>
+
+  <div class="govuk-form-group--error">
+    <p class="govuk-error-message">Fix the errors in your request and try again</p>
+
+    <table class="govuk-table requests-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Email</th>
+          <th class="govuk-table__header">Error</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @service.unprocessed.each do |row| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= row[:email] %>
+            </td>
+            <td class="govuk-table__cell">
+              <span class="govuk-error-message govuk-!-margin-bottom-0"><%= row[:message] %></span>
+            </td>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+  </div>
+<%- end %>
+
+<% if @service.processed.any? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4">
+    <%= "#{@service.processed.size} #{'user'.pluralize(@service.processed.size)} processed" %>
+  </h2>
+
+  <table class="govuk-table requests-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Email</th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% @service.processed.each do |row| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= row[:email] %>
+          </td>
+        </tr>
+      <%- end %>
+    </tbody>
+  </table>
+<%- end %>
+
+<%= govuk_button_link_to('Finish', computacenter_techsource_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,7 @@
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter:
-      home: Users with permission to place orders and receive support through Computacenter
+      home: Home
       techsource: Update TechSource users
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,9 @@
     support_bulk_allocation_result: Bulk allocation summary
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
-    computacenter_home: Users with permission to place orders and receive support through Computacenter
+    computacenter:
+      home: Users with permission to place orders and receive support through Computacenter
+      techsource: Update TechSource users
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
       schools: Each school will place their own orders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,8 @@ Rails.application.routes.draw do
     get '/', to: 'home#show', as: :home
     get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
     get '/chromebooks', to: 'chromebooks#index', as: :chromebooks
+    get '/techsource', to: 'techsource#new'
+    post '/techsource', to: 'techsource#create'
     resources :api_tokens, path: '/api-tokens'
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection

--- a/db/migrate/20200923115939_add_techsource_account_to_users.rb
+++ b/db/migrate/20200923115939_add_techsource_account_to_users.rb
@@ -1,0 +1,5 @@
+class AddTechsourceAccountToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :has_techsource_account, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_093949) do
+ActiveRecord::Schema.define(version: 2020_09_23_115939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,6 +230,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_093949) do
     t.datetime "privacy_notice_seen_at"
     t.bigint "school_id"
     t.boolean "orders_devices"
+    t.boolean "has_techsource_account", default: false
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/spec/controllers/computacenter/techsource_controller_spec.rb
+++ b/spec/controllers/computacenter/techsource_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::TechsourceController do
+  let(:user) { create(:computacenter_user) }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#new' do
+    it 'loads the page' do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#create' do
+    let(:mock_service) { double.as_null_object }
+
+    context 'happy path' do
+      it 'calls service' do
+        allow(ConfirmTechsourceAccountCreatedService).to receive(:new).with(emails: ['user@example.com']).and_return(mock_service)
+
+        post :create, params: { bulk_techsource_form: { emails: 'user@example.com' } }
+
+        expect(mock_service).to have_received(:call)
+      end
+
+      it 'renders the summary' do
+        post :create, params: { bulk_techsource_form: { emails: 'user@example.com' } }
+
+        expect(controller).to render_template('computacenter/techsource/summary')
+      end
+    end
+
+    context 'sad path' do
+      it 'does not call service' do
+        allow(ConfirmTechsourceAccountCreatedService).to receive(:new).and_return(mock_service)
+
+        post :create, params: { bulk_techsource_form: { emails: '' } }
+
+        expect(mock_service).not_to have_received(:call)
+      end
+
+      it 'renders the new template' do
+        post :create, params: { bulk_techsource_form: { emails: '' } }
+
+        expect(controller).to render_template('computacenter/techsource/new')
+      end
+    end
+  end
+end

--- a/spec/form_objects/bulk_techsource_form_spec.rb
+++ b/spec/form_objects/bulk_techsource_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe BulkTechsourceForm do
+  describe 'validations' do
+    context 'when no emails' do
+      subject(:form) { described_class.new(emails: '') }
+
+      it 'is invalid' do
+        expect(form).to be_invalid
+      end
+    end
+
+    context 'not one email per line with comma' do
+      subject(:form) { described_class.new(emails: 'a@example.com, b@example.com') }
+
+      it 'is invalid' do
+        expect(form).to be_invalid
+        expect(form.errors[:emails]).to include('Enter no more than one email address per line')
+      end
+    end
+
+    context 'not one email per line with space' do
+      subject(:form) { described_class.new(emails: 'a@example.com b@example.com') }
+
+      it 'is invalid' do
+        expect(form).to be_invalid
+        expect(form.errors[:emails]).to include('Enter no more than one email address per line')
+      end
+    end
+
+    context 'with an invalid email' do
+      subject(:form) { described_class.new(emails: "a@example.com\r\nnoteanemail\r\nb@example.com") }
+
+      it 'is invalid' do
+        expect(form).to be_invalid
+        expect(form.errors[:emails]).to include('Ensure all email addresses are valid')
+      end
+    end
+
+    context 'one email per line' do
+      subject(:form) { described_class.new(emails: "a@example.com\r\nb@example.com\r\n") }
+
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe '#array_of_emails' do
+    subject(:form) { described_class.new(emails: "   a@example.com  \r\n   \r\nB@example.com\r\n\r\n") }
+
+    it 'returns an array of entered emails' do
+      expect(form.array_of_emails).to eql(['a@example.com', 'b@example.com'])
+    end
+  end
+end

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmTechsourceAccountCreatedService do
+  describe '#call' do
+    context 'with one email' do
+      let(:user) { create(:school_user) }
+
+      subject(:service) { described_class.new(emails: [user.email_address]) }
+
+      it 'updates user#has_techsource_account to true' do
+        expect {
+          service.call
+        }.to change { user.reload.has_techsource_account }.from(false).to(true)
+      end
+
+      it 'adds email to processed list' do
+        service.call
+
+        expect(service.processed).to include(email: user.email_address)
+      end
+    end
+
+    context 'with multiple emails' do
+      let(:user1) { create(:school_user) }
+      let(:user2) { create(:school_user) }
+
+      subject(:service) { described_class.new(emails: [user1.email_address, user2.email_address]) }
+
+      it 'updates user#has_techsource_account to true' do
+        service.call
+
+        expect(user1.reload.has_techsource_account).to be_truthy
+        expect(user2.reload.has_techsource_account).to be_truthy
+      end
+    end
+
+    context 'with non-existent email' do
+      subject(:service) { described_class.new(emails: ['nobody@example.com']) }
+
+      it 'adds email with message to unprocessed list' do
+        service.call
+
+        expect(service.unprocessed).to include(email: 'nobody@example.com', message: 'No user with this email found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/1ZdxZJaL/721-form-for-allowing-cc-to-confirm-the-creation-of-techsource-accounts

### Changes proposed in this pull request

- Adds pages to Computacenter area so they can bulk update users who have TechSource accounts
- Add migration to add column on user to track if user has a TechSource accounts, defaults to false
- Pauls changes are also included in this PR https://github.com/DFE-Digital/get-help-with-tech/pull/541 which update the computacenter home page

![image](https://user-images.githubusercontent.com/92580/94044071-921d4d80-fdc5-11ea-83b3-1d5a1d2156ce.png)
![image](https://user-images.githubusercontent.com/92580/94044430-08ba4b00-fdc6-11ea-9561-38b26bf1da65.png)
![image](https://user-images.githubusercontent.com/92580/94045930-ee816c80-fdc7-11ea-9092-9c0190d6395e.png)
![image](https://user-images.githubusercontent.com/92580/94044631-4f0faa00-fdc6-11ea-903d-97caeb045561.png)

### Guidance to review

- Login as a computacenter user
- Should see section at bottom to bulk update users with TechSource accounts
- On form entering blank or not one email per row raise validation error
- Submitting the form should update found users to have a TechSource account