### PR TITLE
Bugfix: remove unnecessary parts from the RB URL for multi-org users

### DIFF
--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -12,7 +12,7 @@
     <%- end %>
     <%- if @user.responsible_body.present? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to @user.responsible_body.name, responsible_body_home_path(@user.responsible_body) %>
+        <%= govuk_link_to @user.responsible_body.name, responsible_body_home_path %>
       </h2>
     <%- end %>
   </div>


### PR DESCRIPTION
### Context / how to reproduce

Given a user is part of a school and an RB
When they navigate from the `/schools` page to the RB page, the URL is

`/responsible-body.<responsible body ID>`

but it should be

`/responsible-body`


### Changes proposed in this pull request

Don't pass the unnecessary extra parameter into the path helper.
