### PR TITLE
[751] TechSource confirmations handle extra cases

### DIFF
--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -17,6 +17,8 @@ module Computacenter
 
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }
 
+    belongs_to :user, optional: true
+
     def self.last_for(user)
       where(user_id: user.id)
         .order(:updated_at_timestamp)

--- a/app/services/confirm_techsource_account_created_service.rb
+++ b/app/services/confirm_techsource_account_created_service.rb
@@ -9,7 +9,7 @@ class ConfirmTechsourceAccountCreatedService
 
   def call
     emails.each do |email|
-      user = User.find_by(email_address: email)
+      user = User.find_by(email_address: email) || Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email).user
 
       if user
         if user.update(techsource_account_confirmed_at: Time.zone.now)

--- a/app/services/confirm_techsource_account_created_service.rb
+++ b/app/services/confirm_techsource_account_created_service.rb
@@ -9,7 +9,7 @@ class ConfirmTechsourceAccountCreatedService
 
   def call
     emails.each do |email|
-      user = User.find_by(email_address: email) || Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email).user
+      user = User.find_by(email_address: email) || user_based_on_previous_email(email)
 
       if user
         if user.update(techsource_account_confirmed_at: Time.zone.now)
@@ -17,6 +17,8 @@ class ConfirmTechsourceAccountCreatedService
         else
           unprocessed << { email: email, message: 'User could not be updated' }
         end
+      elsif email_no_longer_computacenter_relevant(email)
+        processed << { email: email }
       else
         unprocessed << { email: email, message: 'No user with this email found' }
       end
@@ -31,4 +33,12 @@ private
 
   attr_reader :emails
   attr_writer :processed, :unprocessed
+
+  def email_no_longer_computacenter_relevant(email)
+    Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email)&.Remove?
+  end
+
+  def user_based_on_previous_email(email)
+    Computacenter::UserChange.order(updated_at_timestamp: :desc).find_by(original_email_address: email)&.user
+  end
 end

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -47,5 +47,23 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
         expect(service.unprocessed).to include(email: 'nobody@example.com', message: 'No user with this email found')
       end
     end
+
+    context 'when user email has changed' do
+      let!(:user) do
+        create(:school_user, :relevant_to_computacenter, email_address: 'old@example.com')
+      end
+
+      before do
+        user.update(email_address: 'new@example.com')
+      end
+
+      subject(:service) { described_class.new(emails: ['old@example.com']) }
+
+      it 'updates user based on previous email' do
+        expect(user.techsource_account_confirmed_at).to be_falsey
+        service.call
+        expect(user.reload.techsource_account_confirmed_at).to be_truthy
+      end
+    end
   end
 end

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -65,5 +65,24 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
         expect(user.reload.techsource_account_confirmed_at).to be_truthy
       end
     end
+
+    context 'when user has been destroyed' do
+      let!(:user) do
+        create(:school_user, :relevant_to_computacenter)
+      end
+
+      before do
+        user.destroy!
+      end
+
+      subject(:service) { described_class.new(emails: [user.email_address]) }
+
+      it 'adds to processed list' do
+        service.call
+
+        expect(service.processed).to be_present
+        expect(service.unprocessed).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/8zERGQht/751-techsource-account-confirmation-fixes

### Changes proposed in this pull request

- Handle a case where by a user has recently changed email. When sent an old email we do a look up with the user change table and find the current user.
- Handle case of a user that is no longer computacenter relevant by checking if they were last removed from the user change table

### Guidance to review

#### Scenario 1

- Change a users email address
- Visit http://localhost:3000/computacenter/techsource
- Enter the users old email address
- User should now have `techsource_account_confirmed_at` set

#### Scenario 2

- Delete a computercenter relevant user
- Visit http://localhost:3000/computacenter/techsource
- Enter the deleted users email address
- Should not show as unprocessed and should show email as processed