### PR TITLE
Added SAT converter for schools

### DIFF
--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -36,6 +36,8 @@ module Computacenter::ResponsibleBodyUrns
       when 'LocalAuthority'
         "LEA#{gias_id}"
       when 'Trust'
+        return '' if companies_house_number.blank?
+
         "t#{companies_house_number.to_i}"
       end
     end

--- a/app/services/school_to_sat_converter.rb
+++ b/app/services/school_to_sat_converter.rb
@@ -1,0 +1,40 @@
+class SchoolToSatConverter
+  attr_reader :school, :trust
+
+  def initialize(school)
+    @school = school
+    @trust = nil
+  end
+
+  def convert_to_sat(trust_name: school.name, companies_house_number: nil)
+    school.transaction do
+      @trust = create_sat_trust(trust_name, companies_house_number)
+      school.update!(responsible_body: @trust)
+      setup_preorder_information
+      setup_std_device_allocation
+    end
+  end
+
+private
+
+  def create_sat_trust(name, companies_house_number)
+    Trust.create!(name: name,
+                  companies_house_number: companies_house_number,
+                  organisation_type: 'single_academy_trust',
+                  who_will_order_devices: 'schools')
+  end
+
+  def setup_preorder_information
+    if school.preorder_information.nil?
+      school.create_preorder_information!(who_will_order_devices: 'school')
+    else
+      school.preorder_information.update!(who_will_order_devices: 'school')
+    end
+  end
+
+  def setup_std_device_allocation
+    if school.std_device_allocation.nil?
+      school.device_allocations.create!(device_type: 'std_device', allocation: 0)
+    end
+  end
+end

--- a/app/services/school_to_sat_converter.rb
+++ b/app/services/school_to_sat_converter.rb
@@ -21,7 +21,13 @@ private
     Trust.create!(name: name,
                   companies_house_number: companies_house_number,
                   organisation_type: 'single_academy_trust',
-                  who_will_order_devices: 'schools')
+                  who_will_order_devices: 'schools',
+                  address_1: school.address_1,
+                  address_2: school.address_2,
+                  address_3: school.address_3,
+                  town: school.town,
+                  county: school.county,
+                  postcode: school.postcode)
   end
 
   def setup_preorder_information

--- a/docs/support/convert_school_to_SAT.md
+++ b/docs/support/convert_school_to_SAT.md
@@ -1,0 +1,80 @@
+### Convert a non-maintained School to a SAT
+
+There are cases where schools (typically special schools and FE colleges) have been imported and assigned to the Local Authority as their responsible body because there was no or incomplete trust information in the GIAS data file (and the logic uses the LA unless there is Trust info in the data file).
+
+These typically only come to light where the LA contacts support and asked for the school to be removed from their list of schools.
+
+The decision has been made that we will treat these cases a Single Academy Trusts. Normally all trusts require a Companies House Number and this is used by Computacenter for credit checking type of activities. However CC have agreed that as the schools are not actually purchasing anything the CHN can be blank for these SATs.
+
+#### Before converting
+
+Check the GIAS website for the school's details and see if the school has a website. Take a look on the school's website and see if there is a suitable trust name that could be used and possibly a CHN.  I have seen this sort of thing in the main page footer for example for a school named "St. Elizabeth's School":
+
+```
+St Elizabeth's Centre is a company limited by guarantee registered in England and Wales (No. 12345678)
+Registered Charity No: 1234567
+```
+
+So it would make sense to use the name "St. Elizabeth's Centre" for the SAT and the CHN.
+
+If nothing suitable is found the default is to use the school name and blank CHN.
+
+#### Converting the school
+
+Create an instance of the `SchoolToSatConverter` and pass it an instance of the `School`
+
+```ruby
+stsc = SchoolToSatConverter.new(School.find_by(urn: 123456))
+```
+
+Invoke the `convert_to_sat` method
+
+```ruby
+stsc.convert_to_sat(trust_name: 'Trust Name Here', companies_house_number: '12345678')
+```
+
+Or when no extra information is available, simply
+
+```ruby
+stsc.convert_to_sat
+```
+
+This creates a single academy trust, moves the school to that trust and creates or adjusts the `preorder_information` to set the school as the ordering body.  It will also create a zero `std_device_allocation` if one doesn't already exist.
+
+### Notify Computacenter
+
+We need to let Computacenter know of changes to the school and the new trust.  As we've added a new trust we need to export it to a CSV file and send it to CC so that they can send us a `soldTo` number (`computacenter_reference`)
+
+Select the trust and use the `ResponsibleBodyExporter` to generate a CSV for CC:
+
+```ruby
+[15] pry(main)> ResponsibleBodyExporter.new('public/rb-changes.csv').export_responsible_bodies(Trust.where(name: 'Trust Name Here'))
+=> nil
+```
+
+Select the school and use the `SchoolDataExporter` to generate a CSV for CC:
+
+```ruby
+SchoolDataExporter.new('public/school-changes.csv').export_schools(School.where(urn: 123456))
+```
+
+You should be able to download the files with your browser by entering the file name directly after the prod site url as the rails server is currently set to serve static assets
+
+```
+https://get-help-with-tech.education.gov.uk/rb-changes.csv
+https://get-help-with-tech.education.gov.uk/school-changes.csv
+```
+
+Once downloaded, remember to remove the files from the server from the SSH command line
+
+```bash
+$ rm public/rb-changes.csv
+$ rm public/school-changes.csv
+```
+
+Finally open the CSV files in a suitable editor and append an extra column at the end with the header "New/Amended".  For the new trust row in the file indicate that it is a "New" record, for the school it will be an "Amended" record and  to make it easier for CC to process.
+
+Email the CSV files to  CC.
+
+CC will return the file with `soldTo` references added. These should be used to update the `computacenter_reference` for the trust.  Sometimes if a school is added at the same time, only the school data is returned, but the school will have a `soldTo` which is the same reference for the trust, so that can be used to set the trust's `computacenter_reference`.
+

--- a/spec/services/responsible_body_exporter_spec.rb
+++ b/spec/services/responsible_body_exporter_spec.rb
@@ -3,14 +3,16 @@ require 'rails_helper'
 RSpec.describe ResponsibleBodyExporter, type: :model do
   let(:responsible_body) { create(:trust) }
   let(:filename) { Rails.root.join('tmp/responsible_bodies_test_data.csv') }
-  let(:exporter) { described_class.new(filename) }
+
+  subject(:exporter) { described_class.new(filename) }
 
   context 'when exporting responsible_body data' do
-    before do
+    around do |example|
+      responsible_body
       exporter.export_responsible_bodies
-    end
 
-    after do
+      example.run
+
       remove_file(filename)
     end
 
@@ -21,6 +23,31 @@ RSpec.describe ResponsibleBodyExporter, type: :model do
     it 'includes a heading row and all of the responsible bodies in the CSV file' do
       line_count = `wc -l "#{filename}"`.split.first.to_i
       expect(line_count).to eq(ResponsibleBody.count + 1)
+    end
+  end
+
+  context 'when exporting single academy trusts' do
+    let(:sat) { create(:trust, :single_academy_trust, companies_house_number: nil) }
+
+    around do |example|
+      sat
+      exporter.export_responsible_bodies
+      example.run
+      remove_file(filename)
+    end
+
+    it 'handles trusts that have no companies house number' do
+      data = CSV.parse(File.read(filename), headers: true)
+      expect(data.count).to eq(ResponsibleBody.count)
+
+      found = false
+      data.each do |row|
+        if row['Responsible Body Name'] == sat.name
+          expect(row['Responsible body URN']).to be_blank
+          found = true
+        end
+      end
+      expect(found).to be true
     end
   end
 end

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe SchoolDataExporter, type: :model do
   let(:school) { create(:school) }
   let(:filename) { Rails.root.join('tmp/school_test_data.csv') }
-  let(:exporter) { described_class.new(filename) }
+
+  subject(:exporter) { described_class.new(filename) }
 
   context 'when exporting school data' do
-    before do
+    around do |example|
+      school
       exporter.export_schools
-    end
-
-    after do
+      example.run
       remove_file(filename)
     end
 
@@ -21,6 +21,31 @@ RSpec.describe SchoolDataExporter, type: :model do
     it 'includes a heading row and all of the Schools in the CSV file' do
       line_count = `wc -l "#{filename}"`.split.first.to_i
       expect(line_count).to eq(School.count + 1)
+    end
+  end
+
+  context 'when exporting single academy trusts' do
+    let(:sat) { create(:trust, :single_academy_trust, companies_house_number: nil) }
+
+    around do |example|
+      school.update!(responsible_body: sat)
+      exporter.export_schools
+      example.run
+      remove_file(filename)
+    end
+
+    it 'handles trusts that have no companies house number' do
+      data = CSV.parse(File.read(filename), headers: true)
+      expect(data.count).to eq(School.count)
+
+      found = false
+      data.each do |row|
+        if row['School URN + School Name'] == "#{school.urn} #{school.name}"
+          expect(row['Responsible body URN']).to be_blank
+          found = true
+        end
+      end
+      expect(found).to be true
     end
   end
 end

--- a/spec/services/school_to_sat_converter_spec.rb
+++ b/spec/services/school_to_sat_converter_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe SchoolToSatConverter, type: :model do
+  let(:local_authority) { create(:local_authority, name: 'Camden') }
+  let(:school) { create(:school, urn: '103001', responsible_body: local_authority) }
+
+  subject(:converter) { described_class.new(school) }
+
+  context 'no company info available for the school' do
+    it 'creates a Trust with the Schools name and no companies house number' do
+      expect { converter.convert_to_sat }.to change { Trust.count }.by(1)
+      trust = Trust.last
+      expect(trust.name).to eq(school.name)
+      expect(trust.companies_house_number).to be_blank
+      expect(trust.organisation_type).to eq('single_academy_trust')
+      expect(trust.who_will_order_devices).to eq('schools')
+      school.reload
+      expect(school.preorder_information.who_will_order_devices).to eq('school')
+      expect(school.std_device_allocation.allocation).to eq(0)
+    end
+  end
+
+  context 'when a trust name is available but no companies house number' do
+    let(:trust_name) { 'THE NEW TRUST' }
+
+    it 'creates a Trust with the specified name and no companies house number' do
+      expect { converter.convert_to_sat(trust_name: trust_name) }.to change { Trust.count }.by(1)
+      trust = Trust.last
+      expect(trust.name).to eq(trust_name)
+      expect(trust.companies_house_number).to be_blank
+      expect(trust.organisation_type).to eq('single_academy_trust')
+      expect(trust.who_will_order_devices).to eq('schools')
+      school.reload
+      expect(school.preorder_information.who_will_order_devices).to eq('school')
+      expect(school.std_device_allocation.allocation).to eq(0)
+    end
+  end
+
+  context 'when a trust name and companies house number are supplied' do
+    let(:trust_name) { 'THE NEW TRUST' }
+    let(:companies_house_number) { '01231234' }
+
+    it 'creates a Trust with the specified name and companies house number' do
+      expect {
+        converter.convert_to_sat(trust_name: trust_name,
+                                 companies_house_number: companies_house_number)
+      }.to change { Trust.count }.by(1)
+
+      trust = Trust.last
+      expect(trust.name).to eq(trust_name)
+      expect(trust.companies_house_number).to eq(companies_house_number)
+      expect(trust.organisation_type).to eq('single_academy_trust')
+      expect(trust.who_will_order_devices).to eq('schools')
+      school.reload
+      expect(school.preorder_information.who_will_order_devices).to eq('school')
+      expect(school.std_device_allocation.allocation).to eq(0)
+    end
+  end
+
+  context 'when the school has a device allocation' do
+    it 'does not alter the allocation' do
+      school.device_allocations.create!(device_type: 'std_device', allocation: 20)
+
+      converter.convert_to_sat
+      school.reload
+      expect(school.std_device_allocation.allocation).to eq(20)
+    end
+  end
+
+  context 'when the school has preorder information and was centrally managed' do
+    it 'updates the preorder information so the school will order devices' do
+      school.create_preorder_information!(who_will_order_devices: 'responsible_body')
+
+      converter.convert_to_sat
+
+      school.reload
+      expect(school.preorder_information.who_will_order_devices).to eq('school')
+    end
+  end
+end

--- a/spec/services/school_to_sat_converter_spec.rb
+++ b/spec/services/school_to_sat_converter_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe SchoolToSatConverter, type: :model do
       expect(trust.companies_house_number).to be_blank
       expect(trust.organisation_type).to eq('single_academy_trust')
       expect(trust.who_will_order_devices).to eq('schools')
+      expect(trust.address_1).to eq(school.address_1)
+      expect(trust.address_2).to eq(school.address_2)
+      expect(trust.address_3).to eq(school.address_3)
+      expect(trust.town).to eq(school.town)
+      expect(trust.county).to eq(school.county)
+      expect(trust.postcode).to eq(school.postcode)
+
       school.reload
       expect(school.preorder_information.who_will_order_devices).to eq('school')
       expect(school.std_device_allocation.allocation).to eq(0)


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/yK1dGT8m/999-convert-school-to-sat)
Add ability to convert a non-maintained school into a SAT

### Changes proposed in this pull request
Adds `SchoolToSatConverter` that handles the conversion
Add support doc
Handle Trust without `:companies_house_number` in exports to computacenter

### Guidance to review
Intended to be run from the rails console in support ops.

`SchoolToSatConverter.new(School.find_by(urn: 123456)).convert_to_sat`

This will create a new single academy trust, using the name of the school and move the given school into it.
Trust name and companies house number are optional params to `convert_to_sat`
