### PR TITLE
[666] Order users are notified when a school order state allows ordering

### DIFF
--- a/app/controllers/support/devices/order_status_controller.rb
+++ b/app/controllers/support/devices/order_status_controller.rb
@@ -12,7 +12,7 @@ class Support::Devices::OrderStatusController < Support::BaseController
     if @form.valid?
       if params[:confirm].present?
         ActiveRecord::Base.transaction do
-          CapUpdateService.new(school: @school).update!(cap: @form.cap, order_state: @form.order_state)
+          SchoolOrderStateAndCapUpdateService.new(school: @school).update!(cap: @form.cap, order_state: @form.order_state)
         end
         flash[:success] = t(:success, scope: %i[support order_status update])
         redirect_to support_devices_school_path(urn: @school.urn)

--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -1,0 +1,24 @@
+class CanOrderDevicesMailer < ApplicationMailer
+  def notify_user_email
+    @user = params[:user]
+    @school = params[:school]
+
+    template_mail(
+      template_id,
+      to: @user.email_address,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def personalisation
+    {
+      school: @school.name,
+    }
+  end
+
+  def template_id
+    Settings.govuk_notify.templates.devices.can_order_devices
+  end
+end

--- a/app/models/can_order_devices_notifications.rb
+++ b/app/models/can_order_devices_notifications.rb
@@ -6,13 +6,26 @@ class CanOrderDevicesNotifications
   end
 
   def call
-    if FeatureFlag.active?(:notify_can_place_orders) && school.can_order_devices_right_now?
-      school.order_users_with_active_techsource_accounts.each do |user|
-        CanOrderDevicesMailer
-          .with(user: user, school: school)
-          .notify_user_email
-          .deliver_later
-      end
+    if school.can_order_devices_right_now?
+      notify_all_order_users_with_active_techsource_accounts if FeatureFlag.active?(:notify_can_place_orders)
+      send_slack_notifications_for_users_who_can_order_right_now
+    end
+  end
+
+private
+
+  def notify_all_order_users_with_active_techsource_accounts
+    school.order_users_with_active_techsource_accounts.each do |user|
+      CanOrderDevicesMailer
+        .with(user: user, school: school)
+        .notify_user_email
+        .deliver_later
+    end
+  end
+
+  def send_slack_notifications_for_users_who_can_order_right_now
+    school.order_users_with_active_techsource_accounts.each do |user|
+      EventNotificationsService.broadcast(UserCanOrderEvent.new(user: user, school: @school))
     end
   end
 end

--- a/app/models/can_order_devices_notifications.rb
+++ b/app/models/can_order_devices_notifications.rb
@@ -1,0 +1,18 @@
+class CanOrderDevicesNotifications
+  attr_reader :school
+
+  def initialize(school:)
+    @school = school
+  end
+
+  def call
+    if FeatureFlag.active?(:notify_can_place_orders) && school.can_order_devices_right_now?
+      school.order_users_with_active_techsource_accounts.each do |user|
+        CanOrderDevicesMailer
+          .with(user: user, school: school)
+          .notify_user_email
+          .deliver_later
+      end
+    end
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -52,12 +52,7 @@ class School < ApplicationRecord
   end
 
   def active_responsible_users
-    case who_will_order_devices
-    when 'school'
-      users.signed_in_at_least_once
-    else
-      responsible_body.users.signed_in_at_least_once
-    end
+    device_ordering_organisation.users.signed_in_at_least_once
   end
 
   def allocation_for_type!(device_type)
@@ -120,6 +115,10 @@ class School < ApplicationRecord
   end
 
 private
+
+  def device_ordering_organisation
+    who_will_order_devices == 'school' ? self : responsible_body
+  end
 
   def is_eligible_to_order?
     can_order? || can_order_for_specific_circumstances?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -55,6 +55,13 @@ class School < ApplicationRecord
     device_ordering_organisation.users.signed_in_at_least_once
   end
 
+  def order_users_with_active_techsource_accounts
+    device_ordering_organisation
+      .users
+      .who_can_order_devices
+      .with_techsource_account_confirmed
+  end
+
   def allocation_for_type!(device_type)
     device_allocations.find_by_device_type!(device_type)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   scope :from_responsible_body_in_connectivity_pilot, -> { joins(:responsible_body).where('responsible_bodies.in_connectivity_pilot = ?', true) }
   scope :mno_users, -> { where.not(mobile_network: nil) }
   scope :who_can_order_devices, -> { where(orders_devices: true) }
+  scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }
   scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
 
   validates :full_name,

--- a/app/models/user_can_order_event.rb
+++ b/app/models/user_can_order_event.rb
@@ -1,0 +1,9 @@
+class UserCanOrderEvent < Event
+  def message
+    I18n.t(
+      :user_can_order_event,
+      scope: [:events],
+      organisation: @params[:school].name,
+    )
+  end
+end

--- a/app/services/bulk_allocation_service.rb
+++ b/app/services/bulk_allocation_service.rb
@@ -34,7 +34,7 @@ class BulkAllocationService
 private
 
   def update_cap_to_full_allocation!(school)
-    cus = CapUpdateService.new(school: school, device_type: 'std_device')
+    cus = SchoolOrderStateAndCapUpdateService.new(school: school, device_type: 'std_device')
     cus.update!(order_state: 'can_order', cap: nil)
   end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,6 +6,7 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = %i[
     mno_offer
+    notify_can_place_orders
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -1,4 +1,4 @@
-class CapUpdateService
+class SchoolOrderStateAndCapUpdateService
   attr_accessor :school, :device_type
 
   def initialize(args = {})

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -14,6 +14,11 @@ class SchoolOrderStateAndCapUpdateService
       update_cap_on_computacenter!(allocation.id)
       notify_computacenter_by_email(allocation.cap)
     end
+
+    # notifying users should only happen after successful completion of the Computacenter
+    # cap update, because it's possible for that to fail and the whole thing
+    # is rolled back
+    CanOrderDevicesNotifications.new(school: school).call
   end
 
 private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,6 +507,7 @@
     invite_event: "A user from %{organisation} has invited someone to the service"
     responsible_body_will_order_event: "%{responsible_body} will manage orders centrally"
     schools_will_order_event: "%{responsible_body} has devolved ordering to schools"
+    user_can_order_event: A user from %{organisation} is able to place orders
   helpers:
     label:
       support_enable_orders_form:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,6 +40,7 @@ govuk_notify:
       invite_responsible_body_user: '42e5cd7a-deaa-4234-bdea-db63b7c4ad90'
       nominate_contacts: 'ef964a6f-d984-4f35-a074-6f3cb79bfec7'
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
+      can_order_devices: '9df2c08a-c457-4b13-9270-c5a20687d168'
     computacenter:
       device_cap_change: '6e00f2bf-d373-436d-a2c0-2910f20ef521'
       comms_cap_change: '01f1b2a3-a216-44cc-a567-704bfd0a3c56'

--- a/spec/models/can_order_devices_notifications_spec.rb
+++ b/spec/models/can_order_devices_notifications_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe CanOrderDevicesNotifications do
+  let(:school) do
+    create(:school,
+           :with_std_device_allocation,
+           :with_preorder_information,
+           order_state: 'cannot_order')
+  end
+
+  around do |example|
+    FeatureFlag.activate(:notify_can_place_orders)
+    example.run
+    FeatureFlag.deactivate(:notify_can_place_orders)
+  end
+
+  describe '#call' do
+    context 'when school changes from cannot_order to can lockdown order' do
+      subject(:service) do
+        described_class.new(school: school)
+      end
+
+      before do
+        school.update!(order_state: 'can_order')
+        school.std_device_allocation.update!(cap: school.std_device_allocation.allocation)
+        school.preorder_information.update!(who_will_order_devices: 'school')
+      end
+
+      context 'user has confirmed techsource account' do
+        let(:user) do
+          create(:school_user,
+                 school: school,
+                 techsource_account_confirmed_at: 1.second.ago,
+                 orders_devices: true)
+        end
+
+        it 'notifies the user' do
+          user
+
+          expect {
+            service.call
+          }.to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'notify_user_email', 'deliver_now', params: { user: user, school: school }, args: [])
+        end
+
+        context 'when feature is deactivated' do
+          around do |example|
+            FeatureFlag.deactivate(:notify_can_place_orders)
+            example.run
+            FeatureFlag.activate(:notify_can_place_orders)
+          end
+
+          it 'does not notify the user' do
+            expect {
+              service.call
+            }.not_to have_enqueued_job.on_queue('mailers')
+          end
+        end
+      end
+
+      context 'user can order devices but yet to have techsource account' do
+        before do
+          create(:school_user,
+                 school: school,
+                 techsource_account_confirmed_at: nil,
+                 orders_devices: true)
+        end
+
+        it 'does not notify the user' do
+          expect {
+            service.call
+          }.not_to have_enqueued_job.on_queue('mailers')
+        end
+      end
+
+      context 'user can not order devices' do
+        before do
+          create(:school_user, school: school, orders_devices: false)
+        end
+
+        it 'does not notify the user' do
+          expect {
+            service.call
+          }.not_to have_enqueued_job.on_queue('mailers')
+        end
+      end
+    end
+
+    context 'when status change from specfic circumstances to lockdown' do
+      let(:school) { create(:school, order_state: 'can_order_for_specific_circumstances') }
+
+      subject(:service) { described_class.new(school: school) }
+
+      before do
+        school.update!(order_state: 'can_order')
+        service
+      end
+
+      context 'user has confirmed techsource account' do
+        before do
+          create(:school_user,
+                 school: school,
+                 techsource_account_confirmed_at: 1.second.ago,
+                 orders_devices: true)
+        end
+
+        it 'does not notify the user' do
+          expect {
+            service.call
+          }.not_to have_enqueued_job.on_queue('mailers')
+        end
+      end
+    end
+
+    context 'when status change from can_order to cannot_order' do
+      let(:school) { create(:school, order_state: 'can_order') }
+
+      subject(:service) { described_class.new(school: school) }
+
+      before do
+        school.update!(order_state: 'cannot_order')
+      end
+
+      context 'user has confirmed techsource account' do
+        before do
+          create(:school_user,
+                 school: school,
+                 techsource_account_confirmed_at: 1.second.ago,
+                 orders_devices: true)
+        end
+
+        it 'does not notify the user' do
+          expect {
+            service.call
+          }.not_to have_enqueued_job.on_queue('mailers')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -11,14 +11,22 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
 
   describe '#update!' do
     let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789') }
+    let(:notifications) { instance_double(CanOrderDevicesNotifications) }
 
     before do
       allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
       allow(mock_request).to receive(:post!)
+      allow(CanOrderDevicesNotifications).to receive(:new).with(school: school).and_return(notifications)
+      allow(notifications).to receive(:call)
     end
 
     it 'updates the school with the given order_state' do
       expect { service.update!(cap: new_cap, order_state: new_order_state) }.to change(school, :order_state).from('cannot_order').to('can_order')
+    end
+
+    it 'triggers notifications that the school can order' do
+      service.update!(cap: new_cap, order_state: new_order_state)
+      expect(notifications).to have_received(:call)
     end
 
     context 'when a std SchoolDeviceAllocation does not exist' do

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CapUpdateService do
+RSpec.describe SchoolOrderStateAndCapUpdateService do
   let(:school) { create(:school, order_state: 'cannot_order') }
   let(:new_order_state) { 'can_order' }
   let(:new_cap) { 2 }


### PR DESCRIPTION
### Context

If a school cap is set, the order users need to know that they can go in and place their orders.

Out of scope for this PR:

- notifying an order user when their TechSource account has been confirmed (will be a follow-up PR)
- sending an automated email to CC (will be a follow-up PR)

### Changes proposed in this pull request

- Inform the order users when the cap for their school has been set
- Feature flag the email, until we've let the feature run in production for a little bit and see from the Slack messages that it's triggering at the right point in time


