### PR TITLE
[757] Fixes support inviting a school user

### DIFF
--- a/app/controllers/support/devices/users_controller.rb
+++ b/app/controllers/support/devices/users_controller.rb
@@ -6,7 +6,7 @@ class Support::Devices::UsersController < Support::BaseController
 
   def create
     @school = School.find_by(urn: params[:school_urn])
-    user_attributes = @school.users.build(user_params).attributes
+    user_attributes = @school.users.build(user_params).attributes.merge(school_id: @school.id)
     @user = CreateUserService.invite_school_user(user_attributes)
 
     if @user.persisted?

--- a/spec/controllers/support/devices/users_controller_spec.rb
+++ b/spec/controllers/support/devices/users_controller_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Support::Devices::UsersController do
         expect { post! }.to change(User, :count).by(1)
       end
 
+      it 'associates user and school' do
+        post!
+
+        expect(User.last.school).to eql(school)
+      end
+
       it 'sets attributes correctly' do
         post!
         record = User.last

--- a/spec/features/support/devices/inviting_school_users_spec.rb
+++ b/spec/features/support/devices/inviting_school_users_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.feature 'Inviting school users' do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school) }
+  let(:school_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
+  let(:new_school_user_page) { PageObjects::Support::Devices::Schools::NewUserPage.new }
+
+  scenario 'support invites new school user' do
+    given_i_am_signed_in_as_a_support_user
+    when_i_visit_the_school_page
+    and_i_click_the_invite_a_new_user_button
+    then_i_see_the_invite_a_new_school_user_page
+
+    when_fill_in_invite_school_user_form
+    and_i_submit_invite_school_user_form
+    then_i_see_the_school_page
+    and_i_see_the_user_on_the_school_page
+  end
+
+  def given_i_am_signed_in_as_a_support_user
+    sign_in_as support_user
+  end
+
+  def when_i_visit_the_school_page
+    school_page.load(urn: school.urn)
+  end
+
+  def and_i_click_the_invite_a_new_user_button
+    school_page.invite_a_new_user.click
+  end
+
+  def then_i_see_the_invite_a_new_school_user_page
+    expect(new_school_user_page).to be_displayed
+  end
+
+  def when_fill_in_invite_school_user_form
+    new_school_user_page.name.set 'John Doe'
+    new_school_user_page.email.set 'john@example.com'
+    new_school_user_page.phone.set '020 1'
+    new_school_user_page.orders_devices_no.click
+  end
+
+  def and_i_submit_invite_school_user_form
+    new_school_user_page.submit.click
+  end
+
+  def then_i_see_the_school_page
+    expect(school_page).to be_displayed
+  end
+
+  def and_i_see_the_user_on_the_school_page
+    expect(page).to have_content('John Doe')
+    expect(page).to have_content('john@example.com')
+    expect(page).to have_content('020 1')
+  end
+end

--- a/spec/page_objects/support/devices/school_details_page.rb
+++ b/spec/page_objects/support/devices/school_details_page.rb
@@ -7,6 +7,7 @@ module PageObjects
         elements :school_details_rows, '.school-details-summary-list .govuk-summary-list__row'
 
         element :contacts, 'table#contacts'
+        element :invite_a_new_user, 'a', text: 'Invite a new user'
       end
     end
   end

--- a/spec/page_objects/support/devices/schools/new_user_page.rb
+++ b/spec/page_objects/support/devices/schools/new_user_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Support
+    module Devices
+      module Schools
+        class NewUserPage < PageObjects::BasePage
+          set_url '/support/devices/schools/{urn}/users/new'
+
+          element :name, '#user-full-name-field'
+          element :email, '#user-email-address-field'
+          element :phone, '#user-telephone-field'
+          element :orders_devices_yes, '#user-orders-devices-1-field'
+          element :orders_devices_no, '#user-orders-devices-0-field'
+          element :submit, 'input[value="Send invite"]'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/T2A6JdPn/757-add-a-new-school-user-via-support

### Changes proposed in this pull request

- Fixes support inviting a school user
- This was due to a change in association between school and user
- Also added additional coverage to prevent regression

### Guidance to review

- Login as a support user and find a school
- Invite a new user
- Should see user on the school page
- Should send out email to invited user