### PR TITLE
[966] Match cap with allocation if can order

### DIFF
--- a/app/controllers/support/schools/devices/allocation_controller.rb
+++ b/app/controllers/support/schools/devices/allocation_controller.rb
@@ -11,7 +11,7 @@ class Support::Schools::Devices::AllocationController < Support::BaseController
     @current_allocation = @allocation.dup
     @form = Support::AllocationForm.new(allocation_params.merge(school_allocation: @allocation))
     if @form.valid?
-      @allocation.update!(allocation: @form.allocation)
+      update_service.call
       flash[:success] = t(:success, scope: %i[support allocation update])
       redirect_to support_school_path(urn: @school.urn)
     else
@@ -34,5 +34,9 @@ private
 
   def allocation_params
     params.fetch(:support_allocation_form, {}).permit(:allocation)
+  end
+
+  def update_service
+    @update_service ||= AllocationUpdater.new(school: @school, device_type: device_type, value: @form.allocation)
   end
 end

--- a/app/services/allocation_updater.rb
+++ b/app/services/allocation_updater.rb
@@ -1,0 +1,27 @@
+class AllocationUpdater
+  def initialize(school:, device_type:, value:)
+    @school = school
+    @device_type = device_type
+    @value = value
+  end
+
+  def call
+    allocation.update!(allocation: value, cap: cap)
+  end
+
+private
+
+  attr_reader :school, :device_type, :value
+
+  def allocation
+    @allocation ||= SchoolDeviceAllocation.find_or_initialize_by(school: school, device_type: device_type)
+  end
+
+  def cap
+    if school.can_order?
+      value
+    else
+      allocation.cap
+    end
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
       association :coms_device_allocation, factory: %i[school_device_allocation with_coms_allocation]
     end
 
-    trait :with_shielding_pupils do
+    trait :can_order_for_specific_circumstances do
       order_state { 'can_order_for_specific_circumstances' }
     end
 

--- a/spec/features/computacenter/closed_schools_spec.rb
+++ b/spec/features/computacenter/closed_schools_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Viewing closed schools caps' do
   describe 'signed in as a Computacenter user' do
     let(:user) { create(:computacenter_user) }
     let!(:closed_schools) { create_list(:school, 5, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, :in_lockdown) }
-    let!(:partially_closed_schools) { create_list(:school, 10, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, :with_shielding_pupils) }
+    let!(:partially_closed_schools) { create_list(:school, 10, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, :can_order_for_specific_circumstances) }
 
     before do
       given_i_am_signed_in_as_a_computacenter_user

--- a/spec/services/allocation_updater_spec.rb
+++ b/spec/services/allocation_updater_spec.rb
@@ -1,12 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe AllocationUpdater do
+  let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789') }
+  let(:mock_update_service) { instance_double(SchoolOrderStateAndCapUpdateService) }
+
+  before do
+    allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
+    allow(mock_request).to receive(:post!)
+    allow(mock_update_service).to receive(:update!)
+  end
+
   subject(:service) do
     described_class.new(school: school, device_type: 'std_device', value: 100)
   end
 
   context 'allocation exists and school can order full allocation' do
     let(:school) { create(:school, :in_lockdown) }
+    let(:update_service) { instance_double('SchoolOrderStateAndCapUpdateService') }
 
     before do
       create(:school_device_allocation,
@@ -22,6 +32,15 @@ RSpec.describe AllocationUpdater do
       expect(allocation.allocation).to be(100)
       expect(allocation.cap).to be(100)
     end
+
+    it 'calls notifies computacenter with cap updates' do
+      allow(SchoolOrderStateAndCapUpdateService).to receive(:new).and_return(mock_update_service)
+
+      service.call
+
+      expect(SchoolOrderStateAndCapUpdateService).to have_received(:new).with(school: school, order_state: school.order_state, std_device_cap: 100, coms_device_cap: 0)
+      expect(mock_update_service).to have_received(:update!)
+    end
   end
 
   context 'allocation does not exist and school can order full allocation' do
@@ -33,6 +52,15 @@ RSpec.describe AllocationUpdater do
       expect(allocation.allocation).to be(100)
       expect(allocation.cap).to be(100)
       expect(allocation).to be_persisted
+    end
+
+    it 'calls notifies computacenter with cap updates' do
+      allow(SchoolOrderStateAndCapUpdateService).to receive(:new).and_return(mock_update_service)
+
+      service.call
+
+      expect(SchoolOrderStateAndCapUpdateService).to have_received(:new).with(school: school, order_state: school.order_state, std_device_cap: 100, coms_device_cap: 0)
+      expect(mock_update_service).to have_received(:update!)
     end
   end
 

--- a/spec/services/allocation_updater_spec.rb
+++ b/spec/services/allocation_updater_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe AllocationUpdater do
+  subject(:service) do
+    described_class.new(school: school, device_type: 'std_device', value: 100)
+  end
+
+  context 'allocation exists and school can order full allocation' do
+    let(:school) { create(:school, :in_lockdown) }
+
+    before do
+      create(:school_device_allocation,
+             :with_std_allocation,
+             allocation: 10,
+             cap: 10,
+             school: school)
+    end
+
+    it 'updates cap to match allocation' do
+      service.call
+      allocation = school.std_device_allocation.reload
+      expect(allocation.allocation).to be(100)
+      expect(allocation.cap).to be(100)
+    end
+  end
+
+  context 'allocation does not exist and school can order full allocation' do
+    let(:school) { create(:school, :in_lockdown) }
+
+    it 'updates cap to match allocation' do
+      service.call
+      allocation = school.std_device_allocation
+      expect(allocation.allocation).to be(100)
+      expect(allocation.cap).to be(100)
+      expect(allocation).to be_persisted
+    end
+  end
+
+  context 'when school can order for specific circumstances' do
+    let(:school) { create(:school, :can_order_for_specific_circumstances) }
+
+    before do
+      create(:school_device_allocation,
+             :with_std_allocation,
+             allocation: 10,
+             cap: 10,
+             school: school)
+    end
+
+    it 'leaves cap value as is' do
+      service.call
+      allocation = school.std_device_allocation.reload
+      expect(allocation.allocation).to be(100)
+      expect(allocation.cap).to be(10)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/bSKwhZUM/966-updating-the-allocation-should-update-cap-if-a-school-can-order

### Changes proposed in this pull request

- If a school order state is `can_order` and allocation is updated, the cap is also increased to match the allocation

### Guidance to review

- Login as support user
- Find a school that `can_order`
- Increase/decrease the allocation
- Cap value should match the allocation value entered
- Change school so they `can_order_for specific_circumstances` or `cannot_order`
- Update allocation value
- Cap value should not change and remain the same