### PR TITLE
add helper method to return active responsible users

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,6 +47,19 @@ class School < ApplicationRecord
     where(order_state: %w[can_order_for_specific_circumstances can_order])
   end
 
+  def who_will_order_devices
+    preorder_information&.who_will_order_devices || responsible_body.who_will_order_devices
+  end
+
+  def active_responsible_users
+    case who_will_order_devices
+    when 'school'
+      users.signed_in_at_least_once
+    else
+      responsible_body.users.signed_in_at_least_once
+    end
+  end
+
   def allocation_for_type!(device_type)
     device_allocations.find_by_device_type!(device_type)
   end


### PR DESCRIPTION
### Context

See [Trello card 784](https://trello.com/c/zWvwYauu/784-add-a-helper-method-to-school-to-return-the-active-responsible-users)

### Changes proposed in this pull request

* Add a convenience method that returns the users who have signed in at least once, and are responsible for this school on the system (school or responsible body users, depending on who will order devices)

### Guidance to review

