### PR TITLE
777 gias updates stage trust data

### DIFF
--- a/app/jobs/stage_trust_data_job.rb
+++ b/app/jobs/stage_trust_data_job.rb
@@ -1,0 +1,5 @@
+class StageTrustDataJob < ApplicationJob
+  def perform
+    StageTrustData.new.import_trusts
+  end
+end

--- a/app/models/data_stage/trust.rb
+++ b/app/models/data_stage/trust.rb
@@ -1,0 +1,19 @@
+class DataStage::Trust < ApplicationRecord
+  self.table_name = 'staged_trusts'
+
+  enum organisation_type: {
+    multi_academy_trust: 'Multi-academy trust',
+    single_academy_trust: 'Single-academy trust',
+  }
+
+  enum status: {
+    open: 'open',
+    closed: 'closed',
+  }
+
+  validates :name, presence: true
+  validates :organisation_type, presence: true
+  validates :gias_group_uid, presence: true
+
+  scope :updated_since, ->(datetime) { where(arel_table[:updated_at].gt(datetime)) }
+end

--- a/app/models/data_stage/trust.rb
+++ b/app/models/data_stage/trust.rb
@@ -1,20 +1,6 @@
 class DataStage::Trust < ApplicationRecord
   self.table_name = 'staged_trusts'
 
-  ATTR_MAP = {
-    name: 'Group Name',
-    organisation_type: 'Group Type',
-    companies_house_number: 'Companies House Number',
-    gias_group_uid: 'Group UID',
-    status: 'Group Status',
-    address_1: 'Group Street',
-    address_2: 'Group Locality',
-    address_3: 'Group Address 3',
-    town: 'Group Town',
-    county: 'Group County',
-    postcode: 'Group Postcode',
-  }.freeze
-
   enum organisation_type: {
     multi_academy_trust: 'Multi-academy trust',
     single_academy_trust: 'Single-academy trust',

--- a/app/models/data_stage/trust.rb
+++ b/app/models/data_stage/trust.rb
@@ -1,14 +1,23 @@
 class DataStage::Trust < ApplicationRecord
   self.table_name = 'staged_trusts'
 
+  ATTR_MAP = {
+    name: 'Group Name',
+    organisation_type: 'Group Type',
+    companies_house_number: 'Companies House Number',
+    gias_group_uid: 'Group UID',
+    status: 'Group Status',
+    address_1: 'Group Street',
+    address_2: 'Group Locality',
+    address_3: 'Group Address 3',
+    town: 'Group Town',
+    county: 'Group County',
+    postcode: 'Group Postcode',
+  }.freeze
+
   enum organisation_type: {
     multi_academy_trust: 'Multi-academy trust',
     single_academy_trust: 'Single-academy trust',
-  }
-
-  enum status: {
-    open: 'open',
-    closed: 'closed',
   }
 
   validates :name, presence: true

--- a/app/models/get_information_about_schools.rb
+++ b/app/models/get_information_about_schools.rb
@@ -11,6 +11,15 @@ class GetInformationAboutSchools
     }.map(&:to_h)
   end
 
+  def self.trusts(&block)
+    file = Tempfile.new
+    fetch_latest_trusts_file(file)
+    TrustDataFile.new(file.path).trusts(&block)
+  ensure
+    file.close
+    file.unlink
+  end
+
   def self.schools(&block)
     file = Tempfile.new
     fetch_latest_edubase_file(file)
@@ -44,6 +53,10 @@ class GetInformationAboutSchools
 
   def self.fetch_latest_edubase_links_file(file)
     RemoteFile.download(school_links_url, file)
+  end
+
+  def self.fetch_latest_trusts_file(file)
+    RemoteFile.download(groups_url, file)
   end
 
   def self.fetch_contacts_file(file)

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -6,19 +6,11 @@ class TrustDataFile < CsvDataFile
 protected
 
   def extract_record(row)
-    {
-      name: row['Group Name'],
-      organisation_type: row['Group Type'],
-      companies_house_number: row['Companies House Number'],
-      gias_group_uid: row['Group UID'],
-      status: row['Group Status']&.downcase,
-      address_1: row['Group Street'],
-      address_2: row['Group Locality'],
-      address_3: row['Group Address 3'],
-      town: row['Group Town'],
-      county: sanitize_county(row['Group County']),
-      postcode: row['Group Postcode'],
-    }
+    record = {}
+    DataStage::Trust::ATTR_MAP.each do |k, v|
+      record[k] = row[v]
+    end
+    record
   end
 
   def skip?(row)

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -47,6 +47,7 @@ private
 
   def sanitize_county(value)
     return nil if value == 'Not recorded' || value.blank?
+
     value
   end
 

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -1,4 +1,19 @@
 class TrustDataFile < CsvDataFile
+
+  ATTR_MAP = {
+    name: 'Group Name',
+    organisation_type: 'Group Type',
+    companies_house_number: 'Companies House Number',
+    gias_group_uid: 'Group UID',
+    status: 'Group Status',
+    address_1: 'Group Street',
+    address_2: 'Group Locality',
+    address_3: 'Group Address 3',
+    town: 'Group Town',
+    county: 'Group County',
+    postcode: 'Group Postcode',
+  }.freeze
+
   def trusts(&block)
     records(&block)
   end
@@ -7,7 +22,7 @@ protected
 
   def extract_record(row)
     record = {}
-    DataStage::Trust::ATTR_MAP.each do |k, v|
+    ATTR_MAP.each do |k, v|
       record[k] = row[v]
     end
     record

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -1,21 +1,4 @@
 class TrustDataFile < CsvDataFile
-  EXCLUDED_TYPES = [
-    'British schools overseas',
-    "Children's centre",
-    "Children's centre linked site",
-    'Further education',
-    'Higher education institutions',
-    'Institution funded by other government department',
-    'Miscellaneous',
-    'Offshore schools',
-    'Other independent school',
-    'Other independent special school',
-    'Secure units',
-    'Sixth form centres',
-    'Special post 16 institution',
-    'Welsh establishment',
-  ].freeze
-
   def trusts(&block)
     records(&block)
   end
@@ -28,7 +11,7 @@ protected
       organisation_type: row['Group Type'],
       companies_house_number: row['Companies House Number'],
       gias_group_uid: row['Group UID'],
-      status: row['Group Status'].downcase,
+      status: row['Group Status']&.downcase,
       address_1: row['Group Street'],
       address_2: row['Group Locality'],
       address_3: row['Group Address 3'],
@@ -49,61 +32,5 @@ private
     return nil if value == 'Not recorded' || value.blank?
 
     value
-  end
-
-  def find_responsible_body(row)
-    # 3 - Multi-academy trust
-    # 5 - Single-academy trust
-    if row['TrustSchoolFlag (code)'].in? %w[3 5]
-      row['Trusts (name)']
-    else
-      row['LA (name)']
-    end
-  end
-
-  def phase(row)
-    phase_name = row['PhaseOfEducation (name)']
-    case phase_name
-    when 'Primary', 'Middle deemed primary'
-      'primary'
-    when 'Secondary', 'Middle deemed secondary'
-      'secondary'
-    when 'All-through'
-      'all_through'
-    when '16 plus'
-      'sixteen_plus'
-    when 'Nursery'
-      'nursery'
-    else
-      'phase_not_applicable'
-    end
-  end
-
-  def establishment_type(row)
-    est_type = row['EstablishmentTypeGroup (name)']
-    case est_type
-    when 'Academies'
-      'academy'
-    when 'Free Schools'
-      'free'
-    when 'Local authority maintained schools'
-      'local_authority'
-    when 'Special schools'
-      'special'
-    else
-      Rails.logger.info("Other establishment type? '#{est_type}' (urn: #{row['URN']}")
-      'other_type'
-    end
-  end
-
-  def status(row)
-    case row['EstablishmentStatus (name)']
-    when 'Open', 'Open, but proposed to close'
-      'open'
-    when 'Closed', 'Proposed to open'
-      'closed'
-    else
-      Rails.logger.info("Unknown status type: '#{row['EstablishmentStatus (name)']}'")
-    end
   end
 end

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -1,5 +1,4 @@
 class TrustDataFile < CsvDataFile
-
   ATTR_MAP = {
     name: 'Group Name',
     organisation_type: 'Group Type',

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -1,0 +1,108 @@
+class TrustDataFile < CsvDataFile
+  EXCLUDED_TYPES = [
+    'British schools overseas',
+    "Children's centre",
+    "Children's centre linked site",
+    'Further education',
+    'Higher education institutions',
+    'Institution funded by other government department',
+    'Miscellaneous',
+    'Offshore schools',
+    'Other independent school',
+    'Other independent special school',
+    'Secure units',
+    'Sixth form centres',
+    'Special post 16 institution',
+    'Welsh establishment',
+  ].freeze
+
+  def trusts(&block)
+    records(&block)
+  end
+
+protected
+
+  def extract_record(row)
+    {
+      name: row['Group Name'],
+      organisation_type: row['Group Type'],
+      companies_house_number: row['Companies House Number'],
+      gias_group_uid: row['Group UID'],
+      status: row['Group Status'].downcase,
+      address_1: row['Group Street'],
+      address_2: row['Group Locality'],
+      address_3: row['Group Address 3'],
+      town: row['Group Town'],
+      county: sanitize_county(row['Group County']),
+      postcode: row['Group Postcode'],
+    }
+  end
+
+  def skip?(row)
+    !row['Group Type'].in?(['Single-academy trust', 'Multi-academy trust']) ||
+      row['Companies House Number'].blank?
+  end
+
+private
+
+  def sanitize_county(value)
+    return nil if value == 'Not recorded' || value.blank?
+    value
+  end
+
+  def find_responsible_body(row)
+    # 3 - Multi-academy trust
+    # 5 - Single-academy trust
+    if row['TrustSchoolFlag (code)'].in? %w[3 5]
+      row['Trusts (name)']
+    else
+      row['LA (name)']
+    end
+  end
+
+  def phase(row)
+    phase_name = row['PhaseOfEducation (name)']
+    case phase_name
+    when 'Primary', 'Middle deemed primary'
+      'primary'
+    when 'Secondary', 'Middle deemed secondary'
+      'secondary'
+    when 'All-through'
+      'all_through'
+    when '16 plus'
+      'sixteen_plus'
+    when 'Nursery'
+      'nursery'
+    else
+      'phase_not_applicable'
+    end
+  end
+
+  def establishment_type(row)
+    est_type = row['EstablishmentTypeGroup (name)']
+    case est_type
+    when 'Academies'
+      'academy'
+    when 'Free Schools'
+      'free'
+    when 'Local authority maintained schools'
+      'local_authority'
+    when 'Special schools'
+      'special'
+    else
+      Rails.logger.info("Other establishment type? '#{est_type}' (urn: #{row['URN']}")
+      'other_type'
+    end
+  end
+
+  def status(row)
+    case row['EstablishmentStatus (name)']
+    when 'Open', 'Open, but proposed to close'
+      'open'
+    when 'Closed', 'Proposed to open'
+      'closed'
+    else
+      Rails.logger.info("Unknown status type: '#{row['EstablishmentStatus (name)']}'")
+    end
+  end
+end

--- a/app/services/stage_trust_data.rb
+++ b/app/services/stage_trust_data.rb
@@ -1,0 +1,22 @@
+class StageTrustData
+  attr_reader :datasource
+
+  def initialize(trust_datasource = GetInformationAboutSchools)
+    @datasource = trust_datasource
+  end
+
+  def import_trusts
+    datasource.trusts do |trust_data|
+      trust = DataStage::Trust.find_by(companies_house_number: trust_data[:companies_house_number])
+
+      if trust
+        trust.update!(trust_data)
+      else
+        DataStage::Trust.create!(trust_data)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error(e.message)
+    end
+    DataStage::DataUpdateRecord.staged!(:trusts)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,3 +10,7 @@
     cron: '15 5 * * * Europe/London'  # every day at 5:15am
     queue: scheduler
     description: Stage GIAS school data
+  StageTrustDataJob:
+    cron: '30 5 * * * Europe/London' # every daya at 5:30am
+    queue: scheduler
+    description: Stage GIAS trust data

--- a/db/migrate/20201002105725_create_staged_trusts.rb
+++ b/db/migrate/20201002105725_create_staged_trusts.rb
@@ -1,0 +1,19 @@
+class CreateStagedTrusts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :staged_trusts do |t|
+      t.string :name, null: false, index: true
+      t.string :organisation_type, null: false
+      t.string :gias_group_uid, null: false
+      t.string :companies_house_number
+      t.string :address_1
+      t.string :address_2
+      t.string :address_3
+      t.string :town
+      t.string :county
+      t.string :postcode
+      t.string :status, null: false, index: true
+      t.timestamps
+    end
+    add_index :staged_trusts, :gias_group_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_30_145957) do
+ActiveRecord::Schema.define(version: 2020_10_02_105725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -253,6 +253,25 @@ ActiveRecord::Schema.define(version: 2020_09_30_145957) do
     t.index ["name"], name: "index_staged_schools_on_name"
     t.index ["status"], name: "index_staged_schools_on_status"
     t.index ["urn"], name: "index_staged_schools_on_urn"
+  end
+
+  create_table "staged_trusts", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "organisation_type", null: false
+    t.string "gias_group_uid", null: false
+    t.string "companies_house_number"
+    t.string "address_1"
+    t.string "address_2"
+    t.string "address_3"
+    t.string "town"
+    t.string "county"
+    t.string "postcode"
+    t.string "status", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["gias_group_uid"], name: "index_staged_trusts_on_gias_group_uid", unique: true
+    t.index ["name"], name: "index_staged_trusts_on_name"
+    t.index ["status"], name: "index_staged_trusts_on_status"
   end
 
   create_table "user_schools", force: :cascade do |t|

--- a/spec/factories/staged_trusts.rb
+++ b/spec/factories/staged_trusts.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :staged_trust, class: 'DataStage::Trust' do
+    gias_group_uid { Faker::Number.number(digits: 6) }
+    name { Faker::Educator.secondary_school }
+    organisation_type { Trust.organisation_types.values.sample }
+    companies_house_number { Faker::Number.leading_zero_number(digits: 8) }
+
+    address_1 { Faker::Address.street_name }
+    address_2 { Faker::Address.secondary_address }
+    town { Faker::Address.city }
+    postcode { Faker::Address.postcode }
+    status { :open }
+
+    trait :closed do
+      status { :closed }
+    end
+  end
+end

--- a/spec/models/trust_data_file_spec.rb
+++ b/spec/models/trust_data_file_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe TrustDataFile, type: :model do
       let(:attrs) do
         [
           {
-            group_uid: '1001',
+            gias_group_uid: '1001',
             companies_house_number: '01234222',
             name: 'Little Hampton Academy',
             address_1: '12 High St',
-            address_2: 'Little Hampton Count',
+            address_2: 'Little Hampton Court',
             town: 'London',
             postcode: 'NW1 1AA',
             status: 'Open',
-            group_type: 'Multi-academy trust',
+            organisation_type: 'Multi-academy trust',
           },
           {
-            group_uid: '4001',
+            gias_group_uid: '4001',
             companies_house_number: '09933123',
             name: 'Callio Forsythe Academy',
             address_1: 'Big Academy',
@@ -27,7 +27,7 @@ RSpec.describe TrustDataFile, type: :model do
             town: 'Easttown',
             postcode: 'EW1 1AA',
             status: 'Closed',
-            group_type: 'Single-academy trust',
+            organisation_type: 'Single-academy trust',
           },
         ]
       end
@@ -47,10 +47,10 @@ RSpec.describe TrustDataFile, type: :model do
           companies_house_number: '01234222',
           name: 'Little Hampton Academy',
           address_1: '12 High St',
-          address_2: 'Little Hampton Count',
+          address_2: 'Little Hampton Court',
           town: 'London',
           postcode: 'NW1 1AA',
-          status: 'open',
+          status: 'Open',
           organisation_type: 'Multi-academy trust',
         )
         expect(trusts.second).to include(
@@ -61,13 +61,13 @@ RSpec.describe TrustDataFile, type: :model do
           address_2: 'Strange Lane',
           town: 'Easttown',
           postcode: 'EW1 1AA',
-          status: 'closed',
+          status: 'Closed',
           organisation_type: 'Single-academy trust',
         )
       end
     end
 
-    context 'when a trust is has no companies house number or is not a single or multi academy trust' do
+    context 'when a trust has no Companies House number or is not a single- or multi-academy trust' do
       let(:attrs) do
         [
           {
@@ -75,7 +75,7 @@ RSpec.describe TrustDataFile, type: :model do
             companies_house_number: '01234222',
             name: 'Little Hampton Academy',
             address_1: '12 High St',
-            address_2: 'Little Hampton Count',
+            address_2: 'Little Hampton Court',
             town: 'London',
             postcode: 'NW1 1AA',
             status: 'Open',

--- a/spec/models/trust_data_file_spec.rb
+++ b/spec/models/trust_data_file_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe TrustDataFile, type: :model do
+  describe '#trusts' do
+    let(:filename) { Rails.root.join('tmp/trust_test_data.csv') }
+
+    context 'when a trust is a single-academy or multi-academy and has a companies house number' do
+      let(:attrs) do
+        [
+          {
+            group_uid: '1001',
+            companies_house_number: '01234222',
+            name: 'Little Hampton Academy',
+            address_1: '12 High St',
+            address_2: 'Little Hampton Count',
+            town: 'London',
+            postcode: 'NW1 1AA',
+            status: 'Open',
+            group_type: 'Multi-academy trust',
+          },
+          {
+            group_uid: '4001',
+            companies_house_number: '09933123',
+            name: 'Callio Forsythe Academy',
+            address_1: 'Big Academy',
+            address_2: 'Strange Lane',
+            town: 'Easttown',
+            postcode: 'EW1 1AA',
+            status: 'Closed',
+            group_type: 'Single-academy trust',
+          },
+        ]
+      end
+
+      before do
+        create_trust_csv_file(filename, attrs)
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'retrieves the trust data' do
+        trusts = TrustDataFile.new(filename).trusts
+        expect(trusts.first).to include(
+          gias_group_uid: '1001',
+          companies_house_number: '01234222',
+          name: 'Little Hampton Academy',
+          address_1: '12 High St',
+          address_2: 'Little Hampton Count',
+          town: 'London',
+          postcode: 'NW1 1AA',
+          status: 'open',
+          organisation_type: 'Multi-academy trust',
+        )
+        expect(trusts.second).to include(
+          gias_group_uid: '4001',
+          companies_house_number: '09933123',
+          name: 'Callio Forsythe Academy',
+          address_1: 'Big Academy',
+          address_2: 'Strange Lane',
+          town: 'Easttown',
+          postcode: 'EW1 1AA',
+          status: 'closed',
+          organisation_type: 'Single-academy trust',
+        )
+      end
+    end
+
+    context 'when a trust is has no companies house number or is not a single or multi academy trust' do
+      let(:attrs) do
+        [
+          {
+            group_uid: '3001',
+            companies_house_number: '01234222',
+            name: 'Little Hampton Academy',
+            address_1: '12 High St',
+            address_2: 'Little Hampton Count',
+            town: 'London',
+            postcode: 'NW1 1AA',
+            status: 'Open',
+            group_type: 'Trust',
+          },
+          {
+            group_uid: '1031',
+            companies_house_number: '',
+            name: 'Hampton Academy',
+            address_1: '14 High St',
+            address_2: 'Hampton Court',
+            town: 'London',
+            postcode: 'NW1 1DA',
+            status: 'Open',
+            group_type: 'Single-academy trust',
+          },
+        ]
+      end
+
+      before do
+        create_school_csv_file(filename, attrs)
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'does not retrieve the trust data' do
+        trusts = TrustDataFile.new(filename).trusts
+        expect(trusts).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/stage_trust_data_spec.rb
+++ b/spec/services/stage_trust_data_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe StageTrustData, type: :model do
+  describe 'importing trusts' do
+    let(:filename) { Rails.root.join('tmp/trust_test_data.csv') }
+
+    context 'when a trust does not already exist' do
+      let(:attrs) do
+        {
+          group_uid: '4001',
+          companies_house_number: '09933123',
+          name: 'Callio Forsythe Academy',
+          address_1: 'Big Academy',
+          address_2: 'Strange Lane',
+          town: 'Easttown',
+          postcode: 'EW1 1AA',
+          status: 'Closed',
+          group_type: 'Single-academy trust',
+        }
+      end
+
+      before do
+        create_trust_csv_file(filename, [attrs])
+        @service = described_class.new(TrustDataFile.new(filename))
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'creates a new trust record' do
+        expect {
+          @service.import_trusts
+        }.to change { DataStage::Trust.count }.by(1)
+      end
+
+      it 'sets the correct values on the Trust record' do
+        @service.import_trusts
+        expect(DataStage::Trust.last).to have_attributes(
+          gias_group_uid: '4001',
+          companies_house_number: '09933123',
+          name: 'Callio Forsythe Academy',
+          address_1: 'Big Academy',
+          address_2: 'Strange Lane',
+          town: 'Easttown',
+          postcode: 'EW1 1AA',
+          status: 'closed',
+          organisation_type: 'single_academy_trust',
+        )
+      end
+    end
+
+    context 'when a trust already exists' do
+      let!(:trust) { create(:staged_trust, companies_house_number: '09933123') }
+
+      let(:attrs) do
+        {
+          group_uid: '4001',
+          companies_house_number: '09933123',
+          name: 'Academy of Wigtown',
+          address_1: 'Academy Campus',
+          address_2: 'Wigtown Lane',
+          town: 'Wigtown',
+          postcode: 'W1G 1AA',
+          status: 'Open',
+          group_type: 'Multi-academy trust',
+        }
+      end
+
+      before do
+        create_trust_csv_file(filename, [attrs])
+        @service = described_class.new(TrustDataFile.new(filename))
+      end
+
+      after do
+        remove_file(filename)
+      end
+
+      it 'updates the existing trust record' do
+        @service.import_trusts
+        expect(trust.reload).to have_attributes(
+          gias_group_uid: '4001',
+          companies_house_number: '09933123',
+          name: 'Academy of Wigtown',
+          address_1: 'Academy Campus',
+          address_2: 'Wigtown Lane',
+          town: 'Wigtown',
+          postcode: 'W1G 1AA',
+          status: 'open',
+          organisation_type: 'multi_academy_trust',
+        )
+      end
+    end
+  end
+end

--- a/spec/services/stage_trust_data_spec.rb
+++ b/spec/services/stage_trust_data_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StageTrustData, type: :model do
     context 'when a trust does not already exist' do
       let(:attrs) do
         {
-          group_uid: '4001',
+          gias_group_uid: '4001',
           companies_house_number: '09933123',
           name: 'Callio Forsythe Academy',
           address_1: 'Big Academy',
@@ -15,7 +15,7 @@ RSpec.describe StageTrustData, type: :model do
           town: 'Easttown',
           postcode: 'EW1 1AA',
           status: 'Closed',
-          group_type: 'Single-academy trust',
+          organisation_type: 'Single-academy trust',
         }
       end
 
@@ -44,7 +44,7 @@ RSpec.describe StageTrustData, type: :model do
           address_2: 'Strange Lane',
           town: 'Easttown',
           postcode: 'EW1 1AA',
-          status: 'closed',
+          status: 'Closed',
           organisation_type: 'single_academy_trust',
         )
       end
@@ -55,7 +55,7 @@ RSpec.describe StageTrustData, type: :model do
 
       let(:attrs) do
         {
-          group_uid: '4001',
+          gias_group_uid: '4001',
           companies_house_number: '09933123',
           name: 'Academy of Wigtown',
           address_1: 'Academy Campus',
@@ -63,7 +63,7 @@ RSpec.describe StageTrustData, type: :model do
           town: 'Wigtown',
           postcode: 'W1G 1AA',
           status: 'Open',
-          group_type: 'Multi-academy trust',
+          organisation_type: 'Multi-academy trust',
         }
       end
 
@@ -86,7 +86,7 @@ RSpec.describe StageTrustData, type: :model do
           address_2: 'Wigtown Lane',
           town: 'Wigtown',
           postcode: 'W1G 1AA',
-          status: 'open',
+          status: 'Open',
           organisation_type: 'multi_academy_trust',
         )
       end

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -43,12 +43,30 @@ module CSVFileHelper
     link_type: 'LinkType',
   }.freeze
 
+  TRUST_ATTRS = {
+    name: 'Group Name',
+    group_type: 'Group Type',
+    companies_house_number: 'Companies House Number',
+    group_uid: 'Group UID',
+    status: 'Group Status',
+    address_1: 'Group Street',
+    address_2: 'Group Locality',
+    address_3: 'Group Address 3',
+    town: 'Group Town',
+    county: 'Group County',
+    postcode: 'Group Postcode',
+  }.freeze
+
   def create_school_csv_file(filename, array_of_hashes)
     create_csv_file(filename, SCHOOL_ATTRS.values, array_of_hashes)
   end
 
   def create_school_links_csv_file(filename, array_of_hashes)
     create_csv_file(filename, SCHOOL_LINKS_ATTRS.values, array_of_hashes, SCHOOL_LINKS_ATTRS)
+  end
+
+  def create_trust_csv_file(filename, array_of_hashes)
+    create_csv_file(filename, TRUST_ATTRS.values, array_of_hashes, TRUST_ATTRS)
   end
 
   def create_allocations_csv_file(filename, array_of_hashes)

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -43,20 +43,6 @@ module CSVFileHelper
     link_type: 'LinkType',
   }.freeze
 
-  TRUST_ATTRS = {
-    name: 'Group Name',
-    group_type: 'Group Type',
-    companies_house_number: 'Companies House Number',
-    group_uid: 'Group UID',
-    status: 'Group Status',
-    address_1: 'Group Street',
-    address_2: 'Group Locality',
-    address_3: 'Group Address 3',
-    town: 'Group Town',
-    county: 'Group County',
-    postcode: 'Group Postcode',
-  }.freeze
-
   def create_school_csv_file(filename, array_of_hashes)
     create_csv_file(filename, SCHOOL_ATTRS.values, array_of_hashes)
   end
@@ -66,7 +52,8 @@ module CSVFileHelper
   end
 
   def create_trust_csv_file(filename, array_of_hashes)
-    create_csv_file(filename, TRUST_ATTRS.values, array_of_hashes, TRUST_ATTRS)
+    attrs = DataStage::Trust::ATTR_MAP
+    create_csv_file(filename, attrs.values, array_of_hashes, attrs)
   end
 
   def create_allocations_csv_file(filename, array_of_hashes)

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -52,7 +52,7 @@ module CSVFileHelper
   end
 
   def create_trust_csv_file(filename, array_of_hashes)
-    attrs = DataStage::Trust::ATTR_MAP
+    attrs = TrustDataFile::ATTR_MAP
     create_csv_file(filename, attrs.values, array_of_hashes, attrs)
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/8AvaD8wz/777-gias-updates-stage-trust-data)
Import GIAS trusts to the data stage

### Changes proposed in this pull request
Add import and parsing of trust data from GIAS (original import left in place for now).
Add job to schedule daily update of the import staging of the trust data (not sure if this actually needs to be daily?)

### Guidance to review
Running `StageTrustDataJob.perform_now` will download and import the latest Trust data from GIAS to the data stage.
View the imported Trust data via the `DataStage::Trust` model.

__Note:__ this does not affect the `Trust` data in the service as yet, those updates will come in future PRs.
