### PR TITLE
[965] fix daylight savings time detection on Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ USER root
 # dependencies relied upon to build native-extension gems etc
 RUN apk update
 RUN apk add libxml2-dev libxslt-dev build-base postgresql-dev tzdata
+# Fix incompatibility with slim tzdata from 2020b onwards
+RUN wget https://data.iana.org/time-zones/tzdb/tzdata.zi -O /usr/share/zoneinfo/tzdata.zi && \
+    /usr/sbin/zic -b fat /usr/share/zoneinfo/tzdata.zi
+    
 RUN apk add nodejs postgresql-contrib libpq yarn less
 
 ENV RAILS_ROOT /var/www/${APPNAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ USER root
 RUN apk update
 RUN apk add libxml2-dev libxslt-dev build-base postgresql-dev tzdata
 # Fix incompatibility with slim tzdata from 2020b onwards
+# see https://github.com/tzinfo/tzinfo/issues/120 for details
 RUN wget https://data.iana.org/time-zones/tzdb/tzdata.zi -O /usr/share/zoneinfo/tzdata.zi && \
     /usr/sbin/zic -b fat /usr/share/zoneinfo/tzdata.zi
-    
+
 RUN apk add nodejs postgresql-contrib libpq yarn less
 
 ENV RAILS_ROOT /var/www/${APPNAME}


### PR DESCRIPTION
### Context

[Trello card 965](https://trello.com/c/gKYLpzDv/965-users-last-sign-in-time-is-not-showing-or-being-stored-in-the-correct-time-timezone) There's an issue that means since the Daylight Savings Time switch back on Oct 24th 2020, Alpine linux by default is not reporting the DST status correctly. This filters through to [Ruby](https://discuss.rubyonrails.org/t/ruby-on-rails-daylight-saving-detection-does-not-work-in-recent-ruby-2-7-1-alpine-container/76399) and [Rails](https://github.com/rails/rails/issues/40427) via the [tzinfo](https://github.com/tzinfo/tzinfo/issues/120) gem, and means that datetimes are being stored with an incorrect UTC offset.

For more details, see this tzinfo issue [https://github.com/tzinfo/tzinfo/issues/120](https://github.com/tzinfo/tzinfo/issues/120): 

Hopefully this will be fixed in a future release of `tzinfo`, at which point we'll be able to remove this workaround from our Dockerfile. As the maintainer of the project [says](https://github.com/tzinfo/tzinfo/issues/120#issuecomment-714695256):

> Had I known this change was going to be made in 2020b, I'd have planned to add support for the POSIX-style TZ string beforehand. **I'm working on a change to add this support now for both v2.x and v1.x**.

But also :

> Please note that TZInfo is and always has been an unpaid side project for me. I am only able to work on it in my spare time and my spare time is finite.

### Changes proposed in this pull request

Recompile the tzdata as suggested [in this comment on the tzinfo issue](https://github.com/tzinfo/tzinfo/issues/120#issuecomment-718833819)

### Guidance to review

Before (on production):
```
> Time.zone.now
=> Wed, 04 Nov 2020 13:47:40 BST +01:00
> Time.zone.now.dst?
=> true
```

After (tested on dev):

```
> Time.zone.now
=> Wed, 04 Nov 2020 13:14:09 GMT +00:00
> Time.zone.now.dst?
=> false
```
