### PR TITLE
Fix link colour, make text consistent

### DIFF
--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -9,7 +9,7 @@
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
 
-    <p class="govuk-body">Now you’ve emailed us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order.</p>
+    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order.</p>
 
     <p class="govuk-body">You cannot order a school’s full allocation yet because there are no local coronavirus restrictions. The number of devices you can currently place for each school is shown.</p>
 

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <p class="govuk-body">Now you’ve contacted us to <%= link_to 'request devices for specific circumstances', school_request_devices_path %>, you can go ahead with your order.</p>
+    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', school_request_devices_path %>, you can go ahead with your order.</p>
 
     <p class="govuk-body">You cannot order your full allocation yet because there are no local coronavirus restrictions.</p>
 


### PR DESCRIPTION
- Use the govuk_link_to helper so link is the right blue
- Make both messages say "contacted" rather than "emailed"