### PR TITLE
Align guidance page title with its title in the guidance index page

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      How to order laptops and tablets during coronavirus (COVID-19)
+      How and when to order laptops and tablets during coronavirus (COVID-19)
     </h1>
 
     <p class="govuk-body">

--- a/spec/features/devices_guidance/how_to_order_spec.rb
+++ b/spec/features/devices_guidance/how_to_order_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'How to order devices', type: :feature do
 
     expect(devices_guidance_how_to_order_page).to be_displayed
 
-    expect(devices_guidance_how_to_order_page.page_heading).to have_content('How to order laptops and tablets during coronavirus (COVID-19)')
+    expect(devices_guidance_how_to_order_page.page_heading).to have_content('How and when to order laptops and tablets during coronavirus (COVID-19)')
     expect(devices_guidance_how_to_order_page.steps.length).to equal(6)
   end
 end


### PR DESCRIPTION
### Context

The title of the "How to order laptops and tablets" page on the devices guidance index was changed to "How **and when** to order laptops and tablets" in #595. However the title of the actual page wasn't updated at the same time.

### Changes proposed in this pull request

Re-align the name of the page with the name in the index.
