### PR TITLE
[802] After login send user to session return_url

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -21,7 +21,13 @@ class SignInTokensController < ApplicationController
       save_user_to_session!
       EventNotificationsService.broadcast(SignInEvent.new(user: @user))
       @user.clear_token!
-      redirect_to root_url_for(@user)
+
+      if session['return_url'].present?
+        redirect_to session['return_url']
+        session.delete('return_url')
+      else
+        redirect_to root_url_for(@user)
+      end
     end
   end
 

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe SignInTokensController, type: :controller do
       expect(EventNotificationsService).to have_received(:broadcast).with(mock_event)
     end
 
+    context "session['return_url'] is set" do
+      it 'redirects to return_url' do
+        session['return_url'] = 'https://example.com'
+
+        delete :destroy, params: valid_token_params
+
+        expect(response).to redirect_to('https://example.com')
+      end
+
+      it 'deletes it from the session' do
+        session['return_url'] = 'https://example.com'
+
+        delete :destroy, params: valid_token_params
+
+        expect(session.key?('return_url')).to be_falsey
+      end
+    end
+
     context 'when hybrid user is associated with RB and school' do
       let(:school) { create(:school) }
       let(:user) do


### PR DESCRIPTION
### Context

- https://trello.com/c/QJ0Bd31h/802-deep-links-work-across-sign-in

### Changes proposed in this pull request

- After logging in redirect the user to `session['return_url']`
- NOTE: One minor concern is that since I was actually able to write this code means on login we do not change the users session. This increases our exposure to succumbing to a session fixation attack. It is general good practice that on login a new session is given to prevent against this.

### Guidance to review

- Logout
- Navigate to a deep link eg as if you bookmarked a page when logged in
- Click on bookmark
- Login as usual
- After logging in should be on bookmarked page