### PR TITLE
Add Tesco Mobile and O2 to provider list

### DIFF
--- a/app/views/pages/about_increasing_mobile_data.html.erb
+++ b/app/views/pages/about_increasing_mobile_data.html.erb
@@ -39,6 +39,8 @@
       <li>Three</li>
       <li>Virgin</li>
       <li>Smarty</li>
+      <li>Tesco Mobile</li>
+      <li>O2</li>
     </ul>
 
     <h2 class="govuk-heading-l" id="who-well-share-data-with">Who we’ll share data with</h2>


### PR DESCRIPTION
These networks are now on board