### PR TITLE
Add The Key support second level landing page 

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,6 +1,11 @@
 class LandingPagesController < ApplicationController
   layout 'page_with_toc'
 
+  def digital_platforms
+    @title = I18n.t!('landing_pages.digital_platforms.title')
+    render
+  end
+
   def edtech_demonstrator_programme
     @title = I18n.t!('landing_pages.edtech_demonstrator_programme.title')
     render

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -1,0 +1,113 @@
+## About the programme
+
+Government-funded support is available for schools to get set up on one of two free-to-use digital education platforms. You can choose to use either:
+
+* G Suite for Education (Google Classroom)
+* Office 365 Education (Microsoft Teams)
+
+[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/feature-comparison-g-suite-education-and-office-365-education/?marker=content-body) provides feature comparison and case studies on how schools are making the most of these platforms, to help you make the most appropriate choice for your school.
+
+You have until the end of March 2021 to register with this programme and claim your grant.
+
+## What is a digital education platform?
+It's a place where teachers and pupils can continue learning through online virtual classrooms. 
+
+The platforms are purpose-built for remote learning in a way that a school website is not. 
+
+Teachers can:
+
+* communicate with pupils and deliver lessons via video calls
+* record virtual lessons 
+* set tasks
+* let pupils work together through supervised group calls
+* give personalised feedback via video or within shared documents
+* continue with formal assessment for learning
+* set up separate classrooms for smaller groups of students
+* develop structured file and folder storage for different users
+* use tools to support staff planning
+
+Using a digital education platform will allow teachers and pupils to continue education if a school closes.
+
+[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/lead-your-approach/why-every-school-should-be-using-digital-education-platform/) has information on why you should make the move to a digital education platform, if you have not already. 
+
+## Who can apply
+
+The funded support is for schools that:
+
+* do not have a digital education platform
+* have access to Office 365 Education or G Suite for Education, but are not yet set up to assign work and communicate with pupils
+
+Support is available to state funded:
+
+* primary schools
+* secondary schools
+* special schools
+* pupil referral units
+
+Virtual schools are also eligible for the programme. This is especially true for virtual schools that:
+
+* regularly coordinate and deliver elements of educational provision and curricular content 
+* engage with looked-after children
+
+## How to apply
+
+You can choose to apply for support from either a Google or Microsoft partner. 
+
+To apply, complete the support request form for your chosen partner below:
+
+* [Apply for support from a Google partner](https://docs.google.com/forms/d/e/1FAIpQLSc45tWnxrk0ZPyhEE4UioGAxDF_2eYNEuE3lLzY_P6Hpo8jxg/viewform)
+* [Apply for support from a Microsoft partner](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR8OxR8KDk1BHllyTqp9sEZBUNEVJNDlRN0U1WUtQWk1KTjY5RDFCM1M3VyQlQCN0PWcu)
+
+Trusts and sponsors can apply on behalf of their schools.
+
+## What happens after you apply
+
+A member from either Google or Microsoft will receive your request. They’ll confirm if you’re eligible for the programme and, if so, they’ll assign you to an IT supplier. 
+
+Your IT supplier will contact you within 2 days to agree a day and time to start the process of setting up the platform for your school. 
+
+It will take only a few days to install your platform if you respond quickly to the IT supplier’s requests to agree to the scope of work, and share user data and any other relevant information. 
+
+## How to claim your grant funding
+
+After you complete your support request form, you'll receive an email from the DfE Digital Infrastructure Payments team with details on how to claim your grant. 
+
+Once your platform is set up, you can claim the following grant funding:
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Type of school</th>
+      <th scope="col" class="govuk-table__header">Grant funding available</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Individual primary school</th>
+        <td class="govuk-table__cell">£1,500</td>  
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Individual secondary school</th>
+        <td class="govuk-table__cell">£2,000</td>  
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Multi-academy trust</th>
+        <td class="govuk-table__cell">£1,000 per school</td>  
+      </tr>       
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Virtual school</th>
+        <td class="govuk-table__cell">£1,500</td>  
+      </tr>
+  </tbody>
+</table>
+
+## Will platforms continue to be free to use?
+
+Once you have access to a platform, you and your pupils can use it for free.
+
+## How to get support
+You can find more information about the programme and how schools are using digital platforms on [The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/).
+
+[Free training and support to set up and use technology effectively](/EdTech-demonstrator-programme) is available through the EdTech Demonstrator Programme.
+
+If you have a question about this programme, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 3 working days.

--- a/app/views/landing_pages/edtech_demonstrator_programme.md
+++ b/app/views/landing_pages/edtech_demonstrator_programme.md
@@ -28,7 +28,7 @@ Demonstrators are [schools and colleges](https://edtech-demonstrator.lgfl.net/de
 ## Who the programme is for
 Any publicly funded school or college in England can apply for support from an EdTech Demonstrator. Independent schools and training providers are not eligible for the scheme.
 
-The programme offers support to schools and colleges who are setting up a [new online learning platform](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/). 
+The programme offers support to schools and colleges who are setting up a [new online learning platform](/digital-platforms). 
 
 It can also help those that would like support to develop their approach to remote learning to improve learner outcomes, engagement and wellbeing.
 

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -52,21 +52,19 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/digital-education-platform-hub/">
-        Get funding and support to set up a digital education platform
-      </a>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2" data-service-section="digital-platforms">
+      <%= govuk_link_to t('landing_pages.digital_platforms.title'), digital_platforms_landing_page_path %>
     </h2>
 
     <p class="govuk-body">
-      Find out how to apply for government-funded support through The Key for School Leaders and access one of two
-      free-to-use digital education platforms: G Suite for Education or Office 365 Education.
+      Find out how to apply for government-funded support to access one of two free-to-use digital education platforms:
+      G Suite for Education or Office 365 Education.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2" data-service-section="edtech">
-      <%= govuk_link_to  t('landing_pages.edtech_demonstrator_programme.title') ,
+      <%= govuk_link_to t('landing_pages.edtech_demonstrator_programme.title') ,
                         edtech_demonstrator_programme_landing_page_path %>
     </h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,8 @@ en:
     your_schools: Your schools
     your_organisations: Your organisations
   landing_pages:
+    digital_platforms:
+      title: "Get funding and support to set up a digital education platform"
     edtech_demonstrator_programme:
       title: Get free training and support to set up and use technology effectively
   cookie_preferences:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   get '/start', to: 'pages#start'
 
+  get '/digital-platforms', to: 'landing_pages#digital_platforms', as: :digital_platforms_landing_page
   get '/EdTech-demonstrator-programme', to: 'landing_pages#edtech_demonstrator_programme', as: :edtech_demonstrator_programme_landing_page
 
   get '/about-bt-wifi', to: 'pages#about_bt_wifi'

--- a/spec/features/start_journey_spec.rb
+++ b/spec/features/start_journey_spec.rb
@@ -12,6 +12,12 @@ RSpec.feature 'View pages', type: :feature do
     then_i_should_see_the_edtech_programme_page
   end
 
+  scenario 'user would like to find out hot to get a digital platform setup' do
+    when_i_visit_the_home_page
+    and_i_click_on_get_funding_to_setup_platforms_link
+    then_i_should_see_the_digital_platforms_page
+  end
+
 private
 
   def when_i_visit_the_home_page
@@ -27,8 +33,17 @@ private
     @home_page.edtech_landing_page_link.click
   end
 
+  def and_i_click_on_get_funding_to_setup_platforms_link
+    @home_page.digital_platforms_page_link.click
+  end
+
   def then_i_should_see_the_edtech_programme_page
     @edtech_landing_page ||= PageObjects::LandingPages::EdtechDemonstratorProgrammePage.new
     expect(@edtech_landing_page).to be_displayed
+  end
+
+  def then_i_should_see_the_digital_platforms_page
+    @digital_platforms_page ||= PageObjects::LandingPages::DigitalPlatformsPage.new
+    expect(@digital_platforms_page).to be_displayed
   end
 end

--- a/spec/page_objects/landing_pages/digital_platforms_page.rb
+++ b/spec/page_objects/landing_pages/digital_platforms_page.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module LandingPages
+    class DigitalPlatformsPage < PageObjects::BasePage
+      set_url '/digital-platforms'
+    end
+  end
+end

--- a/spec/page_objects/pages/home_page.rb
+++ b/spec/page_objects/pages/home_page.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       element :page_heading, 'h1.govuk-heading-xl'
 
+      element :digital_platforms_page_link, '[data-service-section="digital-platforms"] a'
       element :edtech_landing_page_link, '[data-service-section="edtech"] a'
     end
   end


### PR DESCRIPTION
### Context
This has been tested and researched using spike #525. As the spike is fairly large, I will be creating smaller PR to add the second level pages to the service. 

### Changes proposed in this pull request

### Guidance to review
Visit https://ghwt-review-pr-713.herokuapp.com/
- go to the bottom of the home page and click the "Get funding and support to set up a digital education platform" link
- new second-level page is displayed explaining more about The Key support and the programme. 

