### PR TITLE
[880] Attempt to fix intermittent test failures

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -77,6 +77,7 @@ development:
 test:
   <<: *default
   compile: true
+  cache_manifest: true
 
 production:
   <<: *default


### PR DESCRIPTION
### Context

- https://trello.com/c/Cbdw4wSW/880-fix-intermittent-failing-tests
- Tests both locally and on CI would occasionally fail

### Changes proposed in this pull request

- For webpacker in test env set `cache_manifest` to `true`
- I hypothesize that there may be a race condition when we compile the assets in test. This is despite webpacker having already compiled the assets in a previous CI task. As a result an empty or incomplete manifest would be used
- I have ran this through CI 8 times without failure. Only time will tell if this will actually fix our failure 

### Guidance to review

- Run locally or on CI as many times as you like and there should not be a failure