### PR TITLE
Remove the 'haml' gem as we're no longer using it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'foreman'
 gem 'govuk_design_system_formbuilder'
 gem 'govuk-components'
 
-gem 'haml'
 gem 'http'
 
 # GovUK Notify

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,9 +189,6 @@ GEM
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
-    haml (5.1.2)
-      temple (>= 0.8.0)
-      tilt
     hashdiff (1.0.1)
     highline (1.7.10)
     http (4.4.1)
@@ -409,10 +406,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    temple (0.8.2)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     timecop (0.9.1)
     travis (1.8.13)
       backports
@@ -481,7 +476,6 @@ DEPENDENCIES
   foreman
   govuk-components
   govuk_design_system_formbuilder
-  haml
   http
   i18n-debug
   listen (>= 3.0.5, < 3.3)


### PR DESCRIPTION
### Context

We used to use 'haml' but don't anymore.

### Changes proposed in this pull request

Remove the gem so we don't have to keep upgrading it.
