### PR TITLE
[577] Tweak cannot order page 

### DIFF
--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -1,4 +1,5 @@
-<%- title = t('page_titles.school_cannot_order_devices') %>
+<%- who_cannot_order = @user.orders_devices? ? 'school_user' : 'school' %>
+<%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices") %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <% breadcrumbs([
@@ -21,5 +22,15 @@
     <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', school_request_devices_path %> from any year group who:</p>
 
     <%= render partial: 'shared/devices/who_to_request_for_list' %>
+
+    <% unless @user.orders_devices? %>
+      <h2 class="govuk-heading-m">
+        You won’t be able to place orders yourself
+      </h2>
+
+      <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
+
+      <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path %>.</p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,8 @@
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     school_home: Get devices for your school
-    school_cannot_order_devices: You cannot order devices yet
+    school_cannot_order_devices: Your school cannot order devices yet
+    school_user_cannot_order_devices: You cannot order devices yet
     school_order_devices: Order devices
     school_request_devices: Request devices for specific circumstances
     school_details: Check your school details

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Order devices' do
   end
 
   def then_i_see_that_i_cannot_order_devices_yet
-    expect(page).to have_content('You cannot order devices yet')
+    expect(page).to have_content('Your school cannot order devices yet')
     expect(page).to have_link('request devices for disadvantaged children')
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/vaC4fRyk/577-order-devices-screen-for-people-without-access-to-techsource

### Changes proposed in this pull request

- Change the cannot order page
- Change titles
- Additional copy on they cannot place orders if applicable

### Guidance to review

- Login as school user that cannot `orders_devices`
- Make the school order devices but cannot order at the moment 
- Visit order devices page
- Should see techsource copy at the bottom of the page
- Change user so `orders_devices` is `true` and `techsource_account_confirmed_at` is `1.second ago`
- Reload the page
- Should not see techsource copy