### PR TITLE
718 refactor & simplify user_change generation

### DIFF
--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -2,10 +2,104 @@ module Computacenter
   class UserChange < ApplicationRecord
     self.table_name = 'computacenter_user_changes'
 
+    CSV_ATTRIBUTES = %i[
+      first_name
+      last_name
+      email_address
+      telephone
+      responsible_body
+      responsible_body_urn
+      cc_sold_to_number
+      school
+      school_urn
+      cc_ship_to_number
+    ]
+
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }
 
     def self.read_from_version(version)
       UserChangeGenerator.new(version).call
     end
+
+    def self.for_user(user)
+      last_change_for_user = last_for(user)
+      if change_needed?(user)
+        change = new(consolidated_attributes_for(user))
+        change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
+        change
+      end
+    end
+
+    def self.consolidated_attributes_for(user)
+      computacenter_attributes_for(user)\
+        .merge(meta_attributes_for(user)
+        .merge(type_of_update: type_of_update(user)))
+    end
+
+    def self.change_needed?(user)
+      (user.relevant_to_computacenter? && (user.destroyed? || computacenter_fields_have_changed?(user))) || \
+        (last_for(user).present? && !user.relevant_to_computacenter?)
+    end
+
+    def self.computacenter_fields_have_changed?(user)
+      computacenter_attributes_for(user) != last_for(user)&.computacenter_attributes
+    end
+
+    def self.computacenter_attributes_for(user)
+      attrs = {
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email_address: user.email_address,
+        telephone: user.telephone,
+        responsible_body: user.effective_responsible_body&.name,
+        responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
+        cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
+        school: (user.hybrid? ? '' : user.school&.name),
+        school_urn: (user.hybrid? ? '' : user.school&.urn),
+        cc_ship_to_number: (user.hybrid? ? '' : user.school&.computacenter_reference),
+      }
+    end
+
+    def self.meta_attributes_for(user)
+      {
+        user_id: user.id,
+        updated_at_timestamp: user.updated_at,
+        type_of_update: type_of_update(user),
+      }
+    end
+
+    def self.type_of_update(user)
+      if last_for(user).present?
+        if user.relevant_to_computacenter? && !user.destroyed?
+          'Change'
+        else
+          'Remove'
+        end
+      else
+        'New'
+      end
+    end
+
+    def self.last_for(user)
+      Computacenter::UserChange.where(user_id: user.id)
+                               .order(:updated_at_timestamp)
+                               .last
+    end
+
+    def is_different_to?(user_change)
+      user_change.computacenter_attributes != computacenter_attributes
+    end
+
+    def computacenter_attributes
+      attributes.symbolize_keys.select { |k,v| CSV_ATTRIBUTES.include?(k) }
+    end
+
+    def add_original_fields_from(change)
+      assign_attributes(
+        change.computacenter_attributes&.transform_keys { |k| "original_#{k.to_s}".to_sym }
+      )
+      self
+    end
+
   end
 end

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -13,77 +13,14 @@ module Computacenter
       school
       school_urn
       cc_ship_to_number
-    ]
+    ].freeze
 
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }
 
-    def self.read_from_version(version)
-      UserChangeGenerator.new(version).call
-    end
-
-    def self.for_user(user)
-      last_change_for_user = last_for(user)
-      if change_needed?(user)
-        change = new(consolidated_attributes_for(user))
-        change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
-        change
-      end
-    end
-
-    def self.consolidated_attributes_for(user)
-      computacenter_attributes_for(user)\
-        .merge(meta_attributes_for(user)
-        .merge(type_of_update: type_of_update(user)))
-    end
-
-    def self.change_needed?(user)
-      (user.relevant_to_computacenter? && (user.destroyed? || computacenter_fields_have_changed?(user))) || \
-        (last_for(user).present? && !user.relevant_to_computacenter?)
-    end
-
-    def self.computacenter_fields_have_changed?(user)
-      computacenter_attributes_for(user) != last_for(user)&.computacenter_attributes
-    end
-
-    def self.computacenter_attributes_for(user)
-      attrs = {
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email_address: user.email_address,
-        telephone: user.telephone,
-        responsible_body: user.effective_responsible_body&.name,
-        responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
-        cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
-        school: (user.hybrid? ? '' : user.school&.name),
-        school_urn: (user.hybrid? ? '' : user.school&.urn),
-        cc_ship_to_number: (user.hybrid? ? '' : user.school&.computacenter_reference),
-      }
-    end
-
-    def self.meta_attributes_for(user)
-      {
-        user_id: user.id,
-        updated_at_timestamp: user.updated_at,
-        type_of_update: type_of_update(user),
-      }
-    end
-
-    def self.type_of_update(user)
-      if last_for(user).present?
-        if user.relevant_to_computacenter? && !user.destroyed?
-          'Change'
-        else
-          'Remove'
-        end
-      else
-        'New'
-      end
-    end
-
     def self.last_for(user)
-      Computacenter::UserChange.where(user_id: user.id)
-                               .order(:updated_at_timestamp)
-                               .last
+      where(user_id: user.id)
+        .order(:updated_at_timestamp)
+        .last
     end
 
     def is_different_to?(user_change)
@@ -91,15 +28,14 @@ module Computacenter
     end
 
     def computacenter_attributes
-      attributes.symbolize_keys.select { |k,v| CSV_ATTRIBUTES.include?(k) }
+      attributes.symbolize_keys.select { |k, _| CSV_ATTRIBUTES.include?(k) }
     end
 
     def add_original_fields_from(change)
       assign_attributes(
-        change.computacenter_attributes&.transform_keys { |k| "original_#{k.to_s}".to_sym }
+        change.computacenter_attributes&.transform_keys { |k| "original_#{k}".to_sym },
       )
       self
     end
-
   end
 end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -1,12 +1,11 @@
 class Computacenter::UserChangeGenerator
-  attr_reader :user, :last_change_for_user
+  attr_reader :user
 
   def initialize(user)
     @user = user
   end
 
   def generate!
-    @last_change_for_user = Computacenter::UserChange.last_for(user)
     if change_needed?
       change = Computacenter::UserChange.new(consolidated_attributes)
       change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
@@ -16,6 +15,10 @@ class Computacenter::UserChangeGenerator
   end
 
 private
+
+  def last_change_for_user
+    @last_change_for_user ||= Computacenter::UserChange.last_for(user)
+  end
 
   def consolidated_attributes
     computacenter_attributes\

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -1,194 +1,81 @@
 class Computacenter::UserChangeGenerator
-  attr_reader :version
+  attr_reader :user, :last_change_for_user
 
-  def initialize(version)
-    @version = version
+  def initialize(user)
+    @user = user
   end
 
-  def call
-    return if version.nil?
-
-    case type_of_update
-    when 'New'
-      return unless after_user.relevant_to_computacenter?
-    when 'Change'
-      return unless after_user.relevant_to_computacenter?
-    when 'Remove'
-      return unless before_user.relevant_to_computacenter?
+  def generate!
+    @last_change_for_user = Computacenter::UserChange.last_for(user)
+    if change_needed?
+      change = Computacenter::UserChange.new(consolidated_attributes)
+      change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
+      change.save!
+      change
     end
-
-    return if (version.changeset.keys & fields_to_monitor).empty?
-
-    Computacenter::UserChange.create!(user_change_attributes)
   end
 
 private
 
-  def strip_hybrid_fields!(hash)
-    if before_user.hybrid? || after_user.hybrid?
-      hash.delete(:school)
-      hash.delete(:school_urn)
-      hash.delete(:cc_ship_to_number)
-    end
+  def consolidated_attributes
+    computacenter_attributes\
+      .merge(meta_attributes)
+      .merge(type_of_update: type_of_update)
   end
 
-  def user_change_attributes
-    hash = meta_csv_attributes.merge(current_csv_fields).merge(original_csv_fields)
-    strip_hybrid_fields!(hash)
-    hash
+  def change_needed?
+    is_addition? || is_removal? || (is_change? && computacenter_fields_have_changed?)
   end
 
-  def current_csv_fields
+  def is_addition?
+    user.relevant_to_computacenter? && last_change_for_user.nil?
+  end
+
+  def is_change?
+    last_change_for_user.present? && \
+      user.relevant_to_computacenter? && \
+      !user.destroyed?
+  end
+
+  def is_removal?
+    (last_change_for_user.present? && !user.relevant_to_computacenter?) || \
+      (user.relevant_to_computacenter? && user.destroyed?)
+  end
+
+  def computacenter_fields_have_changed?
+    computacenter_attributes != last_change_for_user&.computacenter_attributes
+  end
+
+  def computacenter_attributes
     {
-      first_name: after_user.first_name,
-      last_name: after_user.last_name,
-      email_address: after_user.email_address,
-      telephone: after_user.telephone,
-      responsible_body: after_user.effective_responsible_body&.name,
-      responsible_body_urn: after_user.effective_responsible_body&.computacenter_identifier,
-      cc_sold_to_number: after_user.effective_responsible_body&.computacenter_reference,
-      school: after_user.school&.name,
-      school_urn: after_user.school&.urn,
-      cc_ship_to_number: after_user.school&.computacenter_reference,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      email_address: user.email_address,
+      telephone: user.telephone,
+      responsible_body: user.effective_responsible_body&.name,
+      responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
+      cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
+      school: (user.hybrid? ? '' : user.school&.name),
+      school_urn: (user.hybrid? ? '' : user.school&.urn),
+      cc_ship_to_number: (user.hybrid? ? '' : user.school&.computacenter_reference),
     }
   end
 
-  def meta_csv_attributes
+  def meta_attributes
     {
-      user_id: version.item_id,
-      updated_at_timestamp: version.created_at,
+      user_id: user.id,
+      updated_at_timestamp: user.updated_at,
       type_of_update: type_of_update,
     }
   end
 
-  def fields_to_diff
-    %w[
-      full_name
-      telephone
-      email_address
-      responsible_body_id
-      school_id
-    ]
-  end
-
-  def fields_to_monitor
-    %w[
-      full_name
-      telephone
-      email_address
-      responsible_body_id
-      school_id
-      privacy_notice_seen_at
-      orders_devices
-    ]
-  end
-
-  def original_attributes
-    case type_of_update
-    when 'New'
-      {}
-    when 'Change'
-      original = version.changeset.transform_values(&:first).to_h
-      diffable_attributes_and_values(original)
-    when 'Remove'
-      original = version.object_deserialized
-      diffable_attributes_and_values(original)
-    end
-  end
-
-  def diffable_attributes_and_values(user_hash)
-    user_hash.filter { |k, _| fields_to_diff.include?(k) }.select { |_k, v| v }
-  end
-
-  def original_csv_fields
-    hash = original_attributes
-
-    expand_full_name_changes(hash)
-    expand_responsible_body_changes(hash)
-    expand_school_changes(hash)
-
-    hash.transform_keys! { |k| "original_#{k}" }
-
-    hash
-  end
-
-  def expand_full_name_changes(hash)
-    if hash.key?('full_name')
-      hash['first_name'] = before_user.first_name
-      hash['last_name'] = before_user.last_name
-
-      hash.delete('full_name')
-    end
-  end
-
-  def expand_responsible_body_changes(hash)
-    if hash.key?('responsible_body_id')
-      responsible_body = ResponsibleBody.find(hash['responsible_body_id'])
-
-      if responsible_body
-        hash['responsible_body'] = responsible_body.name
-        hash['responsible_body_urn'] = responsible_body.computacenter_identifier
-        hash['cc_sold_to_number'] = responsible_body.computacenter_reference
-      end
-
-      hash.delete('responsible_body_id')
-    end
-  end
-
-  def expand_school_changes(hash)
-    if hash.key?('school_id')
-      school = School.find(hash['school_id'])
-
-      if school
-        hash['school'] = school.name
-        hash['school_urn'] = school.urn
-        hash['cc_ship_to_number'] = school.computacenter_reference
-      end
-
-      hash.delete('school_id')
-    end
-  end
-
-  def before_user
-    @before_user ||= case version.event
-                     when 'create'
-                       User.new
-                     when 'update', 'destroy'
-                       User.new(version.object_deserialized)
-                     end
-  end
-
-  def after_user
-    @after_user ||= User.new(after_user_attributes)
-  end
-
-  def after_user_attributes
-    if version.event == 'create'
-      version.changeset.transform_values(&:last)
-    elsif version.event == 'destroy' || version.changeset['orders_devices'] == [true, false]
-      {}
-    elsif version.event == 'update'
-      version.object_deserialized.merge(version.changeset.transform_values(&:last))
-    end
-  end
-
   def type_of_update
-    if Computacenter::UserChange.where(user_id: (before_user.id || after_user.id)).exists?
-      if is_removal?
-        'Remove'
-      else
-        'Change'
-      end
+    if is_change?
+      'Change'
+    elsif is_removal?
+      'Remove'
     else
       'New'
     end
-  end
-
-  def is_removal?
-    version.event == 'destroy' || (
-      version.event == 'update' && \
-      before_user.relevant_to_computacenter? && \
-      !after_user.relevant_to_computacenter?
-    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,11 +39,11 @@ class User < ApplicationRecord
   include SignInWithToken
 
   after_save do |user|
-    Computacenter::UserChange.read_from_version(user.versions.last)
+    Computacenter::UserChange.for_user(user)&.save!
   end
 
   after_destroy do |user|
-    Computacenter::UserChange.read_from_version(user.versions.last)
+    Computacenter::UserChange.for_user(user)&.save!
   end
 
   def is_mno_user?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,11 +39,11 @@ class User < ApplicationRecord
   include SignInWithToken
 
   after_save do |user|
-    Computacenter::UserChange.for_user(user)&.save!
+    Computacenter::UserChangeGenerator.new(user).generate!
   end
 
   after_destroy do |user|
-    Computacenter::UserChange.for_user(user)&.save!
+    Computacenter::UserChangeGenerator.new(user).generate!
   end
 
   def is_mno_user?

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -3,12 +3,17 @@ require 'rails_helper'
 RSpec.describe Computacenter::BackfillLedger do
   subject(:service) { described_class.new }
 
+  before do
+    Computacenter::UserChange.delete_all
+  end
+
   describe '#call when not initalized with given users' do
     context 'happy path' do
-      let!(:user) { create(:local_authority_user, orders_devices: true) }
+      let!(:user) { create(:local_authority_user, :has_seen_privacy_notice, orders_devices: true) }
       let(:now) { Time.zone.now.utc }
 
       it 'persists user to ledger' do
+        Computacenter::UserChange.delete_all
         expect { service.call }.to change(Computacenter::UserChange, :count).by(1)
       end
 
@@ -48,6 +53,7 @@ RSpec.describe Computacenter::BackfillLedger do
     context 'calling backfill multiple times' do
       before do
         create(:local_authority_user, orders_devices: true)
+        Computacenter::UserChange.delete_all
       end
 
       it 'does not persist multiple times' do
@@ -91,6 +97,7 @@ RSpec.describe Computacenter::BackfillLedger do
       create_list(:user, 2, school: school, orders_devices: true)
       other_responsible_body = create(:local_authority)
       create_list(:user, 5, :has_seen_privacy_notice, orders_devices: true, responsible_body: other_responsible_body)
+      Computacenter::UserChange.delete_all
     end
 
     it 'backfills the ledger with just the given users' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -450,11 +450,11 @@ RSpec.describe User, type: :model do
             expect(user_change.type_of_update).to eql('Remove')
           end
 
-          it 'sets all current fields to blank' do
+          it 'sets all current fields' do
             perform_change!
 
             user_change = Computacenter::UserChange.last
-            expect(user_change.email_address).to be_nil
+            expect(user_change.email_address).to eql(user.email_address)
           end
 
           it 'sets all original fields' do
@@ -627,7 +627,7 @@ RSpec.describe User, type: :model do
           user.destroy!
 
           user_change = Computacenter::UserChange.last
-          expect(user_change.email_address).to be_nil
+          expect(user_change.email_address).to eql(user.email_address)
         end
 
         it 'sets all original fields' do


### PR DESCRIPTION
### Context

A necessary precursor of [Trello card 718  - Handle multiple schools in an MVP way](https://trello.com/c/aYQOz3QB/718-spike-handle-multiple-schools-in-a-minimum-viable-way). This will enable us to trigger `Computacenter::UserChange` generation from a future `UserSchool` association. Also simplifies implementation of [700 - Send UserChanges to Computacenter's ServiceNow API](https://trello.com/c/mYNXeNHI/700-send-user-changes-to-computacenters-servicenow-api).

### Changes proposed in this pull request

* Generate `Computacenter::UserChange` records directly, rather than from Papertrail versions
* Determine whether a UserChange is needed (and if so what type) by looking at existing UserChange records, rather than the previous state of the User record
* All expectations of the UserChange attributes stay the same as now, except for one - a 'Remove' type no longer has all of the current attributes blanked out (after a call with Computacenter, we believe this will make it easier for them to process)

Also note that UserChange generation in specs is now _independent_ of whether Papertrail's versioning is on or off. This only affects specs which are actively testing the UserChange generation, where I've had to explicitly delete existing UserChanges after creating users.

### Guidance to review

