### PR TITLE
Stop from auto-generated legend appearing on MNO requests index

### DIFF
--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -6,7 +6,8 @@
       :id,
       :label,
       small: false,
-      classes: 'all-none-item' %>
+      classes: 'all-none-item',
+      legend: { hidden: true } %>
     </div>
   </td>
   <td class="govuk-table__cell">


### PR DESCRIPTION
### Context

One auto-generated legend slipped through after the gem update in #594 😬  

### Changes proposed in this pull request

Hide the default legend

### Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/95179860-1ce44c00-07b9-11eb-8b78-e8c813347a27.png)

After:

![image](https://user-images.githubusercontent.com/23801/95180042-561cbc00-07b9-11eb-989f-dd1173f3a460.png)
