### PR TITLE
Bugfix for crash on the 'request devices for specific circumstances' page

### DIFF
--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -1,4 +1,4 @@
-<% if @user.is_school_user? %>
+<% if @school %>
   <%- title = t('page_titles.school_request_devices') %>
   <%- content_for :before_content do %>
     <% if @school.mno_feature_flag %>
@@ -11,7 +11,7 @@
     <% end %>
   <% end %>
 
-<% elsif @user.is_responsible_body_user? %>
+<% elsif @responsible_body %>
 
   <%- title = t('page_titles.responsible_body_devices_request_devices') %>
   <%- content_for :before_content do %>
@@ -35,13 +35,13 @@
 
     <p class="govuk-body">Tell us:</p>
 
-    <% if @user.is_school_user? %>
+    <% if @school %>
       <ul class="govuk-list govuk-list--bullet">
         <li>how many devices you will need</li>
         <li>the year groups of the children who need devices</li>
         <li>why you need them</li>
       </ul>
-    <% elsif @user.is_responsible_body_user? %>
+    <% elsif @responsible_body %>
       <ul class="govuk-list govuk-list--bullet">
         <li>which schools need the devices</li>
         <li>how many devices they need</li>

--- a/spec/features/responsible_body/request_devices_for_specific_circumstances_spec.rb
+++ b/spec/features/responsible_body/request_devices_for_specific_circumstances_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'Requesting devices for specific circumstances' do
+  let(:responsible_body) { create(:local_authority, who_will_order_devices: 'responsible_body') }
+  let(:rb_user) { create(:local_authority_user, responsible_body: responsible_body) }
+
+  before do
+    sign_in_as rb_user
+  end
+
+  scenario 'understanding how to request devices for specific circumstances' do
+    click_on 'Get laptops and tablets'
+    click_on 'Request devices for specific circumstances'
+
+    expect(page).to have_text('Request devices for specific circumstances')
+    expect(page).to have_text('which schools need the devices')
+  end
+
+  context 'when the user belongs to both the responsible body and a school' do
+    let(:schools) { create_list(:school, 2) }
+    let(:rb_user) { create(:local_authority_user, responsible_body: responsible_body, schools: schools) }
+
+    scenario 'understanding how to request devices for specific circumstances' do
+      visit responsible_body_home_path
+
+      click_on 'Get laptops and tablets'
+      click_on 'Request devices for specific circumstances'
+
+      expect(page).to have_text('Request devices for specific circumstances')
+      expect(page).to have_text('which schools need the devices')
+    end
+  end
+end


### PR DESCRIPTION
### Context

When a user is part of both a responsible body and a school, and tries to access the 'request devices for specific circumstances' page via the responsible body side of the service, an exception occurs:

https://sentry.io/organizations/dfe-get-help-with-tech/issues/2018379706/?environment=production&project=5320558&query=is%3Aunresolved

This is an edge-case and should be only affecting a small number of users.

### Changes proposed in this pull request

Fix the crash

### Guidance to review

Is this edge case worth a spec? Not sure...