### PR TITLE
[961] Add dashboard for school mno performance

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -59,7 +59,7 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   include ExportableAsCsv
 
-  scope :from_responsible_bodies, -> { where('responsible_body_id IS NOT NULL') }
+  scope :from_responsible_bodies, -> { where.not(responsible_body: nil) }
   scope :from_schools, -> { where('school_id IS NOT NULL') }
 
   def self.exportable_attributes

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -59,6 +59,9 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   include ExportableAsCsv
 
+  scope :from_responsible_bodies, -> { where('responsible_body_id IS NOT NULL') }
+  scope :from_schools, -> { where('school_id IS NOT NULL') }
+
   def self.exportable_attributes
     {
       id: 'ID',

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -60,7 +60,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   include ExportableAsCsv
 
   scope :from_responsible_bodies, -> { where.not(responsible_body: nil) }
-  scope :from_schools, -> { where('school_id IS NOT NULL') }
+  scope :from_schools, -> { where.not(school: nil) }
 
   def self.exportable_attributes
     {

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -58,16 +58,16 @@ class Support::ServicePerformance
       .count
   end
 
-  def total_extra_mobile_data_requests
-    ExtraMobileDataRequest.count
+  def total_extra_mobile_data_requests(scope: ExtraMobileDataRequest)
+    scope.count
   end
 
-  def extra_mobile_data_requests_by_status
-    ExtraMobileDataRequest.group(:status).count
+  def extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest)
+    scope.group(:status).count
   end
 
-  def extra_mobile_data_requests_by_mobile_network_brand
-    ExtraMobileDataRequest
+  def extra_mobile_data_requests_by_mobile_network_brand(scope: ExtraMobileDataRequest)
+    scope
       .joins(:mobile_network)
       .group('mobile_networks.brand')
       .count

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -1,10 +1,10 @@
-<h2 class="govuk-heading-l">Mobile data requests</h2>
+<h2 class="govuk-heading-l">Mobile data requests from responsible bodies</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">
     <%= render Support::TileComponent.new(
-                 count: @stats.total_extra_mobile_data_requests,
-                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests),
+                 count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_responsible_bodies),
+                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_responsible_bodies)),
                  colour: :blue) %>
   </div>
 </div>
@@ -12,26 +12,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['requested'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['requested'] || 0,
                  label: 'new',
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['in_progress'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['in_progress'] || 0,
                  label: 'in progress',
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: (@stats.extra_mobile_data_requests_by_status['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status['cancelled'] || 0),
+                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['cancelled'] || 0),
                  label: 'not valid or cancelled',
                  colour: :red,
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['complete'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['complete'] || 0,
                  label: 'completed',
                  colour: :green,
                  size: :reduced) %>
@@ -49,7 +49,69 @@
       </thead>
 
       <tbody class="govuk-table__body">
-        <% @stats.extra_mobile_data_requests_by_mobile_network_brand.each do |mno_name, count| %>
+        <% @stats.extra_mobile_data_requests_by_mobile_network_brand(scope: ExtraMobileDataRequest.from_responsible_bodies).each do |mno_name, count| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= mno_name %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<h2 class="govuk-heading-l">Mobile data requests from schools</h2>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <%= render Support::TileComponent.new(
+                 count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_schools),
+                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_schools)),
+                 colour: :blue) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render Support::TileComponent.new(
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['requested'] || 0,
+                 label: 'new',
+                 size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render Support::TileComponent.new(
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['in_progress'] || 0,
+                 label: 'in progress',
+                 size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render Support::TileComponent.new(
+                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['cancelled'] || 0),
+                 label: 'not valid or cancelled',
+                 colour: :red,
+                 size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render Support::TileComponent.new(
+                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['complete'] || 0,
+                 label: 'completed',
+                 colour: :green,
+                 size: :reduced) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-top-4">
+  <div class="govuk-grid-column-one-half">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Network</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Requests</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @stats.extra_mobile_data_requests_by_mobile_network_brand(scope: ExtraMobileDataRequest.from_schools).each do |mno_name, count| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= mno_name %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= count %></td>

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -30,24 +30,31 @@ RSpec.feature 'Viewing service performance', type: :feature do
     ee = create(:mobile_network, brand: 'EE')
     three = create(:mobile_network, brand: 'Three')
     virgin = create(:mobile_network, brand: 'Virgin')
-    requester = create(:user, responsible_body: local_authority)
+    rb_requester = create(:user, responsible_body: local_authority)
+    rb = local_authority
+    school_requester = create(:school_user)
+    school = school_requester.school
 
     create_list(:extra_mobile_data_request, 1,
                 status: :requested,
                 mobile_network: virgin,
-                created_by_user: requester)
+                responsible_body: rb,
+                created_by_user: rb_requester)
     create_list(:extra_mobile_data_request, 3,
                 status: :in_progress,
                 mobile_network: ee,
-                created_by_user: requester)
-    create_list(:extra_mobile_data_request, 5,
+                responsible_body: rb,
+                created_by_user: rb_requester)
+    create_list(:extra_mobile_data_request, 4,
                 status: :complete,
                 mobile_network: three,
-                created_by_user: create(:user, responsible_body: local_authority))
+                school: school,
+                created_by_user: school_requester)
     create_list(:extra_mobile_data_request, 1,
                 status: :cancelled,
                 mobile_network: virgin,
-                created_by_user: requester)
+                responsible_body: rb,
+                created_by_user: rb_requester)
   end
 
   def when_i_sign_in_as_a_dfe_user
@@ -59,14 +66,22 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   def then_i_see_stats_about_extra_mobile_data_requests
-    expect(page).to have_text('10 requests')
+    expect(page).to have_text('5 requests')
     expect(page).to have_text('1 new')
     expect(page).to have_text('3 in progress')
     expect(page).to have_text('1 not valid or cancelled')
-    expect(page).to have_text('5 completed')
+    expect(page).to have_text('0 completed')
+
     expect(page).to have_text('EE 3')
-    expect(page).to have_text('Three 5')
     expect(page).to have_text('Virgin 2')
+
+    expect(page).to have_text('4 requests')
+    expect(page).to have_text('0 new')
+    expect(page).to have_text('0 in progress')
+    expect(page).to have_text('0 not valid or cancelled')
+    expect(page).to have_text('4 completed')
+
+    expect(page).to have_text('Three 4')
   end
 
   def then_i_see_stats_about_responsible_body_user_engagement


### PR DESCRIPTION
### Context

- https://trello.com/c/wq16Tk5m/961-update-dashboard-to-track-connectivity-rollout-to-schools

### Changes proposed in this pull request

- Add to connectivity dashboard
- Upper half is now related to requests from responsible bodies
- Lower half is now related to requests from schools

### Screenshots

![image](https://user-images.githubusercontent.com/92580/98351636-e21e3f80-2014-11eb-9d84-508281bc8aba.png)

### Guidance to review

- Factory some data for mno request from responsible bodies and schools
- Login as support user
- View connectivity dashboard
- Should see this data displayed correctly split by responsible body and school