### PR TITLE
Introduce a spec helper for stubbing the outgoing Computacenter API

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,8 @@
 computacenter:
   outgoing_api:
     endpoint: http://computacenter.example.com/
+    username: user
+    password: pass
 
 govuk_notify:
   # API key for the GOV.UK Notify service, used for sending emails

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -5,9 +5,8 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   let(:schools) { create_list(:school, 3, :with_std_device_allocation, order_state: :cannot_order) }
   let(:bad_urn) { '12492903' }
 
-  # disable the sending of cap update requests & emails
   before do
-    Settings.computacenter.outgoing_api.endpoint = nil
+    allow_computacenter_outgoing_api_calls
   end
 
   scenario 'visiting the full allocations page' do

--- a/spec/features/support/devices/bulk_school_allocations_spec.rb
+++ b/spec/features/support/devices/bulk_school_allocations_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   let(:bad_urn) { '12492903' }
 
   before do
-    allow_computacenter_outgoing_api_calls
+    stub_computacenter_outgoing_api_calls
   end
 
   scenario 'visiting the full allocations page' do

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -64,7 +64,6 @@ RSpec.feature 'Enabling orders for a school from the support area' do
             allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
             allow(mock_request).to receive(:post!)
             fill_in('How many devices can they order?', with: 2)
-            Settings.computacenter.outgoing_api.endpoint = 'https://example.com/'
           end
 
           it 'takes me to the Check your answers page' do

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -6,20 +6,9 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
   let(:school_2) { create(:school, computacenter_reference: '98765432') }
   let(:allocation_1) { create(:school_device_allocation, school: school_1, device_type: 'std_device', allocation: 11, cap: 1) }
   let(:allocation_2) { create(:school_device_allocation, school: school_2, device_type: 'coms_device', allocation: 22, cap: 0) }
-  let(:mock_status) { instance_double(HTTP::Response::Status, code: 200, success?: true) }
-  let(:mock_response) { instance_double(HTTP::Response, status: mock_status, body: response_body) }
-  let(:expected_xml) do
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
-        <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="1"/>
-        <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="0"/>
-      </CapAdjustmentRequest>
-    XML
-  end
 
   before do
-    allow_computacenter_outgoing_api_calls(response_body: response_body)
+    @network_call = allow_computacenter_outgoing_api_calls(response_body: response_body)
   end
 
   describe '#post!' do
@@ -29,58 +18,37 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       expect { request.post! }.to change(request, :payload_id)
     end
 
-    it 'renders the cap_update_request XML builder template' do
-      allow(Computacenter::OutgoingAPI::BaseController).to receive(:render).and_return('mock body')
-      request.post!
-      expect(Computacenter::OutgoingAPI::BaseController).to have_received(:render).with(:cap_update_request, hash_including(format: :xml))
-    end
-
-    it 'passes allocations and payload_id to the render call' do
-      allow(Computacenter::OutgoingAPI::BaseController).to receive(:render).and_return('mock body')
-      request.post!
-      expect(Computacenter::OutgoingAPI::BaseController).to have_received(:render).with(
-        anything,
-        hash_including(
-          assigns: {
-            allocations: [allocation_1, allocation_2],
-            payload_id: request.payload_id,
-            timestamp: anything,
-          },
-        ),
-      )
-    end
-
     it 'POSTs the body to the endpoint using Basic Auth' do
-      allow(Computacenter::OutgoingAPI::BaseController).to receive(:render).and_return('mock body')
-      allow(HTTP).to receive(:basic_auth).and_return(HTTP)
-      allow(HTTP).to receive(:post).and_return(mock_response)
-
       request.post!
-      expect(HTTP).to have_received(:basic_auth).with(user: request.username, pass: request.password)
-      expect(HTTP).to have_received(:post).with(request.endpoint, body: 'mock body')
+
+      expect(@network_call.with(basic_auth: %w[user pass])).to have_been_requested
     end
 
     it 'generates a correct body' do
       request.payload_id = '123456789'
       request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
       request.post!
-      expect(a_request(:post, request.endpoint).with(body: expected_xml)).to have_been_made
+
+      expected_xml = <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
+          <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="1"/>
+          <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="0"/>
+        </CapAdjustmentRequest>
+      XML
+      expect(@network_call.with(body: expected_xml)).to have_been_requested
     end
 
     context 'when the response status is success' do
-      let(:mock_status) { instance_double(HTTP::Response::Status, code: 200, success?: true) }
-
-      it 'returns the response ' do
+      it 'returns an HTTP::Response object' do
         expect(request.post!).to be_a(HTTP::Response)
       end
     end
 
     context 'when the response status is not a success' do
-      let(:mock_status) { instance_double(HTTP::Response::Status, code: 401, success?: false) }
-
       before do
-        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
-        allow(HTTP).to receive(:post).and_return(mock_response)
+        WebMock.reset!
+        allow_computacenter_outgoing_api_calls(response_body: response_body, response_status: 401)
       end
 
       it 'raises an error' do
@@ -103,11 +71,6 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
         '<CapAdjustmentResponse dateTime="2020-08-21T12:30:40Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult errorDetails="Non of the records are processed" piMessageID="11111111111111111111111111111111" status="Failed"/><FailedRecords><Record capAmount="9" capType="DfE_RemainThresholdQty|Std_Device" errorDetails="New cap must be greater than or equal to used quantity" shipTO="11111111" status="Failed"/></FailedRecords></CapAdjustmentResponse>'
       end
 
-      before do
-        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
-        allow(HTTP).to receive(:post).and_return(mock_response)
-      end
-
       it 'raises an error' do
         expect { request.post! }.to raise_error(Computacenter::OutgoingAPI::Error)
       end
@@ -116,11 +79,6 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
     context 'when the response does not contain an error' do
       let(:response_body) do
         '<CapAdjustmentResponse dateTime="2020-09-14T21:55:37Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult piMessageID="11111111111111111111111111111111" status="Success"/><FailedRecords/></CapAdjustmentResponse>'
-      end
-
-      before do
-        allow(HTTP).to receive(:basic_auth).and_return(HTTP)
-        allow(HTTP).to receive(:post).and_return(mock_response)
       end
 
       it 'does not raise an error' do

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
   end
 
   before do
-    stub_request(:post, Settings.computacenter.outgoing_api.endpoint).to_return(status: 200, body: response_body)
+    allow_computacenter_outgoing_api_calls(response_body: response_body)
   end
 
   describe '#post!' do

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
   let(:allocation_2) { create(:school_device_allocation, school: school_2, device_type: 'coms_device', allocation: 22, cap: 0) }
 
   before do
-    @network_call = allow_computacenter_outgoing_api_calls(response_body: response_body)
+    @network_call = stub_computacenter_outgoing_api_calls(response_body: response_body)
   end
 
   describe '#post!' do
@@ -48,7 +48,7 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
     context 'when the response status is not a success' do
       before do
         WebMock.reset!
-        allow_computacenter_outgoing_api_calls(response_body: response_body, response_status: 401)
+        stub_computacenter_outgoing_api_calls(response_body: response_body, response_status: 401)
       end
 
       it 'raises an error' do

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -48,11 +48,9 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
         end
 
         context 'when the endpoint setting is present' do
-          before do
-            Settings.computacenter.outgoing_api.endpoint = 'HERE'
-          end
-
           it 'sends an email to computacenter' do
+            expect(Settings.computacenter.outgoing_api.endpoint).to be_present
+
             expect { service.update!(cap: new_cap, order_state: new_order_state) }.to have_enqueued_mail(ComputacenterMailer, :notify_of_comms_cap_change).once
           end
         end
@@ -114,7 +112,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
 
     context 'when the endpoint setting is present' do
       before do
-        Settings.computacenter.outgoing_api.endpoint = 'HERE'
+        raise 'Outgoing CC API endpoint not set' if Settings.computacenter.outgoing_api.endpoint.blank?
       end
 
       it 'notifies the computacenter API' do
@@ -135,8 +133,11 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
     end
 
     context 'when the endpoint setting is not present' do
-      before do
+      around do |example|
+        original_value = Settings.computacenter.outgoing_api.endpoint
         Settings.computacenter.outgoing_api.endpoint = ''
+        example.run
+        Settings.computacenter.outgoing_api.endpoint = original_value
       end
 
       it 'does not notify the computacenter API' do

--- a/spec/support/computacenter_helper.rb
+++ b/spec/support/computacenter_helper.rb
@@ -1,5 +1,5 @@
 module ComputacenterHelper
-  def allow_computacenter_outgoing_api_calls(response_body: '', response_status: 200)
+  def stub_computacenter_outgoing_api_calls(response_body: '', response_status: 200)
     stub_request(:post, 'http://computacenter.example.com/')
       .to_return(status: response_status, body: response_body, headers: {})
   end

--- a/spec/support/computacenter_helper.rb
+++ b/spec/support/computacenter_helper.rb
@@ -1,0 +1,10 @@
+module ComputacenterHelper
+  def allow_computacenter_outgoing_api_calls(response_body: '')
+    stub_request(:post, 'http://computacenter.example.com/')
+      .to_return(status: 200, body: response_body, headers: {})
+  end
+end
+
+RSpec.configure do |c|
+  c.include ComputacenterHelper
+end

--- a/spec/support/computacenter_helper.rb
+++ b/spec/support/computacenter_helper.rb
@@ -1,7 +1,7 @@
 module ComputacenterHelper
-  def allow_computacenter_outgoing_api_calls(response_body: '')
+  def allow_computacenter_outgoing_api_calls(response_body: '', response_status: 200)
     stub_request(:post, 'http://computacenter.example.com/')
-      .to_return(status: 200, body: response_body, headers: {})
+      .to_return(status: response_status, body: response_body, headers: {})
   end
 end
 


### PR DESCRIPTION
`Settings.computacenter.outgoing_api.endpoint` is a global setting. Specs
should ensure they don't modify this setting during setup and execution,
otherwise it affects the outcome of other specs.

As a rule, it should be on in the specs (like it is in production). Any resultant
network calls should be stubbed out via the newly introduced spec helper. If it's
necessary to change this setting, the spec should put it back to its original value.

