### PR TITLE
Clean up view templates using the Details govuk-components component

### DIFF
--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -18,20 +18,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-bottom-2"><%= pluralize(@schools.size, 'school') %></h2>
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Is this list wrong?
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <% if @responsible_body.is_a_local_authority? %>
-          <p>This is a list of all local authority maintained and special schools.</p>
-        <% end %>
-        <p>Email <%= ghwt_contact_mailto(subject: 'Problem with list of schools') %>
-          and tell us what to change.</p>
-      </div>
-    </details>
+
+    <%= render GovukComponent::Details.new(summary: 'Is this list wrong?') do %>
+      <% if @responsible_body.is_a_local_authority? %>
+        <p>This is a list of all local authority maintained and special schools.</p>
+      <% end %>
+      <p>Email <%= ghwt_contact_mailto(subject: 'Problem with list of schools') %>
+        and tell us what to change.</p>
+    <%- end %>
   </div>
 </div>
 

--- a/app/views/sign_in_tokens/sign_in_only.html.erb
+++ b/app/views/sign_in_tokens/sign_in_only.html.erb
@@ -10,16 +10,9 @@
 
       <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter your email address, and we’ll send you a link to sign in.' } %>
 
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Change email address
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p>Contact <%= ghwt_contact_mailto(subject: 'Request access for another email address') %> to request access for a different email address.</p>
-        </div>
-      </details>
+      <%= render GovukComponent::Details.new(summary: 'Change email address') do %>
+        <p>Contact <%= ghwt_contact_mailto(subject: 'Request access for another email address') %> to request access for a different email address.</p>
+      <%- end %>
 
       <%= f.govuk_submit %>
     <% end %>


### PR DESCRIPTION
### Context

The `govuk-components` gem includes a view component for details.

### Changes proposed in this pull request

Clean up two view templates using the component.


