### PR TITLE
[829] Ensure available_devices_count is > 0

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -32,7 +32,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def available_devices_count
-    cap.to_i - devices_ordered.to_i
+    [0, (cap.to_i - devices_ordered.to_i)].max
   end
 
   def computacenter_cap_type

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -70,4 +70,14 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       end
     end
   end
+
+  describe '#available_devices_count' do
+    subject(:allocation) { described_class.new(cap: 100, devices_ordered: 200) }
+
+    context 'when negative' do
+      it 'returns zero' do
+        expect(allocation.available_devices_count).to be_zero
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Validation has been removed so devices_ordered > cap is possible
- So to prevent negative number being displayed to user we limit this to
zero

### Context

### Changes proposed in this pull request

### Guidance to review

