### PR TITLE
Set encoding for incoming csv data to CP1252

### DIFF
--- a/app/models/csv_data_file.rb
+++ b/app/models/csv_data_file.rb
@@ -37,7 +37,7 @@ private
 
   def read_file
     csv = download_to_temp_file_if_needed(@csv_uri)
-    CSV.foreach(csv, headers: true, encoding: 'ISO8859-1:utf-8') do |row|
+    CSV.foreach(csv, headers: true, encoding: 'CP1252') do |row|
       next if skip?(row)
 
       yield row


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/gXzz8uYD/549-gias-data-import-encoding)
Use `CP1252` (Windows) encoding on incoming CSV files. Also no need to force encoding to UTF-8

### Changes proposed in this pull request
Change encoding type when reading CSV data

### Guidance to review
Once imported, School and Trust names should now appear correctly if they contain extra characters such as accents.
e.g. `FIERTÉ MULTI-ACADEMY TRUST`
