### PR TITLE
Remove "reduced due to supply chain delays" link from school details summary

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -58,22 +58,12 @@ private
   end
 
   def allocation_row
-    allocation_row_value = pluralize(@school.std_device_allocation&.allocation.to_i, 'device') + supply_chain_delays
-
     {
       key: 'Allocation',
-      value: allocation_row_value.html_safe,
+      value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query allocation',
     }
-  end
-
-  def supply_chain_delays
-    if FeatureFlag.active?(:reduced_allocations)
-      " (#{govuk_link_to('reduced due to supply chain delays', responsible_body_devices_reduced_allocations_path)})"
-    else
-      ''
-    end
   end
 
   def devices_ordered_row

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -10,12 +10,10 @@ class School::SchoolDetailsSummaryListComponent < ViewComponent::Base
   end
 
   def rows
-    allocation_row_value = pluralize(@school.std_device_allocation&.allocation.to_i, 'device') + supply_chain_delays
-
     [
       {
         key: 'Allocation',
-        value: allocation_row_value.html_safe,
+        value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
         action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
         action: 'Query allocation',
       },
@@ -27,14 +25,6 @@ class School::SchoolDetailsSummaryListComponent < ViewComponent::Base
   end
 
 private
-
-  def supply_chain_delays
-    if FeatureFlag.active?(:reduced_allocations)
-      " (#{govuk_link_to('reduced due to supply chain delays', reduced_allocation_school_path(@school))})"
-    else
-      ''
-    end
-  end
 
   def preorder_information
     @school.preorder_information


### PR DESCRIPTION
This message was intended as a temporary message which would be removed when we increased allocations again. This is less likely to happen now. We have sufficient messaging elsewhere that covers reduced allocations.