### PR TITLE
Make it easier to navigate around connectivity pages

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -3,7 +3,7 @@
 
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => guidance_page_path },
-                  t('page_titles.devices_guidance_how_to_order'),
+                  "Get laptops and tablets",
                  ]) %>
 <% end %>
 

--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -1,9 +1,10 @@
 <% content_for :browser_title, "#{@title} – #{t('page_titles.guide_to_collecting_mobile_information')}" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { t('page_titles.about_increasing_mobile_data') => about_increasing_mobile_data_path },
-                   t('page_titles.guide_to_collecting_mobile_information') ,
+  <% breadcrumbs([{ "Home" => guidance_page_path },
+                  { t('page_titles.internet_access') => connectivity_home_path },
+                  { t('page_titles.about_increasing_mobile_data_short') => about_increasing_mobile_data_path },
+                  t('page_titles.guide_to_collecting_mobile_information'),
                  ]) %>
 <% end %>
 

--- a/app/views/pages/about_bt_wifi.html.erb
+++ b/app/views/pages/about_bt_wifi.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, t('page_titles.about_bt_wifi') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => guidance_page_path },
+                  { t('page_titles.internet_access') => connectivity_home_path },
+                  t('page_titles.about_bt_wifi'),
+                 ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/about_increasing_mobile_data.html.erb
+++ b/app/views/pages/about_increasing_mobile_data.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, t('page_titles.about_increasing_mobile_data') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => guidance_page_path },
+                  { t('page_titles.internet_access') => connectivity_home_path },
+                  t('page_titles.about_increasing_mobile_data_short'),
+                 ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -35,7 +35,7 @@
 
     <p class="govuk-body">Choose this option if:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>the account holder is with a <%= govuk_link_to 'participating network', guide_to_collecting_mobile_information_telling_about_offer_path %></li>
+      <li>the account holder is with a <%= govuk_link_to 'participating network', guide_to_collecting_mobile_information_telling_about_offer_path(anchor: 'network-offers') %></li>
       <li>the child or young person can use the mobile device’s internet connection on a device suitable for learning (this is known as tethering)</li>
       <li>the owner of the mobile device will be at home when the child or young person is learning remotely</li>
       <li>the mobile phone has a strong signal at home</li>

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, t('page_titles.choosing_help_with_internet_access') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => guidance_page_path },
+                  { t('page_titles.internet_access') => connectivity_home_path },
+                  t('page_titles.choosing_help_with_internet_access'),
+                 ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, t('page_titles.how_request_4g_routers') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => guidance_page_path },
+                  { t('page_titles.internet_access') => connectivity_home_path },
+                  t('page_titles.how_request_4g_routers'),
+                 ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t('page_titles.internet_access') %>
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => guidance_page_path },
                   t('page_titles.internet_access'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
   page_titles:
     how_request_4g_routers: How to request 4G wireless routers
     choosing_help_with_internet_access: Choosing help with internet access
-    about_bt_wifi: Increasing children’s internet access through free BT hotspots
+    about_bt_wifi: Offering free access to BT wifi hotspots
     api_tokens: Your API tokens
     bt_wifi_privacy_notice: How we look after personal data for the BT wifi hotspot scheme
     about_increasing_mobile_data: Increasing data allowances on mobile devices to support disadvantaged children

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
     weve_processed_your_spreadsheet: We’ve processed your spreadsheet
     guide_to_collecting_mobile_information: Guide to collecting mobile information
     start: Get help with technology
-    internet_access: Getting internet access
+    internet_access: Get internet access
     who_needs_the_data: Who needs the extra mobile data?
     report_a_problem: Report a problem
     devices_guidance_how_to_order: "How and when to order laptops and tablets during coronavirus (COVID-19)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     api_tokens: Your API tokens
     bt_wifi_privacy_notice: How we look after personal data for the BT wifi hotspot scheme
     about_increasing_mobile_data: Increasing data allowances on mobile devices to support disadvantaged children
+    about_increasing_mobile_data_short: Increasing data allowances on mobile devices
     increasing_mobile_data_privacy_notice: How we look after personal information for the Increasing Children’s Mobile Data scheme
     sign_in_or_create_account: Create an account or sign in
     sign_in: Sign in


### PR DESCRIPTION
- Use breadcrumbs in the Get internet access section
- Simplify some of the longer page titles

<img width="662" alt="Screen Shot 2020-11-11 at 20 55 41" src="https://user-images.githubusercontent.com/319055/98863477-59623200-2460-11eb-8a4f-316db972f296.png">
<img width="716" alt="Screen Shot 2020-11-11 at 20 55 35" src="https://user-images.githubusercontent.com/319055/98863479-59fac880-2460-11eb-8066-147fbd32477a.png">
<img width="682" alt="Screen Shot 2020-11-11 at 20 55 26" src="https://user-images.githubusercontent.com/319055/98863481-5a935f00-2460-11eb-949c-050d57b5ce9e.png">
<img width="732" alt="Screen Shot 2020-11-11 at 20 55 22" src="https://user-images.githubusercontent.com/319055/98863482-5a935f00-2460-11eb-8f26-157992733e8f.png">
<img width="978" alt="Screen Shot 2020-11-11 at 20 55 51" src="https://user-images.githubusercontent.com/319055/98863471-57986e80-2460-11eb-8e55-eb86159884a2.png">
