### PR TITLE
Update order pages to match design, tweak TechSource guidance

### DIFF
--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -24,6 +24,5 @@
 </table>
 
 <h2 class="govuk-heading-m">Help signing in to TechSource</h2>
-<p class="govuk-body">You need to place orders on a website called TechSource, which is run by Computacenter.</p>
 
 <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address } %>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <% breadcrumbs([
-    { t('page_titles.school_home') => school_home_path },
+    { 'Home' => school_home_path },
     'Order devices',
   ]) %>
 <%- end %>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -3,16 +3,21 @@
 <%- content_for :before_content do %>
   <% breadcrumbs([
     { t('page_titles.school_home') => school_home_path },
-    title,
+    'Order devices',
   ]) %>
 <%- end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Order devices</span>
+      <%= title %>
+    </h1>
 
     <p class="govuk-body">You can only place orders when local coronavirus restrictions are confirmed.</p>
     <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
+
+    <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
     <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', school_request_devices_path %> from any year group who:</p>
 
     <%= render partial: 'shared/devices/who_to_request_for_list' %>

--- a/app/views/school/devices/order.html.erb
+++ b/app/views/school/devices/order.html.erb
@@ -27,7 +27,6 @@
 
     <p class="govuk-body">Order your devices now. Do not delay.</p>
     <p class="govuk-body">They will arrive on the next working day if you order before 4pm.</p>
-    <p class="govuk-body">You need to place orders on a website called TechSource.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know your device allocation before you sign in. If you try to order more devices that you’ve been allocated, the order will be cancelled.</p>

--- a/app/views/school/devices/order.html.erb
+++ b/app/views/school/devices/order.html.erb
@@ -2,7 +2,7 @@
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <% breadcrumbs([
-    { t('page_titles.school_home') => school_home_path },
+    { 'Home' => school_home_path },
     title,
   ]) %>
 <%- end %>

--- a/app/views/school/users/edit.html.erb
+++ b/app/views/school/users/edit.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+      <%= link_to 'Home', school_home_path, class: 'govuk-breadcrumbs__link' %>
     </li>
     <li class="govuk-breadcrumbs__list-item">
       <%= link_to t('page_titles.school_users'), school_users_path, class: 'govuk-breadcrumbs__link' %>

--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+      <%= link_to 'Home', school_home_path, class: 'govuk-breadcrumbs__link' %>
     </li>
     <li class="govuk-breadcrumbs__list-item">
       <%= title %>

--- a/app/views/school/users/new.html.erb
+++ b/app/views/school/users/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+      <%= link_to 'Home', school_home_path, class: 'govuk-breadcrumbs__link' %>
     </li>
     <li class="govuk-breadcrumbs__list-item">
       <%= link_to t('page_titles.school_users'), school_users_path, class: 'govuk-breadcrumbs__link' %>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -1,6 +1,10 @@
-<p class="govuk-body">Your ‘User ID’ is your email address: <%= local_assigns[:email_address] %></p>
+<p class="govuk-body">You need to place orders on a website called TechSource.</p>
 
-<p class="govuk-body">If you do not remember your password use the ‘Forgotten password?’ link to reset it.</p>
+<p class="govuk-body">Use these details to sign in:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>User ID: <%= local_assigns[:email_address] %></li>
+  <li>Password: Use the ‘Forgotten password?’ link to set a password the first time you sign in</li>
+</ul>
 
 <%= govuk_start_button_link_to('Start now', techsource_url, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
 

--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -4,7 +4,7 @@
     <div class="govuk-breadcrumbs">
       <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item">
-          <%= link_to t('page_titles.school_home'), school_home_path, class: 'govuk-breadcrumbs__link' %>
+          <%= link_to 'Home', school_home_path, class: 'govuk-breadcrumbs__link' %>
         </li>
         <li class="govuk-breadcrumbs__list-item">
           <%= title %>


### PR DESCRIPTION
### Context

- Now the invitation email is not being sent, we need to be explicit about how to sign in to TechSource the very first time
- Update 'Cannot order yet' page to match design
- Use "Home" as first breadcrumb title