### PR TITLE
add school order_state to performance data API

### DIFF
--- a/app/controllers/support/performance_data/schools_controller.rb
+++ b/app/controllers/support/performance_data/schools_controller.rb
@@ -33,6 +33,7 @@ private
       cap: school.std_device_allocation.cap,
       devices_ordered: school.std_device_allocation.devices_ordered,
       preorder_info_status: school.preorder_information&.status,
+      school_order_state: school.order_state,
     }
   end
 end

--- a/spec/controllers/support/performance_data/schools_controller_spec.rb
+++ b/spec/controllers/support/performance_data/schools_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
       'cap' => school.std_device_allocation.cap,
       'devices_ordered' => school.std_device_allocation.devices_ordered,
       'preorder_info_status' => school.preorder_information.status,
+      'school_order_state' => school.order_state,
     }
   end
 


### PR DESCRIPTION
### Context

The analysts have requested us to add each school's order status to the performance data API

### Changes proposed in this pull request

Add the order_state to the performance data API

### Guidance to review

