### PR TITLE
Update specific circumstances

### DIFF
--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -16,9 +16,8 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>in years 3 to 11 who do not have access to the internet and whose face-to-face education is disrupted. In this event, you will also have been invited to order laptops and tablets.</li>
-      <li>who are <%= govuk_link_to 'extremely clinically vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and need to shield on current official advice (this could be from a doctor or hospital consultant)</li>
-      <li>who live in a household that’s been advised to shield because a family member is clinically extremely vulnerable</li>
-      <li>who cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+      <li>who are <%= govuk_link_to 'extremely clinically vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and have been advised not to attend school face-to-face</li>
+      <li>who cannot attend school – even though theirs is open – because restrictions prevent it</li>
     </ul>
 
     <h2 class="govuk-heading-l">

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -44,8 +44,8 @@
     <p class="govuk-body">Use this section to request devices for children who:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>are shielding on official advice</li>
-      <li>cannot attend school because they live in a different area with coronavirus restrictions</li>
+      <li>are clinically extremely vulnerable and not attending school face-to-face</li>
+      <li>cannot attend school because restrictions prevent them from going</li>
     </ul>
   </div>
 </div>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -41,8 +41,8 @@
     <p class="govuk-body">Use this section to request devices for children who:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>are shielding on official advice</li>
-      <li>cannot attend school because they live in a different area with coronavirus restrictions</li>
+      <li>are clinically extremely vulnerable and not attending school face-to-face</li>
+      <li>cannot attend school because restrictions prevent them from going</li>
     </ul>
 
     <% if @school.mno_feature_flag %>

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -15,7 +15,7 @@
         <li>add more users</li>
         <li>change your Chromebook settings</li>
         <li>review your allocation</li>
-        <li>request devices for clinically vulnerable children who are shielding</li>
+        <li>request devices for specific circumstances</li>
       </ul>
 
       <p class="govuk-body govuk-!-margin-bottom-6">If your school is affected by local coronavirus restrictions, we’ll contact you as soon as you’re able to place orders.</p>

--- a/app/views/shared/_privacy_notice_text.html.erb
+++ b/app/views/shared/_privacy_notice_text.html.erb
@@ -40,7 +40,7 @@
 
 <p class="govuk-body">For example, DfE may share the email address of a local authority’s technical IT contact with a school that received devices from that LA, so the school may contact them to resolve support queries.</p>
 
-<p class="govuk-body">This service, which requires your personal information for ordering computing devices and other related products and services, is considered necessary and proportionate to support young people in their education during disruption caused by the current coronavirus (COVID-19) pandemic. This includes scenarios where there’s a local lockdown or where a young person needs to shield for clinical reasons.</p>
+<p class="govuk-body">This service, which requires your personal information for ordering computing devices and other related products and services, is considered necessary and proportionate to support young people in their education during disruption caused by the current coronavirus (COVID-19) pandemic. This includes scenarios where there are restrictions, or where a young person is advised not to attend school because they’re clinically extremely vulnerable.</p>
 
 <h3 class="govuk-heading-m">How long we hold personal information</h3>
 

--- a/app/views/shared/devices/_who_to_request_for_list.html.erb
+++ b/app/views/shared/devices/_who_to_request_for_list.html.erb
@@ -1,5 +1,4 @@
 <ul class="govuk-list govuk-list--bullet">
-  <li>are <%= govuk_link_to 'extremely clinically vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and need to shield on current official advice (this could be from a doctor or hospital consultant)</li>
-  <li>live in a household that’s been advised to shield because a family member is clinically extremely vulnerable</li>
-  <li>cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+  <li>are <%= govuk_link_to 'extremely clinically vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and have been advised not to attend school face-to-face</li>
+  <li>cannot attend school – even though theirs is open – because restrictions prevent it</li>
 </ul>

--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -43,8 +43,6 @@
       </ul>
     <% end %>
 
-    <p class="govuk-body">If shielding is not recommended in your area (see the <%= govuk_link_to 'guidance on local restrictions', 'https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19' %>), you’ll need to show evidence that children have received official advice to continue shielding outside of national guidelines.</p>
-
     <h2 class="govuk-heading-m">Where to send your request</h2>
 
     <p class="govuk-body">

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -62,7 +62,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
     end
 
-    context "when the school isn't under lockdown restrictions or has any shielding children" do
+    context "when the school isn't under lockdown restrictions or has any clinically extremely vulnerable children" do
       before do
         school.cannot_order!
       end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -59,7 +59,7 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
     end
 
-    context "when the school isn't under lockdown restrictions or has any shielding children" do
+    context "when the school isn't under lockdown restrictions or has any clinically extremely vulnerable children" do
       it 'cannot place orders' do
         expect(value_for_row(result, 'Can place orders?').text).to include('Not yet because there are no local coronavirus')
       end


### PR DESCRIPTION
- Remove references to shielding, replace with "advised not to attend"
- Policy updates mean we no longer support children in families where someone else is shielding
- clarify point about "because they live in a different area with local coronavirus restrictions" to mean they cannot attend because restrictions prevent it (eg crossing a border from Wales to England to go to a school that's open)