### PR TITLE
Add extra information to automated CC cap update email.

### DIFF
--- a/app/mailers/computacenter_mailer.rb
+++ b/app/mailers/computacenter_mailer.rb
@@ -31,6 +31,11 @@ private
       school_name: @school.name,
       urn: @school.urn,
       new_cap_value: @new_cap_value,
+      ship_to_number: @school.computacenter_reference,
+      responsible_body_name: @school.responsible_body.name,
+      responsible_body_type: @school.responsible_body.humanized_type,
+      responsible_body_reference: @school.responsible_body.computacenter_identifier,
+      sold_to_number: @school.responsible_body.computacenter_reference,
     }
   end
 


### PR DESCRIPTION
### Context

Computacenter have requested extra info in the automated cap update email. This email is sent to them after every cap change.

### Changes proposed in this pull request

Add extra school and RB fields into the personalisation of the email. These will be exposed in Notify when this change is released.
