### PR TITLE
Add paper_trail to SchoolDeviceAllocation

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -1,4 +1,6 @@
 class SchoolDeviceAllocation < ApplicationRecord
+  has_paper_trail
+
   belongs_to  :school
   belongs_to  :created_by_user, class_name: 'User', optional: true
   belongs_to  :last_updated_by_user, class_name: 'User', optional: true

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SchoolDeviceAllocation, type: :model do
+  it { is_expected.to be_versioned }
+
   describe '#cap_implied_by_order_state' do
     subject(:allocation) { described_class.new(allocation: 27, cap: nil, devices_ordered: 13) }
 


### PR DESCRIPTION
### Context

We're getting an increasing number of queries from support where diagnosing a problem depends on finding out exactly when a cap (or allocation) was modified, and how.

We only have `created_at` / `updated_at` plus the `cc_cap_update_request_timestamp` to go on, and we can't see any previous versions, only what the latest state is.

### Changes proposed in this pull request

Add paper trail integration to `SchoolDeviceAllocation`.

### Guidance to review

Is there anything else that needs adding?