### PR TITLE
[737] Support can search schools by URN

### DIFF
--- a/app/components/nav_component.rb
+++ b/app/components/nav_component.rb
@@ -37,6 +37,7 @@ class NavComponent < ViewComponent::Base
     [
       NavLinkComponent.new(title: 'Performance', url: support_devices_service_performance_path),
       NavLinkComponent.new(title: 'RBs', url: support_devices_responsible_bodies_path),
+      NavLinkComponent.new(title: 'Schools', url: search_support_devices_schools_path),
       NavLinkComponent.new(title: 'Full allocations', url: new_support_devices_school_bulk_allocation_path),
     ]
   end

--- a/app/controllers/support/devices/schools_controller.rb
+++ b/app/controllers/support/devices/schools_controller.rb
@@ -1,5 +1,12 @@
 class Support::Devices::SchoolsController < Support::BaseController
-  def index; end
+  def search
+    @search_form = BulkUrnSearchForm.new
+  end
+
+  def results
+    @search_form = BulkUrnSearchForm.new(search_params)
+    @schools = @search_form.schools
+  end
 
   def show
     @school = School.find_by!(urn: params[:urn])
@@ -25,5 +32,11 @@ class Support::Devices::SchoolsController < Support::BaseController
       flash[:warning] = I18n.t('support.schools.invite.failure', name: school.name)
     end
     redirect_to support_devices_responsible_body_path(school.responsible_body)
+  end
+
+private
+
+  def search_params
+    params.require(:bulk_urn_search_form).permit(:urns)
   end
 end

--- a/app/form_objects/bulk_urn_search_form.rb
+++ b/app/form_objects/bulk_urn_search_form.rb
@@ -1,0 +1,29 @@
+class BulkUrnSearchForm
+  include ActiveModel::Model
+
+  attr_accessor :urns
+
+  def array_of_urns
+    @array_of_urns ||= urns.split("\r\n").map(&:strip).reject(&:blank?)
+  end
+
+  def request_count
+    array_of_urns.size
+  end
+
+  def missing_count
+    request_count - result_count
+  end
+
+  def result_count
+    schools.count
+  end
+
+  def schools
+    @schools ||= School.where(urn: array_of_urns)
+  end
+
+  def missing_urns
+    array_of_urns - schools.pluck(:urn).map(&:to_s)
+  end
+end

--- a/app/views/support/devices/schools/results.html.erb
+++ b/app/views/support/devices/schools/results.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title, t('page_titles.support.devices.schools.results') %>
+<% content_for :before_content, govuk_link_to('Back', search_support_devices_schools_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.support.devices.schools.results') %>
+    </h1>
+
+    <p class="govuk-body">You searched for <%= @search_form.request_count %> <%= 'schools'.pluralize(@search_form.request_count) %> and we found <%= @search_form.result_count %> <%= 'schools'.pluralize(@search_form.result_count) %></p>
+
+    <% if @search_form.missing_urns.any? %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= "#{@search_form.missing_count} #{'error'.pluralize(@search_form.missing_count)} found" %></h2>
+
+      <div class="govuk-form-group--error">
+        <p class="govuk-error-message">Fix the errors in your search and try again</p>
+
+        <table class="govuk-table requests-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header">URN</th>
+              <th class="govuk-table__header">Error</th>
+            </tr>
+          </thead>
+
+          <tbody class="govuk-table__body">
+            <% @search_form.missing_urns.each do |urn| %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  <%= urn %>
+                </td>
+                <td class="govuk-table__cell">
+                  <span class="govuk-error-message govuk-!-margin-bottom-0">No school with this URN could be found</span>
+                </td>
+              </tr>
+            <%- end %>
+          </tbody>
+        </table>
+      </div>
+    <%- end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if @schools.present? %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">URN</th>
+            <th scope="col" class="govuk-table__header">School</th>
+            <th scope="col" class="govuk-table__header">Responsible body</th>
+            <th scope="col" class="govuk-table__header">Establishment type</th>
+            <th scope="col" class="govuk-table__header">Who is ordering</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @schools.each do |school| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= school.urn %></th>
+              <td class="govuk-table__cell"><%= link_to school.name, support_devices_school_path(urn: school.urn) %></td>
+              <td class="govuk-table__cell"><%= link_to school.responsible_body.name, support_devices_responsible_body_path(id: school.responsible_body_id) %></td>
+              <td class="govuk-table__cell"><%= school.establishment_type.humanize %></td>
+              <td class="govuk-table__cell"><%= school&.preorder_information&.who_will_order_devices %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+
+    <%= govuk_button_link_to 'Perform another search', search_support_devices_schools_path, classes: 'govuk-!-margin-top-4' %>
+  </div>
+</div>

--- a/app/views/support/devices/schools/search.html.erb
+++ b/app/views/support/devices/schools/search.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('page_titles.support.devices.schools.search') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.support.devices.schools.search') %>
+    </h1>
+
+    <p class="govuk-body">Search for schools by entering their URNs. Use one line per URN.</p>
+
+    <%= form_with model: @search_form, url: results_support_devices_schools_path do |f| %>
+      <%= f.govuk_text_area :urns,
+                            label: { text: 'URNs', size: 'm' },
+                            rows: 12 %>
+
+      <%= f.govuk_submit 'Search' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,11 @@
     internet_service_performance: Internet service performance
     service_performance: Service performance
     accessibility: Accessibility statement
+    support:
+      devices:
+        schools:
+          search: Search for schools by URN
+          results: School search results
     support_devices_responsible_bodies: Devices pilot on-boarded responsible bodies
     support_internet_responsible_bodies: Internet pilot on-boarded responsible bodies
     support_responsible_bodies: On-boarded responsible bodies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,10 @@ Rails.application.routes.draw do
             put :set_as_school_contact, path: 'set-as-school-contact'
           end
         end
+        collection do
+          get 'search'
+          post 'results'
+        end
         get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
         post '/invite', to: 'schools#invite'
         get '/enable-orders', to: 'order_status#edit', as: :enable_orders

--- a/spec/controllers/support/devices/schools_controller_spec.rb
+++ b/spec/controllers/support/devices/schools_controller_spec.rb
@@ -2,6 +2,36 @@ require 'rails_helper'
 
 RSpec.describe Support::Devices::SchoolsController, type: :controller do
   let(:school) { create(:school, name: 'Alpha School') }
+  let(:another_school) { create(:school, name: 'Beta School') }
+  let(:support_user) { create(:support_user) }
+
+  describe '#search' do
+    before do
+      sign_in_as support_user
+    end
+
+    it 'responds successfully' do
+      get :search
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#results' do
+    before do
+      sign_in_as support_user
+    end
+
+    it 'renders results' do
+      allow(School).to receive(:where)
+
+      post :results, params: { bulk_urn_search_form: { urns: "#{school.urn}\r\n#{another_school.urn}" } }
+
+      expect(School).to have_received(:where).with(urn: [school.urn.to_s, another_school.urn.to_s])
+
+      expect(response).to be_successful
+      expect(response).to render_template('results')
+    end
+  end
 
   describe 'show' do
     it 'is forbidden for MNO users' do

--- a/spec/form_objects/bulk_urn_search_form_spec.rb
+++ b/spec/form_objects/bulk_urn_search_form_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe BulkUrnSearchForm do
+  let(:school) { create(:school) }
+
+  describe '#array_of_urns' do
+    subject(:form) do
+      described_class.new(urns: "   123  \r\ \r\n456\r\n")
+    end
+
+    it 'returns correct array of urns' do
+      expect(form.array_of_urns).to eql(%w[123 456])
+    end
+  end
+
+  describe '#missing_urns' do
+    subject(:form) do
+      described_class.new(urns: "   #{school.urn}  \r\ \r\n456\r\n")
+    end
+
+    it 'returns array of urns with no matches' do
+      expect(form.missing_urns).to eql(%w[456])
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/0RnBhnLD/737-lockdown-dashboard

### Changes proposed in this pull request

- Add schools to nav header which links to school search
- Able to search for schools via list of URNS
- This has not been added to `index` as it needs to handle the form and the `POST` and use of query params I feel would have been a fiddly path to go down

#### Header

![image](https://user-images.githubusercontent.com/92580/94291888-1ac9f400-ff54-11ea-917f-cf2082b512e5.png)

#### Search form

![image](https://user-images.githubusercontent.com/92580/94291976-3cc37680-ff54-11ea-995c-62b6c95d7375.png)

#### Search results

![image](https://user-images.githubusercontent.com/92580/94292147-77c5aa00-ff54-11ea-9f10-76d1069f5094.png)

### Guidance to review

- Login as support user
- Click on schools in the nav
- Paste a list of URNs into search form with valid and invalid URNs
- Should see search results