### PR TITLE
[995] Update guidance on Get Internet page

### DIFF
--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -45,16 +45,15 @@
         <li>are shielding on official advice</li>
         <li>cannot attend school because they live in a different area with coronavirus restrictions</li>
       </ul>
-    <% end %>
-
-    <% if @school.mno_feature_flag %>
+    <% else %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Get the internet', internet_school_path(@school) %>
+        <%= govuk_link_to 'Get internet access', internet_school_path(@school) %>
       </h2>
 
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>request extra data for mobile devices</li>
+        <li>request 4G wireless routers</li>
       </ul>
 
       <h2 class="govuk-heading-l govuk-!-font-size-27">

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -12,10 +12,16 @@
       <%= govuk_link_to 'Request extra data for mobile devices', extra_data_requests_internet_mobile_school_path(@school) %>
     </h2>
 
-    <p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children and young people can continue their remote education without incurring extra data charges.</p>
+    <p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children can continue their remote education without incurring extra data charges.</p>
 
-    <p class="govuk-body">If a child or young person doesn’t have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
+    <p class="govuk-body">If they do not have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
 
-    <p class="govuk-body">Once you submit mobile numbers and network details through our service, we’ll request extra data. How much data someone gets will depend on their network.</p>
+    <p class="govuk-body">If they do not have access to a mobile device, or are not on a participating network a 4G wireless router might be more suitable.</p>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
+   </h2>
+
+    <p class="govuk-body">If your school is facing disruption to education and you’ve been invited to order devices, you can request 4G wireless routers.</p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
       internet:
         home:
           show:
-            title: Get the internet
+            title: Get internet access
     school_order_devices: Order devices
     school_order_devices_soon: Order devices soon
     school_request_devices: Request devices for specific circumstances

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
 
   context 'when the MNO offer is activated' do
     scenario 'the user can navigate to the manual request form from the home page' do
-      click_on 'Get the internet'
+      click_on 'Get internet access'
       click_on 'Request extra data for mobile devices'
 
       expect(page).to have_css('h1', text: 'Request extra mobile data')
@@ -24,7 +24,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     end
 
     scenario 'the user can navigate to the bulk upload form from the home page' do
-      click_on 'Get the internet'
+      click_on 'Get internet access'
       click_on 'Request extra data for mobile devices'
 
       expect(page).to have_css('h1', text: 'Request extra mobile data')

--- a/spec/features/school/specific_circumstances_spec.rb
+++ b/spec/features/school/specific_circumstances_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Accessing the get help for specific circumstances area as a schoo
       visit specific_circumstances_school_path(school)
 
       click_on 'Request extra mobile data for specific circumstances'
-      expect(page).to have_css('h1', text: 'Get the internet')
+      expect(page).to have_css('h1', text: 'Get internet access')
     end
   end
 

--- a/spec/features/school/wireless_router_requests_spec.rb
+++ b/spec/features/school/wireless_router_requests_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Accessing the 4G wireless routers requests area as a school user', type: :feature do
+  let(:user) { create(:school_user) }
+  let(:school) { user.school }
+
+  before do
+    school.update!(mno_feature_flag: true)
+    sign_in_as user
+  end
+
+  context 'when the MNO offer is activated' do
+    scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
+      click_on 'Get internet access'
+      click_on 'Request 4G wireless routers'
+
+      expect(page).to have_css('h1', text: 'How to request 4G wireless routers')
+      expect(page).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'school/home/show.html.erb' do
   let(:user) { build(:school_user) }
 
   context 'when school mno_feature_flag is not enabled' do
-    it 'does not show Get the internet section' do
+    it 'does not show Get internet access section' do
       assign(:school, school)
       assign(:user, user)
 
       render
-      expect(rendered).not_to include('Get the internet')
+      expect(rendered).not_to include('Get internet access')
     end
   end
 
@@ -19,12 +19,12 @@ RSpec.describe 'school/home/show.html.erb' do
       school.update(mno_feature_flag: true)
     end
 
-    it 'does not show Get the internet section' do
+    it 'does not show Get internet access section' do
       assign(:school, school)
       assign(:user, user)
 
       render
-      expect(rendered).to include('Get the internet')
+      expect(rendered).to include('Get internet access')
     end
   end
 end


### PR DESCRIPTION
### Context

Part 2/3 of https://trello.com/c/pualSpPd/955-update-content-around-mno-offer-on-school-journey

### Changes proposed in this pull request

- Rename Get the internet page to Get internet access
- Add request 4G wireless routers link to page
- Update request extra data for mobile devices guidance

### Guidance to review

1. Login as user belonging to a school within the MMO feature
2. Get internet access page should be linked to from homepage
3. Guidance should be updated on homepage
4. Guidance should be visible on Get internet access page
5. Request 4G routers link should be visible on Get internet access page 

---

1. Login as user belonging to a school not within the MMO feature
2. Get internet access page should not be visible

### Screenshots

![screencapture-localhost-3000-schools-100000-2020-11-06-09_56_28](https://user-images.githubusercontent.com/31316/98352780-61604300-2016-11eb-9189-565893fe29ed.png)
![screencapture-localhost-3000-schools-100000-internet-2020-11-06-09_56_35](https://user-images.githubusercontent.com/31316/98352783-62917000-2016-11eb-86d6-f9f44db30326.png)

