### PR TITLE
775 gias updates changes to trusts

### DIFF
--- a/app/models/data_stage/trust.rb
+++ b/app/models/data_stage/trust.rb
@@ -1,6 +1,11 @@
 class DataStage::Trust < ApplicationRecord
   self.table_name = 'staged_trusts'
 
+  enum status: {
+    open: 'open',
+    closed: 'closed',
+  }
+
   enum organisation_type: {
     multi_academy_trust: 'Multi-academy trust',
     single_academy_trust: 'Single-academy trust',

--- a/app/models/trust_data_file.rb
+++ b/app/models/trust_data_file.rb
@@ -22,7 +22,7 @@ protected
   def extract_record(row)
     record = {}
     ATTR_MAP.each do |k, v|
-      record[k] = row[v]
+      record[k] = (k == :status ? row[v]&.downcase : row[v])
     end
     record
   end

--- a/app/services/trust_update_service.rb
+++ b/app/services/trust_update_service.rb
@@ -1,0 +1,38 @@
+class TrustUpdateService
+  def update_trusts
+    # look at the trusts that have changed since the last update
+    last_update = DataStage::DataUpdateRecord.last_update_for(:trusts)
+
+    # simple updates for trusts that are open
+    DataStage::Trust.updated_since(last_update).open.each do |staged_trust|
+      trust = Trust.find_by(urn: staged_trust.urn)
+      if trust
+        update_trust(trust, staged_trust)
+      else
+        create_trust(staged_trust)
+      end
+    end
+
+    DataStage::DataUpdateRecord.updated!(:trusts)
+  end
+
+private
+
+  def update_trust(trust, staged_trust)
+    # update trust details
+    attrs = staged_attributes(staged_trust)
+    trust.update!(attrs)
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error(e.record.errors)
+  end
+
+  def create_trust(staged_trust)
+    Trust.create!(staged_attributes(staged_trust))
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error(e.record.errors)
+  end
+
+  def staged_attributes(staged_trust)
+    staged_trust.attributes.except('id', 'created_at', 'updated_at')
+  end
+end

--- a/app/services/trust_update_service.rb
+++ b/app/services/trust_update_service.rb
@@ -5,7 +5,7 @@ class TrustUpdateService
 
     # simple updates for trusts that are open
     DataStage::Trust.updated_since(last_update).open.each do |staged_trust|
-      trust = Trust.find_by(urn: staged_trust.urn)
+      trust = Trust.find_by(companies_house_number: staged_trust.companies_house_number)
       if trust
         update_trust(trust, staged_trust)
       else
@@ -33,6 +33,6 @@ private
   end
 
   def staged_attributes(staged_trust)
-    staged_trust.attributes.except('id', 'created_at', 'updated_at')
+    staged_trust.attributes.except('id', 'status', 'created_at', 'updated_at')
   end
 end

--- a/db/migrate/20201006105307_add_address_to_responsible_bodies.rb
+++ b/db/migrate/20201006105307_add_address_to_responsible_bodies.rb
@@ -1,0 +1,12 @@
+class AddAddressToResponsibleBodies < ActiveRecord::Migration[6.0]
+  def change
+    change_table :responsible_bodies do |t|
+      t.string :address_1
+      t.string :address_2
+      t.string :address_3
+      t.string :town
+      t.string :county
+      t.string :postcode
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_160200) do
+ActiveRecord::Schema.define(version: 2020_10_06_105307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,12 @@ ActiveRecord::Schema.define(version: 2020_10_05_160200) do
     t.string "gias_group_uid"
     t.string "gias_id"
     t.bigint "key_contact_id"
+    t.string "address_1"
+    t.string "address_2"
+    t.string "address_3"
+    t.string "town"
+    t.string "county"
+    t.string "postcode"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
     t.index ["gias_id"], name: "index_responsible_bodies_on_gias_id", unique: true

--- a/spec/models/trust_data_file_spec.rb
+++ b/spec/models/trust_data_file_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TrustDataFile, type: :model do
           address_2: 'Little Hampton Court',
           town: 'London',
           postcode: 'NW1 1AA',
-          status: 'Open',
+          status: 'open',
           organisation_type: 'Multi-academy trust',
         )
         expect(trusts.second).to include(
@@ -61,7 +61,7 @@ RSpec.describe TrustDataFile, type: :model do
           address_2: 'Strange Lane',
           town: 'Easttown',
           postcode: 'EW1 1AA',
-          status: 'Closed',
+          status: 'closed',
           organisation_type: 'Single-academy trust',
         )
       end

--- a/spec/services/stage_trust_data_spec.rb
+++ b/spec/services/stage_trust_data_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe StageTrustData, type: :model do
           address_2: 'Strange Lane',
           town: 'Easttown',
           postcode: 'EW1 1AA',
-          status: 'Closed',
+          status: 'closed',
           organisation_type: 'single_academy_trust',
         )
       end
@@ -86,7 +86,7 @@ RSpec.describe StageTrustData, type: :model do
           address_2: 'Wigtown Lane',
           town: 'Wigtown',
           postcode: 'W1G 1AA',
-          status: 'Open',
+          status: 'open',
           organisation_type: 'multi_academy_trust',
         )
       end

--- a/spec/services/trust_update_service_spec.rb
+++ b/spec/services/trust_update_service_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe TrustUpdateService, type: :model do
+  describe 'importing trusts from staging' do
+    let(:service) { subject }
+    let!(:trust) { create(:trust, companies_house_number: '098765432') }
+    let!(:staged_trust) { create(:staged_trust, companies_house_number: '01111222') }
+
+    context 'data update timestamps' do
+      it 'updates the DataUpdateRecord timestamp for trusts' do
+        t = Time.zone.now
+        Timecop.freeze(t) do
+          service.update_trusts
+          expect(DataStage::DataUpdateRecord.last_update_for(:trusts)).to be_within(1.second).of(t)
+        end
+      end
+
+      it 'only applies changes since the last update' do
+        Timecop.travel(6.hours.ago)
+        create(:staged_trust, companies_house_number: '01234567')
+        Timecop.return
+
+        Timecop.travel(2.hours.ago)
+        DataStage::DataUpdateRecord.updated!(:trusts)
+        Timecop.return
+
+        expect {
+          service.update_trusts
+        }.to change { Trust.count }.by(1)
+
+        expect(Trust.last).to have_attributes(
+          companies_house_number: staged_trust.companies_house_number,
+          name: staged_trust.name,
+          address_1: staged_trust.address_1,
+          address_2: staged_trust.address_2,
+          address_3: staged_trust.address_3,
+          town: staged_trust.town,
+          postcode: staged_trust.postcode,
+          organisation_type: staged_trust.organisation_type,
+        )
+      end
+    end
+
+    context 'when a trust does not already exist' do
+      it 'creates a new trust record' do
+        expect {
+          service.update_trusts
+        }.to change { Trust.count }.by(1)
+      end
+
+      it 'sets the correct values on the Trust record' do
+        service.update_trusts
+
+        expect(Trust.last).to have_attributes(
+          companies_house_number: staged_trust.companies_house_number,
+          name: staged_trust.name,
+          address_1: staged_trust.address_1,
+          address_2: staged_trust.address_2,
+          address_3: staged_trust.address_3,
+          town: staged_trust.town,
+          postcode: staged_trust.postcode,
+          organisation_type: staged_trust.organisation_type,
+        )
+      end
+    end
+
+    context 'when a trust already exists' do
+      let!(:trust) { create(:trust, companies_house_number: '01111222') }
+
+      it 'updates the existing trust record' do
+        service.update_trusts
+        expect(trust.reload).to have_attributes(
+          companies_house_number: staged_trust.companies_house_number,
+          name: staged_trust.name,
+          address_1: staged_trust.address_1,
+          address_2: staged_trust.address_2,
+          address_3: staged_trust.address_3,
+          town: staged_trust.town,
+          postcode: staged_trust.postcode,
+          organisation_type: staged_trust.organisation_type,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/xuCqURSA/775-gias-updates-changes-to-trusts)

### Changes proposed in this pull request
Update Trusts from the staged GIAS data
Adds address to responsible bodies

### Guidance to review
Basic mechanism is the same as updates to schools, the last update is recorded and changes made to the staging area since the last update are applied to the Trusts.
Use `TrustUpdateService.new.update_trusts` to process updates
