### PR TITLE
[995] Add specific circumstances page

### DIFF
--- a/app/controllers/school/home_controller.rb
+++ b/app/controllers/school/home_controller.rb
@@ -6,4 +6,6 @@ class School::HomeController < School::BaseController
   def request_devices
     render 'shared/devices/request_devices'
   end
+
+  def specific_circumstances; end
 end

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -34,16 +34,18 @@
       <li>access the Computacenter TechSource website to order devices</li>
     </ul>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to t('page_titles.school_request_devices'), request_devices_school_path(@school) %>
-    </h2>
+    <% if !@school.mno_feature_flag %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to t('page_titles.school_request_devices'), request_devices_school_path(@school) %>
+      </h2>
 
-    <p class="govuk-body">Use this section to request devices for children who:</p>
+      <p class="govuk-body">Use this section to request devices for children who:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>are shielding on official advice</li>
-      <li>cannot attend school because they live in a different area with coronavirus restrictions</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>are shielding on official advice</li>
+        <li>cannot attend school because they live in a different area with coronavirus restrictions</li>
+      </ul>
+    <% end %>
 
     <% if @school.mno_feature_flag %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
@@ -53,6 +55,16 @@
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>request extra data for mobile devices</li>
+      </ul>
+
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to t('page_titles.school_specific_circumstances'), specific_circumstances_school_path(@school) %>
+      </h2>
+      
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>understand when children can get support</li>
+        <li>see what help they can get</li>
       </ul>
     <% end %>
 

--- a/app/views/school/home/specific_circumstances.html.erb
+++ b/app/views/school/home/specific_circumstances.html.erb
@@ -1,0 +1,32 @@
+<%- title = t('page_titles.school_specific_circumstances') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs items: title, school: @school, user: @user %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+   <p class="govuk-body">Full support is only available when you use the <%= govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status' %> to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>report a closure</li>
+      <li>tell us that more than 15 children are self-isolating</li>
+    </ul>
+
+    <p class="govuk-body">Partial support is available for specific circumstances.</p>
+
+    <h2 class="govuk-heading-m">Specific circumstances</h2>
+
+    <p class="govuk-body">You can get help immediately for disadvantaged children from any year group who:</p>
+    <%= render partial: 'shared/devices/who_to_request_for_list' %>
+
+    <h2 class="govuk-heading-m">Help available</h2>
+
+    <ul class="govuk-list">
+      <li><%= govuk_link_to 'Request devices for specific circumstances', request_devices_school_path(@school) %></li>
+      <li><%= govuk_link_to 'Request extra mobile data for specific circumstances', internet_school_path(@school) %></li>
+    </ul>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,7 @@ en:
     school_order_devices: Order devices
     school_order_devices_soon: Order devices soon
     school_request_devices: Request devices for specific circumstances
+    school_specific_circumstances: Get help for specific circumstances
     school_details: Check your school details
     school_edit_chromebooks: Will your school need to order Chromebooks?
     school_users: Manage users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
       get '/before-you-can-order', to: 'school/before_can_order#edit'
       patch '/before-you-can-order', to: 'school/before_can_order#update'
       get '/request-devices', to: 'school/devices#request_devices'
+      get '/specific-circumstances', to: 'school/home#specific_circumstances'
       get '/order-devices', to: 'school/devices#order'
       get '/changed-allocation', to: 'school/devices#changed_allocation'
       get '/details', to: 'school/details#show', as: :details

--- a/spec/controllers/school/home_controller_spec.rb
+++ b/spec/controllers/school/home_controller_spec.rb
@@ -31,4 +31,16 @@ RSpec.describe School::HomeController do
       end
     end
   end
+
+  describe '#specific_circumstances' do
+    context 'when the given URN is one of the users schools' do
+      let(:urn) { user.schools.first.urn }
+
+      it 'shows the school home page' do
+        get :specific_circumstances, params: { urn: urn }
+        expect(controller).to render_template(:specific_circumstances)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end

--- a/spec/features/school/specific_circumstances_spec.rb
+++ b/spec/features/school/specific_circumstances_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'Accessing the get help for specific circumstances area as a school user', type: :feature do
+  let(:user) { create(:school_user) }
+  let(:school) { user.school }
+
+  context 'when the MNO offer is activated' do
+    before do
+      school.update!(mno_feature_flag: true)
+      sign_in_as user
+    end
+
+    scenario 'the user can navigate to the specific circumstances page from the home page' do
+      click_on 'Get help for specific circumstances'
+
+      expect(page).to have_css('h1', text: 'Get help for specific circumstances')
+      expect(page).to have_http_status(:ok)
+    end
+
+    scenario 'the user can navigate to request devices from the specific circumstances page' do
+      visit specific_circumstances_school_path(school)
+
+      click_on 'Request devices for specific circumstances'
+      expect(page).to have_css('h1', text: 'Request devices for specific circumstances')
+    end
+
+    scenario 'the user can navigate to request extra mobile data from the specific circumstances page' do
+      visit specific_circumstances_school_path(school)
+
+      click_on 'Request extra mobile data for specific circumstances'
+      expect(page).to have_css('h1', text: 'Get the internet')
+    end
+  end
+
+  context 'when the MNO offer is not activated' do
+    before do
+      school.update!(mno_feature_flag: false)
+      sign_in_as user
+    end
+
+    scenario 'the user cannot navigate to the specific circumstances page from the home page' do
+      expect(page).not_to have_content('Get help for specific circumstances')
+    end
+  end
+end


### PR DESCRIPTION
### Context

This is the first PR of https://trello.com/c/pualSpPd/955-update-content-around-mno-offer-on-school-journey

### Changes proposed in this pull request

- Add a specific circumstances page
- Link to given page on the homepage if the school is within the MNO feature.
- Page links to existing 'devices' and 'extra data for mobile devices' request pages for circumstances, the latter of which will be updated in a subsequent PR. 

### Guidance to review

1. Login as user belonging to a school within the MMO feature
2. New page should be linked to from homepage

1. Login as user belonging to a school not within the MMO feature
2. New page should not be linked to from homepage

### Screenshots

![screencapture-localhost-3000-schools-100000-specific-circumstances-2020-11-05-16_04_45](https://user-images.githubusercontent.com/31316/98265150-a8035e00-1f80-11eb-9253-009fe18a62d8.png)

![screencapture-localhost-3000-schools-100000-2020-11-05-16_05_25](https://user-images.githubusercontent.com/31316/98265222-bea9b500-1f80-11eb-9fc0-0399252d97ab.png)
