### PR TITLE
[946] updating an RB or school can generate user changes

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -18,6 +18,8 @@ class ResponsibleBody < ApplicationRecord
     closed: 'closed',
   }, _prefix: 'gias_status'
 
+  after_update :maybe_generate_user_changes
+
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end
@@ -118,5 +120,11 @@ class ResponsibleBody < ApplicationRecord
 
   def has_any_schools_that_can_order_now?
     schools.that_can_order_now.any?
+  end
+
+private
+
+  def maybe_generate_user_changes
+    users.each(&:generate_user_change_if_needed!)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -45,6 +45,8 @@ class School < ApplicationRecord
     can_order: 'can_order',
   }
 
+  after_update :maybe_generate_user_changes
+
   def self.that_will_order_devices
     joins(:preorder_information).merge(PreorderInformation.school_will_order_devices)
   end
@@ -149,6 +151,10 @@ class School < ApplicationRecord
   end
 
 private
+
+  def maybe_generate_user_changes
+    users.each(&:generate_user_change_if_needed!)
+  end
 
   def device_ordering_organisation
     who_will_order_devices == 'school' ? self : responsible_body

--- a/spec/models/computacenter/user_change_generator_spec.rb
+++ b/spec/models/computacenter/user_change_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::UserChangeGenerator do
+  context 'when RB is updated and affects a user' do
+    let(:rb) { create(:trust, computacenter_reference: nil) }
+
+    before do
+      create(:trust_user, :relevant_to_computacenter, responsible_body: rb)
+    end
+
+    it 'generates a user change' do
+      expect {
+        rb.update!(computacenter_reference: 'ABC')
+      }.to change(Computacenter::UserChange, :count).by(1)
+
+      user_change = Computacenter::UserChange.last
+      expect(user_change.cc_sold_to_number).to eql('ABC')
+    end
+  end
+
+  context 'when school is updated and affects a user' do
+    let(:school) { create(:school, computacenter_reference: nil) }
+
+    before do
+      create(:school_user, :relevant_to_computacenter, school: school)
+    end
+
+    it 'generates a user change' do
+      expect {
+        school.update!(computacenter_reference: 'ABC')
+      }.to change(Computacenter::UserChange, :count).by(1)
+
+      user_change = Computacenter::UserChange.last
+      expect(user_change.cc_ship_to_number).to eql('ABC')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/dcWNdAET/946-computacenter-arent-getting-soldtos-for-users-when-the-computacenterreference-is-added-to-the-rb-after-the-user-is-last-updated
- This fixes an issue where updating an RB or school does not generate a user change despite the new row would be different

### Changes proposed in this pull request

- Updating a RB or school can generate user changes

### Guidance to review

- Create/Find an RB that does not have `computacenter_reference`
- Add a user to the RB that is computacenter relevant
- Note the `Computacenter::UserChange.count`
- Update the RB `computacenter_reference` to some value
- Should increment `Computacenter::UserChange.count` by 1
- This change should have populated the `cc_sold_to_number` 
- Should behave the same for a school update except should update `cc_ship_to_number`