### PR TITLE
[943] Fix paging of long output in the console in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ ARG APPNAME=get-help-with-tech
 USER root
 
 # dependencies relied upon to build native-extension gems etc
+RUN apk update
 RUN apk add libxml2-dev libxslt-dev build-base postgresql-dev tzdata
-RUN apk update && apk add nodejs postgresql-contrib libpq yarn
+RUN apk add nodejs postgresql-contrib libpq yarn less
 
 ENV RAILS_ROOT /var/www/${APPNAME}
 RUN mkdir -p $RAILS_ROOT


### PR DESCRIPTION
### Context

[Trello card 943](https://trello.com/c/4ZJe26dp/943-paging-broken-in-the-console-on-production) - Any console output that requires paging will break, since the move to Alpine linux.

This is an [issue with Pry's paging settings on any non-GNU-base linux less version](https://github.com/pry/pry/issues/1494)

### Changes proposed in this pull request

* install GNU-base `less` 
* make sure `apk update` is called first, before adding new packages

### Guidance to review


