### PR TITLE
Enable paper trail for School

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,4 +1,6 @@
 class School < ApplicationRecord
+  has_paper_trail
+
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
   has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe School, type: :model do
+  it { is_expected.to be_versioned }
+
   describe 'validating URN' do
     let(:school) { subject }
 


### PR DESCRIPTION
This is predominantly to be able to track changes to `order_state` but
will be useful for other attributes as well.
