### PR TITLE
Allow support users to search for school or responsible body users

### DIFF
--- a/app/components/support/user_search_result_component.html.erb
+++ b/app/components/support/user_search_result_component.html.erb
@@ -1,0 +1,8 @@
+<h3 class="govuk-heading-l">
+  <%= user.full_name %>
+</h3>
+
+<%= govuk_summary_list(classes: 'govuk-summary-list--no-border') do |component|
+  component.slot(:row, key: 'Email address', value: user.email_address)
+  component.slot(:row, key: 'Associated with', value: unordered_list_of_orgs)
+end %>

--- a/app/components/support/user_search_result_component.rb
+++ b/app/components/support/user_search_result_component.rb
@@ -1,0 +1,30 @@
+class Support::UserSearchResultComponent < ViewComponent::Base
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def unordered_list_of_orgs
+    tag.ul(class: 'govuk-list') do
+      safe_join(user.organisations.sort_by(&:name).map do |organisation|
+        tag.li do
+          organisation_link_or_text(organisation)
+        end
+      end)
+    end
+  end
+
+private
+
+  def organisation_link_or_text(organisation)
+    case organisation
+    when School
+      govuk_link_to organisation.name, support_school_path(urn: organisation.urn)
+    when ResponsibleBody
+      govuk_link_to organisation.name, support_responsible_body_path(organisation)
+    else
+      organisation.name
+    end
+  end
+end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,0 +1,26 @@
+class Support::UsersController < Support::BaseController
+  SEARCH_RESULTS_LIMIT = 100
+
+  def search
+    @search_form = Support::UserSearchForm.new
+  end
+
+  def results
+    @search_form = Support::UserSearchForm.new(search_params)
+    @search_term = @search_form.email_address_or_full_name
+    @results = User
+      .from_responsible_body_or_schools
+      .search_by_email_address_or_full_name(@search_term)
+      .distinct
+      .includes(:responsible_body, :schools)
+      .order(full_name: :asc)
+      .limit(SEARCH_RESULTS_LIMIT)
+    @maximum_search_result_number_reached = (@results.size == SEARCH_RESULTS_LIMIT)
+  end
+
+private
+
+  def search_params
+    params.require(:support_user_search_form).permit(:email_address_or_full_name)
+  end
+end

--- a/app/form_objects/support/user_search_form.rb
+++ b/app/form_objects/support/user_search_form.rb
@@ -1,0 +1,5 @@
+class Support::UserSearchForm
+  include ActiveModel::Model
+
+  attr_accessor :email_address_or_full_name
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,9 @@ class User < ApplicationRecord
   scope :who_have_seen_privacy_notice, -> { where.not(privacy_notice_seen_at: nil) }
   scope :deleted, -> { where.not(deleted_at: nil) }
   scope :not_deleted, -> { where(deleted_at: nil) }
+  scope :search_by_email_address_or_full_name, lambda { |search_term|
+    where('email_address ILIKE ? OR full_name ILIKE ?', "%#{search_term}%", "%#{search_term}%")
+  }
 
   validates :full_name,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
   scope :signed_in_at_least_once, -> { where('sign_in_count > 0') }
   scope :responsible_body_users, -> { where.not(responsible_body: nil) }
   scope :from_responsible_body_in_connectivity_pilot, -> { joins(:responsible_body).where('responsible_bodies.in_connectivity_pilot = ?', true) }
+  scope :from_responsible_body_or_schools, -> { left_joins(:user_schools).where('responsible_body_id IS NOT NULL or user_schools.id IS NOT NULL') }
   scope :mno_users, -> { where.not(mobile_network: nil) }
   scope :who_can_order_devices, -> { where(orders_devices: true) }
   scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,10 @@ class User < ApplicationRecord
       (is_support? && 'DfE Support')
   end
 
+  def organisations
+    [schools, responsible_body].flatten.compact
+  end
+
   def first_name
     cleansed_full_name.split(' ').first.to_s
   end

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -15,6 +15,12 @@
     </ul>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Find users', search_support_users_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to find school and responsible body users by name or email address</p>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Find and manage schools', support_schools_path %>
     </h2>
 

--- a/app/views/support/users/results.html.erb
+++ b/app/views/support/users/results.html.erb
@@ -1,0 +1,50 @@
+<%- title = t('page_titles.support.users.results') %>
+<% content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { 'Support home' => support_home_path },
+    { t('page_titles.support.users.search') => search_support_users_path },
+    title,
+  ]) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <p class="govuk-body search-results__count" data-qa="course-count">
+          <% if @maximum_search_result_number_reached %>First<% end %>
+          <%= pluralize(@results.size, 'user') %> found matching ‘<%= @search_term %>’
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <p class="govuk-body search-results__new-search">
+          <%= govuk_link_to 'New search', search_support_users_path %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ul class="govuk-list search-results">
+      <% @results.each do |user| %>
+        <li>
+          <%= render Support::UserSearchResultComponent.new(user) %>
+        </li>
+      <%- end %>
+    </ul>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Search again', search_support_users_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/users/search.html.erb
+++ b/app/views/support/users/search.html.erb
@@ -1,0 +1,23 @@
+<%- title = t('page_titles.support.users.search') %>
+<% content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { 'Support home' => support_home_path },
+    title,
+  ]) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%= form_with model: @search_form, url: results_support_users_path do |f| %>
+      <%= f.govuk_text_field :email_address_or_full_name,
+                             label: { text: 'Enter an email address or name', size: 'm' } %>
+
+      <%= f.govuk_submit 'Search' %>
+    <% end %>
+  </div>
+</div>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -38,3 +38,22 @@ $govuk-image-url-function: frontend-image-url;
 .app-schools-table__school-column {
   width: 50%;
 }
+
+.search-results {
+  border-top: 1px solid $govuk-border-colour;
+
+  > li {
+    @include govuk-responsive-padding(4, "top");
+    @include govuk-responsive-padding(4, "bottom");
+    border-bottom: 1px solid $govuk-border-colour;
+    margin: 0;
+  }
+
+  &__count {
+    float: left;
+  }
+
+  &__new-search {
+    float: right;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,9 @@ en:
         schools:
           search: Search for schools by URN
           results: School search results
+      users:
+        search: Find responsible body or school users
+        results: Users
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact
     support_devices: Devices

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,12 @@ Rails.application.routes.draw do
     namespace :performance_data, path: 'performance-data' do
       resources :schools, only: :index
     end
+    resources :users, only: %i[] do
+      collection do
+        get 'search'
+        post 'results'
+      end
+    end
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin
   end
 

--- a/spec/components/support/user_search_result_component_spec.rb
+++ b/spec/components/support/user_search_result_component_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Support::UserSearchResultComponent do
+  include Rails.application.routes.url_helpers
+
+  let(:st_marys) { create(:school, name: 'St Mary’s School') }
+  let(:st_josephs) { create(:school, name: 'St Joseph’s School') }
+  let(:coventry) { create(:local_authority, name: 'Coventry') }
+  let(:user) { create(:user, schools: [st_marys, st_josephs], responsible_body: coventry, email_address: 'jsmith@school.sch.uk') }
+
+  subject { described_class.new(user) }
+
+  it 'renders the user’s email address' do
+    expect(rendered_result_text).to include('jsmith@school.sch.uk')
+  end
+
+  it 'renders links to the responsible body support page' do
+    expect(rendered_result_html).to include(support_responsible_body_path(coventry))
+  end
+
+  it 'renders links to the school support pages' do
+    expect(rendered_result_html).to include(support_school_path(urn: st_marys.urn))
+    expect(rendered_result_html).to include(support_school_path(urn: st_josephs.urn))
+  end
+
+  def rendered_result_html
+    render_inline(subject).to_html
+  end
+
+  def rendered_result_text
+    render_inline(subject).text
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     email_address { Faker::Internet.unique.email }
     has_seen_privacy_notice
     telephone { [Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone].sample }
+    orders_devices { false }
 
     trait :has_seen_privacy_notice do
       privacy_notice_seen_at { 3.days.ago }

--- a/spec/features/support/searching_for_school_or_rb_users_spec.rb
+++ b/spec/features/support/searching_for_school_or_rb_users_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching for school or RB users' do
+  let(:search_page) { PageObjects::Support::Users::SearchPage.new }
+  let(:results_page) { PageObjects::Support::Users::ResultsPage.new }
+  let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+  let(:support_user) { create(:support_user) }
+
+  scenario 'finding a user by their name or email address' do
+    given_i_am_signed_in_as_a_support_user
+    and_there_are_school_and_responsible_body_users
+
+    when_i_follow_the_links_to_find_users
+    and_i_search_for_an_existing_school_user_by_their_name
+    then_i_see_the_school_user_on_the_results_page
+
+    when_i_search_again
+    and_i_search_for_an_existing_school_user_by_their_email
+    then_i_see_the_school_user_on_the_results_page
+    and_i_can_navigate_to_the_support_page_for_their_school
+  end
+
+  def given_i_am_signed_in_as_a_support_user
+    sign_in_as support_user
+  end
+
+  def and_there_are_school_and_responsible_body_users
+    create(:school_user, full_name: 'Jane Smith', email_address: 'jsmith@school.sch.uk')
+    create(:school_user, full_name: 'David Jones', email_address: 'djones@another-school.sch.uk')
+    create(:local_authority_user, full_name: 'Debbie Barry', email_address: 'dbarry@council.gov.uk')
+  end
+
+  def when_i_follow_the_links_to_find_users
+    click_link 'Find users'
+  end
+
+  def when_i_search_again
+    results_page.another_search.click
+  end
+
+  def and_i_search_for_an_existing_school_user_by_their_name
+    search_page.search_term.set 'Jane Smith'
+    search_page.submit.click
+  end
+
+  def and_i_search_for_an_existing_school_user_by_their_email
+    search_page.search_term.set 'jsmith@school.sch.uk'
+    search_page.submit.click
+  end
+
+  def then_i_see_the_school_user_on_the_results_page
+    expect(results_page).to be_displayed
+    expect(results_page.users.size).to eq(1)
+    expect(results_page.users.first).to have_text('jsmith@school.sch.uk')
+    expect(results_page).not_to have_text('djones@another-school.sch.uk')
+  end
+
+  def and_i_can_navigate_to_the_support_page_for_their_school
+    click_link User.find_by(full_name: 'Jane Smith').school.name
+    expect(school_page).to be_displayed
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe User, type: :model do
   describe '#organisation_name' do
     let(:user) { build(:user) }
 
-    context 'when the user is from a mobilenetwork' do
+    context 'when the user is from a mobile network' do
       before { user.mobile_network = build(:mobile_network) }
 
       it 'returns the mobile networks brand' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1081,4 +1081,23 @@ RSpec.describe User, type: :model do
       expect(user.organisations).to include(*user.schools)
     end
   end
+
+  describe '.search_by_email_address_or_full_name' do
+    def user_search(search_string)
+      User.search_by_email_address_or_full_name(search_string)
+    end
+
+    it 'filters case insensitively on parts of the email address' do
+      user = create(:school_user, email_address: 'admin@school.sch.uk')
+      expect(user_search('Admin')).to eq([user])
+      expect(user_search('xxx')).to be_empty
+    end
+
+    it 'filters case insensitively on parts of the name' do
+      user = create(:school_user, full_name: 'Jane Smith')
+      expect(user_search('jane')).to eq([user])
+      expect(user_search('smith')).to eq([user])
+      expect(user_search('bob')).to be_empty
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1071,4 +1071,14 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#organisations' do
+    it 'includes the schools and responsible body that the user belongs to' do
+      user = create(:local_authority_user, schools: create_list(:school, 2))
+
+      expect(user.organisations.size).to eq(3)
+      expect(user.organisations).to include(user.responsible_body)
+      expect(user.organisations).to include(*user.schools)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1100,4 +1100,23 @@ RSpec.describe User, type: :model do
       expect(user_search('bob')).to be_empty
     end
   end
+
+  describe '.from_responsible_body_or_schools' do
+    it 'filters school users' do
+      user = create(:school_user)
+      expect(User.from_responsible_body_or_schools).to eq([user])
+    end
+
+    it 'filters responsible body users' do
+      user = create(:local_authority_user)
+      expect(User.from_responsible_body_or_schools).to eq([user])
+    end
+
+    it 'ignores MNO, CC and support users' do
+      create(:computacenter_user, full_name: 'Jane Smith 1')
+      create(:mno_user, full_name: 'Jane Smith 2')
+      create(:support_user, full_name: 'Jane Smith 3')
+      expect(User.from_responsible_body_or_schools).to be_empty
+    end
+  end
 end

--- a/spec/page_objects/support/users/results_page.rb
+++ b/spec/page_objects/support/users/results_page.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Support
+    module Users
+      class ResultsPage < PageObjects::BasePage
+        set_url '/support/users/results'
+
+        element :another_search, 'a', text: 'Search again'
+        elements :users, 'ul.search-results > li'
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/users/search_page.rb
+++ b/spec/page_objects/support/users/search_page.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Support
+    module Users
+      class SearchPage < PageObjects::BasePage
+        set_url '/support/users/search'
+
+        element :search_term, 'input[type=text]'
+        element :submit, 'input[value=Search]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

When someone writes into the support mailbox, it's not always clear which organisation they belong to. The support agent often needs to figure this out using the sender's signature, email address or domain name.

### Changes proposed in this pull request

Add a way for support agents to search for school and responsible body users, by the user's name or email address. This works case-insensitively and partial matches work too.

The search results list the matching users' email addresses and organisations they belong to, including links to the organisations' support pages.

The results are capped to 100 if the search term is too generic and matches too many users.

### Guidance to review

I'm sure the visual design could use some love.

![image](https://user-images.githubusercontent.com/23801/98487629-eec0b480-221b-11eb-98be-0a0a2001c81f.png)

![screencapture-localhost-3000-support-users-results-2020-11-08-23_42_14](https://user-images.githubusercontent.com/23801/98487661-131c9100-221c-11eb-9704-9b42bf519285.png)
