### PR TITLE
[881] fix UserChange generation for reactivation of user

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -41,7 +41,7 @@ private
   end
 
   def is_addition?
-    user.relevant_to_computacenter? && last_change_for_user.nil?
+    user.relevant_to_computacenter? && (last_change_for_user.nil? || last_change_for_user.type_of_update == 'Remove')
   end
 
   def is_change?
@@ -84,12 +84,12 @@ private
   end
 
   def type_of_update
-    if is_change?
+    if is_addition?
+      'New'
+    elsif is_change?
       'Change'
     elsif is_removal?
       'Remove'
-    else
-      'New'
     end
   end
 end


### PR DESCRIPTION
### Context

[Trello card 881](https://trello.com/c/bpTiLJEH/881-computacenteruserchange-generation-stalls-if-a-user-is-active-then-deactivated-then-reactivated) - when a user has an existing UserChange of type 'Remove', you can't re-activate them.

### Changes proposed in this pull request

Fix the loophole in the logic to allow reactivation of a user w.r.t. `Computacenter::UserChange` records

### Guidance to review

