### PR TITLE
Remove unused feature flags

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,6 @@ class FeatureFlag
     public_account_creation
     slack_notifications
     rbs_can_manage_users
-    computacenter_cap_update_api
     notify_computacenter_of_cap_changes
   ].freeze
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,6 @@ class FeatureFlag
     public_account_creation
     slack_notifications
     rbs_can_manage_users
-    notify_computacenter_of_cap_changes
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[


### PR DESCRIPTION
### Context

The feature flag branching was removed in #532, but the flags themselves were left in.

### Changes proposed in this pull request

Remove the unused feature flags.


