### PR TITLE
Note that existing BT vouchers will continue until December

### DIFF
--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -32,6 +32,10 @@
     </p>
 
     <p class="govuk-body">
+      Any vouchers that have already been downloaded and distributed will still work until the end of December 2020.
+    </p>
+
+    <p class="govuk-body">
       If you were invited to take part in the pilot and have not downloaded your vouchers yet, please contact <%= ghwt_contact_mailto %> for support.
     </p>
 


### PR DESCRIPTION
Anyone with an active voucher can continue to use it until the end of the year.