### PR TITLE
Fix school status when school user added via support

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -27,13 +27,13 @@ class PreorderInformation < ApplicationRecord
 
   # If this method is added, we may need to update School::SchoolDetailsSummaryListComponent
   def infer_status
-    if school_will_order_devices? && school_contact.nil?
+    if school_will_order_devices? && !any_school_users? && school_contact.nil?
       'needs_contact'
-    elsif school_will_order_devices? && school_contacted_at.nil?
+    elsif school_will_order_devices? && !any_school_users? && school_contact.present?
       'school_will_be_contacted'
-    elsif school_will_order_devices? && school_contacted_at.present? && !chromebook_information_complete?
+    elsif school_will_order_devices? && any_school_users? && !chromebook_information_complete?
       'school_contacted'
-    elsif school_will_order_devices? && school_contacted_at.present? && chromebook_information_complete?
+    elsif school_will_order_devices? && any_school_users? && chromebook_information_complete?
       'school_ready'
     elsif chromebook_information_complete?
       'ready'
@@ -106,6 +106,10 @@ class PreorderInformation < ApplicationRecord
   end
 
 private
+
+  def any_school_users?
+    school&.users&.any?
+  end
 
   def set_defaults
     self.status ||= infer_status

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -42,6 +42,10 @@ class PreorderInformation < ApplicationRecord
     end
   end
 
+  def refresh_status!
+    update!(status: infer_status)
+  end
+
   def change_who_will_order_devices!(who)
     self.who_will_order_devices = who
     self.status = infer_status
@@ -82,7 +86,7 @@ class PreorderInformation < ApplicationRecord
 
   def update_chromebook_information_and_status!(params)
     update!(params)
-    update!(status: infer_status)
+    refresh_status!
   end
 
   def self.for_responsible_bodies_in_devices_pilot

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -11,6 +11,7 @@ class CreateUserService
     user = User.new(user_params.merge(approved_at: Time.zone.now))
     if user.save
       InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
+      user.school.preorder_information&.refresh_status!
     end
     user
   end

--- a/spec/features/support/devices/inviting_school_users_spec.rb
+++ b/spec/features/support/devices/inviting_school_users_spec.rb
@@ -6,6 +6,10 @@ RSpec.feature 'Inviting school users' do
   let(:school_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
   let(:new_school_user_page) { PageObjects::Support::Devices::Schools::NewUserPage.new }
 
+  before do
+    create(:preorder_information, school: school, who_will_order_devices: 'school')
+  end
+
   scenario 'support invites new school user' do
     given_i_am_signed_in_as_a_support_user
     when_i_visit_the_school_page
@@ -16,6 +20,7 @@ RSpec.feature 'Inviting school users' do
     and_i_submit_invite_school_user_form
     then_i_see_the_school_page
     and_i_see_the_user_on_the_school_page
+    and_the_school_is_shown_as_contacted
   end
 
   def given_i_am_signed_in_as_a_support_user
@@ -53,5 +58,9 @@ RSpec.feature 'Inviting school users' do
     expect(page).to have_content('John Doe')
     expect(page).to have_content('john@example.com')
     expect(page).to have_content('020 1')
+  end
+
+  def and_the_school_is_shown_as_contacted
+    expect(page).to have_content('School contacted')
   end
 end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -25,36 +25,49 @@ RSpec.describe PreorderInformation, type: :model do
     end
 
     context "when the school orders devices, it's been contacted but hasn't logged in to input the Chromebook details" do
-      subject do
-        build(:preorder_information,
-              who_will_order_devices: :school,
-              school_contact: build(:school_contact),
-              school_contacted_at: Time.zone.now,
-              will_need_chromebooks: nil).infer_status
+      let(:preorder_information) do
+        create(:preorder_information,
+               who_will_order_devices: :school,
+               school_contact: build(:school_contact),
+               will_need_chromebooks: nil)
+      end
+
+      subject { preorder_information.infer_status }
+
+      before do
+        create(:school_user, school: preorder_information.school)
       end
 
       it { is_expected.to eq('school_contacted') }
     end
 
     context "when the school orders devices, it has logged in and doesn't plan to order Chromebooks" do
-      subject do
-        build(:preorder_information,
-              :does_not_need_chromebooks,
-              who_will_order_devices: :school,
-              school_contact: build(:school_contact),
-              school_contacted_at: Time.zone.now).infer_status
+      let(:preorder_information) do
+        create(:preorder_information,
+               :does_not_need_chromebooks,
+               who_will_order_devices: :school)
+      end
+
+      subject { preorder_information.infer_status }
+
+      before do
+        create(:school_user, school: preorder_information.school)
       end
 
       it { is_expected.to eq('school_ready') }
     end
 
     context 'when the school orders devices, it has logged in and plans to order Chromebooks' do
-      subject do
-        build(:preorder_information,
-              :needs_chromebooks,
-              who_will_order_devices: :school,
-              school_contact: build(:school_contact),
-              school_contacted_at: Time.zone.now).infer_status
+      let(:preorder_information) do
+        create(:preorder_information,
+               :needs_chromebooks,
+               who_will_order_devices: :school)
+      end
+
+      subject { preorder_information.infer_status }
+
+      before do
+        create(:school_user, school: preorder_information.school)
       end
 
       it { is_expected.to eq('school_ready') }

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe CreateUserService do
 
   describe 'invite_school_user' do
     let(:school) { create(:school) }
+    let(:preorder_information) { create(:preorder_information, school: school, who_will_order_devices: 'school') }
+
+    before do
+      preorder_information
+    end
 
     context 'given valid user params' do
       let(:valid_params) do
@@ -94,6 +99,10 @@ RSpec.describe CreateUserService do
         expect(result).to be_a(User)
         expect(result).to have_attributes(valid_params.except(:approved_at))
         expect(result.approved_at).to be_within(5.seconds).of(now)
+      end
+
+      it 'updates the school status to reflect that the school has been contacted' do
+        expect(result.school.preorder_information.status).to eq('school_contacted')
       end
     end
 


### PR DESCRIPTION
### Context

Before #560, the only way to add the first user to a school was to invite a school contact. It's now possible for support users to add the first user directly. The school status isn't being updated correctly in this case.

### Changes proposed in this pull request

Update the school status inference logic to correctly calculate the status, irrespective of how the first user was added.
Ensure that the school status is recalculated when a school user is added.

