### PR TITLE
[795] School can order + awaiting on TechSource

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,7 +1,11 @@
 class School::DevicesController < School::BaseController
   def order
     if @school.can_order? && @school.can_order_devices?
-      render :can_order
+      if @user.awaiting_techsource_account?
+        render :can_order_awaiting_techsource
+      else
+        render :can_order
+      end
     elsif @school.can_order_for_specific_circumstances? && @school.can_order_devices?
       render :can_order_for_specific_circumstances
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,10 @@ class User < ApplicationRecord
     techsource_account_confirmed_at.present?
   end
 
+  def awaiting_techsource_account?
+    orders_devices? && !techsource_account_confirmed?
+  end
+
   def hybrid?
     school_id && responsible_body_id
   end

--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -1,0 +1,23 @@
+<%- title = t('page_titles.school_order_devices_soon') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { 'Home' => school_home_path },
+    'Order devices',
+  ]) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= render partial: 'shared/techsource_unavailable_banner' %>
+
+    <p class="govuk-body">Your school is now eligible to place orders.</p>
+    <p class="govuk-body">You need to do this on a website called TechSource.</p>
+
+    <h2 class="govuk-heading-m">Your TechSource account will be ready soon</h2>
+
+    <p class="govuk-body">You cannot order devices until your TechSource account is ready. This should be in the next 24 hours. We’ll email you when you can order.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@
     school_cannot_order_devices: Your school cannot order devices yet
     school_user_cannot_order_devices: You cannot order devices yet
     school_order_devices: Order devices
+    school_order_devices_soon: Order devices soon
     school_request_devices: Request devices for specific circumstances
     school_details: Check your school details
     school_edit_chromebooks: Will your school need to order Chromebooks?

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -17,6 +17,22 @@ RSpec.feature 'Order devices' do
     and_i_see_a_link_to_techsource
   end
 
+  context 'when I am awaiting my TechSource account' do
+    let(:school_user) do
+      create(:school_user,
+             school: school,
+             full_name: 'AAA Smith',
+             orders_devices: true,
+             techsource_account_confirmed_at: nil)
+    end
+
+    scenario 'when my school can order devices' do
+      given_i_can_order_devices
+      when_i_visit_the_order_devices_page
+      then_i_see_techsource_ready_soon
+    end
+  end
+
   scenario 'when my school cannot order devices' do
     given_i_cannot_order_devices
     when_i_visit_the_order_devices_page
@@ -52,5 +68,9 @@ RSpec.feature 'Order devices' do
   def then_i_see_that_i_cannot_order_devices_yet
     expect(page).to have_content('Your school cannot order devices yet')
     expect(page).to have_link('request devices for disadvantaged children')
+  end
+
+  def then_i_see_techsource_ready_soon
+    expect(page).to have_content('Your TechSource account will be ready soon')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -774,4 +774,44 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#awaiting_techsource_account?' do
+    context 'user orders devices and techsource account not confirmed' do
+      subject(:user) do
+        described_class.new(
+          orders_devices: true,
+          techsource_account_confirmed_at: nil,
+        )
+      end
+
+      it 'returns true' do
+        expect(user.awaiting_techsource_account?).to be_truthy
+      end
+    end
+
+    context 'user orders devices and techsource account confirmed' do
+      subject(:user) do
+        described_class.new(
+          orders_devices: true,
+          techsource_account_confirmed_at: 1.second.ago,
+        )
+      end
+
+      it 'returns false' do
+        expect(user.awaiting_techsource_account?).to be_falsey
+      end
+    end
+
+    context 'user does not order devices' do
+      subject(:user) do
+        described_class.new(
+          orders_devices: false,
+        )
+      end
+
+      it 'returns false' do
+        expect(user.awaiting_techsource_account?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/mZTOpn2R/795-build-techsource-account-not-yet-ready-page

### Changes proposed in this pull request

- Minor copy changes and ui tweaks

![image](https://user-images.githubusercontent.com/92580/94821572-9f57bf00-03f9-11eb-8de3-c307e1206fe8.png)

### Guidance to review

- Login as a school user who can `order_devices` `true` but `techsource_account_confirmed_at` `nil` 
- Make the school allowed to order devices
- As school user attempt to order devices
- Should see copy related to TechSource account will be ready soon