### PR TITLE
Allow further education establishments

### DIFF
--- a/app/models/school_data_file.rb
+++ b/app/models/school_data_file.rb
@@ -3,7 +3,6 @@ class SchoolDataFile < CsvDataFile
     'British schools overseas',
     "Children's centre",
     "Children's centre linked site",
-    'Further education',
     'Higher education institutions',
     'Institution funded by other government department',
     'Miscellaneous',


### PR DESCRIPTION
### Context
Some schools that are Further Education establishments should be in the service. This allows them to come into the Data Stage where the permitted ones could be onboarded.

### Changes proposed in this pull request
Remove 'Further Education' from the filter for the schools data file

### Guidance to review
Running `StageGiasDataJob.perform_now` should now bring schools with the 'EstablishmentType' of 'Further education'
