### PR TITLE
[732] If all devices ordered page

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,15 +1,17 @@
 class School::DevicesController < School::BaseController
   def order
-    if @school.can_order? && @school.can_order_devices?
-      if @user.awaiting_techsource_account?
-        render :can_order_awaiting_techsource
-      elsif !@user.orders_devices?
-        render :school_can_order_user_cannot
-      else
+    if @school.can_order_devices_right_now?
+      if @user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
+        render :can_order_for_specific_circumstances
+      elsif @user.has_an_active_techsource_account? && @school.can_order?
         render :can_order
+      elsif @user.awaiting_techsource_account?
+        render :can_order_awaiting_techsource
+      else # user has no techsource account
+        render :school_can_order_user_cannot
       end
-    elsif @school.can_order_for_specific_circumstances? && @school.can_order_devices?
-      render :can_order_for_specific_circumstances
+    elsif @school.all_devices_ordered?
+      render :cannot_order_as_cap_reached
     else
       render :cannot_order
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -64,9 +64,12 @@ class School < ApplicationRecord
     device_allocations.find_by_device_type!(device_type)
   end
 
-  def can_order_devices?
-    (can_order? || can_order_for_specific_circumstances?) &&
-      (std_device_allocation&.has_devices_available_to_order? == true)
+  def can_order_devices_right_now?
+    is_eligible_to_order? && has_devices_available_to_order?
+  end
+
+  def all_devices_ordered?
+    is_eligible_to_order? && !has_devices_available_to_order?
   end
 
   def has_std_device_allocation?
@@ -114,5 +117,15 @@ class School < ApplicationRecord
     else
       false
     end
+  end
+
+private
+
+  def is_eligible_to_order?
+    can_order? || can_order_for_specific_circumstances?
+  end
+
+  def has_devices_available_to_order?
+    std_device_allocation&.has_devices_available_to_order?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,10 @@ class User < ApplicationRecord
     orders_devices? && !techsource_account_confirmed?
   end
 
+  def has_an_active_techsource_account?
+    orders_devices? && techsource_account_confirmed?
+  end
+
   def hybrid?
     school_id && responsible_body_id
   end

--- a/app/views/school/devices/cannot_order_as_cap_reached.html.erb
+++ b/app/views/school/devices/cannot_order_as_cap_reached.html.erb
@@ -1,0 +1,43 @@
+<%- who_orders = @user.orders_devices? ? 'user' : 'school' %>
+<%- title = t("page_titles.school.devices.cannot_order_as_cap_reached.#{who_orders}.title") %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+    { 'Home' => school_home_path },
+    'Order devices',
+  ]) %>
+<%- end %>
+
+<%-
+  device_count = @school.std_device_allocation.available_devices_count
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Order devices</span>
+      <%= title %>
+    </h1>
+
+    <div class="app-card app-card__order">
+      <h2 class="govuk-panel__title govuk-!-font-size-36 govuk-!-margin-bottom-2">
+        All devices ordered
+      </h2>
+      <div class="govuk-panel__body govuk-!-font-size-24">
+        You’ve ordered <%= @school.std_device_allocation.devices_ordered %> of
+        <%= @school.std_device_allocation.cap %> devices
+      </div>
+    </div>
+
+    <p class="govuk-body">We’ll contact you if you can place more orders.</p>
+
+    <% if @user.orders_devices? && @user.techsource_account_confirmed? %>
+      <p class="govuk-body"><%= link_to 'View your order history on TechSource', techsource_start_path %></p>
+    <% end %>
+
+    <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
+    <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', school_request_devices_path %> from any year group who:</p>
+
+    <%= render partial: 'shared/devices/who_to_request_for_list' %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,13 @@
     school_home: Get devices for your school
     school_can_order_devices: Your school can order devices
     school_cannot_order_devices: Your school cannot order devices yet
+    school:
+      devices:
+        cannot_order_as_cap_reached:
+          school:
+            title: Your school has ordered all the devices it can
+          user:
+            title: You’ve ordered all the devices you can
     school_user_cannot_order_devices: You cannot order devices yet
     school_order_devices: Order devices
     school_order_devices_soon: Order devices soon

--- a/spec/controllers/school/devices_controller_spec.rb
+++ b/spec/controllers/school/devices_controller_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe School::DevicesController do
                  cap: 0)
         end
 
-        it 'renders can_order' do
+        it 'renders cannot_order_as_cap_reached' do
           get :order
-          expect(controller).to render_template('school/devices/cannot_order')
+          expect(controller).to render_template('school/devices/cannot_order_as_cap_reached')
         end
       end
     end
@@ -76,9 +76,9 @@ RSpec.describe School::DevicesController do
                  cap: 0)
         end
 
-        it 'renders cannot_order' do
+        it 'renders cannot_order_as_cap_reached' do
           get :order
-          expect(controller).to render_template('school/devices/cannot_order')
+          expect(controller).to render_template('school/devices/cannot_order_as_cap_reached')
         end
       end
     end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -207,12 +207,12 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe '#can_order_devices?' do
+  describe '#can_order_devices_right_now?' do
     let(:school) { create(:school, :in_lockdown) }
 
     context 'when there is no allocation of the given type' do
       it 'is false' do
-        expect(school.can_order_devices?).to be false
+        expect(school.can_order_devices_right_now?).to be_falsey
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'is false' do
-        expect(school.can_order_devices?).to eq(false)
+        expect(school.can_order_devices_right_now?).to be_falsey
       end
     end
 
@@ -243,7 +243,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'is true' do
-        expect(school.can_order_devices?).to eq(true)
+        expect(school.can_order_devices_right_now?).to be_truthy
       end
     end
 
@@ -262,7 +262,7 @@ RSpec.describe School, type: :model do
       end
 
       it 'is false' do
-        expect(school.can_order_devices?).to eq(false)
+        expect(school.can_order_devices_right_now?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/tEnKg7FQ/732-build-all-devices-ordered-page-for-schools

### Changes proposed in this pull request

- This is displayed instead of the cannot order page when the user can order but have reached their cap

### Screenshots

![image](https://user-images.githubusercontent.com/92580/94951202-c8508080-04db-11eb-8387-c3d3d9691b4d.png)

### Guidance to review

- Login as a school user
- The school can order devices but cap == allocation
- Attempt to user
- Should see the new page instead of the cannot order page