### PR TITLE
[981] stop generating UserChanges for users with a school but no shipTo

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -37,7 +37,12 @@ private
 
   def change_needed?
     @user&.id.present? && \
-      (is_addition? || is_removal? || (is_change? && computacenter_fields_have_changed?))
+      (is_addition? || is_removal? || (is_change? && computacenter_fields_have_changed?)) && \
+      (!user_has_a_school_but_no_ship_to? || user.is_a_single_academy_trust_user?)
+  end
+
+  def user_has_a_school_but_no_ship_to?
+    user.user_schools.present? && cc_ship_to_number_list.blank?
   end
 
   def is_addition?
@@ -71,8 +76,12 @@ private
       # NOTE: we must loop round user_schools (which may be dirty) not schools (which won't be)
       school: (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.name }.join('|')),
       school_urn: (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.urn }.join('|')),
-      cc_ship_to_number: (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.computacenter_reference }.join('|')),
+      cc_ship_to_number: cc_ship_to_number_list,
     }
+  end
+
+  def cc_ship_to_number_list
+    (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.computacenter_reference }.join('|'))
   end
 
   def meta_attributes

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -404,6 +404,24 @@ RSpec.describe User, type: :model do
         it 'does not create any UserChanges without a user_id (bug found & fixed in PR #634)' do
           expect(Computacenter::UserChange.where(user_id: nil).count).to eq(0)
         end
+
+        context 'when the school has a computacenter_reference' do
+          let(:school) { create(:school, computacenter_reference: '123456') }
+          let!(:user) { create(:school_user, :relevant_to_computacenter, email_address: 'user@example.com', schools: [school]) }
+
+          it 'creates a UserChange' do
+            expect(Computacenter::UserChange.latest_for_user(user)).not_to be_nil
+          end
+        end
+
+        context 'when the school does not have a computacenter_reference' do
+          let(:school) { create(:school, computacenter_reference: '') }
+          let!(:user) { create(:school_user, :relevant_to_computacenter, email_address: 'user@example.com', schools: [school]) }
+
+          it 'does not create a UserChange' do
+            expect(Computacenter::UserChange.latest_for_user(user)).to be_nil
+          end
+        end
       end
 
       it 'persists correct data for single academy trust user' do

--- a/spec/services/confirm_techsource_account_created_service_spec.rb
+++ b/spec/services/confirm_techsource_account_created_service_spec.rb
@@ -96,8 +96,9 @@ RSpec.describe ConfirmTechsourceAccountCreatedService do
     end
 
     context 'when user has been destroyed' do
+      let(:school) { create(:school, computacenter_reference: '123456') }
       let!(:user) do
-        create(:school_user, :relevant_to_computacenter)
+        create(:school_user, :relevant_to_computacenter, school: school)
       end
 
       before do


### PR DESCRIPTION
### Context

[Trello card 981](https://trello.com/c/IZa6S3hI/981-stop-userchange-being-created-when-a-school-user-has-a-school-urn-but-no-shipto) - This closes a loophole that means a user thinks they can order, and our system thinks they're all set up, but the user can't actually be setup on TechSource because they are not linked to a `shipTo` reference on Computacenter's side.

### Changes proposed in this pull request

stop `Computacenter::UserChangeGenerator` thinking a change is needed in this case (where a user has at least one school, but no corresponding `shipTo` number.... and they're not a `single_academy_trust_user`)

### Guidance to review

From the console:

```
> s = School.where(computacenter_reference: nil).first
=> <School: ....>
> u = User.create!(full_name: '...', email_address: '...', orders_devices: true, privacy_notice_seen_at: Time.now.utc)
=> <User: .....>
> Computacenter::UserChange.latest_for_user(u)
=> nil
```
