### PR TITLE
Fix missing govuk-link class on link

### DIFF
--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -25,7 +25,7 @@
       <% end %>
     </ul>
 
-    <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <a href="https://form.education.gov.uk/service/educational-setting-status">DfE educational settings status form</a>.</p>
+    <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status' %>.</p>
 
     <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
     <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> reported disruption.</p>


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/get-help-with-tech/pull/588#discussion_r510020951 flagged a missing CSS class, but the PR was merged already.

### Changes proposed in this pull request

Use the `govuk_link_to` helper.
