### PR TITLE
[730] Wizard shows TechSource if orders devices

### DIFF
--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -32,7 +32,7 @@ class SchoolWelcomeWizard < ApplicationRecord
     when 'allocation'
       order_your_own!
     when 'order_your_own'
-      if user_is_first_school_user?
+      if user_orders_devices?
         techsource_account!
       else
         devices_you_can_order!
@@ -124,8 +124,8 @@ private
     end
   end
 
-  def user_is_first_school_user?
-    first_school_user.nil? ? set_first_user_flag! : first_school_user
+  def user_orders_devices?
+    user.orders_devices?
   end
 
   def show_chromebooks_form?
@@ -134,12 +134,6 @@ private
 
   def less_than_3_users_can_order?
     school.users.who_can_order_devices.count < 3
-  end
-
-  def set_first_user_flag!
-    is_first_user_for_school = school.users.count == 1
-    update!(first_school_user: is_first_user_for_school)
-    is_first_user_for_school
   end
 
   def set_show_chromebooks_flag!

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -106,7 +106,7 @@ RSpec.feature 'Navigate school welcome wizard' do
   end
 
   def as_a_new_school_user
-    @user = create(:school_user, :new_visitor, school: school)
+    @user = create(:school_user, :new_visitor, school: school, orders_devices: true)
   end
 
   def as_a_subsequent_school_user

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
       end
     end
 
-    context 'when the step is order_your_own and user is the only school user' do
+    context 'when the step is order_your_own and user orders devices' do
+      let(:school_user) { create(:school_user, :new_visitor, school: school, orders_devices: true) }
+
       before do
         wizard.order_your_own!
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/KPN6ELXJ/730-not-showing-techsource-account-page-on-school-wizard-to-subsequent-users

### Changes proposed in this pull request

- Welcome wizard shows TechSource page if user orders devices
- This is no longer based on whether they are the first user or not

### Guidance to review

- Regardless of first or nth school user
- If `orders_devices` is true should see techsource page