### PR TITLE
[995] Separate 'Your Requests' from guidance on getting mobile data

### DIFF
--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -5,6 +5,8 @@ class School::Internet::Mobile::ExtraDataRequestsController < School::BaseContro
     @extra_mobile_data_requests = @school.extra_mobile_data_requests
   end
 
+  def guidance; end
+
   def new
     if params.fetch(:commit, '') == 'Continue'
       @submission_type = ExtraMobileDataSubmissionForm.new(submission_type_params)

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Request extra data for mobile devices', extra_data_requests_internet_mobile_school_path(@school) %>
+      <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
     </h2>
 
     <p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children and young people can continue their remote education without incurring extra data charges.</p>

--- a/app/views/school/internet/mobile/bulk_requests/summary.html.erb
+++ b/app/views/school/internet/mobile/bulk_requests/summary.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', extra_data_requests_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_link_to('Back', extra_data_guidance_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/internet/mobile/extra_data_requests/guidance.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/guidance.html.erb
@@ -1,0 +1,59 @@
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs(items: [
+      { t('page_titles.school.internet.home.show.title') => internet_school_path(@school) },
+      t('page_titles.request_extra_mobile_data')
+    ],
+    user: @user,
+    school: @school) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.request_extra_mobile_data') %>
+    </h1>
+
+    <h2 class="govuk-heading-m">1. Check who is eligible for extra mobile data</h2>
+
+    <p class="govuk-body">You can request extra mobile data for disadvantaged children who:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>have no broadband connection at home</li>
+      <li>cannot afford additional data</li>
+    </ul>
+
+    <p class="govuk-body">One of the following must also apply. They are children:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>in years 3 to 11 and whose face-to-face education is disrupted</li>
+      <li>who are <%= govuk_link_to 'extremely clinically vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and need to shield on current official advice (this could be from a doctor or hospital consultant)</li>
+      <li>who live in a household that’s been advised to shield because a family member is clinically extremely vulnerable</li>
+      <li>who cannot attend school – even though theirs is open – because they live in a different area with local coronavirus restrictions</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">2. Use our guide to gather the information you need</h2>
+
+    <p class="govuk-body">
+      You will need to collect names, telephone numbers and network details from households. They also need to understand how we’ll use their personal information.
+    </p>
+    <p class="govuk-body">Use our guide to tell people what’s available and collect the information you&nbsp;need: </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Guide to collecting mobile information from families', guide_to_collecting_mobile_information_path %>
+    </p>
+
+    <h2 class="govuk-heading-m">3. Enter the information you collect</h2>
+
+    <p class="govuk-body">Once you submit mobile numbers and network details through our service, we’ll request extra data. How much data someone gets will depend on their network.</p>
+
+    <p class="govuk-body">
+      <%= govuk_button_link_to 'New request',
+        extra_data_requests_type_internet_mobile_school_path(@school)
+      %>
+    </p>
+
+    <h2 class="govuk-heading-m">4. Check your requests</h2>
+
+    <p class="govuk-body">Check whether a network has received and approved your requests.</p>
+
+    <p class="govuk-body"><%= govuk_link_to 'Check your requests', extra_data_requests_internet_mobile_school_path(@school) %></p>
+  </div>
+</div>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -1,7 +1,8 @@
 <%- content_for :before_content do %>
   <%- school_breadcrumbs(items: [
       { t('page_titles.school.internet.home.show.title') => internet_school_path(@school) },
-      t('page_titles.request_extra_mobile_data')
+      { t('page_titles.request_extra_mobile_data') => extra_data_guidance_internet_mobile_school_path(@school) },
+      t('page_titles.your_requests')
     ],
     user: @user,
     school: @school) %>
@@ -10,7 +11,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.request_extra_mobile_data') %>
+      <%= t('page_titles.your_requests') %>
     </h1>
 
     <% unless @extra_mobile_data_requests.any? %>
@@ -26,7 +27,6 @@
 </div>
 
 <% if @extra_mobile_data_requests.any? %>
-  <h2 class="govuk-heading-l govuk-!-margin-top-6">Your requests</h2>
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,8 @@ en:
     responsible_body_schools_list: Get schools ready
     requests_for_extra_mobile_data: Requests for extra mobile data
     suggested_email_to_schools: A suggested email for you to send to schools
-    request_extra_mobile_data: Request extra mobile data
+    request_extra_mobile_data: Request extra data for mobile devices
+    your_requests: Your requests
     how_would_you_like_to_submit_information: How would you like to submit information?
     upload_a_spreadsheet_of_extra_data_requests: Upload a spreadsheet of extra data requests
     weve_processed_your_spreadsheet: We’ve processed your spreadsheet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,8 @@ Rails.application.routes.draw do
           get '/', to: 'home#show'
 
           namespace :mobile, path: '/mobile' do
-            get '/', to: 'extra_data_requests#index', as: :extra_data_requests
+            get '/', to: 'extra_data_requests#guidance', as: :extra_data_guidance
+            get '/requests', to: 'extra_data_requests#index', as: :extra_data_requests
             get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type
             resources :manual_requests, only: %i[new create], path: '/manual'
             resources :bulk_requests, only: %i[new create], path: '/bulk'

--- a/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe School::Internet::Mobile::ExtraDataRequestsController, type: :con
       sign_in_as user
     end
 
+    describe '#index' do
+      it 'shows the previous mobile data requests page' do
+        get :index, params: { urn: school.urn }
+        expect(controller).to render_template(:index)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe '#guidance' do
+      it 'shows the request data for mobile devices guidance page' do
+        get :guidance, params: { urn: school.urn }
+        expect(controller).to render_template(:guidance)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     describe 'submitting spreadsheet choice' do
       it 'redirects to bulk requests' do
         request_data = {

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       click_on 'Get the internet'
       click_on 'Request extra data for mobile devices'
 
-      expect(page).to have_css('h1', text: 'Request extra mobile data')
+      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
       expect(page).to have_http_status(:ok)
       click_on 'New request'
       expect(page).to have_css('h1', text: 'How would you like to submit information?')
@@ -27,7 +27,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       click_on 'Get the internet'
       click_on 'Request extra data for mobile devices'
 
-      expect(page).to have_css('h1', text: 'Request extra mobile data')
+      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
       expect(page).to have_http_status(:ok)
       click_on 'New request'
       expect(page).to have_css('h1', text: 'How would you like to submit information?')
@@ -45,10 +45,23 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       @requests.last.unavailable!
     end
 
+    scenario 'the user can navigate to their previous requests from the home page' do
+      click_on 'Get the internet'
+      click_on 'Request extra data for mobile devices'
+
+      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
+      expect(page).to have_http_status(:ok)
+
+      click_on 'Check your requests'
+
+      expect(page).to have_css('h1', text: 'Your requests')
+      expect(page).to have_http_status(:ok)
+    end
+
     scenario 'the user can see their previous requests' do
       visit extra_data_requests_internet_mobile_school_path(school)
 
-      expect(page).to have_css('h2', text: 'Your requests')
+      expect(page).to have_css('h1', text: 'Your requests')
 
       @requests.each do |request|
         expect(page).to have_content(request.device_phone_number)


### PR DESCRIPTION
### Context

This is the last part of https://trello.com/c/pualSpPd/955-update-content-around-mno-offer-on-school-journey

### Changes proposed in this pull request

- Add an intermediate mobile data guidance page that links to new request and previous request pages
- Adjust titles and breadcrumbs of guidance and previous request pages

### Guidance to review

#769 updates the copy on the Get internet access page.

1. Login as user belonging to a school within the MMO feature
2. Get internet access page should be linked to from homepage
3. From there, you should be able to navigate to the request mobile data guidance page
4. The guidance page should link to the new request and existing request pages

### Screenshots

![screencapture-localhost-3000-schools-100000-internet-mobile-2020-11-06-12_23_53](https://user-images.githubusercontent.com/31316/98365887-fc631800-202a-11eb-9eb4-6645acb69fad.png)

![screencapture-localhost-3000-schools-100000-internet-mobile-requests-2020-11-06-12_24_01](https://user-images.githubusercontent.com/31316/98365893-ff5e0880-202a-11eb-8bf8-d231005543b2.png)

