### PR TITLE
Order closure banner: replace the timing mechanism with a feature flag

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -41,14 +41,6 @@ class School < ApplicationRecord
     can_order: 'can_order',
   }
 
-  def self.show_temporary_cannot_order_yet_banner?
-    now = Time.zone.now
-    start_period = Time.zone.local(2020, 10, 22)
-    end_period = Time.zone.local(2020, 10, 24)
-
-    now > start_period && now < end_period
-  end
-
   def self.that_will_order_devices
     joins(:preorder_information).merge(PreorderInformation.school_will_order_devices)
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,6 +9,7 @@ class FeatureFlag
     notify_can_place_orders
     reduced_allocations
     no_chromebook_or_ipad_stock
+    half_term_order_closure
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.order_devices.you_cannot_order_yet') %>
     </h1>
 
-    <% if School.show_temporary_cannot_order_yet_banner? %>
+    <% if FeatureFlag.active?(:half_term_order_closure) %>
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -12,7 +12,7 @@
       <%= title %>
     </h1>
 
-    <% if School.show_temporary_cannot_order_yet_banner? %>
+    <% if FeatureFlag.active?(:half_term_order_closure) %>
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,38 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe School, type: :model do
-  describe '::show_temporary_cannot_order_yet_banner?' do
-    context 'before timeframe' do
-      it 'returns falsey' do
-        Timecop.freeze(Time.zone.local(2020, 10, 21, 22)) do
-          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_falsey
-        end
-      end
-    end
-
-    context 'during timeframe' do
-      it 'at start returns truthy' do
-        Timecop.freeze(Time.zone.local(2020, 10, 22, 2)) do
-          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_truthy
-        end
-      end
-
-      it 'at end returns truthy' do
-        Timecop.freeze(Time.zone.local(2020, 10, 23, 22)) do
-          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_truthy
-        end
-      end
-    end
-
-    context 'after timeframe' do
-      it 'returns falsey' do
-        Timecop.freeze(Time.zone.local(2020, 10, 24, 1)) do
-          expect(described_class.show_temporary_cannot_order_yet_banner?).to be_falsey
-        end
-      end
-    end
-  end
-
   describe 'validating URN' do
     let(:school) { subject }
 


### PR DESCRIPTION
The timing is inexact and we don't want to release again to turn it on or off.

