### PR TITLE
Add the ability to prevent new MNO requests via a feature flag

### DIFF
--- a/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
@@ -1,4 +1,6 @@
 class ResponsibleBody::Internet::Mobile::BulkRequestsController < ResponsibleBody::BaseController
+  before_action { render_404_if_feature_flag_inactive(:mno_offer) }
+
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -1,4 +1,8 @@
 class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
+  before_action only: :new do
+    render_404_if_feature_flag_inactive(:mno_offer)
+  end
+
   def index
     @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests
   end

--- a/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
@@ -1,4 +1,6 @@
 class ResponsibleBody::Internet::Mobile::ManualRequestsController < ResponsibleBody::BaseController
+  before_action { render_404_if_feature_flag_inactive(:mno_offer) }
+
   def index
     @extra_mobile_data_requests = @user.extra_mobile_data_requests
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,7 +9,9 @@ class FeatureFlag
     notify_computacenter_of_cap_changes
   ].freeze
 
-  TEMPORARY_FEATURE_FLAGS = %i[].freeze
+  TEMPORARY_FEATURE_FLAGS = %i[
+    mno_offer
+  ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
 

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -18,14 +18,22 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.request_extra_mobile_data') %>
     </h1>
-    <% unless @extra_mobile_data_requests.any? %>
-      <%= render partial: 'shared/use_the_mobile_guide' %>
+
+    <% if FeatureFlag.active?(:mno_offer) %>
+      <% unless @extra_mobile_data_requests.any? %>
+        <%= render partial: 'shared/use_the_mobile_guide' %>
+      <% end %>
+      <p class="govuk-body">
+        <%= govuk_button_link_to 'New request',
+          responsible_body_internet_mobile_extra_data_requests_type_path
+        %>
+      </p>
+    <% else %>
+      <h2 class="govuk-heading-l">You cannot request data at the&nbsp;moment</h2>
+      <p class="govuk-body">Our initial pilot ended on 30 September 2020, and we are now working with mobile network providers to prepare for the next phase.</p>
+      <p class="govuk-body">If you were planning to request a data increase, please hold on to the information you’ve gathered and wait for an update on the scheme.</p>
+      <p class="govuk-body">Data increases already received will continue until 31 December 2020.</p>
     <% end %>
-    <p class="govuk-body">
-      <%= govuk_button_link_to 'New request',
-        responsible_body_internet_mobile_extra_data_requests_type_path
-      %>
-    </p>
   </div>
 </div>
 <% if @extra_mobile_data_requests.any? %>

--- a/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: 
 
   context 'when authenticated' do
     before do
+      FeatureFlag.activate(:mno_offer)
       sign_in_as local_authority_user
+    end
+
+    after do
+      FeatureFlag.deactivate(:mno_offer)
     end
 
     describe 'create' do

--- a/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe ResponsibleBody::Internet::Mobile::ExtraDataRequestsController, t
 
   context 'when authenticated' do
     before do
+      FeatureFlag.activate(:mno_offer)
       sign_in_as local_authority_user
+    end
+
+    after do
+      FeatureFlag.deactivate(:mno_offer)
     end
 
     describe 'submitting spreadsheet choice' do

--- a/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe ResponsibleBody::Internet::Mobile::ManualRequestsController, type
 
   context 'when authenticated' do
     before do
+      FeatureFlag.activate(:mno_offer)
       sign_in_as local_authority_user
+    end
+
+    after do
+      FeatureFlag.deactivate(:mno_offer)
     end
 
     describe 'create' do

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -7,30 +7,40 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     sign_in_as rb_user
   end
 
-  scenario 'the user can navigate to the manual request form from the responsible body home page' do
-    click_on 'Get the internet'
-    click_on 'Request extra data for mobile devices'
+  context 'when the MNO offer is activated' do
+    before do
+      FeatureFlag.activate(:mno_offer)
+    end
 
-    expect(page).to have_css('h1', text: 'Request extra mobile data')
-    expect(page).to have_http_status(:ok)
-    click_on 'New request'
-    expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Manually (entering details one at a time)'
-    click_on 'Continue'
-    expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
-  end
+    after do
+      FeatureFlag.deactivate(:mno_offer)
+    end
 
-  scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
-    click_on 'Get the internet'
-    click_on 'Request extra data for mobile devices'
+    scenario 'the user can navigate to the manual request form from the responsible body home page' do
+      click_on 'Get the internet'
+      click_on 'Request extra data for mobile devices'
 
-    expect(page).to have_css('h1', text: 'Request extra mobile data')
-    expect(page).to have_http_status(:ok)
-    click_on 'New request'
-    expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Using a spreadsheet'
-    click_on 'Continue'
-    expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
+      expect(page).to have_css('h1', text: 'Request extra mobile data')
+      expect(page).to have_http_status(:ok)
+      click_on 'New request'
+      expect(page).to have_css('h1', text: 'How would you like to submit information?')
+      choose 'Manually (entering details one at a time)'
+      click_on 'Continue'
+      expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
+    end
+
+    scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
+      click_on 'Get the internet'
+      click_on 'Request extra data for mobile devices'
+
+      expect(page).to have_css('h1', text: 'Request extra mobile data')
+      expect(page).to have_http_status(:ok)
+      click_on 'New request'
+      expect(page).to have_css('h1', text: 'How would you like to submit information?')
+      choose 'Using a spreadsheet'
+      click_on 'Continue'
+      expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
+    end
   end
 
   context 'when the user has already submitted requests' do

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -19,11 +19,16 @@ RSpec.feature 'Submitting an ExtraMobileDataRequest', type: :feature do
     let(:mobile_network) { create(:mobile_network) }
 
     before do
+      FeatureFlag.activate(:mno_offer)
       mobile_network
       sign_in_as user
       # prevent api call to Notify
       stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms')
         .to_return(status: 201, body: '{}')
+    end
+
+    after do
+      FeatureFlag.deactivate(:mno_offer)
     end
 
     scenario 'Navigating to the form' do

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -15,9 +15,14 @@ RSpec.feature 'Session behaviour', type: :feature do
       create(:mobile_network)
     end
 
-    # this seems overly-verbose compared to let!, but this is what rubocop wants
     before do
+      FeatureFlag.activate(:mno_offer)
+      # this seems overly-verbose compared to let!, but this is what rubocop wants
       participating_mobile_network
+    end
+
+    after do
+      FeatureFlag.activate(:mno_offer)
     end
 
     # TODO: need to think about how verification should work


### PR DESCRIPTION
### Context

Alternative to #587.

### Changes proposed in this pull request

If the feature flag is deactivated:

- Remove new request button.
- Show 404 if trying to deep-link to the forms.

### Guidance to review

