### PR TITLE
Make migration empty as it times out

### DIFF
--- a/db/migrate/20201012110726_refresh_preorder_statuses.rb
+++ b/db/migrate/20201012110726_refresh_preorder_statuses.rb
@@ -1,5 +1,3 @@
 class RefreshPreorderStatuses < ActiveRecord::Migration[6.0]
-  def change
-    PreorderInformation.all.each(&:refresh_status!)
-  end
+  def change; end
 end


### PR DESCRIPTION
### Context

- The following migration is timing out with a large dataset

### Changes proposed in this pull request

- Make migration do nothing so container can boot

### Guidance to review

