### PR TITLE
Chromebook form content changes

### DIFF
--- a/app/views/responsible_body/devices/chromebook_information/edit.html.erb
+++ b/app/views/responsible_body/devices/chromebook_information/edit.html.erb
@@ -9,7 +9,6 @@
       <%= title %>
     </h1>
 
-    <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
     <%= render partial: 'shared/chromebook_information_intro' %>
     <%= render partial: 'shared/chromebook_information_form', locals: { url: responsible_body_devices_school_chromebooks_path(@school.urn), form_object: @chromebook_information_form } %>
   </div>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -13,9 +13,12 @@
 
     <%- if @school.preorder_information.orders_managed_centrally? %>
       <%- unless @school.preorder_information.chromebook_information_complete? %>
-      <h2 class="govuk-heading-l">Will the school need Chromebooks?</h2>
-      <%= render partial: 'shared/chromebook_information_intro' %>
-      <%= render partial: 'shared/chromebook_information_form', locals: { url: responsible_body_devices_school_chromebooks_path(@school.urn), form_object: @chromebook_information_form } %>
+        <h2 class="govuk-heading-l">Before you can order, we need more information</h2>
+        <%= render partial: 'shared/chromebook_information_intro' %>
+        <%= render partial: 'shared/chromebook_information_form', locals: {
+          legend_text: 'Will the school’s order include Chromebooks?',
+          url: responsible_body_devices_school_chromebooks_path(@school.urn),
+          form_object: @chromebook_information_form } %>
       <%- end %>
     <%- end %>
   </div>

--- a/app/views/school/welcome_wizard/chromebooks.html.erb
+++ b/app/views/school/welcome_wizard/chromebooks.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/chromebook_information_intro', locals: { show_different_devices_text: true } %>
+    <p class="govuk-body">If you’re going to order Google Chromebooks, we need information to configure them before you place your order.</p>
     <%= render partial: 'shared/chromebook_information_form', locals: { url: school_welcome_wizard_path(step: @wizard.step), form_object: @wizard, show_i_dont_know_option: true, submit_label: 'Continue', scope: scope } %>
   </div>
 </div>

--- a/app/views/school/welcome_wizard/devices_you_can_order.html.erb
+++ b/app/views/school/welcome_wizard/devices_you_can_order.html.erb
@@ -9,13 +9,7 @@
       <p class="govuk-body">Your school will own the devices. It’s up to you to decide who will benefit most from them.</p>
 
       <p class="govuk-body">You can choose from:</p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Microsoft Windows laptop</li>
-        <li>Microsoft Windows tablet</li>
-        <li>Google Chromebook</li>
-        <li>Apple iPad</li>
-      </ul>
+      <%= render partial: 'shared/device_list' %>
 
       <p class="govuk-body govuk-!-margin-bottom-6"><%= link_to_devices_guidance_subpage 'Read more about the device specifications', 'device-specification', target: '_blank' %></p>
 

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -17,7 +17,7 @@
                               label: { text: "Recovery email address", size: 's' },
                               hint_text: "This email address must be on a different domain to the school domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." %>
       <p class="govuk-body govuk-!-margin-top-4">
-        If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
+        If you need help finding these details, email <%= ghwt_contact_mailto(subject: 'Chromebook details') %>
       </p>
     <%- end %>
     <%= f.govuk_radio_button  :will_need_chromebooks,

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -1,11 +1,12 @@
 <%-
   submit_label = local_assigns[:submit_label] || 'Save'
+  legend_text = local_assigns[:legend_text] || nil
   scope = local_assigns[:scope] || 'activerecord.attributes.preorder_information.will_need_chromebooks'
 %>
 <%= form_for local_assigns[:form_object], url: local_assigns[:url], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: nil } ) do %>
+  <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: { text: legend_text } ) do %>
     <%= f.govuk_radio_button  :will_need_chromebooks,
                               'yes',
                               label: { text: t(:yes, scope: scope) } do %>
@@ -15,6 +16,9 @@
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },
                               hint_text: "This email address must be on a different domain to the school domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." %>
+      <p class="govuk-body govuk-!-margin-top-4">
+        If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
+      </p>
     <%- end %>
     <%= f.govuk_radio_button  :will_need_chromebooks,
                               'no',

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -26,7 +26,9 @@
     <% if local_assigns[:show_i_dont_know_option] %>
       <%= f.govuk_radio_button :will_need_chromebooks,
                               'i_dont_know',
-                              label: { text: t(:i_dont_know, scope: scope) } %>
+                              label: { text: t(:i_dont_know, scope: scope) } do %>
+        <p class="govuk-body">You cannot place an order until you tell us whether you’ll be ordering Chromebooks or not</p>
+      <%- end %>
     <%- end %>
   <%- end %>
   <%= f.govuk_submit submit_label %>

--- a/app/views/shared/_chromebook_information_intro.html.erb
+++ b/app/views/shared/_chromebook_information_intro.html.erb
@@ -1,10 +1,5 @@
 <p class="govuk-body">When you order you can choose from these devices:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>Microsoft Windows laptop</li>
-  <li>Microsoft Windows tablet</li>
-  <li>Google Chromebook</li>
-  <li>Apple iPad</li>
-</ul>
+<%= render partial: 'shared/device_list' %>
 
 <p class="govuk-body">If you’re going to order Google Chromebooks, we need information to configure them before you place your order.</p>

--- a/app/views/shared/_chromebook_information_intro.html.erb
+++ b/app/views/shared/_chromebook_information_intro.html.erb
@@ -1,17 +1,10 @@
-<p class="govuk-body">
-<% if local_assigns[:show_different_devices_text] %>
-  It’s possible to order a range of different devices (laptops, tablets, Chromebooks).
-<%- end %>
-  If you are going to order Google Chromebooks, we’ll need 2 pieces of information to configure them:
-</p>
+<p class="govuk-body">When you order you can choose from these devices:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>the domain a school uses for its Google services</li>
-  <li>the school’s recovery email address</li>
+  <li>Microsoft Windows laptop</li>
+  <li>Microsoft Windows tablet</li>
+  <li>Google Chromebook</li>
+  <li>Apple iPad</li>
 </ul>
-<p class="govuk-body">
-  We need this information so we can secure the devices.
-</p>
-<p class="govuk-body">
-  If you need help finding these details, email <%= govuk_link_to('COVID.TECHNOLOGY@education.gov.uk', 'mailto:COVID.TECHNOLOGY@education.gov.uk') %>
-</p>
+
+<p class="govuk-body">If you’re going to order Google Chromebooks, we need information to configure them before you place your order.</p>

--- a/app/views/shared/_device_list.html.erb
+++ b/app/views/shared/_device_list.html.erb
@@ -1,0 +1,6 @@
+<ul class="govuk-list govuk-list--bullet">
+  <li>Microsoft Windows laptop</li>
+  <li>Microsoft Windows tablet</li>
+  <li>Google Chromebook</li>
+  <li>Apple iPad</li>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,8 +381,8 @@
           maybe_participating: 'May offer data when the service launches'
       preorder_information:
         will_need_chromebooks:
-          "yes": Yes, they will need Chromebooks
-          'no': No, they will not need Chromebooks
+          "yes": Yes, we will order Chromebooks
+          'no': No, we will not order Chromebooks
         status:
           needs_contact: Needs a contact
           needs_info: Needs information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,7 @@
       devices_you_can_order:
         title: You can order a range of laptops and tablets
       chromebooks:
-        title: Will your school’s order include a request for Chromebooks?
+        title: Will your school’s order include Chromebooks?
         'yes': Yes, we will need Chromebooks
         'no': No, we do not need Chromebooks
         i_dont_know: I don’t know

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -41,7 +41,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details without links to change it' do
-      expect(result.css('.govuk-summary-list__row')[6].text).to include('Yes, they will need Chromebooks')
+      expect(result.css('.govuk-summary-list__row')[6].text).to include('Yes, we will order Chromebooks')
       expect(result.css('.govuk-summary-list__row')[7].text).to include('school.domain.org')
       expect(result.css('.govuk-summary-list__row')[8].text).to include('admin@recovery.org')
     end
@@ -118,7 +118,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details' do
-      expect(result.css('.govuk-summary-list__row')[5].text).to include('Yes, they will need Chromebooks')
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('Yes, we will order Chromebooks')
       expect(result.css('.govuk-summary-list__row')[6].text).to include('school.domain.org')
       expect(result.css('.govuk-summary-list__row')[7].text).to include('admin@recovery.org')
 

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -448,7 +448,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def when_i_choose_no_they_will_not_need_chromebooks
-    choose 'No, they will not need Chromebooks'
+    choose 'No, we will not order Chromebooks'
     click_on 'Save'
   end
 end

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_asks_me_if_the_school_will_need_chromebooks
-    expect(page).to have_content 'Will the school need Chromebooks?'
+    expect(page).to have_content 'Will the school’s order include Chromebooks?'
   end
 
   def when_i_choose_no_they_will_not_need_chromebooks

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def when_i_choose_no_they_will_not_need_chromebooks
-    choose 'No, they will not need Chromebooks'
+    choose 'No, we will not order Chromebooks'
   end
 
   def and_i_click_save
@@ -56,7 +56,7 @@ RSpec.feature 'Setting up the devices ordering' do
 
   def it_shows_me_that_they_will_not_need_chromebooks
     within('.govuk-summary-list') do
-      expect(page).to have_content 'No, they will not need Chromebooks'
+      expect(page).to have_content 'No, we will not order Chromebooks'
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_choose_yes_they_will_need_chromebooks
-    choose 'Yes, they will need Chromebooks'
+    choose 'Yes, we will order Chromebooks'
   end
 
   def it_shows_me_fields_for_domain_and_recovery_email_address

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -26,18 +26,18 @@ RSpec.feature 'Change school Chromebook information' do
       end
 
       it 'lets me choose Yes or No' do
-        expect(page).to have_field('Yes, they will need Chromebooks')
-        expect(page).to have_field('No, they will not need Chromebooks')
+        expect(page).to have_field('Yes, we will order Chromebooks')
+        expect(page).to have_field('No, we will not order Chromebooks')
       end
 
       it 'shows fields for domain and recovery email when I choose Yes' do
-        choose('Yes, they will need Chromebooks')
+        choose('Yes, we will order Chromebooks')
         expect(page).to have_field('School or local authority domain')
         expect(page).to have_field('Recovery email address')
       end
 
       it 'shows an error when I do not supply valid information' do
-        choose('Yes, they will need Chromebooks')
+        choose('Yes, we will order Chromebooks')
         fill_in('School or local authority domain', with: '')
         click_on 'Save'
         expect(page).to have_http_status(:unprocessable_entity)
@@ -45,7 +45,7 @@ RSpec.feature 'Change school Chromebook information' do
       end
 
       it 'goes back to the school details page when I save valid information' do
-        choose('Yes, they will need Chromebooks')
+        choose('Yes, we will order Chromebooks')
         fill_in('School or local authority domain', with: 'some.domain.org')
         fill_in('Recovery email address', with: 'someone@someotherdomain.org')
         click_on 'Save'

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def then_im_asked_whether_my_school_will_order_chromebooks
     expect(page).to have_current_path(school_welcome_wizard_chromebooks_path)
-    expect(page).to have_text('Will your school’s order include a request for Chromebooks?')
+    expect(page).to have_text('Will your school’s order include Chromebooks?')
   end
 
   def when_i_choose_yes_and_submit_the_chromebooks_form


### PR DESCRIPTION
### Context

Apply the content changes from https://ghwt-design-history.herokuapp.com/chromebook-iteration

Part of https://trello.com/c/k7ItZJIp/729-indicate-what-devices-are-available-to-rbs

The main change is that we now list all the devices on the Chromebooks form.