### PR TITLE
Fix: added date to groups filename from GIAS

### DIFF
--- a/app/models/get_information_about_schools.rb
+++ b/app/models/get_information_about_schools.rb
@@ -63,16 +63,20 @@ class GetInformationAboutSchools
     RemoteFile.download(school_contacts_url, file)
   end
 
-  def self.groups_url
-    "#{EDUBASE_URL}allgroupsdata.csv"
+  def self.groups_url(date: Time.zone.now)
+    make_edubase_url('allgroupsdata', date)
   end
 
   def self.schools_url(date: Time.zone.now)
-    "#{EDUBASE_URL}edubasealldata#{date.strftime('%Y%m%d')}.csv"
+    make_edubase_url('edubasealldata', date)
   end
 
   def self.school_links_url(date: Time.zone.now)
-    "#{EDUBASE_URL}links_edubasealldata#{date.strftime('%Y%m%d')}.csv"
+    make_edubase_url('links_edubasealldata', date)
+  end
+
+  def self.make_edubase_url(filename, date)
+    "#{EDUBASE_URL}#{filename}#{date.strftime('%Y%m%d')}.csv"
   end
 
   def self.school_contacts_url

--- a/spec/models/get_information_about_schools_spec.rb
+++ b/spec/models/get_information_about_schools_spec.rb
@@ -29,4 +29,31 @@ RSpec.describe GetInformationAboutSchools, type: :model do
       'Group Status' => 'Open',
     })
   end
+
+  describe '.groups_url' do
+    it 'returns the groups file url for the date specified' do
+      t = Time.zone.now
+      file = "allgroupsdata#{t.strftime('%Y%m%d')}.csv"
+      url = GetInformationAboutSchools.groups_url(date: t)
+      expect(url).to end_with(file)
+    end
+  end
+
+  describe '.schools_url' do
+    it 'returns the schools file url for the date specified' do
+      t = Time.zone.now
+      file = "edubasealldata#{t.strftime('%Y%m%d')}.csv"
+      url = GetInformationAboutSchools.schools_url(date: t)
+      expect(url).to end_with(file)
+    end
+  end
+
+  describe '.school_links_url' do
+    it 'returns the school links file url for the date specified' do
+      t = Time.zone.now
+      file = "links_edubasealldata#{t.strftime('%Y%m%d')}.csv"
+      url = GetInformationAboutSchools.school_links_url(date: t)
+      expect(url).to end_with(file)
+    end
+  end
 end


### PR DESCRIPTION
### Context
The `StageTrustDataJob` has had failures and it stems from GIAS changing the filename of the datafile we download to include a timestamp.

### Changes proposed in this pull request
Add the date to the filename we wish to download.

### Guidance to review
Running the `StageTrustDataJob.perform_now` from your local dev console should successfully download the trust data file from GIAS and update the DataStage (assuming changes were present).
