### PR TITLE
Advise users to contact IT support for Chromebook details

### DIFF
--- a/app/views/school/details/show.html.erb
+++ b/app/views/school/details/show.html.erb
@@ -36,7 +36,7 @@
     <p class="govuk-body">We need this information so we can secure the devices.</p>
 
     <p class="govuk-body">
-      If you need help finding these details, email <%= ghwt_contact_mailto %>
+      If you need help finding these details, speak to the people you usually contact for IT support.
     </p>
   </div>
 </div>

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -18,7 +18,7 @@
                               label: { text: "Recovery email address", size: 's' },
                               hint: { text: "This email address must be on a different domain to the school domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." } %>
       <p class="govuk-body govuk-!-margin-top-4">
-        If you need help finding these details, email <%= ghwt_contact_mailto(subject: 'Chromebook details') %>
+        If you need help finding these details, speak to the people you usually contact for IT support.
       </p>
     <%- end %>
     <%= f.govuk_radio_button  :will_need_chromebooks,


### PR DESCRIPTION
When users contact us for Chromebook help, we ask them to contact their IT support team. They do not need to contact us and we can advise them to go straight there.