### PR TITLE
[930] Notify support if school can order but no one contacted

### DIFF
--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -39,6 +39,14 @@ class CanOrderDevicesMailer < ApplicationMailer
                           personalisation: personalisation)
   end
 
+  def notify_support_school_can_order_but_no_one_contacted
+    @school = params[:school]
+
+    template_mail(notify_support_school_can_order_but_no_one_contacted_template_id,
+                  to: 'COVID.TECHNOLOGY@education.gov.uk',
+                  personalisation: personalisation)
+  end
+
 private
 
   def tracked_template_mail(message_type, template_id, mail_params = {})
@@ -54,6 +62,7 @@ private
   def personalisation
     {
       school: @school.name,
+      urn: @school.urn,
     }
   end
 
@@ -71,5 +80,9 @@ private
 
   def can_order_but_action_needed_template_id
     Settings.govuk_notify.templates.devices.can_order_but_action_needed
+  end
+
+  def notify_support_school_can_order_but_no_one_contacted_template_id
+    Settings.govuk_notify.templates.devices.notify_support_school_can_order_but_no_one_contacted
   end
 end

--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -8,6 +8,7 @@ class SchoolCanOrderDevicesNotifications
   def call
     if school&.can_order_devices_right_now?
       notify_about_school_being_able_to_order
+      notify_support_if_no_one_to_contact
       notify_computacenter
     end
   end
@@ -25,6 +26,15 @@ private
         message_type: message_type,
       )
     end
+  end
+
+  def notify_support_if_no_one_to_contact
+    return if all_relevant_users.present?
+
+    CanOrderDevicesMailer
+      .with(school: school)
+      .send(:notify_support_school_can_order_but_no_one_contacted)
+      .deliver_later
   end
 
   def all_relevant_users

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,7 +50,7 @@ govuk_notify:
       user_added_to_additional_school: 'f3ec0c69-17f8-424d-9c33-f17438355c2c'
       nudge_rb_to_add_school_contact: '867df323-b377-4906-8386-79db71e9c428'
       nudge_user_to_read_privacy_policy: '0ae8dc73-121b-4d24-8346-a80bbbcc5cea'
-
+      notify_support_school_can_order_but_no_one_contacted: 'b673e290-47d3-4744-84fb-a1be7002d201'
     computacenter:
       device_cap_change: '6e00f2bf-d373-436d-a2c0-2910f20ef521'
       comms_cap_change: '01f1b2a3-a216-44cc-a567-704bfd0a3c56'


### PR DESCRIPTION
### Context

- https://trello.com/c/jP4OIh88/930-send-an-automated-email-to-ghwt-support-when-a-school-is-closed-and-it-has-no-users-responsible-for-it

### Changes proposed in this pull request

- Contact support if school can order but no one has been contacted as school or responsible body does not have any associated users

### Screenshots

#### Email template
![image](https://user-images.githubusercontent.com/92580/97865893-d83dc900-1d02-11eb-9360-d31fc5f1e6d5.png)

### Guidance to review

- Find a school that does not have users or a responsible body that does not have any users
- Ensure the school can order devices. ie has correct caps and allocations spaces then change to `can_order`
- Should send email to support regarding the fact the school can order but no one was contacted