### PR TITLE
[hotfix] fix deploy-to-paas job failure on main 

### DIFF
--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -5,12 +5,10 @@ on:
   push:
     branches:
       - main
-      - hotfix-cf-cli-version-on-ci
 
 jobs:
   build-and-push-container:
     runs-on: ubuntu-latest
-    if: ${{ false }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -37,15 +35,13 @@ jobs:
 
   deploy-to-paas:
     runs-on: ubuntu-latest
-    # needs: build-and-push-container
+    needs: build-and-push-container
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli
-        # curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
-        # sudo mv cf /usr/local/bin
         run: |
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list


### PR DESCRIPTION
### Context

A previous PR (#724) removed support for CF CLI v6, as all developers are using v7. However, our Github Actions use the ubuntu-latest Github action runner, which uses the /stable/ apt source, which is still on CF CLI v6. As a result, the final `deploy-to-paas` job in a merge workflow was failing.

### Changes proposed in this pull request

* Use an up-to-date package source, and install `cf7-cli`, so that the job works
 
### Guidance to review

Merging this PR should deploy successfully to dev