### PR TITLE
Allow and strip whitespace in Chromebook details

### DIFF
--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -1,7 +1,8 @@
 class ChromebookInformationForm
   include ActiveModel::Model
 
-  attr_accessor :school, :will_need_chromebooks, :school_or_rb_domain, :recovery_email_address
+  attr_accessor :school, :will_need_chromebooks
+  attr_reader :school_or_rb_domain, :recovery_email_address
 
   validates :will_need_chromebooks, presence: true
 
@@ -18,6 +19,10 @@ class ChromebookInformationForm
 
   def recovery_email_address=(new_value)
     @recovery_email_address = new_value&.strip
+  end
+
+  def school_or_rb_domain=(new_value)
+    @school_or_rb_domain = new_value&.strip
   end
 
   def will_need_chromebooks?

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -16,6 +16,10 @@ class ChromebookInformationForm
     condition.validate :recovery_email_address_cannot_be_same_domain_as_school_or_rb
   end
 
+  def recovery_email_address=(new_value)
+    @recovery_email_address = new_value&.strip
+  end
+
   def will_need_chromebooks?
     will_need_chromebooks == 'yes'
   end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ChromebookInformationForm do
-  before do
+  it 'handles whitespace in the email address' do
     stub_request(:get, 'https://www.google.com/a/school.sch.uk/ServiceLogin')
       .to_return(status: 200, body: '', headers: {})
-  end
 
-  it 'handles whitespace in the email address' do
     form = described_class.new(will_need_chromebooks: 'yes',
                                recovery_email_address: ' ab@c.com ',
                                school_or_rb_domain: 'school.sch.uk')
@@ -15,5 +13,18 @@ RSpec.describe ChromebookInformationForm do
 
     expect(form.errors[:recovery_email_address]).to be_blank
     expect(form.recovery_email_address).to eq('ab@c.com')
+  end
+
+  it 'handles whitespace in the school/RB domain' do
+    request = stub_request(:get, 'https://www.google.com/a/school.sch.uk/ServiceLogin')
+      .to_return(status: 200, body: '', headers: {})
+
+    form = described_class.new(will_need_chromebooks: 'yes',
+                               recovery_email_address: 'ab@c.com',
+                               school_or_rb_domain: ' school.sch.uk ')
+
+    form.validate
+
+    expect(request).to have_been_made
   end
 end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ChromebookInformationForm do
+  before do
+    stub_request(:get, 'https://www.google.com/a/school.sch.uk/ServiceLogin')
+      .to_return(status: 200, body: '', headers: {})
+  end
+
+  it 'handles whitespace in the email address' do
+    form = described_class.new(will_need_chromebooks: 'yes',
+                               recovery_email_address: ' ab@c.com ',
+                               school_or_rb_domain: 'school.sch.uk')
+
+    form.validate
+
+    expect(form.errors[:recovery_email_address]).to be_blank
+    expect(form.recovery_email_address).to eq('ab@c.com')
+  end
+end


### PR DESCRIPTION
### Context

Some schools are inadvertently padding Chromebook domains and recovery emails with whitespace. This triggers a validation message and has caused them to get in touch with support.

### Changes proposed in this pull request

Strip whitespace on entry for Chromebook domains and recovery emails.


