### PR TITLE
[995] Keep shorter breadcrumb on request devices for specific circumstances

### DIFF
--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -1,7 +1,14 @@
 <% if @user.is_school_user? %>
   <%- title = t('page_titles.school_request_devices') %>
   <%- content_for :before_content do %>
-    <% breadcrumbs([{ "Home" => home_school_path }, title ]) %>
+    <% if @school.mno_feature_flag %>
+      <% breadcrumbs([{ "Home" => home_school_path },
+                    { t('page_titles.school_specific_circumstances') => specific_circumstances_school_path(@school) },
+                    title
+      ]) %>
+    <% else %>
+      <% breadcrumbs([{ "Home" => home_school_path }, title ]) %>
+    <% end %>
   <% end %>
 
 <% elsif @user.is_responsible_body_user? %>

--- a/spec/features/school/request_devices_spec.rb
+++ b/spec/features/school/request_devices_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Request devices in special circumstances' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
+  let(:school) { school_user.school }
 
   context 'logged in as a school user' do
     before do
@@ -12,6 +13,28 @@ RSpec.feature 'Request devices in special circumstances' do
       click_on 'Request devices for specific circumstances'
 
       expect(page).to have_content('You can request devices at any time for disadvantaged children')
+    end
+
+    context 'when the MNO offer is activated' do
+      before do
+        school.update!(mno_feature_flag: true)
+      end
+
+      scenario 'includes the intermediary specific circumstances page in breadcrumbs' do
+        visit request_devices_school_path(school)
+        expect(page).to have_link('Get help for specific circumstances')
+      end
+    end
+
+    context 'when the MNO offer is not activated' do
+      before do
+        school.update!(mno_feature_flag: false)
+      end
+
+      scenario 'does not include the intermediary specific circumstances page in breadcrumbs' do
+        visit request_devices_school_path(school)
+        expect(page).not_to have_link('Get help for specific circumstances')
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/pualSpPd/955-update-content-around-mno-offer-on-school-journey

### Changes proposed in this pull request

Keep shorter breadcrumb on request devices for specific circumstances, but include the intermediary page when the school user is within the MNO feature.

### Guidance to review

1. View 'Request devices for specific circumstances' page within MNO feature
2. Intermediary page should be in breadcrumb

---
1. View 'Request devices for specific circumstances' page outside of MNO feature
2. Intermediary page should not be in breadcrumb


### Screenshots

Inside feature:

![screencapture-localhost-3000-schools-100000-request-devices-2020-11-06-15_00_47](https://user-images.githubusercontent.com/31316/98380941-258ea300-2041-11eb-9d26-9786440596dc.png)

Outside feature:

![screencapture-localhost-3000-schools-100000-request-devices-2020-11-06-15_00_57](https://user-images.githubusercontent.com/31316/98380948-27586680-2041-11eb-9a13-d37e9a8bbb54.png)

