### PR TITLE
[721] Remove unused db column

### DIFF
--- a/db/migrate/20200924142403_remove_has_techsource_account_from_users.rb
+++ b/db/migrate/20200924142403_remove_has_techsource_account_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveHasTechsourceAccountFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :has_techsource_account, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_111409) do
+ActiveRecord::Schema.define(version: 2020_09_24_142403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,7 +230,6 @@ ActiveRecord::Schema.define(version: 2020_09_24_111409) do
     t.datetime "privacy_notice_seen_at"
     t.bigint "school_id"
     t.boolean "orders_devices"
-    t.boolean "has_techsource_account", default: false
     t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"


### PR DESCRIPTION
### Context

- https://trello.com/c/1ZdxZJaL/721-form-for-allowing-cc-to-confirm-the-creation-of-techsource-accounts
- There was a change of mind so in the end one of the db columns in no longer needed

### Changes proposed in this pull request

- remove db column from users `has_techsource_account` as it has been superceded by `techsource_account_confirmed_at`

### Guidance to review

- users `techsource_account_confirmed_at` column no longer exists