### PR TITLE
Make the 'change' links in support more accessible

### DIFF
--- a/app/components/support/enable_orders_confirm_summary_list_component.rb
+++ b/app/components/support/enable_orders_confirm_summary_list_component.rb
@@ -23,6 +23,7 @@ private
       key: 'Can they order devices?',
       value: School.translate_enum_value(:order_state, order_state),
       change_path: change_path,
+      action: 'whether they can place orders',
     }
   end
 
@@ -35,12 +36,14 @@ private
         key: 'How many devices?',
         value: "Their full allocation of #{allocation}",
         change_path: change_path,
+        action: 'how many devices',
       }
     when :can_order_for_specific_circumstances
       {
         key: 'How many devices?',
         value: "Up to #{cap} from an allocation of #{allocation}",
         change_path: change_path,
+        action: 'how many devices',
       }
     end
   end

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -11,11 +11,21 @@ private
   end
 
   def allocation_row
-    super.except(:action_path, :action).merge(change_path: support_devices_school_allocation_edit_path(school_urn: @school.urn))
+    super
+      .except(:action_path, :action)
+      .merge(
+        change_path: support_devices_school_allocation_edit_path(school_urn: @school.urn),
+        action: 'provisional allocation',
+      )
   end
 
   def order_status_row
-    super.except(:action_path, :action).merge(change_path: support_devices_school_enable_orders_path(school_urn: @school.urn))
+    super
+      .except(:action_path, :action)
+      .merge(
+        change_path: support_devices_school_enable_orders_path(school_urn: @school.urn),
+        action: 'whether they can place orders',
+      )
   end
 
   def school_contact_row_if_contact_present

--- a/spec/features/support/devices/adjusting_a_schools_allocation_spec.rb
+++ b/spec/features/support/devices/adjusting_a_schools_allocation_spec.rb
@@ -17,15 +17,13 @@ RSpec.feature 'Adjusting a schools allocation' do
     end
 
     it 'shows a link to Change whether they can order devices' do
-      expect(school_details_page.school_details_rows[2]).to have_text 'Provisional allocation'
-      expect(school_details_page.school_details_rows[2]).to have_link 'Change'
+      expect(school_details_page).to have_text 'Provisional allocation'
+      expect(school_details_page).to have_link 'Change provisional allocation'
     end
 
     describe 'clicking Change' do
       before do
-        within(school_details_page.school_details_rows[2]) do
-          click_on 'Change'
-        end
+        click_on 'Change provisional allocation'
       end
 
       it 'shows me a form to change the allocation' do

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -17,15 +17,13 @@ RSpec.feature 'Enabling orders for a school from the support area' do
     end
 
     it 'shows a link to Change whether they can order devices' do
-      expect(school_details_page.school_details_rows[3]).to have_text 'Can place orders?'
-      expect(school_details_page.school_details_rows[3]).to have_link 'Change'
+      expect(school_details_page).to have_text 'Can place orders?'
+      expect(school_details_page).to have_link 'Change whether they can place orders'
     end
 
     describe 'clicking Change' do
       before do
-        within(school_details_page.school_details_rows[3]) do
-          click_on 'Change'
-        end
+        click_on 'Change whether they can place orders'
       end
 
       it 'shows the order status form' do
@@ -86,9 +84,7 @@ RSpec.feature 'Enabling orders for a school from the support area' do
           context 'clicking Change' do
             before do
               click_on 'Continue'
-              within(enable_orders_confirm_page.can_order_devices_row) do
-                click_on 'Change'
-              end
+              click_on 'Change whether they can place orders'
             end
 
             it 'shows the order status form with my previously entered values preserved' do


### PR DESCRIPTION
### Context

It's possible to define actions for summary list component rows, which adds visually hidden text to the change links. This hidden text is visible to screen readers and to Capybara.

### Changes proposed in this pull request

In the support interface, define actions for the 'change' summary list links.

### Guidance to review

Defining the action on the change links means the capybara specs don't need
to be scoped to a particular element on the page, which makes the spec more brittle
and harder to follow.