### PR TITLE
Fix links in the header of the MNO requests table

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -43,7 +43,7 @@ module ViewHelper
     render GovukComponent::Breadcrumbs.new(breadcrumbs: breadcrumbs)
   end
 
-  def sortable_table_header(title, value = title, opts = params)
+  def sortable_extra_mobile_data_requests_table_header(title, value = title, opts = params)
     if opts[:sort] == value.to_s
       if opts[:dir] == 'd'
         suffix = '▲'
@@ -52,9 +52,9 @@ module ViewHelper
         suffix = '▼'
         dir = 'd'
       end
-      safe_join([govuk_link_to(title, sort: value, dir: dir), suffix], ' ')
+      safe_join([govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value, dir: dir)), suffix], ' ')
     else
-      govuk_link_to(title, sort: value)
+      govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value))
     end
   end
 

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -40,16 +40,16 @@
                 </div>
               </th>
               <th class="govuk-table__header">
-                <%= sortable_table_header( 'Account holder', :account_holder_name ) %>
+                <%= sortable_extra_mobile_data_requests_table_header('Account holder', :account_holder_name) %>
               </th>
               <th class="govuk-table__header govuk-table__header--numeric">
-                <%= sortable_table_header( 'Mobile number', :mobile_number ) %>
+                <%= sortable_extra_mobile_data_requests_table_header('Mobile number', :mobile_number) %>
               </th>
               <th class="govuk-table__header">
-                <%= sortable_table_header( 'Requested', :requested ) %>
+                <%= sortable_extra_mobile_data_requests_table_header('Requested', :requested) %>
               </th>
               <th class="govuk-table__header">
-                <%= sortable_table_header( 'Status', :status ) %>
+                <%= sortable_extra_mobile_data_requests_table_header('Status', :status) %>
               </th>
               <th class="govuk-table__header">Actions</th>
             </tr>


### PR DESCRIPTION
### Context

We recently switched out the implementation of `govuk_link_to`, from
the one that was defined in the app, to a version that is defined in the
`govuk-components` gem.

This meant that the MNO requests table links weren't being generated quite correctly
and weren't getting the 'govuk-link' class applied to them.

### Changes proposed in this pull request

This change hardcodes the path helper to the MNO request index path, so
I've changed the helper name to reflect that.
