### PR TITLE
[868] Show temporary banner for cannot order yet

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -36,6 +36,14 @@ class School < ApplicationRecord
     can_order: 'can_order',
   }
 
+  def self.show_temporary_cannot_order_yet_banner?
+    now = Time.zone.now
+    start_period = Time.zone.local(2020, 10, 22)
+    end_period = Time.zone.local(2020, 10, 24)
+
+    now > start_period && now < end_period
+  end
+
   def self.that_will_order_devices
     joins(:preorder_information).merge(PreorderInformation.school_will_order_devices)
   end

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -7,6 +7,16 @@
       <%= t('page_titles.order_devices.you_cannot_order_yet') %>
     </h1>
 
+    <% if School.show_temporary_cannot_order_yet_banner? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          As we won’t be able to deliver devices before half term, schools reporting closures on 22 and 23 October will not be invited to order.
+        </strong>
+      </div>
+    <% end %>
+
     <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
     <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> local coronavirus restrictions.</p>
 

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -12,6 +12,16 @@
       <%= title %>
     </h1>
 
+    <% if School.show_temporary_cannot_order_yet_banner? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          As we won’t be able to deliver devices before half term, schools reporting closures on 22 and 23 October will not be invited to order.
+        </strong>
+      </div>
+    <% end %>
+
     <p class="govuk-body">You should only order the devices you need. You can do this when local coronavirus restrictions are confirmed.</p>
     <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe School, type: :model do
+  describe '::show_temporary_cannot_order_yet_banner?' do
+    context 'before timeframe' do
+      it 'returns falsey' do
+        Timecop.freeze(Time.zone.local(2020, 10, 21, 22)) do
+          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_falsey
+        end
+      end
+    end
+
+    context 'during timeframe' do
+      it 'at start returns truthy' do
+        Timecop.freeze(Time.zone.local(2020, 10, 22, 2)) do
+          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_truthy
+        end
+      end
+
+      it 'at end returns truthy' do
+        Timecop.freeze(Time.zone.local(2020, 10, 23, 22)) do
+          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_truthy
+        end
+      end
+    end
+
+    context 'after timeframe' do
+      it 'returns falsey' do
+        Timecop.freeze(Time.zone.local(2020, 10, 24, 1)) do
+          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_falsey
+        end
+      end
+    end
+  end
+
   describe 'validating URN' do
     let(:school) { subject }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/2szW5e8j/868-build-warning-notice-about-closures-on-22-and-23-oct

### Changes proposed in this pull request

- Show temporary banner during 22 and 23 October

### Screenshots

#### RB
![image](https://user-images.githubusercontent.com/92580/96615343-0d0c5200-12f9-11eb-8ad7-31c6adffba65.png)

#### School
![image](https://user-images.githubusercontent.com/92580/96615352-11d10600-12f9-11eb-9c8b-f358a16cb79b.png)

### Guidance to review

- Set new method to true otherwise need to change local time
- Login as RB that cannot order yet
- Should see banner
- Login as school user that cannot order yet
- Should see banner