### PR TITLE
Remove the 'notify_can_place_orders' feature flag

### DIFF
--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -44,12 +44,10 @@ private
   end
 
   def notify_computacenter
-    if FeatureFlag.active?(:notify_can_place_orders)
-      ComputacenterMailer
-        .with(school: school, new_cap_value: new_cap_value)
-        .notify_of_school_can_order
-        .deliver_later
-    end
+    ComputacenterMailer
+      .with(school: school, new_cap_value: new_cap_value)
+      .notify_of_school_can_order
+      .deliver_later
   end
 
   def notify_users(users:, school:, message_type:)
@@ -59,15 +57,13 @@ private
   end
 
   def notify_user(user:, school:, message_type:)
-    if FeatureFlag.active?(:notify_can_place_orders)
-      CanOrderDevicesMailer
-        .with(user: user, school: school)
-        .send(message_type)
-        .deliver_later
-      EventNotificationsService.broadcast(
-        UserCanOrderEvent.new(user: user, school: school, type: message_type),
-      )
-    end
+    CanOrderDevicesMailer
+      .with(user: user, school: school)
+      .send(message_type)
+      .deliver_later
+    EventNotificationsService.broadcast(
+      UserCanOrderEvent.new(user: user, school: school, type: message_type),
+    )
   end
 
   def new_cap_value

--- a/app/models/user_can_order_devices_notifications.rb
+++ b/app/models/user_can_order_devices_notifications.rb
@@ -18,8 +18,6 @@ private
   end
 
   def notify_user(school:)
-    return unless FeatureFlag.active?(:notify_can_place_orders)
-
     message_type = message_type_for_school(school)
 
     return unless message_type

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,7 +6,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = %i[
     mno_offer
-    notify_can_place_orders
     reduced_allocations
     no_chromebook_or_ipad_stock
     half_term_order_closure

--- a/app/views/support/devices/order_status/confirm.html.erb
+++ b/app/views/support/devices/order_status/confirm.html.erb
@@ -16,7 +16,7 @@
       allocation: @allocation,
       change_path: support_devices_school_enable_orders_path(@school.urn, pass_through_params)) %>
 
-    <% if FeatureFlag.active?(:notify_can_place_orders) && @form.will_enable_orders? %>
+    <% if @form.will_enable_orders? %>
       <%= render partial: 'what_happens_next' %>
     <% end %>
 

--- a/spec/features/computacenter/techsource_spec.rb
+++ b/spec/features/computacenter/techsource_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Computacenter confirming TechSource accounts', with_feature_flags: { notify_can_place_orders: 'active' } do
+RSpec.describe 'Computacenter confirming TechSource accounts' do
   scenario 'when school user + school can order devices' do
     given_school_exists_that_can_order_devices
     and_school_user_awaiting_techsource_confirmation

--- a/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/devices/enabling_orders_for_a_school_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Enabling orders for a school from the support area', with_feature_flags: { notify_can_place_orders: 'active' } do
+RSpec.feature 'Enabling orders for a school from the support area' do
   let(:school_details_page) { PageObjects::Support::Devices::SchoolDetailsPage.new }
   let(:enable_orders_confirm_page) { PageObjects::Support::Devices::EnableOrdersConfirmPage.new }
 

--- a/spec/models/school_can_order_devices_notifications_spec.rb
+++ b/spec/models/school_can_order_devices_notifications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SchoolCanOrderDevicesNotifications, with_feature_flags: { notify_can_place_orders: 'active', slack_notifications: 'active' } do
+RSpec.describe SchoolCanOrderDevicesNotifications, with_feature_flags: { slack_notifications: 'active' } do
   let(:school) do
     create(:school,
            :with_std_device_allocation,
@@ -47,14 +47,6 @@ RSpec.describe SchoolCanOrderDevicesNotifications, with_feature_flags: { notify_
             text: "[User can order event] We emailed a user to tell them that they can place orders for #{school.name}",
             mrkdwn: true,
           )
-        end
-
-        context 'when feature is deactivated', with_feature_flags: { notify_can_place_orders: 'inactive' } do
-          it 'does not notify the user' do
-            expect {
-              service.call
-            }.not_to have_enqueued_job.on_queue('mailers')
-          end
         end
       end
 
@@ -189,14 +181,6 @@ RSpec.describe SchoolCanOrderDevicesNotifications, with_feature_flags: { notify_
             text: "[User can order event] We emailed a user to tell them that action is needed before #{school.name} can place orders",
             mrkdwn: true,
           )
-        end
-      end
-
-      context 'when feature is deactivated', with_feature_flags: { notify_can_place_orders: 'inactive' } do
-        it 'does not notify the user' do
-          expect {
-            service.call
-          }.not_to have_enqueued_job.on_queue('mailers')
         end
       end
     end

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe UserCanOrderDevicesNotifications, with_feature_flags: { notify_can_place_orders: 'active' } do
+RSpec.describe UserCanOrderDevicesNotifications do
   subject(:service) { described_class.new(user: user) }
 
   context 'when orders can be placed' do

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -30,27 +30,17 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
           user.school.update!(order_state: :can_order)
         end
 
-        context 'and the "notify_can_place_orders" feature flag is activated', with_feature_flags: { notify_can_place_orders: 'active' } do
-          it 'sends an email' do
-            expect {
-              service.call
-            }.to have_enqueued_job.on_queue('mailers')
-          end
-
-          it 'only sends one email if touched multiple times' do
-            expect {
-              service.call
-              service.call
-            }.to have_enqueued_job.on_queue('mailers')
-          end
+        it 'sends an email' do
+          expect {
+            service.call
+          }.to have_enqueued_job.on_queue('mailers')
         end
 
-        context 'and the "notify_can_place_orders" feature flag is deactivated' do
-          it 'does not send an email' do
-            expect {
-              service.call
-            }.not_to have_enqueued_job.on_queue('mailers')
-          end
+        it 'only sends one email if touched multiple times' do
+          expect {
+            service.call
+            service.call
+          }.to have_enqueued_job.on_queue('mailers')
         end
       end
 


### PR DESCRIPTION
### Context

The 'notify_can_place_orders' feature has been in place for a few days and we're not planning to disable it.

### Changes proposed in this pull request

Remove the feature flag and the specs testing the case where it's disabled.

### Guidance to review

Probably slightly less noise in the PR if you [ignore whitespace changes](https://github.com/DFE-Digital/get-help-with-tech/pull/702/files?diff=split&w=1).