### PR TITLE
Remove rbs_can_manage_users feature flag as it's fine in production

### DIFF
--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -1,6 +1,4 @@
 class ResponsibleBody::UsersController < ResponsibleBody::BaseController
-  before_action :require_feature_flag!, only: %i[edit update]
-
   def index
     @users = @responsible_body.users.order(:full_name)
   end
@@ -47,9 +45,5 @@ private
       :email_address,
       :telephone,
     )
-  end
-
-  def require_feature_flag!
-    render_404_if_feature_flag_inactive(:rbs_can_manage_users)
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,7 +4,6 @@ class FeatureFlag
     rate_limiting
     public_account_creation
     slack_notifications
-    rbs_can_manage_users
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/views/responsible_body/users/_user.html.erb
+++ b/app/views/responsible_body/users/_user.html.erb
@@ -1,9 +1,7 @@
 <div class="user">
   <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
-  <%- if FeatureFlag.active?(:rbs_can_manage_users) %>
-    <p class="govuk-body">
-      <%= govuk_link_to 'Edit user', edit_responsible_body_user_path(user) %>
-    </p>
-  <%- end %>
+  <p class="govuk-body">
+    <%= govuk_link_to 'Edit user', edit_responsible_body_user_path(user) %>
+  </p>
   <%= render UserSummaryListComponent.new(user: user) %>
 </div>

--- a/app/views/responsible_body/users/index.html.erb
+++ b/app/views/responsible_body/users/index.html.erb
@@ -21,11 +21,7 @@
 
     <p class="govuk-body">Everyone has the same level of access, they can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-      <%- if FeatureFlag.active?(:rbs_can_manage_users) %>
-        <li>add or edit existing users</li>
-      <%- else %>
-        <li>add users</li>
-      <%- end %>
+      <li>add or edit existing users</li>
       <li>view the list of existing users</li>
       <li>order devices for centrally managed schools</li>
       <%- if @responsible_body.in_connectivity_pilot? %>

--- a/spec/controllers/responsible_body/users_controller_spec.rb
+++ b/spec/controllers/responsible_body/users_controller_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe ResponsibleBody::UsersController do
   let(:user_from_other_rb) { create(:local_authority_user, responsible_body: other_local_authority) }
 
   describe '#edit' do
-    before do
-      FeatureFlag.activate(:rbs_can_manage_users)
-    end
-
     context 'logged in as a RB user' do
       before do
         sign_in_as rb_user

--- a/spec/features/responsible_body/manage_users_spec.rb
+++ b/spec/features/responsible_body/manage_users_spec.rb
@@ -64,84 +64,37 @@ RSpec.feature 'Managing ResponsibleBody users' do
     expect(page).not_to have_content(user_from_other_rb.full_name)
   end
 
-  context 'when the rbs_can_manage_users feature flag is not active' do
+  context 'clicking "Edit user"' do
     before do
-      FeatureFlag.deactivate(:rbs_can_manage_users)
-    end
-
-    it 'does not show a link to Edit user' do
       click_on 'Manage local authority users'
-      expect(page).not_to have_content 'Edit user'
-    end
-  end
-
-  context 'when the rbs_can_manage_users feature flag is active' do
-    before do
-      FeatureFlag.activate(:rbs_can_manage_users)
-    end
-
-    context 'clicking "Edit user"' do
-      before do
-        click_on 'Manage local authority users'
-        within(rb_users_index_page.user_rows[0]) do
-          click_on 'Edit user'
-        end
-      end
-
-      it 'shows the edit user form' do
-        expect(page).to have_content 'Edit user'
-        expect(page).to have_field 'Name'
-        expect(page).to have_field 'Email address'
-        expect(page).to have_field 'Telephone number'
-        expect(page).to have_button 'Save changes'
-      end
-
-      it 'shows an error when I submit the form with missing fields' do
-        fill_in('Name', with: '')
-        click_on('Save changes')
-        expect(page).to have_content('There is a problem')
-        expect(page).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'update the user when I submit the form with all required fields' do
-        fill_in('Name', with: 'ZZZ New RB User')
-        fill_in('Email address', with: 'new.user@rb.example.com')
-        fill_in('Telephone number', with: '01234 567890')
-        click_on('Save changes')
-
-        expect(rb_users_index_page).to be_displayed
-        expect(rb_users_index_page.user_rows[1]).to have_content('ZZZ New RB User')
+      within(rb_users_index_page.user_rows[0]) do
+        click_on 'Edit user'
       end
     end
 
-    context 'clicking "Invite a new user"' do
-      before do
-        click_on 'Manage local authority users'
-        click_on 'Invite a new user'
-      end
+    it 'shows the edit user form' do
+      expect(page).to have_content 'Edit user'
+      expect(page).to have_field 'Name'
+      expect(page).to have_field 'Email address'
+      expect(page).to have_field 'Telephone number'
+      expect(page).to have_button 'Save changes'
+    end
 
-      it 'shows the new user form' do
-        expect(new_rb_user_form).to be_displayed
-        expect(page).to have_field 'Name'
-        expect(page).to have_field 'Email address'
-        expect(page).to have_field 'Telephone number'
-      end
+    it 'shows an error when I submit the form with missing fields' do
+      fill_in('Name', with: '')
+      click_on('Save changes')
+      expect(page).to have_content('There is a problem')
+      expect(page).to have_http_status(:unprocessable_entity)
+    end
 
-      it 'shows an error when I submit the form with missing fields' do
-        click_on('Send invite')
-        expect(page).to have_content('There is a problem')
-        expect(page).to have_http_status(:unprocessable_entity)
-      end
+    it 'update the user when I submit the form with all required fields' do
+      fill_in('Name', with: 'ZZZ New RB User')
+      fill_in('Email address', with: 'new.user@rb.example.com')
+      fill_in('Telephone number', with: '01234 567890')
+      click_on('Save changes')
 
-      it 'adds the user when I submit the form with all required fields' do
-        fill_in('Name', with: 'ZZZ New RB User')
-        fill_in('Email address', with: 'new.user@rb.example.com')
-        fill_in('Telephone number', with: '01234 567890')
-        click_on('Send invite')
-
-        expect(rb_users_index_page).to be_displayed
-        expect(rb_users_index_page.user_rows[2]).to have_content('ZZZ New RB User')
-      end
+      expect(rb_users_index_page).to be_displayed
+      expect(rb_users_index_page.user_rows[1]).to have_content('ZZZ New RB User')
     end
   end
 end


### PR DESCRIPTION
### Context

The feature allowing RBs to edit users has been on for a while, so the feature flag is no longer necessary.

### Changes proposed in this pull request

Remove the feature flag.

### Guidance to review

