### PR TITLE
Fix the notification for order users to place orders

### DIFF
--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -15,6 +15,10 @@ class SchoolOrderStateAndCapUpdateService
       notify_computacenter_by_email(allocation.cap)
     end
 
+    # ensure the updates are picked up
+    @school.std_device_allocation&.reload
+    @school.coms_device_allocation&.reload
+
     # notifying users should only happen after successful completion of the Computacenter
     # cap update, because it's possible for that to fail and the whole thing
     # is rolled back

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -122,5 +122,9 @@ FactoryBot.define do
       has_not_seen_privacy_notice
       orders_devices { false }
     end
+
+    trait :with_a_confirmed_techsource_account do
+      techsource_account_confirmed_at { Time.zone.now }
+    end
   end
 end


### PR DESCRIPTION
Fix the notification for order users to place orders. It wasn't being sent due to objects going stale after updates.