### PR TITLE
Temporarily prevent new MNO requests

### DIFF
--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -18,14 +18,11 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.request_extra_mobile_data') %>
     </h1>
-    <% unless @extra_mobile_data_requests.any? %>
-      <%= render partial: 'shared/use_the_mobile_guide' %>
-    <% end %>
-    <p class="govuk-body">
-      <%= govuk_button_link_to 'New request',
-        responsible_body_internet_mobile_extra_data_requests_type_path
-      %>
-    </p>
+
+    <h2 class="govuk-heading-l">You cannot request data at the&nbsp;moment</h2>
+    <p class="govuk-body">Our initial pilot ended on 30 September 2020, and we are now working with mobile network providers to prepare for the next phase.</p>
+    <p class="govuk-body">If you were planning to request a data increase, please hold on to the information you’ve gathered and wait for an update on the scheme.</p>
+    <p class="govuk-body">Data increases already received will continue until 31 December 2020.</p>
   </div>
 </div>
 <% if @extra_mobile_data_requests.any? %>

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     sign_in_as rb_user
   end
 
-  scenario 'the user can navigate to the manual request form from the responsible body home page' do
+  xscenario 'the user can navigate to the manual request form from the responsible body home page' do
     click_on 'Get the internet'
     click_on 'Request extra data for mobile devices'
 
@@ -20,7 +20,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
   end
 
-  scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
+  xscenario 'the user can navigate to the bulk upload form from the responsible body home page' do
     click_on 'Get the internet'
     click_on 'Request extra data for mobile devices'
 

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -27,8 +27,7 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
     end
 
     scenario 'Navigating to the form' do
-      visit responsible_body_internet_mobile_extra_data_requests_path
-      click_on('New request')
+      visit new_responsible_body_internet_mobile_bulk_request_path
       expect(page).to have_text('How would you like to submit information?')
       choose('Using a spreadsheet')
       click_on('Continue')

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -27,8 +27,7 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     end
 
     scenario 'Navigating to the form' do
-      visit responsible_body_internet_mobile_extra_data_requests_path
-      click_on('New request')
+      visit new_responsible_body_internet_mobile_bulk_request_path
       expect(page).to have_text('How would you like to submit information?')
       choose('Manually (entering details one at a time)')
       click_on('Continue')


### PR DESCRIPTION
- Remove new request button until MNO is extended

@benilovj I don't know if you want to do anything more thorough to disable requests, such as redirecting pages.

![Screen Shot 2020-10-02 at 12 20 44](https://user-images.githubusercontent.com/319055/94918068-b6ee8080-04a9-11eb-867f-54759e53c491.png)
