### PR TITLE
Tweak collecting mobile information guide

### DIFF
--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -12,7 +12,7 @@
 </h1>
 
 <h2 class="govuk-heading-s">Contents</h2>
-<ol class="govuk-list govuk-list--bullet">
+<ol class="govuk-list govuk-list--number">
   <% @contents.each do |item| %>
     <li>
       <% if item[:active] %>
@@ -26,4 +26,4 @@
 
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
-<h2 class="govuk-heading-l"><%= @title %></h2>
+<h2 class="govuk-heading-l"><%= index %>. <%= @title %></h2>

--- a/app/views/guide_to_collecting_mobile_information/asking_for_account_holder.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/asking_for_account_holder.html.erb
@@ -9,7 +9,7 @@
       <li>their mobile phone number (this should always start with ‘07’)</li>
     </ul>
 
-    <p class="govuk-body">Check you’ve noted down these details correctly, then record them in the spreadsheet. Also make a note of their mobile network, and whether they’re on a contract or a Pay-as-you-go deal.</p>
+    <p class="govuk-body">Also make a note of their mobile network, and whether they’re on a contract or a Pay-as-you-go deal.</p>
 
     <p class="govuk-body">We need these details to arrange the increase in data with the relevant mobile network.</p>
 

--- a/app/views/guide_to_collecting_mobile_information/asking_for_account_holder.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/asking_for_account_holder.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'guide_contents' %>
+    <%= render partial: 'guide_contents', locals: { index: 5 } %>
 
     <p class="govuk-body">Find out the following from the account holder:</p>
 

--- a/app/views/guide_to_collecting_mobile_information/asking_for_network.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/asking_for_network.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'guide_contents' %>
+    <%= render partial: 'guide_contents', locals: { index: 2 } %>
 
     <p class="govuk-body">To check if the child or young person qualifies for an offer, you need to find out:</p>
 

--- a/app/views/guide_to_collecting_mobile_information/index.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/index.html.erb
@@ -30,12 +30,12 @@
 
     <p class="govuk-body">You also need to <%= govuk_link_to 'explain our privacy policy', guide_to_collecting_mobile_information_privacy_path %> to the account holder.</p>
 
-    <h3 class="govuk-heading-m" id="how-to-save-information">How to save information</h3>
+    <h3 class="govuk-heading-m" id="submit-information">Submit the information you collect</h3>
 
-    <p class="govuk-body">You can use the following template spreadsheet to save the information you’re collecting:</p>
-
+    <p class="govuk-body">You can submit information by using:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= govuk_link_to 'Excel Spreadsheet', '/collecting-mobile-information/extra-mobile-data-requests-template.xlsx' %></li>
+      <li>the ‘New request’ form on the service, making requests one at a time</li>
+      <li>an <%= govuk_link_to 'Excel Spreadsheet', '/collecting-mobile-information/extra-mobile-data-requests-template.xlsx' %>, which allows you to make multiple requests once you upload to the service</li>
     </ul>
 
     <%= render partial: 'shared/guide_navigation' %>

--- a/app/views/guide_to_collecting_mobile_information/index.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'guide_contents' %>
+    <%= render partial: 'guide_contents', locals: { index: 1 } %>
 
     <p class="govuk-body">This guide is for anyone who needs to explain the Department for Education’s pilot offer to increase mobile data allowances for children and young people.</p>
 

--- a/app/views/guide_to_collecting_mobile_information/index.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/index.html.erb
@@ -32,13 +32,11 @@
 
     <h3 class="govuk-heading-m" id="how-to-save-information">How to save information</h3>
 
-    <p class="govuk-body">Use one of the following template spreadsheets to save the information you’re collecting:</p>
+    <p class="govuk-body">You can use the following template spreadsheet to save the information you’re collecting:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= govuk_link_to 'Excel Spreadsheet', '/collecting-mobile-information/extra-mobile-data-requests-template.xlsx' %></li>
     </ul>
-
-    <p class="govuk-body">Return the completed spreadsheet to the local authority or trust that approached you about this scheme.</p>
 
     <%= render partial: 'shared/guide_navigation' %>
   </div>

--- a/app/views/guide_to_collecting_mobile_information/privacy.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/privacy.html.erb
@@ -31,7 +31,7 @@
 
     <p class="govuk-body">If the account holder wants to receive some written information first, you can send them a link to our <%= govuk_link_to 'privacy information', increasing_mobile_data_privacy_notice_path %>.</p>
 
-    <p class="govuk-body">If they want to take up the offer, you need to confirm you’ve explained the privacy policy. Once you’ve done this, complete the privacy column in the spreadsheet.</p>
+    <p class="govuk-body">If they want to take up the offer, you will need to confirm you’ve explained the privacy policy.</p>
 
     <%= render partial: 'shared/guide_navigation' %>
   </div>

--- a/app/views/guide_to_collecting_mobile_information/privacy.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/privacy.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body">Those affected by the offer need to understand how we’ll use their personal information.</p>
 
-    <p class="govuk-body">Please read the following privacy statement out loud to:</p>
+    <p class="govuk-body">Please share the following privacy statement with:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the adult account holder for the mobile device</li>
@@ -31,7 +31,7 @@
 
     <p class="govuk-body">If the account holder wants to receive some written information first, you can send them a link to our <%= govuk_link_to 'privacy information', increasing_mobile_data_privacy_notice_path %>.</p>
 
-    <p class="govuk-body">If they want to take up the offer, you will need to confirm you’ve explained the privacy policy.</p>
+    <p class="govuk-body">If they want to take up the offer, you will need to confirm you’ve shared the privacy policy.</p>
 
     <%= render partial: 'shared/guide_navigation' %>
   </div>

--- a/app/views/guide_to_collecting_mobile_information/privacy.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/privacy.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'guide_contents' %>
+    <%= render partial: 'guide_contents', locals: { index: 4 } %>
 
     <p class="govuk-body">Those affected by the offer need to understand how we’ll use their personal information.</p>
 

--- a/app/views/guide_to_collecting_mobile_information/telling_about_offer.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/telling_about_offer.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'guide_contents' %>
+    <%= render partial: 'guide_contents', locals: { index: 3 } %>
 
     <p class="govuk-body">What data someone will get depends on their mobile network. Some networks can’t offer data to Pay-as-you-go (PAYG) customers.</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,9 +256,9 @@ en:
   guide_to_collecting_mobile_information:
     overview: Overview
     asking_for_network: Asking about mobile network, contracts and Pay-as-you-go (PAYG)
-    asking_for_account_holder: Asking for account holder name and mobile number
     telling_about_offer: Telling them about their offer
     privacy: Explaining our privacy policy
+    asking_for_account_holder: Asking for account holder name and mobile number
   school:
     chromebooks:
       success: We’ve saved your choices


### PR DESCRIPTION
### Context

- Add numbers to pages of guide to highlight it's a multi-step process
- Remove references to spreadsheets, users might be recording in spreadsheet or directly (before they had to use the spreadsheet)
- Fix spreadsheet description, it does not need to be returned anywhere
- Don't emphasis "reading out" the privacy statement, a written version could be shared

<img width="742" alt="Screen Shot 2020-11-11 at 21 58 19" src="https://user-images.githubusercontent.com/319055/98869158-42740d80-2469-11eb-9ce2-c630a4e34fbf.png">


