### PR TITLE
[721] Timestamp when techsource account confirmed

### DIFF
--- a/app/services/confirm_techsource_account_created_service.rb
+++ b/app/services/confirm_techsource_account_created_service.rb
@@ -12,7 +12,7 @@ class ConfirmTechsourceAccountCreatedService
       user = User.find_by(email_address: email)
 
       if user
-        if user.update(has_techsource_account: true)
+        if user.update(techsource_account_confirmed_at: Time.zone.now)
           processed << { email: email }
         else
           unprocessed << { email: email, message: 'User could not be updated' }

--- a/db/migrate/20200924111409_add_techsource_account_confirmed_at_to_users.rb
+++ b/db/migrate/20200924111409_add_techsource_account_confirmed_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddTechsourceAccountConfirmedAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :techsource_account_confirmed_at, :datetime, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_115939) do
+ActiveRecord::Schema.define(version: 2020_09_24_111409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -231,6 +231,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_115939) do
     t.bigint "school_id"
     t.boolean "orders_devices"
     t.boolean "has_techsource_account", default: false
+    t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -4,13 +4,17 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
   describe '#call' do
     context 'with one email' do
       let(:user) { create(:school_user) }
+      let(:now) { Time.zone.now }
 
       subject(:service) { described_class.new(emails: [user.email_address]) }
 
-      it 'updates user#has_techsource_account to true' do
-        expect {
+      it 'updates user#techsource_account_confirmed_at to now' do
+        expect(user.reload.techsource_account_confirmed_at).to be_nil
+
+        Timecop.freeze(now) do
           service.call
-        }.to change { user.reload.has_techsource_account }.from(false).to(true)
+          expect(user.reload.techsource_account_confirmed_at).to be_within(1.second).of(now)
+        end
       end
 
       it 'adds email to processed list' do
@@ -26,11 +30,11 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
 
       subject(:service) { described_class.new(emails: [user1.email_address, user2.email_address]) }
 
-      it 'updates user#has_techsource_account to true' do
+      it 'updates user#techsource_account_confirmed_at to truthy' do
         service.call
 
-        expect(user1.reload.has_techsource_account).to be_truthy
-        expect(user2.reload.has_techsource_account).to be_truthy
+        expect(user1.reload.techsource_account_confirmed_at).to be_truthy
+        expect(user2.reload.techsource_account_confirmed_at).to be_truthy
       end
     end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/1ZdxZJaL/721-form-for-allowing-cc-to-confirm-the-creation-of-techsource-accounts

### Changes proposed in this pull request

- This is to replace `has_techsource_account` with `techsource_account_confirmed_at`
- `has_techsource_account` is now useless and will be removed in a later change

### Guidance to review

- Perform bulk update of users with TechSource account
- Should see users have `techsource_account_confirmed_at` updated to current timestamp
- `has_techsource_account` should no longer be updated