### PR TITLE
Add missing i18n translation for event

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,6 +541,7 @@ en:
     user_can_order_event: A user has been told they can place orders for %{school}
     user_can_order_but_action_needed_event: A user has been told action is needed so %{school} can place orders
     nudge_rb_to_add_school_contact_event: A responsible body user has been told to add a contact for %{school}
+    nudge_user_to_read_privacy_policy_event: A user from %{school} was nudged to read the privacy policy
   helpers:
     label:
       support_enable_orders_form:

--- a/spec/models/user_can_order_event_spec.rb
+++ b/spec/models/user_can_order_event_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe UserCanOrderEvent do
+  let(:school) { build(:school) }
+
+  subject(:event) do
+    described_class.new(type: 'nudge_user_to_read_privacy_policy',
+                        school: school)
+  end
+
+  describe '#message' do
+    it 'returns meaningful message' do
+      expect(event.message).to eql("A user from #{school.name} was nudged to read the privacy policy")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Bug

### Changes proposed in this pull request

- Add missing translation

### Guidance to review

- Create a school can order event with user that has not read the privacy policy
- Should see notification with translation