### PR TITLE
add Makefile tasks to aid rollback of releases, and update the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ prod:
 	@true
 
 .PHONY: require_env_stub build push deploy setup_paas_env setup_paas_db setup_paas_app promote ssh \
-				logs logs-recent dockerhub-tags
+				logs logs-recent remote-docker-tags push-tag rollback-to timestamp-latest
 
 require_env_stub:
 	@test ${env_stub} || (echo ">> env_stub is not set (${env_stub})- please use make dev|staging|prod (task)"; exit 1)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ When this happens, you'll probably want to minimize user impact by rolling back 
 
 There are some make tasks that can help:
 
-`make (env) remote-docker-tags` - list all available tags for the given environment's Docker image, on Docker Hub
-`make (env) rollback-to TAG=...` - re-deploy the Docker image tagged with the given TAG
+`make prod remote-docker-tags` - list all available tags for production Docker image, on Docker Hub (you can replace `prod` with another environment)
+`make prod rollback-to TAG=...` - re-deploy the Docker image tagged with the given TAG
 
 #### How does this work?
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For performing releases:
 - CloudFoundry CLI >= v7.0
 - make
 - a bash-compatible shell (bash, or Mac OS/X)
+- [jq](https://github.com/stedolan/jq) (only required for listing remote Docker tags, not required for normal releases)
 
 ## Setting up the app in development
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The normal release process works as follows:
 1. Build a new Docker image called `get-help-with-tech-(env name)`
 2. Pull any existing image from Docker Hub called `dfedigital/get-help-with-tech-(env name):latest`. Re-tag it with `replaced-at-(timestamp)` and push it back up to Docker Hub.  
 3. Tag the newly-built image as `dfedigital/get-help-with-tech-(env name):latest`, and push it to Docker Hub, overwriting any existing image with the same name and tag
-4. Tell Gov.uk PaaS to pull `dfedigital/get-help-with-tech-(env name):latest` from Docker Hub, and deploy it to the app called `get-help-with-tech-(env name)`
+4. Tell GOV.UK PaaS to pull `dfedigital/get-help-with-tech-(env name):latest` from Docker Hub, and deploy it to the app called `get-help-with-tech-(env name)`
 
 If you're not building a new image but promoting an image from another environment, the process is a little simpler, but largely the same:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you're not building a new image but promoting an image from another environme
 
 1. Pull any existing image from Docker Hub called `dfedigital/get-help-with-tech-(env name):latest`. Re-tag it with `replaced-at-(timestamp)` and push it back up to Docker Hub.
 2. Pull the image `dfedigital/get-help-with-tech-(FROM env name):latest`, re-tag it as `dfedigital/get-help-with-tech-(TO env name):latest`' and push it back up to Docker Hub
-3. Tell Gov.uk PaaS to pull `dfedigital/get-help-with-tech-(env name):latest` from Docker Hub, and deploy it to the app called `get-help-with-tech-(env name)`
+3. Tell GOV.UK PaaS to pull `dfedigital/get-help-with-tech-(env name):latest` from Docker Hub, and deploy it to the app called `get-help-with-tech-(env name)`
 
 In either case, before replacing the `dfedigital/get-help-with-tech-(env name):latest` image on Docker Hub, it will automatically re-tag the existing image as `replaced-at-(timestamp)` - making it straightforward to rollback to any available previous tag.
 


### PR DESCRIPTION
### Context

[Trello card #832](https://trello.com/c/q6ym64rf/832-make-it-much-easier-to-rollback-an-unsuccessful-release)
A recent incident involving a failed release led to a tense period of figuring out the best way to rollback (and in the end rolling forward a null migration), resulting in around 20 mins of total downtime. There was no way to rollback without re-building a new container image.

It would have been much better to have an easy way to re-release a previous version

### Changes proposed in this pull request

* add new makefile tasks `timestamp-latest`, `rollback-to`, `push-tag` and `remote-docker-tags`
* add `timestamp-latest` as a dependency of `push` and `push-tag`, so that any future release will automatically 'back-up' the currently-deployed version before replacing it
* add explanatory 'If you need to rollback a release' and 'How does this work?' sections in the README

### Guidance to review

`make dev remote-docker-tags` - to list the available tags for dev
`make dev rollback-to TAG=(...)` - to rollback to an available tag

etc etc.... but please note that the comprehensibility of the documentation in the README is just as important as whether the tasks work, so please make sure that it makes sense to you, and try following the instructions from _there_ rather than _here_ to actually try it out
