### PR TITLE
[950] Fix school status

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -37,7 +37,7 @@ class PreorderInformation < ApplicationRecord
     elsif school_will_order_devices? && any_school_users? && !chromebook_information_complete?
       'school_contacted'
     elsif school_will_order_devices? && any_school_users? && chromebook_information_complete?
-      if school.std_device_allocation&.has_devices_available_to_order?
+      if school.can_order_devices_right_now?
         'school_can_order'
       elsif (school.std_device_allocation&.devices_ordered || 0).positive?
         'ordered'
@@ -45,7 +45,7 @@ class PreorderInformation < ApplicationRecord
         'school_ready'
       end
     elsif chromebook_information_complete?
-      if orders_managed_centrally? && school.std_device_allocation&.has_devices_available_to_order?
+      if orders_managed_centrally? && school.can_order_devices_right_now?
         'rb_can_order'
       elsif orders_managed_centrally? && (school.std_device_allocation&.devices_ordered || 0).positive?
         'ordered'

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Ordering via a school' do
     let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
 
     before do
-      school.update!(std_device_allocation: allocation)
+      school.update!(std_device_allocation: allocation, order_state: 'can_order')
       school.preorder_information.refresh_status!
     end
 

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -104,59 +104,75 @@ RSpec.describe PreorderInformation, type: :model do
     end
 
     context 'when rb orders and status is ready' do
-      let(:school) { build(:school, std_device_allocation: allocation) }
+      let(:order_state) { 'can_order' }
+      let(:school) { create(:school, std_device_allocation: allocation, order_state: order_state) }
 
       subject do
-        build(:preorder_information,
-              :needs_chromebooks,
-              school: school,
-              who_will_order_devices: :responsible_body).infer_status
+        create(:preorder_information,
+               :needs_chromebooks,
+               school: school,
+               who_will_order_devices: :responsible_body).infer_status
       end
 
       context 'when there are devices available to order' do
-        let(:allocation) { build(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
 
         it { is_expected.to eq('rb_can_order') }
       end
 
+      context 'when there are devices available to order but school cannot order' do
+        let(:order_state) { 'cannot_order' }
+        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+
+        it { is_expected.to eq('ready') }
+      end
+
       context 'when all devices have been ordered' do
-        let(:allocation) { build(:school_device_allocation, :fully_ordered) }
+        let(:allocation) { create(:school_device_allocation, :fully_ordered) }
 
         it { is_expected.to eq('ordered') }
       end
 
       context 'when there are no devices available to order' do
-        let(:allocation) { build(:school_device_allocation) }
+        let(:allocation) { create(:school_device_allocation) }
 
         it { is_expected.to eq('ready') }
       end
     end
 
     context 'when school orders and status is school ready' do
-      let(:user) { build(:school_user) }
-      let(:school) { build(:school, std_device_allocation: allocation, users: [user]) }
+      let(:user) { create(:school_user) }
+      let(:order_state) { 'can_order' }
+      let(:school) { create(:school, std_device_allocation: allocation, users: [user], order_state: order_state) }
 
       subject do
-        build(:preorder_information,
-              :needs_chromebooks,
-              school: school,
-              who_will_order_devices: 'school').infer_status
+        create(:preorder_information,
+               :needs_chromebooks,
+               school: school,
+               who_will_order_devices: 'school').infer_status
       end
 
       context 'when there are devices available to order' do
-        let(:allocation) { build(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
 
         it { is_expected.to eq('school_can_order') }
       end
 
+      context 'when there are devices available to order but school cannot order' do
+        let(:order_state) { 'cannot_order' }
+        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+
+        it { is_expected.to eq('school_ready') }
+      end
+
       context 'when all devices have been ordered' do
-        let(:allocation) { build(:school_device_allocation, :fully_ordered) }
+        let(:allocation) { create(:school_device_allocation, :fully_ordered) }
 
         it { is_expected.to eq('ordered') }
       end
 
       context 'when there are no devices available to order' do
-        let(:allocation) { build(:school_device_allocation) }
+        let(:allocation) { create(:school_device_allocation) }
 
         it { is_expected.to eq('school_ready') }
       end


### PR DESCRIPTION

### Context

- https://trello.com/c/OYp10nrK/950-school-status-no-reflected-correctly

### Changes proposed in this pull request

- There is a bug in `infer_status` where if the school cannot order but has devices available it would show as `school can order` when it should say `school ready` or `ready`

### Guidance to review

- Sign in as support user
- View a school
- Make he school `order_state` as `cannot_order` but the school should have devices available in an allocation
- Refresh
- Should see status of `School ready` if school is ordering or `ready` if RB orders
- Change the school `order_state` to `can_order`
- Should now say `school can order` if school orders or `responsible body can order`