### PR TITLE
Show TechSource account confirmation in support

### DIFF
--- a/app/components/support/school_user_summary_list_component.html.erb
+++ b/app/components/support/school_user_summary_list_component.html.erb
@@ -1,0 +1,3 @@
+<div class="user-summary-list">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/support/school_user_summary_list_component.rb
+++ b/app/components/support/school_user_summary_list_component.rb
@@ -23,6 +23,24 @@ class Support::SchoolUserSummaryListComponent < ViewComponent::Base
         key: 'Sign in count',
         value: @user.sign_in_count,
       },
+      {
+        key: 'Can order devices?',
+        value: can_order_devices_label,
+      },
     ]
+  end
+
+private
+
+  def can_order_devices_label
+    if @user.relevant_to_computacenter? && @user.techsource_account_confirmed?
+      'Yes, TechSource account confirmed'
+    elsif @user.relevant_to_computacenter?
+      'No, waiting for TechSource account'
+    elsif @user.orders_devices? && !@user.seen_privacy_notice?
+      'No, will get a TechSource account once they sign in'
+    else
+      'No'
+    end
   end
 end

--- a/app/components/support/school_user_summary_list_component.rb
+++ b/app/components/support/school_user_summary_list_component.rb
@@ -1,0 +1,28 @@
+class Support::SchoolUserSummaryListComponent < ViewComponent::Base
+  validates :user, presence: true
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def rows
+    [
+      {
+        key: 'Email address',
+        value: @user.email_address,
+      },
+      {
+        key: 'Telephone',
+        value: @user.telephone,
+      },
+      {
+        key: 'Last sign in',
+        value: @user.last_signed_in_at ? l(@user.last_signed_in_at, format: :short) : 'Never',
+      },
+      {
+        key: 'Sign in count',
+        value: @user.sign_in_count,
+      },
+    ]
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,6 +117,10 @@ class User < ApplicationRecord
     seen_privacy_notice? && orders_devices?
   end
 
+  def techsource_account_confirmed?
+    techsource_account_confirmed_at.present?
+  end
+
   def hybrid?
     school_id && responsible_body_id
   end

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -18,37 +18,23 @@
 
 <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school) %>
 
-<% if @users.present? %>
-  <table id="responsible-body-users" class="govuk-table govuk-!-margin-top-6">
-    <caption class="govuk-table__caption govuk-heading-l">Users</caption>
-    <caption class="govuk-table__caption">School users</caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Email address</th>
-        <th scope="col" class="govuk-table__header">Full name</th>
-        <th scope="col" class="govuk-table__header">Sign-in count</th>
-        <th scope="col" class="govuk-table__header">Last sign in</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric">Actions</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Users</h2>
+
+    <% if @users.present? %>
       <% @users.each do |user| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= user.email_address %></td>
-          <td class="govuk-table__cell"><%= user.full_name %></td>
-          <td class="govuk-table__cell"><%= user.sign_in_count %></td>
-          <td class="govuk-table__cell"><%= user.last_signed_in_at&.to_date&.to_s(:govuk) || 'Never' %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            <%= govuk_link_to "Change <span class='govuk-visually-hidden'>details for #{user.full_name}</span>".html_safe, edit_support_devices_school_user_path(school_urn: @school.urn, id: user.id) %>
-          </td>
-        </tr>
+        <div class="user">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+          <p class="govuk-body">
+            <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_devices_school_user_path(school_urn: @school.urn, id: user.id) %>
+          </p>
+          <%= render Support::SchoolUserSummaryListComponent.new(user: user) %>
+        </div>
       <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <h2 class="govuk-heading-l">Users</h2>
-  <p class="govuk-body">None</p>
-<% end %>
+    <% end %>
+  </div>
+</div>
 
 <% if @contacts.present? %>
   <table id="contacts" class="govuk-table govuk-!-margin-top-6">

--- a/app/views/support/devices/schools/show.html.erb
+++ b/app/views/support/devices/schools/show.html.erb
@@ -32,6 +32,8 @@
           <%= render Support::SchoolUserSummaryListComponent.new(user: user) %>
         </div>
       <% end %>
+    <% else %>
+      <p class="govuk-body">None</p>
     <% end %>
   </div>
 </div>

--- a/spec/components/support/school_user_summary_list_component_spec.rb
+++ b/spec/components/support/school_user_summary_list_component_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe Support::SchoolUserSummaryListComponent do
   subject(:result) { render_inline(described_class.new(user: user)) }
-  let(:user) {
+
+  let(:user) do
     build(:school_user, telephone: '12345')
-  }
+  end
 
   it 'displays the email address' do
     expect(result.css('.govuk-summary-list__row')[0].text).to include(user.email_address)
@@ -12,5 +13,53 @@ describe Support::SchoolUserSummaryListComponent do
 
   it 'displays the telephone' do
     expect(result.css('.govuk-summary-list__row')[1].text).to include('12345')
+  end
+
+  context 'for a user who cannot order devices' do
+    let(:user) do
+      build(:school_user, telephone: '12345', orders_devices: false)
+    end
+
+    it 'displays the user as unable to order devices' do
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('No')
+    end
+  end
+
+  context 'for a user who orders devices but has not seen the privacy notice' do
+    let(:user) do
+      build(:school_user, telephone: '12345', orders_devices: true, privacy_notice_seen_at: nil)
+    end
+
+    it 'displays the user as able to order devices once they sign in' do
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('No, will get a TechSource account once they sign in')
+    end
+  end
+
+  context 'for a user who orders devices, has seen the privacy notice but has no TechSource account yet' do
+    let(:user) do
+      build(:school_user,
+            telephone: '12345',
+            orders_devices: true,
+            privacy_notice_seen_at: 5.days.ago,
+            techsource_account_confirmed_at: nil)
+    end
+
+    it "displays the user as able to order devices once it's confirmed that they have a TechSource account" do
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('No, waiting for TechSource account')
+    end
+  end
+
+  context 'for a user who orders devices, has seen the privacy notice and has a TechSource account yet' do
+    let(:user) do
+      build(:school_user,
+            telephone: '12345',
+            orders_devices: true,
+            privacy_notice_seen_at: 5.days.ago,
+            techsource_account_confirmed_at: 4.days.ago)
+    end
+
+    it 'displays the user as able to order devices' do
+      expect(result.css('.govuk-summary-list__row')[4].text).to include('Yes')
+    end
   end
 end

--- a/spec/components/support/school_user_summary_list_component_spec.rb
+++ b/spec/components/support/school_user_summary_list_component_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Support::SchoolUserSummaryListComponent do
+  subject(:result) { render_inline(described_class.new(user: user)) }
+  let(:user) {
+    build(:school_user, telephone: '12345')
+  }
+
+  it 'displays the email address' do
+    expect(result.css('.govuk-summary-list__row')[0].text).to include(user.email_address)
+  end
+
+  it 'displays the telephone' do
+    expect(result.css('.govuk-summary-list__row')[1].text).to include('12345')
+  end
+end

--- a/spec/features/support/devices/managing_schools_spec.rb
+++ b/spec/features/support/devices/managing_schools_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
   end
 
   def when_i_click_on_the_change_link_for_the_user
-    click_link 'Change details for Mike Wazowski'
+    click_link 'Edit user Mike Wazowski'
   end
 
   def then_i_see_a_form_with_the_users_details


### PR DESCRIPTION
### Context

DfE support users need to know when it's appropriate to ask users to go place orders.

### Changes proposed in this pull request

- On the schools page in support, convert the users table to a list of summary lists. This is keeping with the user lists for responsible bodies and schools.
- Surface whether the user has everything necessary to order, and if not, then why not.
- Introduce a new view component for ease of testability

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/94494844-14ec4100-01e8-11eb-867b-824665e72660.png)
