### PR TITLE
add commented-out dev endpoint for Computacenters CapUpdate API

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,7 @@
+computacenter:
+  outgoing_api:
+    # Computacenter's dev endpoint
+    # Uncomment this to automatically send allocation cap updates to Computacenter
+    # (assuming you also have valid settings for username: and password:
+    # under the same scope)
+    # endpoint: https://b2b-uat.gw.computacenter.com/?resource=DFE/CapAdjustment&zAdpt=rest&zl=nc2


### PR DESCRIPTION
### Context

We have credentials for Computacenter's dev CapUpdateRequest endpoint, and devs need convenient access to them for testing - but if we put the endpoint URL in to env vars on _our_ dev server, it will start posting spurious unsolicited updates to them, which may not be welcome.  

### Changes proposed in this pull request

* add a correct but commented-out value for the endpoint in `config/settings/development.yml` 

### Guidance to review

