### PR TITLE
718 mvp multiple schools

### DIFF
--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -39,5 +39,15 @@ module Computacenter
       )
       self
     end
+
+    def self.for_destroyed_user(user)
+    end
+
+    def self.for_new_user(user)
+    end
+
+    def self.for_updated_user(user)
+      
+    end
   end
 end

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -19,14 +19,21 @@ module Computacenter
 
     belongs_to :user, optional: true
 
-    def self.last_for(user)
-      where(user_id: user.id)
-        .order(:updated_at_timestamp)
-        .last
+    scope :for_user, ->(user) { where(user_id: user.id) }
+
+    def self.latest_for_user(user)
+      # when we have multiple UserChanges created in one transaction (e.g. for
+      # creating a user and assigning a school), they both get the user.updated_at
+      # as updated_at_timestamp. So we need a tie-breaker in that case:
+      for_user(user).order(updated_at_timestamp: :asc, created_at: :asc).last
     end
 
     def is_different_to?(user_change)
       user_change.computacenter_attributes != computacenter_attributes
+    end
+
+    def differences_from(user_change)
+      computacenter_attributes.reject { |k, v| v == user_change.computacenter_attributes[k] }
     end
 
     def computacenter_attributes
@@ -38,100 +45,6 @@ module Computacenter
         change.computacenter_attributes&.transform_keys { |k| "original_#{k}".to_sym },
       )
       self
-    end
-
-    def self.for_deleted_user(user)
-      if user.relevant_to_computacenter?
-        # AR's previous_changes stores the last changes on an object, and
-        # *doesn't* clear them after the changes have been committed -
-        # so if a user is updated and then destroyed, we could get false
-        # changes showing up in the deletion UserChange.
-        # Fix: explicitly pass in before_user: user for a deletion
-        change = for_user(user: user, before_user: user)
-        change.type_of_update = 'Remove'
-        change
-      end
-    end
-
-    def self.for_saved_user(user)
-      if user.relevant_to_computacenter? || user_before_changes(user).relevant_to_computacenter?
-        if any_relevant_fields_have_changed?(user)
-          for_user(user: user)
-        end
-      end
-    end
-
-    def self.for_user_school(user_school)
-      user = user_school.user
-    end
-
-    def self.any_relevant_fields_have_changed?(user)
-      user.previous_changes.any? { |attr, _changes| fields_to_monitor.include?(attr.to_sym) }
-    end
-
-    def self.for_user(user:, before_user: nil)
-      before_user ||= user_before_changes(user)
-      change = new(
-        {
-          user_id: user.id,
-          updated_at_timestamp: user.updated_at,
-          type_of_update: type_of_update(user: user, before_user: before_user),
-        }.merge(user_fields(user))
-      )
-      change.assign_attributes(original_user_fields(before_user)) unless change.type_of_update == 'New'
-      change
-    end
-
-    def self.user_fields(user)
-      {
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email_address: user.email_address,
-        telephone: user.telephone,
-        responsible_body: user.effective_responsible_body&.name,
-        responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
-        cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
-        school: user.schools.map(&:name).join('|'),
-        school_urn: user.schools.map(&:urn).join('|'),
-        cc_ship_to_number: user.schools.map(&:computacenter_reference).join('|'),
-      }
-    end
-
-    def self.original_user_fields(before_user)
-      user_fields(before_user).transform_keys{ |k| "original_#{k}" }
-    end
-
-    def self.type_of_update(user:, before_user:)
-      if user.relevant_to_computacenter?
-        if before_user.relevant_to_computacenter?
-          'Change'
-        else
-          'New'
-        end
-      elsif before_user.relevant_to_computacenter?
-        'Remove'
-      end
-    end
-
-    def self.fields_to_monitor
-      %i[
-        full_name
-        telephone
-        email_address
-        responsible_body_id
-        privacy_notice_seen_at
-        orders_devices
-      ]
-    end
-
-    def self.user_before_changes(user)
-      if user.id_previously_changed? # => new record
-        before_user = User.new
-      else
-        before_user = user.dup
-        before_user.assign_attributes(user.previous_changes.transform_values(&:first))
-      end
-      before_user
     end
   end
 end

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -40,14 +40,98 @@ module Computacenter
       self
     end
 
-    def self.for_destroyed_user(user)
+    def self.for_deleted_user(user)
+      if user.relevant_to_computacenter?
+        # AR's previous_changes stores the last changes on an object, and
+        # *doesn't* clear them after the changes have been committed -
+        # so if a user is updated and then destroyed, we could get false
+        # changes showing up in the deletion UserChange.
+        # Fix: explicitly pass in before_user: user for a deletion
+        change = for_user(user: user, before_user: user)
+        change.type_of_update = 'Remove'
+        change
+      end
     end
 
-    def self.for_new_user(user)
+    def self.for_saved_user(user)
+      if user.relevant_to_computacenter? || user_before_changes(user).relevant_to_computacenter?
+        if any_relevant_fields_have_changed?(user)
+          for_user(user: user)
+        end
+      end
     end
 
-    def self.for_updated_user(user)
-      
+    def self.for_user_school(user_school)
+      user = user_school.user
+    end
+
+    def self.any_relevant_fields_have_changed?(user)
+      user.previous_changes.any? { |attr, _changes| fields_to_monitor.include?(attr.to_sym) }
+    end
+
+    def self.for_user(user:, before_user: nil)
+      before_user ||= user_before_changes(user)
+      change = new(
+        {
+          user_id: user.id,
+          updated_at_timestamp: user.updated_at,
+          type_of_update: type_of_update(user: user, before_user: before_user),
+        }.merge(user_fields(user))
+      )
+      change.assign_attributes(original_user_fields(before_user)) unless change.type_of_update == 'New'
+      change
+    end
+
+    def self.user_fields(user)
+      {
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email_address: user.email_address,
+        telephone: user.telephone,
+        responsible_body: user.effective_responsible_body&.name,
+        responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
+        cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
+        school: user.schools.map(&:name).join('|'),
+        school_urn: user.schools.map(&:urn).join('|'),
+        cc_ship_to_number: user.schools.map(&:computacenter_reference).join('|'),
+      }
+    end
+
+    def self.original_user_fields(before_user)
+      user_fields(before_user).transform_keys{ |k| "original_#{k}" }
+    end
+
+    def self.type_of_update(user:, before_user:)
+      if user.relevant_to_computacenter?
+        if before_user.relevant_to_computacenter?
+          'Change'
+        else
+          'New'
+        end
+      elsif before_user.relevant_to_computacenter?
+        'Remove'
+      end
+    end
+
+    def self.fields_to_monitor
+      %i[
+        full_name
+        telephone
+        email_address
+        responsible_body_id
+        privacy_notice_seen_at
+        orders_devices
+      ]
+    end
+
+    def self.user_before_changes(user)
+      if user.id_previously_changed? # => new record
+        before_user = User.new
+      else
+        before_user = user.dup
+        before_user.assign_attributes(user.previous_changes.transform_values(&:first))
+      end
+      before_user
     end
   end
 end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -17,7 +17,7 @@ class Computacenter::UserChangeGenerator
 private
 
   def last_change_for_user
-    @last_change_for_user ||= Computacenter::UserChange.last_for(user)
+    @last_change_for_user ||= Computacenter::UserChange.latest_for_user(user)
   end
 
   def consolidated_attributes
@@ -59,7 +59,7 @@ private
       responsible_body_urn: user.effective_responsible_body&.computacenter_identifier,
       cc_sold_to_number: user.effective_responsible_body&.computacenter_reference,
       school: (user.hybrid? ? '' : user.school&.name),
-      school_urn: (user.hybrid? ? '' : user.school&.urn),
+      school_urn: (user.hybrid? ? '' : user.school&.urn.to_s),
       cc_ship_to_number: (user.hybrid? ? '' : user.school&.computacenter_reference),
     }
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -5,7 +5,8 @@ class School < ApplicationRecord
   has_one    :coms_device_allocation, -> { where device_type: 'coms_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
-  has_many :users
+  has_many :user_schools
+  has_many :users, through: :user_schools
   has_one :preorder_information
 
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -95,7 +95,7 @@ private
     elsif @invite_user == 'yes'
       user_attrs = user_params(params)
 
-      @invited_user = school.users.build(user_attrs)
+      @invited_user = User.new(user_attrs.merge(school_id: school.id))
       if @invited_user.valid?
         save_and_invite_user!(@invited_user)
         @invited_user = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,9 +39,6 @@ class User < ApplicationRecord
 
   include SignInWithToken
 
-  attribute :school_id, :integer
-  attribute :relevant_to_computacenter, :boolean
-
   after_save do |user|
     Computacenter::UserChangeGenerator.new(user).generate!
   end
@@ -111,36 +108,16 @@ class User < ApplicationRecord
     responsible_body || school&.responsible_body
   end
 
-  def relevant_to_computacenter
+  def relevant_to_computacenter?
     seen_privacy_notice? && orders_devices?
   end
-  alias :relevant_to_computacenter? :relevant_to_computacenter
 
   def hybrid?
     school_id && responsible_body_id
   end
 
-  def hybrid_setup!
-    return if responsible_body.blank?
-
-    one_school = responsible_body.schools.count == 1
-    only_user = responsible_body.users == [self]
-
-    return unless one_school && only_user
-
-    school = responsible_body.schools.first
-
-    update!(school: school)
-    responsible_body.update_who_will_order_devices('schools')
-    contact = school.contacts.create!(email_address: email_address,
-                                      full_name: full_name,
-                                      role: :contact,
-                                      phone_number: telephone)
-    school.preorder_information.update!(school_contact: contact)
-  end
-
-  # Wrapper methods to ease the transition from user belongs_to school,
-  # to user has_many schools
+  # Wrapper methods to ease the transition from 'user belongs_to school',
+  # to 'user has_many schools'
   def school
     schools.first
   end
@@ -151,7 +128,7 @@ class User < ApplicationRecord
 
   def school_id=(new_school_id)
     user_schools.delete_all
-    user_schools.create(school_id: new_school_id) if new_school_id
+    schools << School.find(new_school_id) if new_school_id
   end
 
   def school=(new_school)

--- a/app/models/user_school.rb
+++ b/app/models/user_school.rb
@@ -1,0 +1,4 @@
+class UserSchool < ApplicationRecord
+  belongs_to :user
+  belongs_to :school
+end

--- a/app/models/user_school.rb
+++ b/app/models/user_school.rb
@@ -1,4 +1,21 @@
 class UserSchool < ApplicationRecord
   belongs_to :user
   belongs_to :school
+
+  after_save do |user_school|
+    # Need to reload to pick up the new school, otherwise the cached value
+    # from before the change will be used
+    Computacenter::UserChangeGenerator.new(user_school.user.reload).generate!
+    if user_school.saved_change_to_attribute?(:user_id)
+      previous_user_id = user_school.saved_change_to_attribute(:user_id).first
+      if previous_user_id
+        previous_user = User.find(previous_user_id)
+        Computacenter::UserChangeGenerator.new(previous_user).generate!
+      end
+    end
+  end
+
+  after_destroy do |user_school|
+    Computacenter::UserChangeGenerator.new(user_school.user.reload).generate!
+  end
 end

--- a/app/services/confirm_techsource_account_created_service.rb
+++ b/app/services/confirm_techsource_account_created_service.rb
@@ -35,10 +35,10 @@ private
   attr_writer :processed, :unprocessed
 
   def email_no_longer_computacenter_relevant(email)
-    Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email)&.Remove?
+    Computacenter::UserChange.order(updated_at_timestamp: :desc, created_at: :desc).find_by(original_email_address: email)&.Remove?
   end
 
   def user_based_on_previous_email(email)
-    Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email)&.user
+    Computacenter::UserChange.order(updated_at_timestamp: :desc, created_at: :desc).find_by(original_email_address: email)&.user
   end
 end

--- a/db/migrate/20200922130419_add_user_schools.rb
+++ b/db/migrate/20200922130419_add_user_schools.rb
@@ -1,0 +1,35 @@
+class AddUserSchools < ActiveRecord::Migration[6.0]
+  def up
+    create_table :user_schools do |t|
+      t.references :user
+      t.references :school
+      t.timestamps
+    end
+
+    populate_table_sql = <<~SQL
+      INSERT INTO user_schools(user_id, school_id, created_at, updated_at)
+      SELECT      id, school_id, NOW(), NOW()
+      FROM        users
+      WHERE       school_id IS NOT NULL
+    SQL
+
+    add_index :user_schools, %i[user_id school_id], unique: true
+    add_index :user_schools, %i[school_id user_id], unique: true
+
+    remove_column :users, :school_id
+  end
+
+  def down
+    add_reference :users, :school
+
+    populate_column_sql = <<~SQL
+      UPDATE  users
+      SET     school_id = (SELECT school_id FROM user_schools WHERE user_id = users.id)
+      WHERE   users.id IN (SELECT user_id FROM user_schools)
+    SQL
+
+    add_index :users, [:school_id, :full_name]
+
+    drop_table :user_schools
+  end
+end

--- a/db/migrate/20200922130419_add_user_schools.rb
+++ b/db/migrate/20200922130419_add_user_schools.rb
@@ -12,6 +12,7 @@ class AddUserSchools < ActiveRecord::Migration[6.0]
       FROM        users
       WHERE       school_id IS NOT NULL
     SQL
+    connection.execute populate_table_sql
 
     add_index :user_schools, %i[user_id school_id], unique: true
     add_index :user_schools, %i[school_id user_id], unique: true
@@ -27,8 +28,9 @@ class AddUserSchools < ActiveRecord::Migration[6.0]
       SET     school_id = (SELECT school_id FROM user_schools WHERE user_id = users.id)
       WHERE   users.id IN (SELECT user_id FROM user_schools)
     SQL
+    connection.execute populate_column_sql
 
-    add_index :users, [:school_id, :full_name]
+    add_index :users, %i[school_id full_name]
 
     drop_table :user_schools
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,10 +240,13 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
     t.boolean "orders_devices"
+    t.bigint "legacy_school_id"
     t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["legacy_school_id", "full_name"], name: "index_users_on_legacy_school_id_and_full_name"
+    t.index ["legacy_school_id"], name: "index_users_on_legacy_school_id"
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
-    t.integer "responsible_body_id", null: false
+    t.bigint "responsible_body_id", null: false
     t.string "contract_type"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"
@@ -212,6 +212,17 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "user_schools", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "school_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id", "user_id"], name: "index_user_schools_on_school_id_and_user_id", unique: true
+    t.index ["school_id"], name: "index_user_schools_on_school_id"
+    t.index ["user_id", "school_id"], name: "index_user_schools_on_user_id_and_school_id", unique: true
+    t.index ["user_id"], name: "index_user_schools_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "full_name"
     t.string "email_address"
@@ -228,7 +239,6 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.boolean "is_support", default: false, null: false
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
-    t.bigint "school_id"
     t.boolean "orders_devices"
     t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
@@ -236,7 +246,6 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
-    t.index ["school_id"], name: "index_users_on_school_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true
   end
 
@@ -259,5 +268,4 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
   add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "school_welcome_wizards", "users", column: "invited_user_id"
   add_foreign_key "schools", "responsible_bodies"
-  add_foreign_key "users", "schools"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.integer "created_by_user_id"
     t.boolean "agrees_with_privacy_statement"
     t.string "problem"
-    t.bigint "responsible_body_id", null: false
+    t.integer "responsible_body_id", null: false
     t.string "contract_type"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -54,11 +54,12 @@ FactoryBot.define do
 
     factory :school_user do
       transient do
-        school { nil }
+        school { build(:school) }
       end
       after(:build) do |user, evaluator|
-        user.schools << (evaluator.school || build(:school)) if user.schools.empty?
+        user.schools << evaluator.school if user.schools.empty? && evaluator.school.present?
       end
+
       orders_devices { false }
       has_completed_wizard
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -53,7 +53,12 @@ FactoryBot.define do
     end
 
     factory :school_user do
-      school
+      transient do
+        school { nil }
+      end
+      after(:build) do |user, evaluator|
+        user.schools << (evaluator.school || build(:school)) if user.schools.empty?
+      end
       orders_devices { false }
       has_completed_wizard
 

--- a/spec/models/computacenter/backfill_ledger_spec.rb
+++ b/spec/models/computacenter/backfill_ledger_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Computacenter::BackfillLedger do
         expect(user_change.responsible_body).to eql(user.effective_responsible_body.name)
         expect(user_change.responsible_body_urn).to eql(user.effective_responsible_body.computacenter_identifier)
         expect(user_change.cc_sold_to_number).to eql(user.effective_responsible_body.computacenter_reference)
-        expect(user_change.school).to eql(user.school&.name)
-        expect(user_change.school_urn).to eql(user.school&.urn)
-        expect(user_change.cc_ship_to_number).to eql(user.school&.computacenter_reference)
+        expect(user_change.school).to be_blank
+        expect(user_change.school_urn).to be_blank
+        expect(user_change.cc_ship_to_number).to be_blank
         expect(user_change.updated_at_timestamp).to be_within(1.second).of(now)
         expect(user_change.type_of_update).to eql('New')
         expect(user_change.original_first_name).to be(nil)

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
 
       it 'updates the preorder_information with the form details' do
         wizard.update_step!(request)
+        school.reload
         expect(school.preorder_information.will_need_chromebooks).to eq(request[:will_need_chromebooks])
         expect(school.preorder_information.school_or_rb_domain).to eq(request[:school_or_rb_domain])
         expect(school.preorder_information.recovery_email_address).to eq(request[:recovery_email_address])
@@ -228,7 +229,7 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
 
       it 'updates the preorder_information with the form details' do
         wizard.update_step!(request)
-        expect(school.preorder_information.will_need_chromebooks).to eq('no')
+        expect(school.preorder_information.reload.will_need_chromebooks).to eq('no')
       end
 
       it 'moves to the what_happens_next step' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -304,15 +304,15 @@ RSpec.describe User, type: :model do
           expect(user_change.updated_at_timestamp).to eql(user.created_at)
           expect(user_change.type_of_update).to eql('New')
           expect(user_change.original_email_address).to be_nil
-          expect(user_change.original_first_name).to be_nil
-          expect(user_change.original_last_name).to be_nil
+          expect(user_change.original_first_name).to be_blank
+          expect(user_change.original_last_name).to be_blank
           expect(user_change.original_telephone).to be_nil
           expect(user_change.original_responsible_body).to be_nil
           expect(user_change.original_responsible_body_urn).to be_nil
           expect(user_change.original_cc_sold_to_number).to be_nil
-          expect(user_change.original_school).to be_nil
-          expect(user_change.original_school_urn).to be_nil
-          expect(user_change.original_cc_ship_to_number).to be_nil
+          expect(user_change.original_school).to be_blank
+          expect(user_change.original_school_urn).to be_blank
+          expect(user_change.original_cc_ship_to_number).to be_blank
         end
 
         it 'persists correct data for school user' do
@@ -333,15 +333,15 @@ RSpec.describe User, type: :model do
           expect(user_change.updated_at_timestamp).to eql(user.created_at)
           expect(user_change.type_of_update).to eql('New')
           expect(user_change.original_email_address).to be_nil
-          expect(user_change.original_first_name).to be_nil
-          expect(user_change.original_last_name).to be_nil
+          expect(user_change.original_first_name).to be_blank
+          expect(user_change.original_last_name).to be_blank
           expect(user_change.original_telephone).to be_nil
           expect(user_change.original_responsible_body).to be_nil
           expect(user_change.original_responsible_body_urn).to be_nil
           expect(user_change.original_cc_sold_to_number).to be_nil
-          expect(user_change.original_school).to be_nil
-          expect(user_change.original_school_urn).to be_nil
-          expect(user_change.original_cc_ship_to_number).to be_nil
+          expect(user_change.original_school).to be_blank
+          expect(user_change.original_school_urn).to be_blank
+          expect(user_change.original_cc_ship_to_number).to be_blank
         end
       end
 
@@ -587,9 +587,9 @@ RSpec.describe User, type: :model do
             perform_change!
             user_change = Computacenter::UserChange.last
 
-            expect(user_change.original_school).to be_nil
-            expect(user_change.original_school_urn).to be_nil
-            expect(user_change.original_cc_ship_to_number).to be_nil
+            expect(user_change.original_school).to be_blank
+            expect(user_change.original_school_urn).to be_blank
+            expect(user_change.original_cc_ship_to_number).to be_blank
           end
 
           it 'stores correct current fields' do
@@ -622,13 +622,6 @@ RSpec.describe User, type: :model do
 
           user_change = Computacenter::UserChange.last
           expect(user_change.type_of_update).to eql('Remove')
-        end
-
-        it 'sets all current fields to blank' do
-          user.destroy!
-
-          user_change = Computacenter::UserChange.last
-          expect(user_change.email_address).to eql(user.email_address)
         end
 
         it 'sets all original fields' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -513,7 +513,8 @@ RSpec.describe User, type: :model do
           let!(:user) { create(:school_user, :relevant_to_computacenter, school: original_school) }
 
           def perform_change!
-            user.update(school: other_school)
+            user.school = other_school
+            user.save!
           end
 
           it 'creates a Computacenter::UserChange' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -513,8 +513,7 @@ RSpec.describe User, type: :model do
           let!(:user) { create(:school_user, :relevant_to_computacenter, school: original_school) }
 
           def perform_change!
-            user.school = other_school
-            user.save!
+            user.update!(school: other_school)
           end
 
           it 'creates a Computacenter::UserChange' do
@@ -586,7 +585,6 @@ RSpec.describe User, type: :model do
           it 'stores correct original fields' do
             perform_change!
             user_change = Computacenter::UserChange.last
-
             expect(user_change.original_school).to be_blank
             expect(user_change.original_school_urn).to be_blank
             expect(user_change.original_cc_ship_to_number).to be_blank


### PR DESCRIPTION
### Context

See [Trello Card 718](https://trello.com/c/aYQOz3QB/718-spike-handle-multiple-schools-in-a-minimum-viable-way). We urgently need to support users who genuinely administer multiple schools, but the work involved in supporting that impacts lots of areas where the code and the interface implicitly assume that a user can have only one school. So we're iterating towards full support in several smaller steps which can be reviewed and merged independently.

### Changes proposed in this pull request

This PR does the bare minimum needed to get the model changed to support multiple schools. There are no interface changes - those can come as a separate dedicated PR later.

* Replace `user belongs_to :school` with `user has_many :user_schools / has_many :schools, through: :user_schools`
* Add adapter methods `school / school=` and `school_id / school_id=` to `User`, which maintain compatibility with the rest of the code and just take the first record from the `schools` association

Further smaller PRs can take on the task of making bits of the code genuinely support multiple schools - for instance, the UserChangeGenerator still uses `user.school&.urn` etc. It will be a pretty straightforward change to extend that to `user.schools.map(&:urn).join('|')` and so on - but I wanted to keep _this_ PR as small as possible 

### Guidance to review

Please pay particular attention to the migration which populates the `user_schools` table from existing data. 
It would be a good idea to dump out a list of existing user_id / school_id pairs before and after running the migration to make sure that it has maintained all existing relationships correctly (for instance, with a command like `User.where.not(school_id: nil).each { |user| puts "#{user.id}\t#{user.school_id}" }`)
