### PR TITLE
drop legacy_school_id from user

### DIFF
--- a/db/migrate/20201005160200_drop_legacy_school_id_from_user.rb
+++ b/db/migrate/20201005160200_drop_legacy_school_id_from_user.rb
@@ -1,0 +1,5 @@
+class DropLegacySchoolIdFromUser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :legacy_school_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_122245) do
+ActiveRecord::Schema.define(version: 2020_10_05_160200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -302,13 +302,10 @@ ActiveRecord::Schema.define(version: 2020_10_05_122245) do
     t.boolean "is_computacenter", default: false, null: false
     t.datetime "privacy_notice_seen_at"
     t.boolean "orders_devices"
-    t.bigint "legacy_school_id"
     t.datetime "techsource_account_confirmed_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["approved_at"], name: "index_users_on_approved_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
-    t.index ["legacy_school_id", "full_name"], name: "index_users_on_legacy_school_id_and_full_name"
-    t.index ["legacy_school_id"], name: "index_users_on_legacy_school_id"
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"
     t.index ["sign_in_token"], name: "index_users_on_sign_in_token", unique: true


### PR DESCRIPTION
### Context

This was a fallback column in case PR #551 had any issues on rollout. Looks like we're good, so we can drop this column now,

### Changes proposed in this pull request

Drop the column

### Guidance to review

