### PR TITLE
700 send user changes to Computacenters ServiceNow API

### DIFF
--- a/app/jobs/notify_computacenter_of_latest_change_for_user_job.rb
+++ b/app/jobs/notify_computacenter_of_latest_change_for_user_job.rb
@@ -1,0 +1,31 @@
+class NotifyComputacenterOfLatestChangeForUserJob < ApplicationJob
+  queue_as :default
+
+  # NOTE: we only pass the allocation_ids, not the amounts to update the caps to.
+  # This way, the new caps get read at the time the job is performed rather than
+  # when it was scheduled - so if there are several jobs queued up, it doesn't
+  # matter if the jobs get processed in the right order or not, the last job
+  # processed will always set the latest value.
+  def perform(user_id)
+    @latest_change = Computacenter::UserChange.latest_for_user(User.find(user_id))
+    @request = construct_request
+    @response = @request.post!
+    record_transaction!
+    @response
+  end
+
+private
+
+  def construct_request
+    Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest.new(
+      user_change: @latest_change,
+    )
+  end
+
+  def record_transaction!
+    @latest_change.update!(
+      cc_import_api_timestamp: @request.timestamp,
+      cc_import_api_transaction_id: @request.cc_transaction_id,
+    )
+  end
+end

--- a/app/models/computacenter/service_now_user_import_api/error.rb
+++ b/app/models/computacenter/service_now_user_import_api/error.rb
@@ -1,0 +1,8 @@
+class Computacenter::ServiceNowUserImportAPI::Error < StandardError
+  attr_accessor :import_user_change_request
+
+  def initialize(params = {})
+    @import_user_change_request = params[:import_user_change_request]
+    super
+  end
+end

--- a/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
+++ b/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
@@ -23,6 +23,14 @@ module Computacenter
         handle_response!
       end
 
+      def parsed_response_body
+        JSON.parse(response.body.to_s)
+      end
+
+      def cc_transaction_id
+        response.headers['X-Transaction-Id']
+      end
+
     private
 
       def handle_response!
@@ -76,11 +84,7 @@ module Computacenter
       end
 
       def parsed_result_indicates_success?
-        parsed_body['result']&.first&.fetch('status') == 'inserted'
-      end
-
-      def parsed_body
-        JSON.parse(response.body.to_s)
+        parsed_response_body['result']&.first&.fetch('status') != 'error'
       end
     end
   end

--- a/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
+++ b/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
@@ -1,0 +1,87 @@
+module Computacenter
+  module ServiceNowUserImportAPI
+    class ImportUserChangeRequest
+      attr_accessor :endpoint, :username, :password
+      attr_accessor :timestamp, :logger, :response
+      attr_accessor :user_change
+
+      def initialize(args = {})
+        @endpoint       = args[:endpoint] || setting(:endpoint)
+        @username       = args[:username] || setting(:username)
+        @password       = args[:password] || setting(:password)
+        @timestamp      = args[:timestamp] || Time.zone.now
+        @user_change    = args[:user_change]
+        @logger         = args[:logger] || Rails.logger
+      end
+
+      def post!
+        @body = construct_body
+
+        @logger.debug("POSTing to Computacenters' ServiceNow, endpoint: #{@endpoint}, body: \n#{@body}")
+        @response = HTTP.basic_auth(user: @username, pass: @password)
+                        .post(@endpoint, body: @body)
+        handle_response!
+      end
+
+    private
+
+      def handle_response!
+        response_body = @response.body.to_s
+        @logger.debug("Response from Computacenter: \n#{response_body}")
+        unless success?
+          raise(
+            Computacenter::ServiceNowUserImportAPI::Error.new(import_user_change_request: self),
+            "Computacenter responded with #{@response.status}, response_body: #{response_body}",
+          )
+        end
+
+        @response
+      end
+
+      def construct_body
+        {
+          u_email: user_change.email_address,
+          u_type_of_update: 'New',
+          u_cc_sold_to_number: user_change.cc_sold_to_number,
+          u_first_name: user_change.first_name,
+          u_last_name: user_change.last_name,
+          u_responsible_body: user_change.responsible_body,
+          u_responsible_body_urn: user_change.responsible_body_urn,
+          u_cc_ship_to_number: user_change.cc_ship_to_number,
+          u_date_of_update: user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+          u_school: user_change.school,
+          u_school_urn: user_change.school_urn,
+          u_telephone: user_change.telephone,
+          u_timestamp_of_update: user_change.updated_at_timestamp.utc.iso8601,
+          u_time_of_update: user_change.updated_at_timestamp.utc.strftime('%R %z'),
+          u_original_email: user_change.original_email_address,
+          u_original_cc_sold_to_number: user_change.original_cc_sold_to_number,
+          u_original_first_name: user_change.original_first_name,
+          u_original_last_name: user_change.original_last_name,
+          u_original_responsible_body: user_change.original_responsible_body,
+          u_original_responsible_body_urn: user_change.original_responsible_body_urn,
+          u_original_cc_ship_to_number: user_change.original_cc_ship_to_number,
+          u_original_school: user_change.original_school,
+          u_original_school_urn: user_change.original_school_urn,
+          u_original_telephone: user_change.original_telephone,
+        }.to_json
+      end
+
+      def setting(name)
+        Settings.computacenter.service_now_user_import_api.send(name)
+      end
+
+      def success?
+        response.status.success? && parsed_result_indicates_success?
+      end
+
+      def parsed_result_indicates_success?
+        parsed_body['result']&.first&.fetch('status') == 'inserted'
+      end
+
+      def parsed_body
+        JSON.parse(response.body.to_s)
+      end
+    end
+  end
+end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -10,6 +10,7 @@ class Computacenter::UserChangeGenerator
       change = Computacenter::UserChange.new(consolidated_attributes)
       change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
       change.save!
+      NotifyComputacenterOfLatestChangeForUserJob.perform_later(@user.id) if Settings.computacenter.service_now_user_import_api.endpoint.present?
       change
     end
   end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -10,12 +10,20 @@ class Computacenter::UserChangeGenerator
       change = Computacenter::UserChange.new(consolidated_attributes)
       change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
       change.save!
-      NotifyComputacenterOfLatestChangeForUserJob.perform_later(@user.id) if Settings.computacenter.service_now_user_import_api.endpoint.present?
+      notify_computacenter_via_api if computacenter_api_configured?
       change
     end
   end
 
 private
+
+  def computacenter_api_configured?
+    Settings.computacenter.service_now_user_import_api.endpoint.present?
+  end
+
+  def notify_computacenter_via_api
+    NotifyComputacenterOfLatestChangeForUserJob.perform_later(@user.id)
+  end
 
   def last_change_for_user
     @last_change_for_user ||= Computacenter::UserChange.latest_for_user(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true
+
   has_many :user_schools, dependent: :destroy, after_add: :generate_user_change_if_needed!, after_remove: :generate_user_change_if_needed!
   has_many :schools, through: :user_schools
 
@@ -124,25 +125,6 @@ class User < ApplicationRecord
     school_id && responsible_body_id
   end
 
-  def hybrid_setup!
-    return if responsible_body.blank?
-
-    one_school = responsible_body.schools.count == 1
-    only_user = responsible_body.users == [self]
-
-    return unless one_school && only_user
-
-    school = responsible_body.schools.first
-
-    update!(school: school)
-    responsible_body.update_who_will_order_devices('schools')
-    contact = school.contacts.create!(email_address: email_address,
-                                      full_name: full_name,
-                                      role: :contact,
-                                      phone_number: telephone)
-    school.preorder_information.update!(school_contact: contact)
-  end
-
   # Wrapper methods to ease the transition from 'user belongs_to school',
   # to 'user has_many schools'
   def school
@@ -155,7 +137,7 @@ class User < ApplicationRecord
 
   def school_id=(new_school_id)
     user_schools.delete_all
-    user_schools.create(school_id: new_school_id) if new_school_id
+    schools << School.find(new_school_id) if new_school_id
   end
 
   def school=(new_school)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
 
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true
-
   has_many :user_schools, dependent: :destroy, after_add: :generate_user_change_if_needed!, after_remove: :generate_user_change_if_needed!
   has_many :schools, through: :user_schools
 
@@ -125,6 +124,25 @@ class User < ApplicationRecord
     school_id && responsible_body_id
   end
 
+  def hybrid_setup!
+    return if responsible_body.blank?
+
+    one_school = responsible_body.schools.count == 1
+    only_user = responsible_body.users == [self]
+
+    return unless one_school && only_user
+
+    school = responsible_body.schools.first
+
+    update!(school: school)
+    responsible_body.update_who_will_order_devices('schools')
+    contact = school.contacts.create!(email_address: email_address,
+                                      full_name: full_name,
+                                      role: :contact,
+                                      phone_number: telephone)
+    school.preorder_information.update!(school_contact: contact)
+  end
+
   # Wrapper methods to ease the transition from 'user belongs_to school',
   # to 'user has_many schools'
   def school
@@ -137,7 +155,7 @@ class User < ApplicationRecord
 
   def school_id=(new_school_id)
     user_schools.delete_all
-    schools << School.find(new_school_id) if new_school_id
+    user_schools.create(school_id: new_school_id) if new_school_id
   end
 
   def school=(new_school)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,10 @@ computacenter:
     endpoint:
     username:
     password:
+  service_now_user_import_api:
+    endpoint:
+    username:
+    password:
 
 cookie_consent:
   expiry_time_months: 6

--- a/db/migrate/20200929092315_add_cc_import_api_fields_to_user_change.rb
+++ b/db/migrate/20200929092315_add_cc_import_api_fields_to_user_change.rb
@@ -1,0 +1,9 @@
+class AddCcImportAPIFieldsToUserChange < ActiveRecord::Migration[6.0]
+  def change
+    add_column :computacenter_user_changes, :cc_import_api_timestamp, :datetime, null: true
+    add_column :computacenter_user_changes, :cc_import_api_transaction_id, :string, null: true
+
+    add_index :computacenter_user_changes, :cc_import_api_timestamp, name: 'ix_cc_user_changes_timestamp'
+    add_index :computacenter_user_changes, :cc_import_api_transaction_id, name: 'ix_cc_user_changes_cc_tx_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,9 +70,9 @@ ActiveRecord::Schema.define(version: 2020_09_29_092315) do
     t.text "original_school_urn"
     t.text "original_cc_ship_to_number"
     t.datetime "cc_import_api_timestamp"
-    t.string "cc_import_api_payload_id"
-    t.index ["cc_import_api_payload_id"], name: "index_computacenter_user_changes_on_cc_import_api_payload_id"
-    t.index ["cc_import_api_timestamp"], name: "index_computacenter_user_changes_on_cc_import_api_timestamp"
+    t.string "cc_import_api_transaction_id"
+    t.index ["cc_import_api_timestamp"], name: "ix_cc_user_changes_timestamp"
+    t.index ["cc_import_api_transaction_id"], name: "ix_cc_user_changes_cc_tx_id"
     t.index ["updated_at_timestamp"], name: "index_computacenter_user_changes_on_updated_at_timestamp"
     t.index ["user_id"], name: "index_computacenter_user_changes_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_142403) do
+ActiveRecord::Schema.define(version: 2020_09_29_092315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_142403) do
     t.text "original_school"
     t.text "original_school_urn"
     t.text "original_cc_ship_to_number"
+    t.datetime "cc_import_api_timestamp"
+    t.string "cc_import_api_payload_id"
+    t.index ["cc_import_api_payload_id"], name: "index_computacenter_user_changes_on_cc_import_api_payload_id"
+    t.index ["cc_import_api_timestamp"], name: "index_computacenter_user_changes_on_cc_import_api_timestamp"
     t.index ["updated_at_timestamp"], name: "index_computacenter_user_changes_on_updated_at_timestamp"
     t.index ["user_id"], name: "index_computacenter_user_changes_on_user_id"
   end

--- a/spec/features/school/manage_users_spec.rb
+++ b/spec/features/school/manage_users_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature 'Manage school users' do
   let(:school_users_page) { PageObjects::School::UsersPage.new }
 
   before do
+    # disable computacenter user import API calls
+    Settings.computacenter.service_now_user_import_api.endpoint = nil
     user_from_same_school
     user_from_other_school
 

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -7,6 +7,8 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   let(:validate_token_url) { validate_sign_in_token_url(token: token, identifier: identifier) }
 
   before do
+    # disable computacenter user import API calls
+    Settings.computacenter.service_now_user_import_api.endpoint = nil
     stub_request(:post, Settings.slack.event_notifications.webhook_url).to_return(status: 200, body: '')
   end
 

--- a/spec/jobs/notify_computacenter_of_latest_change_for_user_job_spec.rb
+++ b/spec/jobs/notify_computacenter_of_latest_change_for_user_job_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe NotifyComputacenterOfLatestChangeForUserJob do
+  describe '#perform' do
+    let(:user) { create(:school_user, :relevant_to_computacenter) }
+    let(:request_succeeded) { true }
+    let(:mock_request) do
+      instance_double(
+        Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest,
+        cc_transaction_id: '123456',
+        timestamp: Time.zone.now.utc,
+        success?: request_succeeded,
+      )
+    end
+    let(:job) { described_class.new }
+    let(:user_change) { Computacenter::UserChange.latest_for_user(user) }
+    let(:mock_response) { instance_double(HTTP::Response) }
+
+    before do
+      allow(Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest).to receive(:new).and_return(mock_request)
+      allow(mock_request).to receive(:post!).and_return(mock_response)
+    end
+
+    it 'creates a new Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest with the latest user change for the given user_id' do
+      job.perform(user.id)
+      expect(Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest).to have_received(:new).with(user_change: user_change)
+    end
+
+    it 'posts the request' do
+      job.perform(user.id)
+      expect(mock_request).to have_received(:post!)
+    end
+
+    context 'when the request succeeds' do
+      it 'updates the timestamp and transaction_id on the UserChange' do
+        job.perform(user.id)
+        user_change.reload
+        expect(user_change.cc_import_api_timestamp).not_to be_nil
+        expect(user_change.cc_import_api_transaction_id).to eq('123456')
+      end
+
+      it 'returns the response' do
+        expect(job.perform(user.id)).to eq(mock_response)
+      end
+    end
+
+    context 'when the request does not succeed' do
+      before do
+        allow(mock_request).to receive(:post!).and_raise(Computacenter::ServiceNowUserImportAPI::Error)
+      end
+
+      it 'raises an error' do
+        expect { job.perform(user.id) }.to raise_error(Computacenter::ServiceNowUserImportAPI::Error)
+      end
+
+      it 'does not update the timestamp and transaction_id on the UserChange' do
+        -> { job.perform(user.id) }
+        user_change.reload
+        expect(user_change.cc_import_api_timestamp).to be_nil
+        expect(user_change.cc_import_api_transaction_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/computacenter/service_now_user_import_api/import_user_change_request_spec.rb
+++ b/spec/models/computacenter/service_now_user_import_api/import_user_change_request_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest do
+  let(:user_change) { create(:user_change, :school_user) }
+  let(:request) { described_class.new(user_change: user_change) }
+
+  let(:response_body) do
+    <<~JSON
+      {
+        "import_set": "ISET0010250",
+        "staging_table": "u_dfe_users_import",
+        "result": [
+          {
+            "transform_map": "DFE Users Import TM",
+            "table": "sys_user",
+            "display_name": "name",
+            "display_value": "Test User",
+            "record_link": "https://computacentertest.service-now.com/api/now/table/sys_user/b5adecb5db1b1c10e39ba1ea4b96198b",
+            "status": "inserted",
+            "sys_id": "b5adecb5db1b1c10e39ba1ea4b96198b",
+            "status_message": "Unable to find Sold to with ID provided 1"
+          }
+        ]
+      }
+    JSON
+  end
+  let(:mock_status) { instance_double(HTTP::Response::Status, code: 200, success?: true) }
+  let(:mock_response) { instance_double(HTTP::Response, status: mock_status, body: response_body) }
+  let(:expected_json) do
+    {
+      u_email: user_change.email_address,
+      u_type_of_update: 'New',
+      u_cc_sold_to_number: user_change.cc_sold_to_number,
+      u_first_name: user_change.first_name,
+      u_last_name: user_change.last_name,
+      u_responsible_body: user_change.responsible_body,
+      u_responsible_body_urn: user_change.responsible_body_urn,
+      u_cc_ship_to_number: user_change.cc_ship_to_number,
+      u_date_of_update: user_change.updated_at_timestamp.utc.strftime('%d/%m/%Y'),
+      u_school: user_change.school,
+      u_school_urn: user_change.school_urn,
+      u_telephone: user_change.telephone,
+      u_timestamp_of_update: user_change.updated_at_timestamp.utc.iso8601,
+      u_time_of_update: user_change.updated_at_timestamp.utc.strftime('%R %z'),
+      u_original_email: user_change.original_email_address,
+      u_original_cc_sold_to_number: user_change.original_cc_sold_to_number,
+      u_original_first_name: user_change.original_first_name,
+      u_original_last_name: user_change.original_last_name,
+      u_original_responsible_body: user_change.original_responsible_body,
+      u_original_responsible_body_urn: user_change.original_responsible_body_urn,
+      u_original_cc_ship_to_number: user_change.original_cc_ship_to_number,
+      u_original_school: user_change.original_school,
+      u_original_school_urn: user_change.original_school_urn,
+      u_original_telephone: user_change.original_telephone,
+    }.to_json
+  end
+
+  before do
+    Settings.computacenter.service_now_user_import_api.endpoint = 'http://example.com/import/table'
+    stub_request(:post, Settings.computacenter.service_now_user_import_api.endpoint).to_return(status: 201, body: response_body)
+  end
+
+  describe '#post!' do
+    it 'POSTs the body to the endpoint using Basic Auth' do
+      allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+      allow(HTTP).to receive(:post).and_return(mock_response)
+
+      request.post!
+      expect(HTTP).to have_received(:basic_auth).with(user: request.username, pass: request.password)
+      expect(HTTP).to have_received(:post).with(request.endpoint, body: expected_json)
+    end
+
+    it 'generates a correct body' do
+      request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
+      request.post!
+      expect(a_request(:post, request.endpoint).with(body: expected_json)).to have_been_made
+    end
+
+    context 'when the response status is success' do
+      let(:mock_status) { instance_double(HTTP::Response::Status, code: 200, success?: true) }
+
+      it 'returns the response ' do
+        expect(request.post!).to be_a(HTTP::Response)
+      end
+    end
+
+    context 'when the response status is not a success' do
+      let(:mock_status) { instance_double(HTTP::Response::Status, code: 401, success?: false) }
+
+      before do
+        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+        allow(HTTP).to receive(:post).and_return(mock_response)
+      end
+
+      it 'raises an error' do
+        expect { request.post! }.to raise_error(Computacenter::ServiceNowUserImportAPI::Error)
+      end
+    end
+
+    context 'when the response contains an error' do
+      let(:response_body) do
+        <<~BODY
+          {
+            "import_set":"ISET0010261",
+            "staging_table":"u_dfe_users_import",
+            "result":[
+              {
+                "transform_map":"DFE Users Import TM",
+                "table":"sys_user",
+                "status":"error",
+                "error_message":"Target record not found",
+                "status_message":"Row transform ignored by onBefore script","validation_message":"Sold To Number [u_cc_sold_to_number] not provided - record ignored"
+              }
+            ]
+          }
+        BODY
+      end
+
+      before do
+        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+        allow(HTTP).to receive(:post).and_return(mock_response)
+      end
+
+      it 'raises an error' do
+        expect { request.post! }.to raise_error(Computacenter::ServiceNowUserImportAPI::Error)
+      end
+    end
+
+    context 'when the response does not contain an error' do
+      let(:response_body) do
+        <<~JSON
+          {
+             "import_set": "ISET0010250",
+             "staging_table": "u_dfe_users_import",
+             "result": [
+               {
+                 "transform_map": "DFE Users Import TM",
+                 "table": "sys_user",
+                 "display_name": "name",
+                 "display_value": "Test User",
+                 "record_link": "https://computacentertest.service-now.com/api/now/table/sys_user/b5adecb5db1b1c10e39ba1ea4b96198b",
+                 "status": "inserted",
+                 "sys_id": "b5adecb5db1b1c10e39ba1ea4b96198b",
+                 "status_message": "some message here"
+               }
+             ]
+           }
+        JSON
+      end
+
+      before do
+        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
+        allow(HTTP).to receive(:post).and_return(mock_response)
+      end
+
+      it 'does not raise an error' do
+        expect { request.post! }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
     # disable computacenter user import API calls
     Settings.computacenter.service_now_user_import_api.endpoint = nil
   end
-  
+
   after do
     clear_enqueued_jobs
   end

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
+  before do
+    # disable computacenter user import API calls
+    Settings.computacenter.service_now_user_import_api.endpoint = nil
+  end
+  
   after do
     clear_enqueued_jobs
   end


### PR DESCRIPTION
### Context

[Trello card 700](https://trello.com/c/mYNXeNHI/700-send-user-changes-to-computacenters-servicenow-api)

### Changes proposed in this pull request

* Add a class to encapsulate sending a ServiceNow Import API request for a given UserChange
* Add a job class to instantiate an API request with the latest UserChange for a given user, send it, and record the transaction against the UserChange
* Add a call to enqueue one of those jobs whenever a UserChange is generated, so long as the relevant endpoint is defined in Settings


### Guidance to review

The three additions above are done in order with the three commits in this PR - I suggest reviewing it commit-by-commit.
I've tested this against CC's test server, we don't have credentials for any other server yet, so no jobs will run on prod even if this merged and deployed.