### PR TITLE
[846] On TechSource confirm pick email to send

### DIFF
--- a/app/models/user_can_order_devices_notifications.rb
+++ b/app/models/user_can_order_devices_notifications.rb
@@ -13,23 +13,31 @@ private
 
   def notify_user_about_all_schools_they_can_order_for
     user.schools_i_order_for.select(&:can_order_devices_right_now?).each do |school|
-      notify_user(user: user, school: school)
+      notify_user(school: school)
     end
   end
 
-  def notify_user(user:, school:)
-    if FeatureFlag.active?(:notify_can_place_orders)
-      CanOrderDevicesMailer
-        .with(user: user, school: school)
-        .send(message_type)
-        .deliver_later
-      EventNotificationsService.broadcast(
-        UserCanOrderEvent.new(user: user, school: school, type: message_type),
-      )
-    end
+  def notify_user(school:)
+    return unless FeatureFlag.active?(:notify_can_place_orders)
+
+    message_type = message_type_for_school(school)
+
+    return unless message_type
+
+    CanOrderDevicesMailer
+      .with(user: user, school: school)
+      .send(message_type)
+      .deliver_later
+    EventNotificationsService.broadcast(
+      UserCanOrderEvent.new(user: user, school: school, type: message_type),
+    )
   end
 
-  def message_type
-    :user_can_order
+  def message_type_for_school(school)
+    if %w[rb_can_order school_can_order].include?(school.preorder_information&.status)
+      :user_can_order
+    elsif %w[needs_info].include?(school.preorder_information&.status)
+      :user_can_order_but_action_needed
+    end
   end
 end

--- a/spec/features/computacenter/techsource_spec.rb
+++ b/spec/features/computacenter/techsource_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Computacenter confirming TechSource accounts' do
 
   def given_school_exists_that_can_order_devices
     allocation = create(:school_device_allocation, :with_std_allocation, :with_orderable_devices)
-    preorder = create(:preorder_information, who_will_order_devices: 'school')
+    preorder = create(:preorder_information, who_will_order_devices: 'school', status: :school_can_order)
     @school = create(:school, preorder_information: preorder, order_state: :can_order, std_device_allocation: allocation)
   end
 

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe UserCanOrderDevicesNotifications do
+  subject(:service) { described_class.new(user: user) }
+
+  around do |example|
+    FeatureFlag.activate(:notify_can_place_orders)
+    example.run
+    FeatureFlag.deactivate(:notify_can_place_orders)
+  end
+
+  context 'when orders can be placed' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:preorder) { create(:preorder_information, :school_will_order, status: :school_can_order) }
+    let(:school) { create(:school, preorder_information: preorder, std_device_allocation: allocation, order_state: :can_order) }
+    let(:user) { create(:school_user, orders_devices: true, school: school) }
+
+    it 'sends :user_can_order email' do
+      expect {
+        service.call
+      }.to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'user_can_order', 'deliver_now', params: { user: user, school: school }, args: [])
+    end
+  end
+
+  context 'when orders cannot be placed' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:preorder) { create(:preorder_information, :school_will_order, status: :needs_info) }
+    let(:school) { create(:school, preorder_information: preorder, std_device_allocation: allocation, order_state: :can_order) }
+    let(:user) { create(:school_user, orders_devices: true, school: school) }
+
+    it 'sends :user_can_order_but_action_needed email' do
+      expect {
+        service.call
+      }.to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'user_can_order_but_action_needed', 'deliver_now', params: { user: user, school: school }, args: [])
+    end
+  end
+end

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
       context 'if there are devices orderable' do
         before do
           create(:school_device_allocation, :with_std_allocation, cap: 3, allocation: 5, school: user.school)
-          create(:preorder_information, school: user.school, who_will_order_devices: 'school')
+          create(:preorder_information, school: user.school, who_will_order_devices: 'school', status: :school_can_order)
           user.school.update!(order_state: :can_order)
         end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/XkdBxjOu/846-techsource-account-confirmed-notification-user-message-should-vary-depending-on-whether-school-info-is-ready-or-not

### Changes proposed in this pull request

- When a TechSource account is confirmed we may or may not send the user an email. If we do send them the most appropriate email

### Guidance to review

- On confirming a users TechSource account
- An email is sent if they can place orders there and then
- Another email if the status is `needs_info`
- Otherwise no email is sent