### PR TITLE
[844] Nudge RB when can order but needs contact

### DIFF
--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -21,12 +21,27 @@ class CanOrderDevicesMailer < ApplicationMailer
     )
   end
 
+  def nudge_rb_to_add_school_contact
+    @user = params[:user]
+    @school = params[:school]
+
+    template_mail(
+      nudge_rb_to_add_school_contact_template_id,
+      to: @user.email_address,
+      personalisation: personalisation,
+    )
+  end
+
 private
 
   def personalisation
     {
       school: @school.name,
     }
+  end
+
+  def nudge_rb_to_add_school_contact_template_id
+    Settings.govuk_notify.templates.devices.nudge_rb_to_add_school_contact
   end
 
   def can_order_devices_template_id

--- a/app/models/can_order_devices_notifications.rb
+++ b/app/models/can_order_devices_notifications.rb
@@ -39,7 +39,7 @@ private
   def what_message_to_send_about(school)
     case school.preorder_information&.status
     when nil, 'needs_contact'
-      # TODO: we need to nudge the responsible body that this school needs a contact
+      :nudge_rb_to_add_school_contact
     when 'school_will_be_contacted'
       # This is on the DfE to onboard these schools - there is nothing users can do in this case
     when 'needs_info', 'school_contacted'
@@ -58,6 +58,8 @@ private
     elsif message_type == :user_can_order_but_action_needed
       # TODO: what if there aren't any school organisation users?
       school.organisation_users
+    elsif message_type == :nudge_rb_to_add_school_contact
+      school.responsible_body.users
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -540,6 +540,7 @@ en:
     schools_will_order_event: "%{responsible_body} has devolved ordering to schools"
     user_can_order_event: A user has been told they can place orders for %{school}
     user_can_order_but_action_needed_event: A user has been told action is needed so %{school} can place orders
+    nudge_rb_to_add_school_contact_event: A responsible body user has been told to add a contact for %{school}
   helpers:
     label:
       support_enable_orders_form:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ govuk_notify:
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
       can_order_devices: '9df2c08a-c457-4b13-9270-c5a20687d168'
       can_order_but_action_needed: '9096f09c-0b36-486c-9395-a6626198fd86'
+      nudge_rb_to_add_school_contact: '867df323-b377-4906-8386-79db71e9c428'
     computacenter:
       device_cap_change: '6e00f2bf-d373-436d-a2c0-2910f20ef521'
       comms_cap_change: '01f1b2a3-a216-44cc-a567-704bfd0a3c56'


### PR DESCRIPTION
### Context

- https://trello.com/c/NSUCnuw4/844-school-can-order-notifications-tell-rb-to-add-a-school-contact

### Changes proposed in this pull request

- When a school can order devices but the school requires a contact send a nudge email to the RB to add this info

### Guidance to review

- Find a school that `needs_contact`
- Login as a support agent
- Set the school so they can now order available devices
- Email should be sent to RB to nudge them to add details