### PR TITLE
Harden the 'onboarding single-school responsible body' service

### DIFF
--- a/app/services/onboard_single_school_responsible_body_service.rb
+++ b/app/services/onboard_single_school_responsible_body_service.rb
@@ -4,7 +4,7 @@ class OnboardSingleSchoolResponsibleBodyService
   end
 
   def call
-    return unless single_school_responsible_body?
+    return unless single_school_responsible_body? && !responsible_body.in_devices_pilot?
 
     responsible_body.update!(in_devices_pilot: true)
     devolve_ordering_to_the_school

--- a/app/services/onboard_single_school_responsible_body_service.rb
+++ b/app/services/onboard_single_school_responsible_body_service.rb
@@ -61,7 +61,10 @@ private
   end
 
   def add_school_headteacher_to_responsible_body
-    headteacher_user = school.users.find_by!(email_address: school.headteacher_contact.email_address)
+    # User email addresses are all downcased before being added
+    # however a school contact email address can still contain capitals
+    email_address = school.headteacher_contact.email_address.downcase
+    headteacher_user = school.users.find_by!(email_address: email_address)
     headteacher_user.update!(responsible_body: responsible_body)
   end
 

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -152,4 +152,24 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
       expect(user.responsible_body).to eq(responsible_body)
     end
   end
+
+  context 'when the headteacher email address has upper-case letters' do
+    before do
+      @headteacher = create(:school_contact, :headteacher,
+                            school: school,
+                            email_address: 'JSmith@school.sch.uk')
+
+      described_class.new(urn: school.urn).call
+      responsible_body.reload
+      school.reload
+    end
+
+    it 'adds the headteacher as a hybrid user who can order under their lowercase email' do
+      user = User.find_by!(email_address: 'jsmith@school.sch.uk')
+
+      expect(user).to be_hybrid
+      expect(user.school).to eq(school)
+      expect(user.responsible_body).to eq(responsible_body)
+    end
+  end
 end

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
         .not_to change { User.count }.from(0)
     end
 
+    it 'returns without creating any new users if the responsible body has multiple schools' do
+      create(:school, responsible_body: responsible_body) # another school in the RB
+      create(:school_contact, :headteacher, school: school)
+
+      expect { described_class.new(urn: school.urn).call }
+        .not_to change { User.count }.from(0)
+    end
+
     it 'raises an error if the passed URN cannot be found' do
       expect { described_class.new(urn: '12345').call }
         .to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
   let(:responsible_body) { create(:trust, :single_academy_trust, in_devices_pilot: false) }
   let(:school) { create(:school, responsible_body: responsible_body) }
 
+  context 'cases when the service does not apply' do
+    it 'returns without creating any new users if the responsible body is already in the devices pilot' do
+      responsible_body.update!(in_devices_pilot: true)
+
+      expect { described_class.new(urn: school.urn).call }
+        .not_to change { User.count }.from(0)
+    end
+  end
+
   context 'when the responsible body has no users and the school has no headteacher' do
     it 'raises an error' do
       expect {

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
       expect { described_class.new(urn: school.urn).call }
         .not_to change { User.count }.from(0)
     end
+
+    it 'raises an error if the passed URN cannot be found' do
+      expect { described_class.new(urn: '12345').call }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   context 'when the responsible body has no users and the school has no headteacher' do

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
       expect { described_class.new(urn: '12345').call }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
-  end
 
-  context 'when the responsible body has no users and the school has no headteacher' do
-    it 'raises an error' do
+    it 'raises an error if the responsible body has no users and the school has no headteacher' do
       expect {
         described_class.new(urn: school.urn).call
       }.to raise_error(/Cannot continue without RB users or a school headteacher/)


### PR DESCRIPTION
### Context

We've onboarded 100 single-academy trusts using the `OnboardingSingleSchoolResponsibleBodyService` and encountered some edge-cases that created problems.

### Changes proposed in this pull request

- Prevent the service from running on RBs already in the pilot
- Handle case where the school contact has upper case letters in it
- Spec coverage for various edge cases

### Guidance to review

Review commit-by-commit.