### PR TITLE
[797] School can order but user cannot order page

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -3,6 +3,8 @@ class School::DevicesController < School::BaseController
     if @school.can_order? && @school.can_order_devices?
       if @user.awaiting_techsource_account?
         render :can_order_awaiting_techsource
+      elsif !@user.orders_devices?
+        render :school_can_order_user_cannot
       else
         render :can_order
       end

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -1,0 +1,35 @@
+<%- title = t('page_titles.school_can_order_devices') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { 'Home' => school_home_path },
+    title,
+  ]) %>
+<%- end %>
+
+<%-
+  device_count = @school.std_device_allocation.available_devices_count
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl">Order devices</span>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= render partial: 'shared/techsource_unavailable_banner' %>
+
+    <div class="app-card app-card__order">
+      <h2 class="govuk-panel__title govuk-!-font-size-36 govuk-!-margin-bottom-2">
+        <%= "#{device_count} #{'device'.pluralize(device_count)} available" -%>
+      </h2>
+      <div class="govuk-panel__body govuk-!-font-size-24">
+        You’ve ordered <%= @school.std_device_allocation.devices_ordered %> of
+        <%= @school.std_device_allocation.cap %> devices
+      </div>
+    </div>
+
+    <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
+
+    <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path %>.</p>
+  </div>
+</div>

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -8,7 +8,7 @@
 <%- end %>
 
 <%-
-  device_count = @school.std_device_allocation.available_devices_count
+  device_count = @school&.std_device_allocation&.available_devices_count || 0
 %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     school_home: Get devices for your school
+    school_can_order_devices: Your school can order devices
     school_cannot_order_devices: Your school cannot order devices yet
     school_user_cannot_order_devices: You cannot order devices yet
     school_order_devices: Order devices

--- a/spec/controllers/school/devices_controller_spec.rb
+++ b/spec/controllers/school/devices_controller_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe School::DevicesController do
-  let(:user) { create(:school_user, school: school) }
+  let(:user) do
+    create(:school_user,
+           school: school,
+           orders_devices: true,
+           techsource_account_confirmed_at: 1.second.ago)
+  end
 
   before do
     sign_in_as user

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -4,51 +4,86 @@ RSpec.feature 'Order devices' do
   include ViewHelper
 
   let(:school) { create(:school, :with_std_device_allocation) }
-  let(:school_user) { create(:school_user, school: school, full_name: 'AAA Smith') }
 
-  before do
-    given_i_am_signed_in_as_a_school_user
-  end
-
-  scenario 'when my school can order devices' do
+  scenario 'when my school can order devices and I can order devices' do
+    given_the_school_can_order_devices
     given_i_can_order_devices
+    given_i_am_signed_in_as_a_school_user
+
     when_i_visit_the_order_devices_page
     then_i_see_the_amount_of_devices_i_can_order
     and_i_see_a_link_to_techsource
   end
 
-  context 'when I am awaiting my TechSource account' do
-    let(:school_user) do
-      create(:school_user,
-             school: school,
-             full_name: 'AAA Smith',
-             orders_devices: true,
-             techsource_account_confirmed_at: nil)
-    end
+  scenario 'when my school can order devices and I am awaiting my TechSource account' do
+    given_the_school_can_order_devices
+    given_i_am_awaiting_my_techsource_account
+    given_i_am_signed_in_as_a_school_user
 
-    scenario 'when my school can order devices' do
-      given_i_can_order_devices
-      when_i_visit_the_order_devices_page
-      then_i_see_techsource_ready_soon
-    end
+    when_i_visit_the_order_devices_page
+    then_i_see_techsource_ready_soon
   end
 
-  scenario 'when my school cannot order devices' do
+  scenario 'when my school can order devices but I cannot order devices' do
+    given_the_school_can_order_devices
     given_i_cannot_order_devices
+    given_i_am_signed_in_as_a_school_user
+
+    when_i_visit_the_order_devices_page
+    then_i_see_someone_else_will_order
+  end
+
+  scenario 'when my school cannot order devices but I can' do
+    given_the_school_cannot_order_devices
+    given_i_can_order_devices
+    given_i_am_signed_in_as_a_school_user
+
     when_i_visit_the_order_devices_page
     then_i_see_that_i_cannot_order_devices_yet
   end
 
+  scenario 'when my school cannot order devices and I cannot order devices' do
+    given_the_school_cannot_order_devices
+    given_i_cannot_order_devices
+    given_i_am_signed_in_as_a_school_user
+
+    when_i_visit_the_order_devices_page
+    then_i_see_that_the_school_cannot_order_devices_yet
+  end
+
   def given_i_am_signed_in_as_a_school_user
-    sign_in_as school_user
+    sign_in_as @school_user
   end
 
   def given_i_can_order_devices
+    @school_user = create(:school_user,
+                          school: school,
+                          full_name: 'AAA Smith',
+                          orders_devices: true,
+                          techsource_account_confirmed_at: 1.second.ago)
+  end
+
+  def given_i_am_awaiting_my_techsource_account
+    @school_user = create(:school_user,
+                          school: school,
+                          full_name: 'AAA Smith',
+                          orders_devices: true,
+                          techsource_account_confirmed_at: nil)
+  end
+
+  def given_i_cannot_order_devices
+    @school_user = create(:school_user,
+                          school: school,
+                          full_name: 'AAA Smith',
+                          orders_devices: false)
+  end
+
+  def given_the_school_can_order_devices
     school.std_device_allocation.update!(cap: 50, allocation: 100, devices_ordered: 20)
     school.can_order!
   end
 
-  def given_i_cannot_order_devices
+  def given_the_school_cannot_order_devices
     school.cannot_order!
   end
 
@@ -66,11 +101,21 @@ RSpec.feature 'Order devices' do
   end
 
   def then_i_see_that_i_cannot_order_devices_yet
+    expect(page).to have_content('You cannot order devices yet')
+    expect(page).to have_link('request devices for disadvantaged children')
+  end
+
+  def then_i_see_that_the_school_cannot_order_devices_yet
     expect(page).to have_content('Your school cannot order devices yet')
     expect(page).to have_link('request devices for disadvantaged children')
   end
 
   def then_i_see_techsource_ready_soon
     expect(page).to have_content('Your TechSource account will be ready soon')
+  end
+
+  def then_i_see_someone_else_will_order
+    expect(page).to have_content('You do not have a TechSource account')
+    expect(page).to have_content('Someone else will need to place your school’s orders.')
   end
 end

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -4,7 +4,13 @@ RSpec.feature 'TechSource availability for school' do
   include ViewHelper
 
   let(:school) { create(:school, :with_std_device_allocation) }
-  let(:school_user) { create(:school_user, school: school, full_name: 'AAA Smith') }
+  let(:school_user) do
+    create(:school_user,
+           school: school,
+           orders_devices: true,
+           techsource_account_confirmed_at: 1.second.ago,
+           full_name: 'AAA Smith')
+  end
 
   after do
     Timecop.return


### PR DESCRIPTION
### Context

- https://trello.com/c/FnEmqTN6/797-school-can-orders-devices-user-that-cant-order

### Changes proposed in this pull request

- Handles scenario where the school can order but the user themselves cannot place order

![image](https://user-images.githubusercontent.com/92580/94838102-00d55900-040d-11eb-93b5-644805648ee1.png)

### Guidance to review

- Login as school user
- Set user do `orders_devices` is `false`
- Set the school so it can order devices
- As this school user attempt to place an order
- Should see page explaining the school can place order but they themselves cannot place the order