### PR TITLE
[878] Soft user delete

### DIFF
--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -38,7 +38,7 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
   def destroy
     @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = @responsible_body.users.find(params[:id])
-    @user.update(deleted_at: Time.zone.now)
+    @user.update!(deleted_at: Time.zone.now)
 
     redirect_to support_responsible_body_path(@responsible_body)
   end

--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -40,6 +40,8 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
     @user = @responsible_body.users.find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
+    flash[:success] = 'User has been deleted'
+
     redirect_to support_responsible_body_path(@responsible_body)
   end
 

--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -1,11 +1,11 @@
 class Support::ResponsibleBodies::UsersController < Support::BaseController
+  before_action :set_responsible_body
+
   def new
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = @responsible_body.users.build
   end
 
   def create
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = CreateUserService.invite_responsible_body_user(
       user_params.merge(responsible_body_id: params[:responsible_body_id]),
     )
@@ -19,12 +19,10 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
   end
 
   def edit
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = @responsible_body.users.find(params[:id])
   end
 
   def update
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = @responsible_body.users.find(params[:id])
 
     if @user.update(user_params)
@@ -36,13 +34,12 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
   end
 
   def destroy
-    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
     @user = @responsible_body.users.find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
     flash[:success] = 'User has been deleted'
 
-    redirect_to support_responsible_body_path(@responsible_body)
+    redirect_to return_path
   end
 
 private
@@ -57,5 +54,9 @@ private
       :email_address,
       :telephone,
     )
+  end
+
+  def set_responsible_body
+    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
   end
 end

--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -35,6 +35,14 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
     end
   end
 
+  def destroy
+    @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
+    @user = @responsible_body.users.find(params[:id])
+    @user.update(deleted_at: Time.zone.now)
+
+    redirect_to support_responsible_body_path(@responsible_body)
+  end
+
 private
 
   def return_path

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -11,7 +11,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
 
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
-    @users = @responsible_body.users.order('last_signed_in_at desc nulls last, updated_at desc')
+    @users = @responsible_body.users.not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
     @schools = @responsible_body
       .schools
       .includes(:device_allocations, :preorder_information)

--- a/app/controllers/support/schools/users_controller.rb
+++ b/app/controllers/support/schools/users_controller.rb
@@ -34,6 +34,14 @@ class Support::Schools::UsersController < Support::BaseController
     end
   end
 
+  def destroy
+    @school = School.find_by(urn: params[:school_urn])
+    @user = @school.users.find(params[:id])
+    @user.update(deleted_at: Time.zone.now)
+
+    redirect_to support_school_path(@school)
+  end
+
 private
 
   def present(user)

--- a/app/controllers/support/schools/users_controller.rb
+++ b/app/controllers/support/schools/users_controller.rb
@@ -37,7 +37,7 @@ class Support::Schools::UsersController < Support::BaseController
   def destroy
     @school = School.find_by(urn: params[:school_urn])
     @user = @school.users.find(params[:id])
-    @user.update(deleted_at: Time.zone.now)
+    @user.update!(deleted_at: Time.zone.now)
 
     redirect_to support_school_path(@school)
   end

--- a/app/controllers/support/schools/users_controller.rb
+++ b/app/controllers/support/schools/users_controller.rb
@@ -39,6 +39,8 @@ class Support::Schools::UsersController < Support::BaseController
     @user = @school.users.find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
+    flash[:success] = 'User has been deleted'
+
     redirect_to support_school_path(@school)
   end
 

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -10,7 +10,7 @@ class Support::SchoolsController < Support::BaseController
 
   def show
     @school = School.find_by!(urn: params[:urn])
-    @users = @school.users
+    @users = @school.users.not_deleted
     @contacts = @school.contacts
     @email_audits = @school.email_audits.order(created_at: :desc)
   end

--- a/app/form_objects/sign_in_token_form.rb
+++ b/app/form_objects/sign_in_token_form.rb
@@ -9,6 +9,12 @@ class SignInTokenForm
             format: { with: URI::MailTo::EMAIL_REGEXP, message: 'Enter an email address in the correct format, like name@example.com' }
 
   def email_is_user?
-    SessionService.find_user_by_lowercase_email(email_address).present?
+    SessionService.find_user_by_lowercase_email(email_address).present? && !user_deleted?
+  end
+
+private
+
+  def user_deleted?
+    User.deleted.where('lower(email_address) = ?', email_address.downcase).first
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,7 +3,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   layout 'mailer'
 
   def template_mail(template_id, headers)
-    headers[:to] = Array(headers[:to]) - User.deleted.pluck(:email_address)
+    headers[:to] = Array(headers[:to]) - User.deleted.where(email_address: headers[:to]).pluck(:email_address)
 
     return OpenStruct.new(deliver: nil) if headers[:to].blank?
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,6 +2,14 @@ class ApplicationMailer < Mail::Notify::Mailer
   default from: 'from@example.com'
   layout 'mailer'
 
+  def template_mail(template_id, headers)
+    headers[:to] = Array(headers[:to]) - User.deleted.pluck(:email_address)
+
+    return OpenStruct.new(deliver: nil) if headers[:to].blank?
+
+    super
+  end
+
 private
 
   def url(named_route, *args)

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -47,12 +47,14 @@ private
   def is_change?
     last_change_for_user.present? && \
       user.relevant_to_computacenter? && \
-      !user.destroyed?
+      !user.destroyed? && \
+      !user.soft_deleted?
   end
 
   def is_removal?
     (last_change_for_user.present? && last_change_for_user.type_of_update != 'Remove' && !user.relevant_to_computacenter?) || \
-      (user.relevant_to_computacenter? && user.destroyed?)
+      (user.relevant_to_computacenter? && user.destroyed?) || \
+      (user.relevant_to_computacenter? && user.soft_deleted?)
   end
 
   def computacenter_fields_have_changed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,6 +188,10 @@ class User < ApplicationRecord
     end
   end
 
+  def soft_deleted?
+    deleted_at.present?
+  end
+
 private
 
   def cleansed_full_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,8 @@ class User < ApplicationRecord
   scope :who_can_order_devices, -> { where(orders_devices: true) }
   scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }
   scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
-  scope :deleted, -> { where('deleted_at IS NOT NULL') }
-  scope :not_deleted, -> { where('deleted_at IS NULL') }
+  scope :deleted, -> { where.not(deleted_at: nil) }
+  scope :not_deleted, -> { where(deleted_at: nil) }
 
   validates :full_name,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   scope :who_can_order_devices, -> { where(orders_devices: true) }
   scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }
   scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
+  scope :deleted, -> { where('deleted_at IS NOT NULL') }
 
   validates :full_name,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
   scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }
   scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
   scope :deleted, -> { where('deleted_at IS NOT NULL') }
+  scope :not_deleted, -> { where('deleted_at IS NULL') }
 
   validates :full_name,
             presence: true,

--- a/app/views/support/responsible_bodies/users/edit.html.erb
+++ b/app/views/support/responsible_bodies/users/edit.html.erb
@@ -10,5 +10,9 @@
     <%= form_for @user, url: support_responsible_body_user_path(@responsible_body, @user, pilot: 'devices') do |f| %>
       <%= render partial: 'shared/responsible_body_user_form', locals: { submit_text: 'Save changes', form: f } %>
     <%- end %>
+
+    <%= form_for @user, url: support_responsible_body_user_path(@responsible_body, @user), method: :delete do |f| %>
+      <%= f.govuk_submit 'Delete user', warning: true %>
+    <%- end %>
   </div>
 </div>

--- a/app/views/support/schools/users/edit.html.erb
+++ b/app/views/support/schools/users/edit.html.erb
@@ -7,10 +7,15 @@
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>
+
     <%= form_for @user, url: support_school_user_path(urn: @school.urn, id: @user.id) do |f| %>
       <%= f.govuk_error_summary %>
       <%= render partial: 'shared/school_user_form', locals: { form: f } %>
       <%= f.govuk_submit 'Save changes' %>
+    <%- end %>
+
+    <%= form_for @user, url: support_school_user_path(urn: @school.urn, id: @user.id), method: :delete do |f| %>
+      <%= f.govuk_submit 'Delete user', warning: true %>
     <%- end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,7 @@ Rails.application.routes.draw do
     get '/technical', to: 'home#technical_support', as: :technical_support
     get '/performance', to: 'service_performance#index', as: :service_performance
     resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies' do
-      resources :users, only: %i[new create edit update], controller: 'responsible_bodies/users'
+      resources :users, only: %i[new create edit update destroy], controller: 'responsible_bodies/users'
     end
     resources :schools, only: %i[show], param: :urn do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,7 +160,7 @@ Rails.application.routes.draw do
       end
       get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
       post '/invite', to: 'schools#invite'
-      resources :users, only: %i[new create edit update], controller: 'schools/users'
+      resources :users, only: %i[new create edit update destroy], controller: 'schools/users'
 
       get '/devices/enable-orders', to: 'schools/devices/order_status#edit', as: :enable_orders
       get '/devices/enable-orders/confirm', to: 'schools/devices/order_status#confirm', as: :confirm_enable_orders

--- a/db/migrate/20201102124657_add_deleted_at_to_users.rb
+++ b/db/migrate/20201102124657_add_deleted_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :deleted_at, :datetime, null: true, default: nil
+    add_index :users, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -328,7 +328,9 @@ ActiveRecord::Schema.define(version: 2020_11_04_165458) do
     t.datetime "privacy_notice_seen_at"
     t.boolean "orders_devices"
     t.datetime "techsource_account_confirmed_at"
+    t.datetime "deleted_at"
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
+    t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["mobile_network_id"], name: "index_users_on_mobile_network_id"
     t.index ["responsible_body_id"], name: "index_users_on_responsible_body_id"

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -110,4 +110,15 @@ RSpec.describe SignInTokensController, type: :controller do
       end
     end
   end
+
+  describe '#create' do
+    let(:user) { create(:local_authority_user, :who_has_requested_a_magic_link, deleted_at: 1.second.ago) }
+
+    context 'when user has been marked as deleted' do
+      it 'does not recognise the email' do
+        post :create, params: { sign_in_token_form: { email_address: user.email_address } }
+        expect(response).to redirect_to email_not_recognised_path
+      end
+    end
+  end
 end

--- a/spec/controllers/support/responsible_bodies/users_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies/users_controller_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
+  let(:dfe_user) { create(:dfe_user) }
+
   describe '#create' do
     context 'for support users', versioning: true do
       let(:responsible_body) { create(:local_authority) }
-      let(:dfe_user) { create(:dfe_user) }
 
       before do
         sign_in_as dfe_user
@@ -61,6 +62,25 @@ RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
       post :create, params: { responsible_body_id: 1, user: { some: 'data' } }
 
       expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  describe '#destroy' do
+    let(:user) { create(:trust_user) }
+    let(:rb) { user.responsible_body }
+
+    before do
+      sign_in_as dfe_user
+    end
+
+    it 'sets user deleted_at timestamp' do
+      delete :destroy, params: { responsible_body_id: rb.id, id: user.id }
+      expect(user.reload.deleted_at).to be_present
+    end
+
+    it 'redirects back to the RB' do
+      delete :destroy, params: { responsible_body_id: rb.id, id: user.id }
+      expect(response).to redirect_to(support_responsible_body_path(rb))
     end
   end
 end

--- a/spec/controllers/support/schools/users_controller_spec.rb
+++ b/spec/controllers/support/schools/users_controller_spec.rb
@@ -78,4 +78,23 @@ RSpec.describe Support::Schools::UsersController do
       end
     end
   end
+
+  describe '#destroy' do
+    let(:user) { create(:school_user) }
+    let(:school) { user.school }
+
+    before do
+      sign_in_as support_user
+    end
+
+    it 'sets user deleted_at timestamp' do
+      delete :destroy, params: { school_urn: school.urn, id: user.id }
+      expect(user.reload.deleted_at).to be_present
+    end
+
+    it 'redirects back to the school' do
+      delete :destroy, params: { school_urn: school.urn, id: user.id }
+      expect(response).to redirect_to(support_school_path(school))
+    end
+  end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer do
+  let(:personalisation) do
+    {
+      name: 'bob',
+    }
+  end
+
+  subject(:mailer) { described_class.new }
+
+  describe '#template_mail' do
+    it 'sends emails' do
+      expect {
+        mailer.template_mail('some_template_id',
+                             to: 'user1@example.com',
+                             personalisation: personalisation).deliver
+      }.to change(ActionMailer::Base.deliveries, :size).by(1)
+    end
+
+    context 'when user has been deleted' do
+      let(:user) { create(:school_user, deleted_at: 1.second.ago) }
+
+      it 'does not send the email to deleted user' do
+        expect {
+          mailer.template_mail('some_template_id',
+                               to: user.email_address,
+                               personalisation: personalisation).deliver
+
+          mailer.template_mail('some_template_id',
+                               to: user.email_address,
+                               personalisation: personalisation).deliver_now
+        }.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/QPKfn09A/878-allow-support-to-remove-user-access-from-dfe-and-cc-services

### Changes proposed in this pull request

- Support can soft deletes users
- This simply sets the `deleted_at` on a user with the current timestamp
- These soft deleted users cannot login
- They are also no longer visible to support
- Soft deleted are sent to CC as if the user had been removed
- All mailers should no longer send to deleted users

### Guidance to review

- Login as support user
- Find a user and delete them
- Support user should no longer see user
- Attempt to login as deleted user
- Should no longer be able to login
- If they were CC relevant the user changes should mark them as to be removed
- As support user attempt to mark the school as being able to order
- This user should not get the email notification