### PR TITLE
Redirect /start and /sign-in if user is already signed in

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,11 @@ class PagesController < ApplicationController
 
   def suggested_email_to_schools; end
 
-  def start; end
+  def start
+    if SessionService.is_signed_in?(session) && @user
+      redirect_to root_url_for(@user)
+    end
+  end
 
   def home_page; end
 

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -1,7 +1,11 @@
 class SignInTokensController < ApplicationController
   def new
-    @sign_in_token_form ||= SignInTokenForm.new
-    render :sign_in_only
+    if SessionService.is_signed_in?(session) && @user
+      redirect_to root_url_for(@user)
+    else
+      @sign_in_token_form ||= SignInTokenForm.new
+      render :sign_in_only
+    end
   end
 
   # GET /token/validate

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -20,6 +20,24 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     expect(page).to have_content('Sign in')
   end
 
+  context 'user has already signed in' do
+    let(:user) { create(:local_authority_user, :has_seen_privacy_notice) }
+
+    scenario 'visiting sign in when already signed in redirects user to home page' do
+      sign_in_as user
+      visit sign_in_path
+      expect(page).to have_current_path(responsible_body_home_path)
+      expect(page).to have_text 'Get help with technology'
+    end
+
+    scenario 'visiting start page when already signed in redirects user to home page' do
+      sign_in_as user
+      visit start_path
+      expect(page).to have_current_path(responsible_body_home_path)
+      expect(page).to have_text 'Get help with technology'
+    end
+  end
+
   scenario 'supplying a valid email sends a token' do
     visit sign_in_path
     fill_in('Email address', with: user.email_address)


### PR DESCRIPTION
Send users directly to their appropriate home page

In research we've observed signed in users reaching the "Sign in" and "Start" pages again, and unnecessarily going back through the sign in flow.