### PR TITLE
[757] Support can add new school users

### DIFF
--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -8,7 +8,7 @@ class School::UsersController < School::BaseController
   end
 
   def create
-    @user = CreateUserService.invite_school_user(user_params.merge(school_id: @school.id))
+    @user = CreateUserService.invite_school_user(user_params.merge(school_id: @school.id, approved_at: Time.zone.now, orders_devices: true))
     if @user.persisted?
       redirect_to school_users_path
     else

--- a/app/controllers/support/devices/users_controller.rb
+++ b/app/controllers/support/devices/users_controller.rb
@@ -1,4 +1,20 @@
 class Support::Devices::UsersController < Support::BaseController
+  def new
+    @school = School.find_by(urn: params[:school_urn])
+    @user = @school.users.build
+  end
+
+  def create
+    @school = School.find_by(urn: params[:school_urn])
+    @user = @school.users.build(user_params)
+
+    if @user.save
+      redirect_to support_devices_school_path(urn: @school.urn)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def edit
     @school = School.find_by(urn: params[:school_urn])
     @user = present(@school.users.find(params[:id]))

--- a/app/controllers/support/devices/users_controller.rb
+++ b/app/controllers/support/devices/users_controller.rb
@@ -6,9 +6,10 @@ class Support::Devices::UsersController < Support::BaseController
 
   def create
     @school = School.find_by(urn: params[:school_urn])
-    @user = @school.users.build(user_params)
+    user_attributes = @school.users.build(user_params).attributes
+    @user = CreateUserService.invite_school_user(user_attributes)
 
-    if @user.save
+    if @user.persisted?
       redirect_to support_devices_school_path(urn: @school.urn)
     else
       render :new, status: :unprocessable_entity

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -8,7 +8,7 @@ class CreateUserService
   end
 
   def self.invite_school_user(user_params = {})
-    user = User.new(user_params.merge(override_params))
+    user = User.new(user_params.merge(approved_at: Time.zone.now))
     if user.save
       InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
     end

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -20,6 +20,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_devices_school_user_path(school_urn: @school.urn) %>
+
     <h2 class="govuk-heading-l">Users</h2>
 
     <% if @users.present? %>

--- a/app/views/support/devices/users/new.html.erb
+++ b/app/views/support/devices/users/new.html.erb
@@ -1,0 +1,24 @@
+<%- title = t('page_titles.new_school_user') %>
+<%- content_for :title, title_with_error_prefix(title, @user.errors.any?) %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { t('page_titles.support_responsible_bodies') => support_devices_responsible_bodies_path },
+    { @school.responsible_body.name => support_devices_responsible_body_path(@school.responsible_body) },
+    { @school.name => support_devices_school_path(urn: @school.urn) },
+    title,
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%= form_for @user, url: support_devices_school_users_path(school_urn: @school.urn) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= f.govuk_submit 'Send invite' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@
       can_order_devices: Yes, give them access to the TechSource website
       can_order_devices_hint: This is where they’ll place orders.
       cannot_order_devices: 'No'
+    new_school_user: Invite a new user
     edit_school_user: Change user details
     school_user_welcome_wizard:
       welcome:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,7 +131,7 @@ Rails.application.routes.draw do
       resources :key_contacts, only: %i[new index create], path: '/key-contacts'
       resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies'
       resources :schools, only: %i[show], param: :urn do
-        resources :users, only: %i[edit update]
+        resources :users, only: %i[new create edit update]
         resources :contacts, only: %i[edit update] do
           member do
             put :set_as_school_contact, path: 'set-as-school-contact'

--- a/spec/controllers/support/devices/users_controller_spec.rb
+++ b/spec/controllers/support/devices/users_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Support::Devices::UsersController do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school) }
+
+  before do
+    sign_in_as support_user
+  end
+
+  describe '#new' do
+    it 'loads' do
+      get :new, params: { school_urn: school.urn }
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#create' do
+    context 'happy path' do
+      def post!
+        post :create, params: {
+          school_urn: school.urn,
+          user: {
+            full_name: 'John Doe',
+            email_address: 'john@example.com',
+            orders_devices: '0',
+          },
+        }
+      end
+
+      it 'creates a new user' do
+        expect { post! }.to change(User, :count).by(1)
+      end
+
+      it 'redirects back to the school' do
+        post!
+        expect(response).to redirect_to support_devices_school_path(urn: school.urn)
+      end
+    end
+
+    context 'when there is an error' do
+      def post!
+        post :create, params: {
+          school_urn: school.urn,
+          user: {
+            full_name: '',
+            email_address: 'john@example.com',
+            orders_devices: '0',
+          },
+        }
+      end
+
+      it 'does not create a user' do
+        expect { post! }.not_to change(User, :count)
+      end
+
+      it 're-renders :new' do
+        post!
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/controllers/support/devices/users_controller_spec.rb
+++ b/spec/controllers/support/devices/users_controller_spec.rb
@@ -32,9 +32,21 @@ RSpec.describe Support::Devices::UsersController do
         expect { post! }.to change(User, :count).by(1)
       end
 
+      it 'sets attributes correctly' do
+        post!
+        record = User.last
+        expect(record.orders_devices).to be_falsey
+      end
+
       it 'redirects back to the school' do
         post!
         expect(response).to redirect_to support_devices_school_path(urn: school.urn)
+      end
+
+      it 'sends out an email', sidekiq: true do
+        expect { post! }.to change {
+          ActionMailer::Base.deliveries.size
+        }.by(1)
       end
     end
 

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -70,13 +70,18 @@ RSpec.describe CreateUserService do
           email_address: 'vlad@example.com',
           telephone: '01234 567890',
           school_id: school.id,
+          orders_devices: true,
         }
       end
+
+      let(:now) { Time.zone.now }
+
       let(:result) { CreateUserService.invite_school_user(valid_params) }
 
       it 'creates a user with the given params' do
         expect { result }.to change(User, :count).by(1)
-        expect(User.last).to have_attributes(valid_params)
+        expect(User.last).to have_attributes(valid_params.except(:approved_at))
+        expect(User.last.approved_at).to be_within(5.seconds).of(now)
       end
 
       it 'sends the correct email' do
@@ -87,7 +92,8 @@ RSpec.describe CreateUserService do
 
       it 'returns the user' do
         expect(result).to be_a(User)
-        expect(result).to have_attributes(valid_params)
+        expect(result).to have_attributes(valid_params.except(:approved_at))
+        expect(result.approved_at).to be_within(5.seconds).of(now)
       end
     end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/T2A6JdPn/757-add-a-new-school-user-via-support

### Changes proposed in this pull request

- New page in support to add new school users
- Tweaks to `CreateUserService` to remove overbearing overrides

### Guidance to review

- Login as support user
- Navigate to a school via RB
- Should be a button below users table to add new users
- Click this button
- Should be taken to page to add new user to the school
- Fill it in incorrectly
- Should see errors
- Fix mistakes and submit
- Should create this new user on the school
- Should send email to new user