### PR TITLE
[804] extract privacy page from wizard and make it a single unified standalone page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,7 @@ private
         "couldn't figure out root_url_for user",
         logger: 'logger',
         extra: {
-          time_at: Time.now,
+          time_at: Time.zone.now,
           user_id: user.id,
         },
         tags: {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,4 +50,27 @@ private
   def not_found
     render 'errors/not_found', status: :not_found and return
   end
+
+  def root_url_for(user)
+    if user.needs_to_see_privacy_notice? && !user.seen_privacy_notice?
+      privacy_notice_path
+    elsif user.is_mno_user?
+      mno_extra_mobile_data_requests_path
+    elsif user.is_responsible_body_user? && !user.hybrid?
+      responsible_body_home_path
+    elsif user.is_school_user?
+      if user.school.preorder_information&.school_will_order_devices? &&
+          user.school.preorder_information&.chromebook_info_still_needed?
+        school_before_you_can_order_path
+      else
+        school_home_path
+      end
+    elsif user.is_computacenter?
+      computacenter_home_path
+    elsif user.is_support?
+      support_internet_service_performance_path
+    else
+      '/'
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,6 +70,18 @@ private
     elsif user.is_support?
       support_internet_service_performance_path
     else
+      # this should not happen - so let's tell Sentry
+      Raven.capture_message(
+        "couldn't figure out root_url_for user",
+        logger: 'logger',
+        extra: {
+          time_at: Time.now,
+          user_id: user.id,
+        },
+        tags: {
+          env: Rails.env,
+        },
+      )
       '/'
     end
   end

--- a/app/controllers/privacy_notice_controller.rb
+++ b/app/controllers/privacy_notice_controller.rb
@@ -1,0 +1,10 @@
+class PrivacyNoticeController < ApplicationController
+  before_action :require_sign_in!
+
+  def show; end
+
+  def seen
+    @user.seen_privacy_notice!
+    redirect_to root_url_for(@user)
+  end
+end

--- a/app/controllers/responsible_body/home_controller.rb
+++ b/app/controllers/responsible_body/home_controller.rb
@@ -1,10 +1,3 @@
 class ResponsibleBody::HomeController < ResponsibleBody::BaseController
   def show; end
-
-  def privacy_notice; end
-
-  def seen_privacy_notice
-    @user.seen_privacy_notice!
-    redirect_to responsible_body_home_path
-  end
 end

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -1,5 +1,5 @@
 class School::BaseController < ApplicationController
-  before_action :require_school_user!, :set_school
+  before_action :require_school_user!, :set_school, :require_completed_welcome_wizard!
 
 private
 
@@ -13,5 +13,11 @@ private
 
   def set_school
     @school = @user.school
+  end
+
+  def require_completed_welcome_wizard!
+    unless @user.school_welcome_wizard&.complete? || params[:controller] == 'school/welcome_wizard'
+      redirect_to school_welcome_wizard_allocation_path
+    end
   end
 end

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -86,37 +86,4 @@ private
       :identifier,
     )
   end
-
-  def root_url_for(user)
-    if user.is_mno_user?
-      mno_extra_mobile_data_requests_path
-    elsif user.hybrid?
-      school_user_start_url(user)
-    elsif user.needs_to_see_privacy_notice?
-      responsible_body_privacy_notice_path
-    elsif user.is_responsible_body_user?
-      responsible_body_home_path
-    elsif user.is_school_user?
-      school_user_start_url(user)
-    elsif user.is_computacenter?
-      computacenter_home_path
-    elsif user.is_support?
-      support_internet_service_performance_path
-    else
-      '/'
-    end
-  end
-
-  def school_user_start_url(user)
-    if user.school_welcome_wizard&.complete?
-      if user.school&.preorder_information&.school_will_order_devices? &&
-          user.school&.preorder_information&.chromebook_info_still_needed?
-        school_before_you_can_order_path
-      else
-        school_home_path
-      end
-    else
-      school_welcome_wizard_privacy_path
-    end
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,14 +10,6 @@ class UsersController < ApplicationController
 
     if @user.save
       token = SessionService.send_magic_link_email!(@user.email_address)
-      # NOTE: this is purely to allow us to display the link in the footer
-      # REMOVE when we have emails actually being sent
-      identifier = @user.sign_in_identifier(token)
-      @debug_info = {
-        sign_in_token: token,
-        sign_in_identifier: identifier,
-        sign_in_link: validate_sign_in_token_url(token: token, identifier: identifier),
-      }
       redirect_to sent_token_path(token: token)
     else
       render :new

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -4,7 +4,6 @@ class SchoolWelcomeWizard < ApplicationRecord
   validates :step, presence: true
 
   enum step: {
-    privacy: 'privacy',
     allocation: 'allocation',
     order_your_own: 'order_your_own',
     techsource_account: 'techsource_account',
@@ -26,9 +25,6 @@ class SchoolWelcomeWizard < ApplicationRecord
     return true if complete?
 
     case step
-    when 'privacy'
-      user.seen_privacy_notice!
-      allocation!
     when 'allocation'
       order_your_own!
     when 'order_your_own'
@@ -95,7 +91,8 @@ private
     elsif @invite_user == 'yes'
       user_attrs = user_params(params)
 
-      @invited_user = User.new(user_attrs.merge(school_id: school.id))
+      @invited_user = User.new(user_attrs)
+      @invited_user.schools << school
       if @invited_user.valid?
         save_and_invite_user!(@invited_user)
         @invited_user = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ApplicationRecord
   end
 
   def needs_to_see_privacy_notice?
-    is_responsible_body_user? && !seen_privacy_notice?
+    (is_responsible_body_user? || is_school_user?) && !seen_privacy_notice?
   end
 
   def seen_privacy_notice?

--- a/app/views/privacy_notice/show.html.erb
+++ b/app/views/privacy_notice/show.html.erb
@@ -3,7 +3,7 @@
 
     <%= render partial: 'shared/privacy_notice' %>
 
-    <%= form_for responsible_body_privacy_notice_path do %>
+    <%= form_for seen_privacy_notice_path, method: :patch do %>
       <%= submit_tag 'Continue', class: 'govuk-button' %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,9 @@ Rails.application.routes.draw do
   get '/sign-in', to: 'sign_in_tokens#new', as: :sign_in
   post '/sign-in', to: 'sign_in_tokens#create'
 
+  get '/privacy-notice', to: 'privacy_notice#show'
+  patch '/privacy-notice', to: 'privacy_notice#seen', as: :seen_privacy_notice
+
   get '/techsource-start', to: 'techsource_launcher#start'
 
   get '/403', to: 'errors#forbidden', via: :all

--- a/db/migrate/20201005122245_change_default_wizard_step_to_allocation.rb
+++ b/db/migrate/20201005122245_change_default_wizard_step_to_allocation.rb
@@ -1,0 +1,12 @@
+class ChangeDefaultWizardStepToAllocation < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :school_welcome_wizards, :step, from: 'privacy', to: 'allocation'
+
+    update_sql = <<~SQL
+      UPDATE  school_welcome_wizards
+        SET   step = 'allocation'
+        WHERE step = 'privacy'
+    SQL
+    SchoolWelcomeWizard.connection.execute(update_sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_30_145957) do
+ActiveRecord::Schema.define(version: 2020_10_05_122245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -187,7 +187,7 @@ ActiveRecord::Schema.define(version: 2020_09_30_145957) do
 
   create_table "school_welcome_wizards", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "step", default: "privacy", null: false
+    t.string "step", default: "allocation", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "user_orders_devices"
@@ -282,12 +282,13 @@ ActiveRecord::Schema.define(version: 2020_09_30_145957) do
     t.boolean "is_support", default: false, null: false
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
-    t.bigint "legacy_school_id"
     t.boolean "orders_devices"
+    t.bigint "legacy_school_id"
     t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["legacy_school_id", "full_name"], name: "index_users_on_legacy_school_id_and_full_name"
     t.index ["legacy_school_id"], name: "index_users_on_legacy_school_id"
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
@@ -313,5 +314,4 @@ ActiveRecord::Schema.define(version: 2020_09_30_145957) do
   add_foreign_key "school_device_allocations", "schools"
   add_foreign_key "school_welcome_wizards", "users", column: "invited_user_id"
   add_foreign_key "schools", "responsible_bodies"
-  add_foreign_key "users", "schools", column: "legacy_school_id"
 end

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe SignInTokensController, type: :controller do
 
       it 'redirects them to the school journey' do
         delete :destroy, params: valid_token_params
-        expect(response).to redirect_to('/school/privacy')
+        expect(response).to redirect_to('/school')
       end
 
       context 'when they have not accepted privacy policies' do
@@ -67,9 +67,9 @@ RSpec.describe SignInTokensController, type: :controller do
                  school: school)
         end
 
-        it 'redirects them to the school privacy policies' do
+        it 'redirects them to the privacy policy' do
           delete :destroy, params: valid_token_params
-          expect(response).to redirect_to('/school/privacy')
+          expect(response).to redirect_to(privacy_notice_path)
         end
       end
     end

--- a/spec/factories/school_welcome_wizards.rb
+++ b/spec/factories/school_welcome_wizards.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :school_welcome_wizard do
     user { create(:school_user) }
-    step { 'privacy' }
+    step { 'allocation' }
 
     trait :completed do
       step { 'complete' }

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -106,11 +106,11 @@ RSpec.feature 'Navigate school welcome wizard' do
   end
 
   def as_a_new_school_user
-    @user = create(:school_user, :new_visitor, school: school, orders_devices: true)
+    @user = create(:school_user, :new_visitor, :has_not_seen_privacy_notice, school: school, orders_devices: true)
   end
 
   def as_a_subsequent_school_user
-    @user = create_list(:school_user, 2, :new_visitor, school: school).last
+    @user = create_list(:school_user, 2, :new_visitor, :has_not_seen_privacy_notice, school: school).last
   end
 
   def when_the_chromebooks_question_has_already_been_answered
@@ -134,12 +134,11 @@ RSpec.feature 'Navigate school welcome wizard' do
   end
 
   def then_i_see_a_privacy_notice
-    expect(page).to have_current_path(school_welcome_wizard_privacy_path)
+    expect(page).to have_current_path(privacy_notice_path)
     expect(page).to have_text('Privacy notice')
   end
 
   def then_i_see_the_allocation_for_my_school
-    expect(page).to have_current_path(school_welcome_wizard_allocation_path)
     heading = I18n.t('page_titles.school_user_welcome_wizard.allocation.title', allocation: device_allocation)
     expect(page).to have_text(heading)
   end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -58,17 +58,17 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
 
     context 'who has not seen the privacy notice' do
-      let(:user) { create(:local_authority_user, privacy_notice_seen_at: nil) }
+      let(:user) { create(:local_authority_user, :has_not_seen_privacy_notice) }
 
       scenario 'it redirects to the privacy notice page' do
         sign_in_as user
-        expect(page).to have_current_path(responsible_body_privacy_notice_path)
+        expect(page).to have_current_path(privacy_notice_path)
         expect(page).to have_text 'Privacy notice'
       end
     end
   end
 
-  context 'as a school user who has completed the welcome wizard' do
+  context 'as a school user with only one school who has completed the welcome wizard' do
     let(:user) { create(:school_user) }
 
     scenario 'it redirects to the school homepage' do
@@ -94,7 +94,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   end
 
   context 'as a school user who has not done any of the welcome wizard' do
-    let(:user) { create(:school_user, :new_visitor) }
+    let(:user) { create(:school_user, :new_visitor, :has_not_seen_privacy_notice) }
 
     scenario 'it shows the welcome wizard welcome text on the interstitial page' do
       visit validate_token_url_for(user)
@@ -110,7 +110,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     end
   end
 
-  context 'as a school user who has not done part of the welcome wizard' do
+  context 'as a school user who has only done part of the welcome wizard' do
     let(:user) { create(:school_user, :has_partially_completed_wizard) }
 
     scenario 'clicking on Sign in takes them to their next step' do
@@ -121,7 +121,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   end
 
   context 'as a hybrid user' do
-    let(:user) { create(:hybrid_user) }
+    let(:user) { create(:hybrid_user, :has_not_seen_privacy_notice) }
 
     scenario 'logging in for the first time' do
       visit validate_token_url_for(user)

--- a/spec/models/school_welcome_wizard_spec.rb
+++ b/spec/models/school_welcome_wizard_spec.rb
@@ -11,24 +11,6 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
 
     subject(:wizard) { school_user.school_welcome_wizard }
 
-    context 'when the step is privacy' do
-      before do
-        wizard.privacy!
-      end
-
-      it 'moves to the allocation step' do
-        wizard.update_step!
-        expect(wizard.allocation?).to be true
-      end
-
-      it 'records when the privacy notice was seen' do
-        Timecop.freeze(Time.zone.now) do
-          wizard.update_step!
-          expect(school_user.privacy_notice_seen_at).to eq(Time.zone.now)
-        end
-      end
-    end
-
     context 'when the step is allocation' do
       before do
         wizard.allocation!
@@ -109,7 +91,7 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
         expect(user.email_address).to eq(new_user_attrs[:email_address])
         expect(user.telephone).to eq(new_user_attrs[:telephone])
         expect(user.orders_devices).to eq(new_user_attrs[:orders_devices])
-        expect(user.school).to eq(school_user.school)
+        expect(user.schools.first).to eq(wizard.school)
       end
 
       it 'sends an email to the new user' do
@@ -249,7 +231,7 @@ RSpec.describe SchoolWelcomeWizard, type: :model do
 
       it 'updates the preorder_information with the form details' do
         wizard.update_step!(request)
-        expect(school.preorder_information.will_need_chromebooks).to be_nil
+        expect(school.preorder_information.reload.will_need_chromebooks).to be_nil
       end
 
       it 'moves to the what_happens_next step' do


### PR DESCRIPTION
### Context

As part of the larger ticket [649 - Support multiple schools per user](https://trello.com/c/lDAgx85e/649-handling-multiple-schools), we'll need to have one `SchoolWelcomeWizard` per user-and-school combination. This means we need to remove the privacy notice from the wizard workflow, and make it standalone (the privacy notice is effectively per user, not per school). A subsequent PR will actually add the school ID to the SchoolWelcomeWizard class and deal with the user journey implications.

In discussion with @fofr we agreed that the privacy notices for school users and responsible body users were the same and could be unified into one - which also means that this work is foundational for supporting multiple RBs per user in future too. 

### Changes proposed in this pull request

* change the default step on `SchoolWelcomeWizard` from 'privacy' to 'allocation'
* add a standalone `PrivacyNoticeController` and move the responsible body privacy notice template to that scope 

There should be no noticeable difference in the user flow.

### Guidance to review

* probably a good idea to check actually clicking through with a new user of all three relevant types (RB, school, hybrid)
