### PR TITLE
Tweaks to the 'closed schools' CC report

### DIFF
--- a/app/controllers/computacenter/closed_schools_controller.rb
+++ b/app/controllers/computacenter/closed_schools_controller.rb
@@ -28,15 +28,15 @@ private
 
   def parse_view_mode
     mode = params[:view]
-    mode = 'all' unless mode.in? %w[partially-closed fully-closed]
+    mode = 'all' unless mode.in? %w[specific-circumstances closures-or-self-isolating]
     mode
   end
 
   def query_for_view_mode
     case view_mode
-    when 'partially-closed'
+    when 'specific-circumstances'
       :can_order_for_specific_circumstances
-    when 'fully-closed'
+    when 'closures-or-self-isolating'
       :can_order
     else
       :that_can_order_now

--- a/app/controllers/computacenter/closed_schools_controller.rb
+++ b/app/controllers/computacenter/closed_schools_controller.rb
@@ -5,7 +5,11 @@ class Computacenter::ClosedSchoolsController < Computacenter::BaseController
     @specific_circumstances_count = query.can_order_for_specific_circumstances.count
     @closed_count = query.can_order.count
 
-    @pagination, @schools = pagy(fetch_schools_for_view)
+    # the high number of items per page effectively turns off pagination
+    # this is done to validate an assumption that CC users will want to
+    # search within the page using Ctrl + F, in which case they need
+    # to see all the closed schools
+    @pagination, @schools = pagy(fetch_schools_for_view, items: 10_000)
   end
 
 private

--- a/app/controllers/computacenter/closed_schools_controller.rb
+++ b/app/controllers/computacenter/closed_schools_controller.rb
@@ -16,7 +16,7 @@ private
 
   def fetch_schools_for_view
     School.joins(:responsible_body)
-      .includes(:std_device_allocation, :coms_device_allocation)
+      .includes(:std_device_allocation, :coms_device_allocation, :responsible_body)
       .gias_status_open
       .send(query_for_view_mode)
       .order(ResponsibleBody.arel_table[:type].asc, ResponsibleBody.arel_table[:name].asc, School.arel_table[:name].asc)

--- a/app/views/computacenter/closed_schools/index.html.erb
+++ b/app/views/computacenter/closed_schools/index.html.erb
@@ -18,14 +18,14 @@
         selected: @view_mode.blank? || @view_mode == 'all')
       %>
       <%= render TabComponent.new(
-        label: 'Partially closed',
-        path: computacenter_closed_schools_path(view: 'partially-closed'),
-        selected: @view_mode == 'partially-closed')
+        label: 'Ordering for specific circumstances',
+        path: computacenter_closed_schools_path(view: 'specific-circumstances'),
+        selected: @view_mode == 'specific-circumstances')
       %>
       <%= render TabComponent.new(
-        label: 'Fully closed',
-        path: computacenter_closed_schools_path(view: 'fully-closed'),
-        selected: @view_mode == 'fully-closed')
+        label: 'Ordering for closures or self-isolating pupils',
+        path: computacenter_closed_schools_path(view: 'closures-or-self-isolating'),
+        selected: @view_mode == 'closures-or-self-isolating')
       %>
     </ul>
     <div class="govuk-tabs__panel">

--- a/app/views/computacenter/closed_schools/index.html.erb
+++ b/app/views/computacenter/closed_schools/index.html.erb
@@ -9,64 +9,67 @@
     </h1>
   </div>
 </div>
+
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
-  <div class="govuk-tabs">
-    <ul class="govuk-tabs__list">
-      <%= render TabComponent.new(
-        label: 'All',
-        path: computacenter_closed_schools_path(view: 'all'),
-        selected: @view_mode.blank? || @view_mode == 'all')
-      %>
-      <%= render TabComponent.new(
-        label: 'Ordering for specific circumstances',
-        path: computacenter_closed_schools_path(view: 'specific-circumstances'),
-        selected: @view_mode == 'specific-circumstances')
-      %>
-      <%= render TabComponent.new(
-        label: 'Ordering for closures or self-isolating pupils',
-        path: computacenter_closed_schools_path(view: 'closures-or-self-isolating'),
-        selected: @view_mode == 'closures-or-self-isolating')
-      %>
-    </ul>
-    <div class="govuk-tabs__panel">
-      <table class="govuk-table" id="closed-schools">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">RB Type</th>
-            <th scope="col" class="govuk-table__header">RB Name</th>
-            <th scope="col" class="govuk-table__header">RB URN</th>
-            <th scope="col" class="govuk-table__header">Sold To</th>
-            <th scope="col" class="govuk-table__header">School URN</th>
-            <th scope="col" class="govuk-table__header">School Name</th>
-            <th scope="col" class="govuk-table__header">Ship To</th>
-            <th scope="col" class="govuk-table__header">Device Cap</th>
-            <th scope="col" class="govuk-table__header">Router Cap</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% @schools.each do |school| %>
+  <div class="govuk-grid-column-full">
+    <div class="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <%= render TabComponent.new(
+          label: 'All',
+          path: computacenter_closed_schools_path(view: 'all'),
+          selected: @view_mode.blank? || @view_mode == 'all')
+        %>
+        <%= render TabComponent.new(
+          label: 'Ordering for specific circumstances',
+          path: computacenter_closed_schools_path(view: 'specific-circumstances'),
+          selected: @view_mode == 'specific-circumstances')
+        %>
+        <%= render TabComponent.new(
+          label: 'Ordering for closures or self-isolating pupils',
+          path: computacenter_closed_schools_path(view: 'closures-or-self-isolating'),
+          selected: @view_mode == 'closures-or-self-isolating')
+        %>
+      </ul>
+      <div class="govuk-tabs__panel">
+        <table class="govuk-table" id="closed-schools">
+          <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= school.responsible_body.humanized_type %></td>
-              <td class="govuk-table__cell"><%= school.responsible_body.computacenter_name %></td>
-              <td class="govuk-table__cell"><%= school.responsible_body.computacenter_identifier %></td>
-              <td class="govuk-table__cell"><%= school.responsible_body.computacenter_reference %></td>
-              <td class="govuk-table__cell"><%= school.urn %></td>
-              <td class="govuk-table__cell"><%= school.name %></td>
-              <td class="govuk-table__cell"><%= school.computacenter_reference %></td>
-              <td class="govuk-table__cell"><%= school.std_device_allocation&.cap %></td>
-              <td class="govuk-table__cell"><%= school.coms_device_allocation&.cap %></td>
+              <th scope="col" class="govuk-table__header">RB Type</th>
+              <th scope="col" class="govuk-table__header">RB Name</th>
+              <th scope="col" class="govuk-table__header">RB URN</th>
+              <th scope="col" class="govuk-table__header">Sold To</th>
+              <th scope="col" class="govuk-table__header">School URN</th>
+              <th scope="col" class="govuk-table__header">School Name</th>
+              <th scope="col" class="govuk-table__header">Ship To</th>
+              <th scope="col" class="govuk-table__header">Device Cap</th>
+              <th scope="col" class="govuk-table__header">Router Cap</th>
             </tr>
-          <%- end %>
-        </tbody>
-      </table>
-      <div class="govuk-body govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-        <h4 class="govuk-heading-m govuk-!-margin-top-4">
-          <%= pagy_info(@pagination, "schools").capitalize.html_safe %>
-        </h4>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% @schools.each do |school| %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><%= school.responsible_body.humanized_type %></td>
+                <td class="govuk-table__cell"><%= school.responsible_body.computacenter_name %></td>
+                <td class="govuk-table__cell"><%= school.responsible_body.computacenter_identifier %></td>
+                <td class="govuk-table__cell"><%= school.responsible_body.computacenter_reference %></td>
+                <td class="govuk-table__cell"><%= school.urn %></td>
+                <td class="govuk-table__cell"><%= school.name %></td>
+                <td class="govuk-table__cell"><%= school.computacenter_reference %></td>
+                <td class="govuk-table__cell"><%= school.std_device_allocation&.cap %></td>
+                <td class="govuk-table__cell"><%= school.coms_device_allocation&.cap %></td>
+              </tr>
+            <%- end %>
+          </tbody>
+        </table>
+        <div class="govuk-body govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+          <h4 class="govuk-heading-m govuk-!-margin-top-4">
+            <%= pagy_info(@pagination, "schools").capitalize.html_safe %>
+          </h4>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -23,9 +23,9 @@
     <p class="govuk-body">Download a CSV file of Google Chromebook details for schools.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to 'School closures', computacenter_closed_schools_path %>
+      <%= govuk_link_to 'Schools that can order', computacenter_closed_schools_path %>
     </h2>
 
-    <p class="govuk-body">View details of schools with closures.</p>
+    <p class="govuk-body">View details of schools with that can place orders.</p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
     computacenter:
       home: Home
       techsource: Update TechSource users
-      closed_schools: School closures
+      closed_schools: Schools that can order
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
       schools: Each school will place their own orders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,7 @@ Rails.application.routes.draw do
     get '/', to: 'home#show', as: :home
     get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
     get '/chromebooks', to: 'chromebooks#index', as: :chromebooks
-    get '/school-closures', to: 'closed_schools#index', as: :closed_schools
+    get '/schools-that-can-order', to: 'closed_schools#index', as: :closed_schools
     get '/techsource', to: 'techsource#new'
     post '/techsource', to: 'techsource#create'
     resources :api_tokens, path: '/api-tokens'

--- a/spec/features/computacenter/closed_schools_spec.rb
+++ b/spec/features/computacenter/closed_schools_spec.rb
@@ -38,14 +38,14 @@ RSpec.feature 'Viewing closed schools caps' do
     end
 
     def and_i_click_the_school_closures_link
-      click_on 'School closures'
-      expect(page).to have_text 'School closures'
+      click_on 'Schools that can order'
+      expect(page).to have_text 'Schools that can order'
     end
 
     def then_i_see_the_list_of_all_closed_schools
       expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'All'
-      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Partially closed'
-      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Fully closed'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Ordering for specific circumstances'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Ordering for closures or self-isolating pupils'
 
       closed_schools.each do |s|
         expect(page).to have_text(s.urn)
@@ -61,13 +61,13 @@ RSpec.feature 'Viewing closed schools caps' do
     end
 
     def and_i_click_on_the_partially_closed_tab
-      click_on 'Partially closed'
+      click_on 'Ordering for specific circumstances'
     end
 
     def then_i_see_the_list_of_partially_closed_schools
       expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All'
-      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Partially closed'
-      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Fully closed'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Ordering for specific circumstances'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Ordering for closures or self-isolating pupils'
 
       closed_schools.each do |s|
         expect(page).not_to have_text(s.urn)
@@ -79,13 +79,13 @@ RSpec.feature 'Viewing closed schools caps' do
     end
 
     def and_i_click_on_the_fully_closed_tab
-      click_on 'Fully closed'
+      click_on 'Ordering for closures or self-isolating pupils'
     end
 
     def then_i_see_the_list_of_fully_closed_schools
       expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All'
-      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Partially closed'
-      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Fully closed'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Ordering for specific circumstances'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Ordering for closures or self-isolating pupils'
 
       closed_schools.each do |s|
         expect(page).to have_text(s.urn)


### PR DESCRIPTION
### Context

PR #747 introduced a 'closed schools' report for Computacenter. This PR includes some tweaks some of the functionality and language in this report.

### Changes proposed in this pull request

- Temporarily turn off pagination within the report
  - It's my hunch that the CC ops team is going to use Ctrl+F to find school caps using the `URN`, `shipTo`, or `soldTo` numbers. Because of pagination, it's very unlikely that the school they're looking for is going to be on the first page and there's currently no other search functionality included.
  - I've not actually removed the pagination, I've just made the pages contain 10,000 items. If my hunch is incorrect, then it's easy enough to change this back, or if it's correct, then some of the code can be removed in a subsequent PR.
- Fix an N+1 query problem in the controller (which becomes noticeable/very acute when pagination is disabled)
- Re-align some of the report language with the rest of the service:
  - `School closures` => `Schools that can order` (because the report also includes schools that can order for specific circumstances and don't, strictly speaking, have to be closed)
  - `Partially closed` => `Ordering for specific circumstances` (same thinking as above)
  - `Fully closed` => `Ordering due to COVID-19 disruption` (again, schools don't have to be fully closed in order to have the `can_order` order state)

### Guidance to review

Is the new terminology correct?