### PR TITLE
Prevent MNOs from cancelling extra mobile data requests via the interface

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -13,7 +13,9 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
           extra_mobile_data_requests: @extra_mobile_data_requests,
           extra_mobile_data_request_ids: selected_extra_mobile_data_request_ids(@extra_mobile_data_requests, params),
         )
-        @statuses = ExtraMobileDataRequest.translated_enum_values(:statuses).reject { |status| status.value == 'queried' }
+        @statuses = ExtraMobileDataRequest
+          .translated_enum_values(:statuses)
+          .reject { |status| status.value.in?(%w[queried cancelled]) }
       end
     end
   end

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -13,6 +13,14 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
     sign_in_as mno_user
   end
 
+  describe 'GET index' do
+    it 'does not list "queried" and "cancelled" as possible statuses to transition a request into' do
+      get :index
+
+      expect(assigns(:statuses).map(&:value)).to match_array(%w[requested in_progress complete unavailable])
+    end
+  end
+
   describe 'PATCH update' do
     let(:params) do
       {


### PR DESCRIPTION
### Context

MNOs are inadvertently able to cancel MNO requests without providing a reason why. This shouldn't be possible via the MNO interface.

### Changes proposed in this pull request

Remove the 'cancelled' status from the MNO status changer.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/95179411-7d26be00-07b8-11eb-9e27-058f3cf91bfc.png)
