### PR TITLE
Run rubocop in parallel during CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Compile assets
         run: bundle exec rails webpacker:compile
       - name: Run rubocop
-        run: bundle exec rubocop app config db lib spec Gemfile --format clang
+        run: bundle exec rubocop app config db lib spec Gemfile --format clang --parallel
       - name: Run rspec
         run: bundle exec rake parallel:spec
         env:


### PR DESCRIPTION
### Context

- Rubocop is slow during CI run

### Changes proposed in this pull request

- Run rubocop in parallel during CI run. This approximately halves the time to run this step

### Guidance to review

- CI should pass and this step should be quicker compared to the same step of previous runs