### PR TITLE
[752] Add interstitial before you can order page

### DIFF
--- a/app/controllers/school/before_can_order_controller.rb
+++ b/app/controllers/school/before_can_order_controller.rb
@@ -1,0 +1,13 @@
+class School::BeforeCanOrderController < School::ChromebooksController
+  def edit
+    @chromebook_information_form = ChromebookInformationForm.new(
+      school: @user.school,
+    )
+  end
+
+private
+
+  def after_updated_redirect_location
+    school_home_path
+  end
+end

--- a/app/controllers/school/chromebooks_controller.rb
+++ b/app/controllers/school/chromebooks_controller.rb
@@ -16,13 +16,17 @@ class School::ChromebooksController < School::BaseController
     if @chromebook_information_form.valid?
       @preorder_info.update_chromebook_information_and_status!(chromebook_params)
       flash[:success] = t(:success, scope: %w[school chromebooks])
-      redirect_to school_details_path
+      redirect_to after_updated_redirect_location
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
 private
+
+  def after_updated_redirect_location
+    school_details_path
+  end
 
   def chromebook_params
     params.require(:chromebook_information_form).permit(

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -109,7 +109,12 @@ private
 
   def school_user_start_url(user)
     if user.school_welcome_wizard&.complete?
-      school_home_path
+      if user.school&.preorder_information&.school_will_order_devices? &&
+          user.school&.preorder_information&.chromebook_info_still_needed?
+        school_before_you_can_order_path
+      else
+        school_home_path
+      end
     else
       school_welcome_wizard_privacy_path
     end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -84,6 +84,10 @@ class PreorderInformation < ApplicationRecord
     end
   end
 
+  def chromebook_info_still_needed?
+    will_need_chromebooks.nil? || will_need_chromebooks == 'i_dont_know'
+  end
+
   def update_chromebook_information_and_status!(params)
     update!(params)
     refresh_status!

--- a/app/views/school/before_can_order/edit.html.erb
+++ b/app/views/school/before_can_order/edit.html.erb
@@ -1,0 +1,18 @@
+<%- title = t('page_titles.school_before_can_order') %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%= render 'shared/chromebook_information_intro' %>
+    <%= render partial: 'shared/chromebook_information_form',
+      locals: {
+        url: school_before_you_can_order_path,
+        show_i_dont_know_option: true,
+        scope: 'page_titles.school_user_welcome_wizard.chromebooks',
+        form_object: @chromebook_information_form } %>
+  </div>
+</div>

--- a/app/views/school/chromebooks/edit.html.erb
+++ b/app/views/school/chromebooks/edit.html.erb
@@ -2,7 +2,6 @@
 <%- content_for :title, title %>
 <% content_for :before_content, govuk_link_to('Back', school_details_path, class: 'govuk-back-link') %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,7 @@
     school_details: Check your school details
     school_edit_chromebooks: Will your school need to order Chromebooks?
     school_users: Manage users
+    school_before_can_order: Before you can order, we need more information
     order_devices:
       title: Order devices
       you_cannot_order_yet: You cannot order devices yet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,8 @@ Rails.application.routes.draw do
     patch '/next(/:step)', to: 'welcome_wizard#next_step', as: :welcome_wizard
     patch '/prev', to: 'welcome_wizard#previous_step', as: :welcome_wizard_previous
     resources :users, only: %i[index new create edit update]
+    get '/before-you-can-order', to: 'before_can_order#edit'
+    patch '/before-you-can-order', to: 'before_can_order#update'
   end
 
   namespace :support do

--- a/spec/factories/preorder_information.rb
+++ b/spec/factories/preorder_information.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     who_will_order_devices { %w[school responsible_body].sample }
     status { infer_status }
 
+    trait :school_will_order do
+      who_will_order_devices { 'school' }
+    end
+
     trait :needs_chromebooks do
       will_need_chromebooks { 'yes' }
       school_or_rb_domain { Faker::Internet.domain_name }

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -76,6 +76,21 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
+  context 'as a school user who has completed the welcome wizard but not decided on chromebooks' do
+    let(:preorder) { create(:preorder_information, :school_will_order) }
+    let(:school) { create(:school, preorder_information: preorder) }
+    let(:user) { create(:school_user, school: school) }
+
+    scenario 'it redirects to the before you can order page' do
+      sign_in_as user
+      expect(page).to have_current_path(school_before_you_can_order_path)
+      expect(page).to have_text 'Before you can order'
+      choose 'I don’t know'
+      click_on 'Save'
+      expect(page).to have_text 'Get devices for your school'
+    end
+  end
+
   context 'as a school user who has not done any of the welcome wizard' do
     let(:user) { create(:school_user, :new_visitor) }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/5mKpDVHB/752-build-a-before-you-can-order-page-to-show-to-schools-each-time-they-sign-in-until-chromebook-info-completed

### Changes proposed in this pull request

- Adds a new page post login for schools users that will order
- The page is shown when users still need to supply chromebook answers

### Screenshots

![image](https://user-images.githubusercontent.com/92580/94589305-0734cb00-027d-11eb-9ccd-e1e89d48dd3f.png)

### Guidance to review

- Invite a new school user. The school should be ordering devices. Ideally first school user so clean slate
- Login as school user
- Should see standard school wizard, complete this but delay entering of chromebook details
- Logout and login back in
- After post login screen should see that there is a page prompting the user to enter chromebook details