### PR TITLE
[972] Log Computacenter cap calls to DB

### DIFF
--- a/app/models/cap_update_call.rb
+++ b/app/models/cap_update_call.rb
@@ -1,0 +1,3 @@
+class CapUpdateCall < ApplicationRecord
+  belongs_to :school_device_allocation
+end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -1,9 +1,10 @@
 class SchoolDeviceAllocation < ApplicationRecord
   has_paper_trail
 
-  belongs_to  :school
-  belongs_to  :created_by_user, class_name: 'User', optional: true
-  belongs_to  :last_updated_by_user, class_name: 'User', optional: true
+  belongs_to :school
+  belongs_to :created_by_user, class_name: 'User', optional: true
+  belongs_to :last_updated_by_user, class_name: 'User', optional: true
+  has_many :cap_update_calls
 
   validates_with CapAndAllocationValidator
 

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -70,6 +70,8 @@ private
       cap_update_request_timestamp: api_request.timestamp,
       cap_update_request_payload_id: api_request.payload_id,
     )
+    allocation = SchoolDeviceAllocation.find_by(id: allocation_id)
+    allocation.cap_update_calls << CapUpdateCall.new(request_body: api_request.body, response_body: response.body) if allocation
     response
   end
 end

--- a/db/migrate/20201110103917_create_cap_update_calls.rb
+++ b/db/migrate/20201110103917_create_cap_update_calls.rb
@@ -1,0 +1,11 @@
+class CreateCapUpdateCalls < ActiveRecord::Migration[6.0]
+  def change
+    create_table :cap_update_calls do |t|
+      t.references :school_device_allocation
+      t.text :request_body
+      t.text :response_body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_04_165458) do
+ActiveRecord::Schema.define(version: 2020_11_10_103917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema.define(version: 2020_11_04_165458) do
     t.datetime "distributed_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "cap_update_calls", force: :cascade do |t|
+    t.bigint "school_device_allocation_id"
+    t.text "request_body"
+    t.text "response_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_device_allocation_id"], name: "index_cap_update_calls_on_school_device_allocation_id"
   end
 
   create_table "computacenter_user_changes", force: :cascade do |t|

--- a/spec/services/allocation_updater_spec.rb
+++ b/spec/services/allocation_updater_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AllocationUpdater do
-  let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789') }
+  let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789', body: '<xml>test-request</xml>') }
+  let(:mock_response) { OpenStruct.new(body: '<xml>test-response</xml>') }
   let(:mock_update_service) { instance_double(SchoolOrderStateAndCapUpdateService) }
 
   before do
     allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
-    allow(mock_request).to receive(:post!)
+    allow(mock_request).to receive(:post!).and_return(mock_response)
     allow(mock_update_service).to receive(:update!)
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/GAZWcXlU/972-cap-updates-are-being-logged-our-side-but-cc-dont-have-records

### Changes proposed in this pull request

- When making calls to CC we now log the request and response in the DB against the allocation
- This is so we can determine what actually happens when something does not work as expected with evidence 

### Guidance to review

- Add settings to connect to CC test environment
- Update a cap that would initiate a call to CC
- The request and response should be logged against the allocation record