### PR TITLE
Show a school’s URN on the order page

### DIFF
--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -13,7 +13,7 @@
     <% @schools.each do |school| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= govuk_link_to("#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn)) %>
+          <%= govuk_link_to("#{school.name} (URN: #{school.urn})", responsible_body_devices_school_path(school.urn)) %>
         </td>
         <td class="govuk-table__cell">
           <%= what_to_order_availability(school: school) %>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -19,6 +19,6 @@
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address, school_urn: @school.urn } %>
   </div>
 </div>

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -19,6 +19,6 @@
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @user.email_address, school_urn: @school.urn } %>
   </div>
 </div>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -1,10 +1,16 @@
 <p class="govuk-body">You need to place orders on a website called TechSource.</p>
 
 <p class="govuk-body">Use these details to sign in:</p>
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+<ul class="govuk-list govuk-list--bullet<% unless local_assigns[:school_urn] %> govuk-!-margin-bottom-7<% end %>">
   <li>User ID: <%= local_assigns[:email_address] %></li>
   <li>Password: Use the ‘Forgotten password?’ link to set a password the first time you sign in</li>
 </ul>
+
+<% if local_assigns[:school_urn] %>
+<p class="govuk-body govuk-!-margin-bottom-7">
+  You’ll also need your school’s unique reference number (URN) when you place an order. It is: <%= local_assigns[:school_urn] %>
+</p>
+<% end %>
 
 <%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3', target: '_blank') -%>
 

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -153,17 +153,17 @@ RSpec.feature 'Ordering devices' do
 
   def and_i_see_1_school_that_i_need_to_place_orders_for
     expect(page).to have_text('Schools you need to place orders for')
-    expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
+    expect(page).to have_text("#{schools[2].name} (URN: #{schools[2].urn})")
     expect(page).to have_text(what_to_order_availability(schools[2]))
     expect(page).to have_text(what_to_order_state(schools[2]))
   end
 
   def and_i_see_2_schools_that_i_need_to_place_orders_for
     expect(page).to have_text('Schools you need to place orders for')
-    expect(page).to have_text("#{schools[1].name} (#{schools[1].urn})")
+    expect(page).to have_text("#{schools[1].name} (URN: #{schools[1].urn})")
     expect(page).to have_text(what_to_order_availability(schools[1]))
     expect(page).to have_text(what_to_order_state(schools[1]))
-    expect(page).to have_text("#{schools[2].name} (#{schools[2].urn})")
+    expect(page).to have_text("#{schools[2].name} (URN: #{schools[2].urn})")
     expect(page).to have_text(what_to_order_availability(schools[2]))
     expect(page).to have_text(what_to_order_state(schools[2]))
   end


### PR DESCRIPTION
Schools need to know their URN when they order through Computacenter, to make this easier for them we include it in the email and now also on the order page.