### PR TITLE
Improve the link_to_ed_settings_form helper and use it consistently

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -166,7 +166,7 @@ module ViewHelper
   end
 
   def link_to_ed_settings_form
-    link_to 'Educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status'
+    govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status'
   end
 
 private

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -260,7 +260,7 @@
 
           <div class="app-step-nav__panel" id="step-panel-place-an-order-5">
             <p class="app-step-nav__paragraph">
-              If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <a href="https://form.education.gov.uk/service/educational-setting-status" class="govuk-link" target="_blank">Educational settings status form</a> which is monitored daily.
+              If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <%= link_to_ed_settings_form %> which is monitored daily.
             </p>
             <p class="app-step-nav__paragraph">
               We’ll then email nominated contacts to inform them when device orders can be placed.

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     </ul>
 
-    <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status' %>.</p>
+    <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= link_to_ed_settings_form %>.</p>
 
     <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
     <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> reported disruption.</p>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </ul>
 
-    <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status' %>.</p>
+    <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to_ed_settings_form %>.</p>
 
     <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
     <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', request_devices_school_path(@school) %> from any year group who:</p>

--- a/app/views/school/home/specific_circumstances.html.erb
+++ b/app/views/school/home/specific_circumstances.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-   <p class="govuk-body">Full support is only available when you use the <%= govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status' %> to:</p>
+   <p class="govuk-body">Full support is only available when you use the <%= link_to_ed_settings_form %> to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>report a closure</li>


### PR DESCRIPTION
### Context

We link to the Education Settings Status Form in a few places. We sometimes user a view helper and sometimes it's hard coded. The link text is also inconsistent.

### Changes proposed in this pull request

Use the view helper consistently, which also makes the view templates more concise.
