### PR TITLE
fix deploy users PATH and working directory on all environments

### DIFF
--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -18,3 +18,4 @@ applications:
     - get-help-with-tech-dev-redis
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
+    ENV: $HOME/.profile

--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -18,3 +18,4 @@ applications:
     - get-help-with-tech-prod-redis
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
+    ENV: $HOME/.profile

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -18,3 +18,4 @@ applications:
     - get-help-with-tech-staging-redis
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
+    ENV: $HOME/.profile


### PR DESCRIPTION
### Context

[Trello card 942](https://trello.com/c/99GQ8vCs/942-path-and-working-directory-not-correct-when-a-dev-sshs-onto-production) -
looks like the .profile file is not being called, due to the ENV env var not being correctly set on prod (or staging)

### Changes proposed in this pull request

Set the ENV variable in the manifest, for all environments

### Guidance to review

```
make (env) deploy
make (env) ssh
```

You should land in `/var/www/get-help-with-tech`, and be able to type `bundle exec rails c` and launch a console. I've tested this on staging
