### PR TITLE
add sidekiq-failures gem, so we can see failed jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'sentry-raven'
 
 # Job queue
 gem 'sidekiq'
+gem 'sidekiq-failures'
 gem 'sidekiq-scheduler'
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,8 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-failures (1.0.0)
+      sidekiq (>= 4.0.0)
     sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
@@ -522,6 +524,7 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers (~> 4.4)
   sidekiq
+  sidekiq-failures
   sidekiq-scheduler
   simplecov
   site_prism


### PR DESCRIPTION
### Context

We have a lot (>10k) of failed jobs on prod, yet there's no way out of the box to see which jobs they are. 
Stats from prod:
    80,329 Processed
    10,786 Failed

### Changes proposed in this pull request

Add the `sidekiq-failures` gem, which keeps track of failures and adds a tab in the UI to see them

### Guidance to review

