### PR TITLE
Tweak low stock messaging

### DIFF
--- a/app/views/responsible_body/devices/home/reduced_allocations.html.erb
+++ b/app/views/responsible_body/devices/home/reduced_allocations.html.erb
@@ -3,7 +3,7 @@
 <%- content_for :before_content do %>
   <% breadcrumbs([
     { 'Home' => responsible_body_home_path },
-    'Delays in our supply chain',
+    'Delays in the global supply chain',
   ]) %>
 <% end %>
 
@@ -13,7 +13,7 @@
       <%= title %>
     </h1>
 
-    <p class="govuk-body">Due to delays in our supply chain, we reduced the number of laptops and tablets allocated to schools. This is so we can target support at disadvantaged children in years 6, 10 and 11.</p>
+    <p class="govuk-body">Due to delays in the global supply chain, we reduced the number of laptops and tablets allocated to schools. This is so we can target support at disadvantaged children in years 6, 10 and 11.</p>
 
     <p class="govuk-body">Allocations of devices are now based on:</p>
 

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -11,7 +11,7 @@
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <span class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>
-            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We reduced device allocations because of delays in our supply chain</h2>
+            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We reduced device allocations because of delays in the global supply chain</h2>
             <p class="govuk-body">With fewer devices available we’re targeting support at disadvantaged children in years 6, 10 and 11.</p>
             <p class="govuk-body">
               <%= govuk_link_to('More about changes to allocations', responsible_body_devices_reduced_allocations_path) %>

--- a/app/views/school/devices/reduced_allocation.html.erb
+++ b/app/views/school/devices/reduced_allocation.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_reduced_allocation', allocation: @allocation, count: @allocation) %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: 'Delays in our supply chain', school: @school, user: @user %>
+  <%- school_breadcrumbs items: 'Delays in the global supply chain', school: @school, user: @user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
       <%= title %>
     </h1>
 
-    <p class="govuk-body">Due to delays in our supply chain, we reduced the number of laptops and tablets allocated to you. This is so we can target support at disadvantaged children in years 6, 10 and 11.</p>
+    <p class="govuk-body">Due to delays in the global supply chain, we reduced the number of laptops and tablets allocated to you. This is so we can target support at disadvantaged children in years 6, 10 and 11.</p>
 
     <p class="govuk-body">Your new allocation of <%= pluralize(@allocation, 'device') %> is based on:</p>
 

--- a/app/views/school/devices/reduced_to_zero_allocation.html.erb
+++ b/app/views/school/devices/reduced_to_zero_allocation.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_reduced_to_zero_allocation') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: 'Delays in our supply chain', school: @school, user: @user %>
+  <%- school_breadcrumbs items: 'Delays in the global supply chain', school: @school, user: @user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -10,9 +10,9 @@
       <%= title %>
     </h1>
 
-    <p class="govuk-body">Due to delays in our supply chain, only schools with children in years 6, 10 and 11 will be able to order their allocation of laptops and tablets.</p>
+    <p class="govuk-body">Due to delays in the global supply chain, only schools with children in years 6, 10 and 11 will be able to order their allocation of laptops and tablets.</p>
 
-    <p class="govuk-body">We made this difficult decision so we can target support at disadvantaged children in key exam years.</p>
+    <p class="govuk-body">We made this difficult decision so we can target support at disadvantaged children in years 6, 10 and 11.</p>
 
     <p class="govuk-body">You can still <%= govuk_link_to 'request devices for specific circumstances', request_devices_school_path(@school) %>.</p>
 

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -20,14 +20,14 @@
         <span class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span>
           <% if @allocation.zero? %>
-            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We removed your allocation because of<br />delays in our supply chain</h2>
+            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We removed your allocation because of<br />delays in the global supply chain</h2>
             <p class="govuk-body">
-              Only schools with children in years 6, 10 and 11 will be able to order their allocation of laptops and tablets. We’ve made this difficult decision so we can target support at disadvantaged children in key exam years.</p>
+              Only schools with children in years 6, 10 and 11 will be able to order their allocation of laptops and tablets. We’ve made this difficult decision so we can target support at disadvantaged children in key exam or transition years.</p>
             <p class="govuk-body">
               <%= govuk_link_to('More about this change to your allocation', reduced_allocation_school_path(@school)) %>
             </p>
           <% else %>
-            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We reduced your allocation because of<br />delays in our supply chain</h2>
+            <h2 class="govuk-heading-m govuk-!-font-weight-bold">We reduced your allocation because of<br />delays in the global supply chain</h2>
             <p class="govuk-body">
               <%= govuk_link_to('More about your reduced allocation', reduced_allocation_school_path(@school)) %>
             </p>

--- a/app/views/shared/_school_without_allocation.html.erb
+++ b/app/views/shared/_school_without_allocation.html.erb
@@ -5,7 +5,7 @@
 <p class="govuk-body">Reasons for a 0 allocation include:</p>
 <ul class="govuk-list govuk-list--bullet">
   <% if FeatureFlag.active?(:reduced_allocations) %>
-    <li>the school has no children in years 6, 10 or 11 and <%= govuk_link_to 'their allocation was removed due to supply chain delays', responsible_body_devices_reduced_allocations_path %></li>
+    <li>the school has no children in years 6, 10 or 11 and <%= govuk_link_to 'their allocation was removed due to global supply chain delays', responsible_body_devices_reduced_allocations_path %></li>
   <% else %>
     <li>the school has no children in the eligible year groups, years 3 to 11</li>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
     responsible_body_users_index: Manage %{rb_type} users
     responsible_body_trust_users_index: Manage trust administrators
     responsible_body_devices_chromebooks: Will the school need Chromebooks?
-    responsible_body_reduced_allocations: We reduced device allocations because of delays in our supply chain
+    responsible_body_reduced_allocations: We reduced device allocations because of delays in the global supply chain
     new_responsible_body_user: Invite a new user
     edit_responsible_body_user: Edit user
     responsible_body_schools_list: Get schools ready
@@ -104,10 +104,10 @@ en:
     school_users: Manage users
     school_before_can_order: Before you can order, we need more information
     school_reduced_allocation:
-      one: We reduced your allocation to %{allocation} device because of delays in our supply chain
-      many: We reduced your allocation to %{allocation} devices because of delays in our supply chain
-      other: We reduced your allocation to %{allocation} devices because of delays in our supply chain
-    school_reduced_to_zero_allocation: We removed your allocation because of delays in our supply chain
+      one: We reduced your allocation to %{allocation} device because of delays in the global supply chain
+      many: We reduced your allocation to %{allocation} devices because of delays in the global supply chain
+      other: We reduced your allocation to %{allocation} devices because of delays in the global supply chain
+    school_reduced_to_zero_allocation: We removed your allocation because of delays in the global supply chain
     order_devices:
       title: Order devices
       you_cannot_order_yet: You cannot order devices yet

--- a/spec/features/responsible_body/reduced_allocations_spec.rb
+++ b/spec/features/responsible_body/reduced_allocations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Reduced allocations due to supply chain delays' do
+RSpec.feature 'Reduced allocations due to global supply chain delays' do
   include ViewHelper
 
   let(:responsible_body) { create(:local_authority, :in_devices_pilot) }
@@ -29,7 +29,7 @@ RSpec.feature 'Reduced allocations due to supply chain delays' do
 
   def then_i_see_that_allocations_were_reduced
     expect(page).to have_http_status(:ok)
-    expect(page).to have_text('We reduced device allocations because of delays in our supply chain')
+    expect(page).to have_text('We reduced device allocations because of delays in the global supply chain')
     expect(page).to have_text('Allocations of devices are now based on')
   end
 end

--- a/spec/features/school/reduced_allocation_spec.rb
+++ b/spec/features/school/reduced_allocation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Reduced allocation due to supply chain delays' do
+RSpec.feature 'Reduced allocation due to global supply chain delays' do
   include ViewHelper
 
   around do |example|
@@ -52,6 +52,6 @@ RSpec.feature 'Reduced allocation due to supply chain delays' do
 
   def then_i_see_that_my_allocation_was_removed
     expect(page).to have_http_status(:ok)
-    expect(page).to have_text('We removed your allocation because of delays in our supply chain')
+    expect(page).to have_text('We removed your allocation because of delays in the global supply chain')
   end
 end


### PR DESCRIPTION
### Context

- Add year 6 to list of years
- Remove "key exam years" text
- Keep logic for schools that see an allocation reduced to 0, it will be shown to fewer schools now but is sitll relevant – eg infant schools y1 to y3
- Refer to the global supply chain rather than our supply chain, the problem is more international demand