### PR TITLE
bump govuk-components to 0.5.0, and fix govuk_link_to calls with blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'faker'
 # Manage multiple processes i.e. web server and webpack
 gem 'foreman'
 gem 'govuk_design_system_formbuilder'
-gem 'govuk-components'
+gem 'govuk-components', '>=0.5.0'
 
 gem 'http'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       net-http-pipeline
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-components (0.4.0)
+    govuk-components (0.5.0)
       rails (~> 6.0.3, >= 6.0.3)
       view_component (~> 2.18.1)
     govuk_design_system_formbuilder (2.1.4)
@@ -498,7 +498,7 @@ DEPENDENCIES
   faker
   fakeredis
   foreman
-  govuk-components
+  govuk-components (>= 0.5.0)
   govuk_design_system_formbuilder
   http
   i18n-debug

--- a/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
@@ -28,9 +28,7 @@
           <%= @extra_mobile_data_request.device_phone_number %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-device-phone-number-field') ) do %>
-            Change<span class="govuk-visually-hidden"> Mobile phone number</span>
-          <%- end %>
+          <%= govuk_link_to('Change<span class="govuk-visually-hidden"> Mobile phone number</span>'.html_safe, new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-device-phone-number-field') ) %>
         </dd>
       </div>
 
@@ -42,9 +40,7 @@
           <%= @extra_mobile_data_request.network_name_with_participation_status %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-mobile-network-id-#{@extra_mobile_data_request.mobile_network_id}-field") ) do %>
-            Change<span class="govuk-visually-hidden"> Mobile network</span>
-          <%- end %>
+          <%= govuk_link_to('Change<span class="govuk-visually-hidden"> Mobile network</span>'.html_safe, new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-mobile-network-id-#{@extra_mobile_data_request.mobile_network_id}-field") ) %>
         </dd>
       </div>
 
@@ -57,9 +53,7 @@
               scope: 'responsible_body.extra_mobile_data_requests.new') %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-contract_type-#{@extra_mobile_data_request.contract_type}-field") ) do %>
-            Change<span class="govuk-visually-hidden"> pay monthly or pay as you go</span>
-          <%- end %>
+          <%= govuk_link_to('Change<span class="govuk-visually-hidden"> pay monthly or pay as you go</span>'.html_safe, new_responsible_body_internet_mobile_manual_request_path(anchor: "extra-mobile-data-request-contract_type-#{@extra_mobile_data_request.contract_type}-field") ) %>
         </dd>
       </div>
 
@@ -71,9 +65,7 @@
           <%= @extra_mobile_data_request.agrees_with_privacy_statement ? 'Yes' : 'No' %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to('', new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-agrees-with-privacy-statement-true-field') ) do %>
-            Change<span class="govuk-visually-hidden"> Agrees with privacy statement</span>
-          <%- end %>
+          <%= govuk_link_to('Change<span class="govuk-visually-hidden"> Agrees with privacy statement</span>'.html_safe, new_responsible_body_internet_mobile_manual_request_path( anchor: 'extra-mobile-data-request-agrees-with-privacy-statement-true-field') ) %>
         </dd>
       </div>
     </dl>


### PR DESCRIPTION
..to allow the upgrade to work

### Context

There's been a [dependabot PR that upgrades `govuk-components` from 0.4.0 to 0.5.0](https://github.com/DFE-Digital/get-help-with-tech/pull/629) for a while now, but it has a few specs that are failing.

### Changes proposed in this pull request

* fix the `govuk_link_to ... do` calls that are failing, by changing them to non-block syntax
* bump the gem version

### Guidance to review

