### PR TITLE
Fix build due to component cant inherit template

### DIFF
--- a/app/components/school_user_summary_list_component.html.erb
+++ b/app/components/school_user_summary_list_component.html.erb
@@ -1,0 +1,3 @@
+<div class="user-summary-list">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>


### PR DESCRIPTION
### Context

Failing build
```bash
  1) Manage school users viewing the list of school users who can order devices
     Failure/Error: <%= render SchoolUserSummaryListComponent.new(user: user) %>

     ActionView::Template::Error:
       Could not find a template file or inline render method for SchoolUserSummaryListComponent.
```

### Changes proposed in this pull request

- This file can be removed once view_component is upgraded
- view_component cannot be upgraded as it is pinned by govuk-components
- This is the quickest fix to workround the issue
- See https://github.com/github/view_component/releases/tag/v2.19.0

### Guidance to review

- Checkout main
- Run `bundle exec rspec spec/features/school/manage_users_spec.rb`
- Tests will fail
- Checkout this branch 
- Run `bundle exec rspec spec/features/school/manage_users_spec.rb`
- Test suite should be green