### PR TITLE
689 inform users about ccs downtime on saturday 26th sept

### DIFF
--- a/app/controllers/techsource_launcher_controller.rb
+++ b/app/controllers/techsource_launcher_controller.rb
@@ -1,0 +1,9 @@
+class TechsourceLauncherController < ApplicationController
+  def start
+    if helpers.techsource_unavailable?
+      render 'unavailable'
+    else
+      redirect_to helpers.techsource_url
+    end
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -131,6 +131,13 @@ module ViewHelper
     Settings.computacenter.techsource_url
   end
 
+  def techsource_unavailable?
+    now = Time.zone.now
+    window_start = Time.zone.local(2020,9,26,7,0,0)
+    window_end = Time.zone.local(2020,9,26,23,0,0)
+    now >= window_start && now <= window_end
+  end
+
   def what_to_order(device_count, specific_circumstances)
     if device_count.zero?
       'All devices ordered'

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -133,8 +133,8 @@ module ViewHelper
 
   def techsource_unavailable?
     now = Time.zone.now
-    window_start = Time.zone.local(2020,9,26,7,0,0)
-    window_end = Time.zone.local(2020,9,26,23,0,0)
+    window_start = Time.zone.local(2020, 9, 26, 7, 0, 0)
+    window_end = Time.zone.local(2020, 9, 26, 23, 0, 0)
     now >= window_start && now <= window_end
   end
 

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -6,6 +6,8 @@
       <%= t('page_titles.order_devices.order_devices_now') %>
     </h1>
 
+    <%= render partial: 'shared/techsource_unavailable_banner' %>
+
     <p class="govuk-body">Place an order for each school.</p>
     <p class="govuk-body">Devices will arrive the next working day if you order before 4pm.</p>
   </div>

--- a/app/views/school/devices/order.html.erb
+++ b/app/views/school/devices/order.html.erb
@@ -15,6 +15,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
+    <%= render partial: 'shared/techsource_unavailable_banner' %>
+
     <div class="app-card app-card__order">
       <h2 class="govuk-panel__title govuk-!-font-size-36 govuk-!-margin-bottom-2">
         <%= "#{device_count} #{'device'.pluralize(device_count)} available" -%>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -2,6 +2,6 @@
 
 <p class="govuk-body">If you do not remember your password use the ‘Forgotten password?’ link to reset it.</p>
 
-<%= govuk_start_button_link_to('Start now', techsource_url, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
+<%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3 govuk-!-margin-top-4', target: '_blank') -%>
 
 <p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/views/shared/_techsource_unavailable_banner.html.erb
+++ b/app/views/shared/_techsource_unavailable_banner.html.erb
@@ -1,0 +1,3 @@
+<% if Time.zone.now < Time.zone.local(2020,9,26,23,0,0) %>
+<%= render GovukComponent::Warning.new(text: 'The TechSource website will be closed for maintenance on Saturday 20 September. You can order devices when it reopens on Sunday 21 September.') %>
+<%- end %>

--- a/app/views/shared/_techsource_unavailable_banner.html.erb
+++ b/app/views/shared/_techsource_unavailable_banner.html.erb
@@ -1,3 +1,3 @@
-<% if Time.zone.now < Time.zone.local(2020,9,26,23,0,0) %>
-<%= render GovukComponent::Warning.new(text: 'The TechSource website will be closed for maintenance on Saturday 20 September. You can order devices when it reopens on Sunday 21 September.') %>
+<% if Time.zone.now < Time.zone.local(2020,9,27,0,0,0) %>
+<%= render GovukComponent::Warning.new(text: 'The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.') %>
 <%- end %>

--- a/app/views/techsource_launcher/unavailable.html.erb
+++ b/app/views/techsource_launcher/unavailable.html.erb
@@ -1,0 +1,13 @@
+<%- title = t('page_titles.techsource_unavailable') %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= title %>
+    </h1>
+
+    <p class="govuk-body">The TechSource website is closed for maintenance.</p>
+    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 21 September 2020.</p>
+  </div>
+</div>

--- a/app/views/techsource_launcher/unavailable.html.erb
+++ b/app/views/techsource_launcher/unavailable.html.erb
@@ -8,6 +8,6 @@
     </h1>
 
     <p class="govuk-body">The TechSource website is closed for maintenance.</p>
-    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 21 September 2020.</p>
+    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 27 September.</p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@
           choice: Tell us whether your school will need Chromebooks
       what_happens_next:
         title: What happens next
+    techsource_unavailable: Sorry, TechSource is unavailable
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,8 @@ Rails.application.routes.draw do
   get '/sign-in', to: 'sign_in_tokens#new', as: :sign_in
   post '/sign-in', to: 'sign_in_tokens#create'
 
+  get '/techsource-start', to: 'techsource_launcher#start'
+
   get '/403', to: 'errors#forbidden', via: :all
   get '/404', to: 'errors#not_found', via: :all
   get '/422', to: 'errors#unprocessable_entity', via: :all

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe TechsourceLauncherController, type: :controller do
+  include ViewHelper
+
+  let(:user) { create(:local_authority_user) }
+
+  describe '#start' do
+    context 'before techsource maintenance window' do
+      before do
+        Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+        sign_in_as user
+      end
+
+      it 'redirects to techsource' do
+        get 'start'
+        expect(response).to redirect_to(techsource_url)
+      end
+    end
+
+    context 'during techsource maintenance window' do
+      before do
+        Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+        sign_in_as user
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'renders the unavailable page' do
+        get 'start'
+        expect(response).to render_template('unavailable')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'after techsource maintenance window' do
+      before do
+        Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+        sign_in_as user
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'redirects to techsource' do
+        get 'start'
+        expect(response).to redirect_to(techsource_url)
+      end
+    end
+  end
+end

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Order devices' do
   end
 
   def and_i_see_a_link_to_techsource
-    expect(page).to have_link('Start now', href: techsource_url)
+    expect(page).to have_link('Start now')
   end
 
   def then_i_see_that_i_cannot_order_devices_yet

--- a/spec/features/techsource_availability_for_responsible_body_spec.rb
+++ b/spec/features/techsource_availability_for_responsible_body_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'TechSource availability for responsible body' do
+  include ViewHelper
+
+  let(:local_authority) { create(:local_authority, :in_devices_pilot) }
+  let(:la_user) { create(:local_authority_user, responsible_body: local_authority) }
+  let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: local_authority) }
+
+  after do
+    Timecop.return
+  end
+
+  scenario 'before the techsource maintenance window' do
+    given_it_is_before_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_la_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_a_warning_notice
+  end
+
+  scenario 'during the techsource maintenance window' do
+    given_it_is_during_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_la_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_a_warning_notice
+    when_i_click_the_start_now_button
+    then_i_see_a_service_unavailable_page
+  end
+
+  scenario 'after the techsource maintenance window' do
+    given_it_is_after_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_la_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_do_not_see_a_warning_notice
+  end
+
+  def given_i_am_signed_in_as_a_la_user
+    sign_in_as la_user
+  end
+
+  def given_i_can_order_devices
+    school.preorder_information.responsible_body_will_order_devices!
+    school.std_device_allocation.update!(cap: 50, allocation: 100, devices_ordered: 20)
+    school.can_order!
+  end
+
+  def when_i_visit_the_order_devices_page
+    visit responsible_body_devices_order_devices_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def given_it_is_before_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+  end
+
+  def given_it_is_during_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+  end
+
+  def given_it_is_after_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+  end
+
+  def then_i_see_a_warning_notice
+    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+  end
+
+  def then_i_do_not_see_a_warning_notice
+    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+  end
+
+  def when_i_click_the_start_now_button
+    click_on 'Start now'
+  end
+
+  def then_i_can_access_techsource
+    expect(page).to have_current_path(techsource_url)
+  end
+
+  def then_i_see_a_service_unavailable_page
+    expect(page).to have_current_path(techsource_start_path)
+    expect(page).to have_selector('h1', text: 'Sorry, TechSource is unavailable')
+  end
+end

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'TechSource availability for school' do
+  include ViewHelper
+
+  let(:school) { create(:school, :with_std_device_allocation) }
+  let(:school_user) { create(:school_user, school: school, full_name: 'AAA Smith') }
+
+  after do
+    Timecop.return
+  end
+
+  scenario 'before the techsource maintenance window' do
+    given_it_is_before_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_school_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_a_warning_notice
+  end
+
+  scenario 'during the techsource maintenance window' do
+    given_it_is_during_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_school_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_see_a_warning_notice
+    when_i_click_the_start_now_button
+    then_i_see_a_service_unavailable_page
+  end
+
+  scenario 'after the techsource maintenance window' do
+    given_it_is_after_the_techsource_maintenance_window
+    given_i_am_signed_in_as_a_school_user
+    given_i_can_order_devices
+    when_i_visit_the_order_devices_page
+    then_i_do_not_see_a_warning_notice
+  end
+
+  def given_i_am_signed_in_as_a_school_user
+    sign_in_as school_user
+  end
+
+  def given_i_can_order_devices
+    school.std_device_allocation.update!(cap: 50, allocation: 100, devices_ordered: 20)
+    school.can_order!
+  end
+
+  def when_i_visit_the_order_devices_page
+    visit school_order_devices_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def given_it_is_before_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+  end
+
+  def given_it_is_during_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+  end
+
+  def given_it_is_after_the_techsource_maintenance_window
+    Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+  end
+
+  def then_i_see_a_warning_notice
+    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+  end
+
+  def then_i_do_not_see_a_warning_notice
+    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+  end
+
+  def when_i_click_the_start_now_button
+    click_on 'Start now'
+  end
+
+  def then_i_see_a_service_unavailable_page
+    expect(page).to have_current_path(techsource_start_path)
+    expect(page).to have_selector('h1', text: 'Sorry, TechSource is unavailable')
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/qXZ3BESe/689-inform-users-about-ccs-downtime-on-saturday-26th-sept)
Add warning banner and 'service unavailable' page on order devices pages

### Changes proposed in this pull request
Add warning banner to devices ordering pages for RBs and Schools visible until Sunday 27 Sept.
Add service unavailable page that the 'Start now' button will send the user if clicked during maintenance window on Saturday 26 Sept.

### Guidance to review
![image](https://user-images.githubusercontent.com/333931/94181433-65396b00-fe97-11ea-9a99-aaa189da4a46.png)
![image](https://user-images.githubusercontent.com/333931/94181689-c06b5d80-fe97-11ea-84ff-ce4bb8893625.png)
![image](https://user-images.githubusercontent.com/333931/94181533-8ac67480-fe97-11ea-9737-0999a604bd2a.png)

