### PR TITLE
Enable support users to edit a school's Chromebook details

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -57,7 +57,13 @@ private
   end
 
   def chromebook_rows_if_needed
-    super.map { |row| row.except(:change_path, :action, :action_path) }
+    super.map do |row|
+      row
+        .except(:change_path, :action, :action_path)
+        .merge(
+          change_path: support_school_devices_chromebooks_edit_path(school_urn: @school.urn),
+        )
+    end
   end
 
   def headteacher

--- a/app/controllers/support/schools/devices/chromebooks_controller.rb
+++ b/app/controllers/support/schools/devices/chromebooks_controller.rb
@@ -1,0 +1,40 @@
+class Support::Schools::Devices::ChromebooksController < Support::BaseController
+  before_action :set_school
+
+  def edit
+    @chromebook_information_form = ChromebookInformationForm.new(
+      school: @school,
+      will_need_chromebooks: @school.preorder_information&.will_need_chromebooks,
+      school_or_rb_domain: @school.preorder_information&.school_or_rb_domain,
+      recovery_email_address: @school.preorder_information&.recovery_email_address,
+    )
+  end
+
+  def update
+    @preorder_info = @school.preorder_information
+    @chromebook_information_form = ChromebookInformationForm.new(
+      { school: @school }.merge(chromebook_params),
+    )
+    if @chromebook_information_form.valid?
+      @preorder_info.update_chromebook_information_and_status!(chromebook_params)
+      flash[:success] = t(:success, scope: %w[school chromebooks])
+      redirect_to support_school_path(@school)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_school
+    @school = School.find_by_urn(params[:school_urn])
+  end
+
+  def chromebook_params
+    params.require(:chromebook_information_form).permit(
+      :will_need_chromebooks,
+      :school_or_rb_domain,
+      :recovery_email_address,
+    )
+  end
+end

--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -1,7 +1,7 @@
 <% if @school %>
   <%- title = t('page_titles.school_request_devices') %>
   <%- content_for :before_content do %>
-    <% if @school.mno_feature_flag %>
+    <% if @school&.mno_feature_flag %>
       <% breadcrumbs([{ "Home" => home_school_path },
                     { t('page_titles.school_specific_circumstances') => specific_circumstances_school_path(@school) },
                     title

--- a/app/views/support/schools/devices/chromebooks/edit.html.erb
+++ b/app/views/support/schools/devices/chromebooks/edit.html.erb
@@ -1,0 +1,15 @@
+<%- title = t('page_titles.support_edit_chromebook_details') %>
+<%- content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', support_school_path(@school.urn), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <%= render partial: 'shared/chromebook_information_intro' %>
+    <%= render partial: 'shared/chromebook_information_form', locals: { url: support_school_devices_chromebooks_path(@school), form_object: @chromebook_information_form } %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
     support_edit_allocation:
       std_device: Change device allocation
       coms_device: Change router allocation
+    support_edit_chromebook_details: Will the school need to order Chromebooks?
     support_bulk_allocation: Allow schools to order their full allocation
     support_bulk_allocation_result: Bulk allocation summary
     upload_key_contacts_file: Upload a CSV file of key contacts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,8 @@ Rails.application.routes.draw do
       patch '/devices/enable-orders', to: 'schools/devices/order_status#update'
       get '/devices/allocation/edit', to: 'schools/devices/allocation#edit'
       patch '/devices/allocation', to: 'schools/devices/allocation#update'
+      get '/devices/chromebooks/edit', to: 'schools/devices/chromebooks#edit'
+      patch '/devices/chromebooks', to: 'schools/devices/chromebooks#update'
     end
     namespace :performance_data, path: 'performance-data' do
       resources :schools, only: :index

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -100,9 +100,9 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
 
-      expect(action_for_row(result, 'Ordering Chromebooks?')).not_to be_present
-      expect(action_for_row(result, 'Domain')).not_to be_present
-      expect(action_for_row(result, 'Recovery email')).not_to be_present
+      expect(action_for_row(result, 'Ordering Chromebooks?')).to be_present
+      expect(action_for_row(result, 'Domain')).to be_present
+      expect(action_for_row(result, 'Recovery email')).to be_present
     end
 
     it 'does not show the school contact even if the school contact is set' do

--- a/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
+++ b/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing a school’s Chromebook details from the support area' do
+  let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }
+
+  before do
+    allow(Gsuite).to receive(:is_gsuite_domain?).and_return(true)
+    given_i_sign_in_as_a_support_user_with_access_to_the_computacenter_area
+  end
+
+  scenario 'setting Chromebook information' do
+    given_a_school_with_preorder_information
+    and_the_school_does_not_have_chromebook_information_specified
+
+    when_i_navigate_to_the_school_page_in_support
+    and_i_add_chromebook_information
+
+    then_the_chromebook_details_are_updated_in_the_support_console
+    and_the_chromebook_details_are_updated_in_the_computacenter_chromebook_details_feed
+  end
+
+  scenario 'removing Chromebook information' do
+    given_a_school_with_preorder_information
+    and_the_school_has_chromebook_information_specified
+
+    when_i_navigate_to_the_school_page_in_support
+    and_i_remove_chromebook_information
+
+    then_the_chromebook_details_are_not_present_in_the_support_console
+    and_the_chromebook_details_are_not_present_in_the_computacenter_chromebook_details_feed
+  end
+
+  def given_a_school_with_preorder_information
+    @school = create(:school, :la_maintained, :with_preorder_information)
+  end
+
+  def and_the_school_does_not_have_chromebook_information_specified
+    @school.preorder_information.update(
+      will_need_chromebooks: 'no',
+      school_or_rb_domain: nil,
+      recovery_email_address: nil,
+    )
+  end
+
+  def and_the_school_has_chromebook_information_specified
+    @school.preorder_information.update(
+      will_need_chromebooks: 'yes',
+      school_or_rb_domain: 'somedomain.com',
+      recovery_email_address: 'someone@someotherdomain.com',
+    )
+  end
+
+  def given_i_sign_in_as_a_support_user_with_access_to_the_computacenter_area
+    sign_in_as create(:support_user, is_computacenter: true)
+  end
+
+  def when_i_navigate_to_the_school_page_in_support
+    visit support_school_path(@school.urn)
+    expect(school_details_page).to be_displayed
+  end
+
+  def and_i_add_chromebook_information
+    school_details_page
+      .school_details['Ordering Chromebooks?']
+      .follow_action_link
+
+    choose 'Yes, we will order Chromebooks'
+    fill_in 'School or local authority domain', with: 'somedomain.com'
+    fill_in 'Recovery email address', with: 'someone@someotherdomain.com'
+    click_on 'Save'
+  end
+
+  def and_i_remove_chromebook_information
+    school_details_page
+      .school_details['Ordering Chromebooks?']
+      .follow_action_link
+
+    choose 'No, we will not order Chromebooks'
+    click_on 'Save'
+  end
+
+  def then_the_chromebook_details_are_updated_in_the_support_console
+    expect(school_details_page.school_details['Ordering Chromebooks?'].value).to eq('Yes, we will order Chromebooks')
+    expect(school_details_page.school_details['Domain'].value).to eq('somedomain.com')
+    expect(school_details_page.school_details['Recovery email'].value).to eq('someone@someotherdomain.com')
+  end
+
+  def then_the_chromebook_details_are_not_present_in_the_support_console
+    expect(school_details_page.school_details['Ordering Chromebooks?'].value).to eq('No, we will not order Chromebooks')
+    expect(school_details_page.school_details['Domain']).to be_nil
+    expect(school_details_page.school_details['Recovery email']).to be_nil
+  end
+
+  def and_the_chromebook_details_are_updated_in_the_computacenter_chromebook_details_feed
+    visit computacenter_home_path
+    click_on 'Download Chromebook details'
+    expect(page.body).to include([@school.urn, 'somedomain.com', 'someone@someotherdomain.com'].join(','))
+  end
+
+  def and_the_chromebook_details_are_not_present_in_the_computacenter_chromebook_details_feed
+    visit computacenter_home_path
+    click_on 'Download Chromebook details'
+    expect(page.body).not_to include(@school.urn.to_s)
+  end
+end

--- a/spec/page_objects/support/school_details_page.rb
+++ b/spec/page_objects/support/school_details_page.rb
@@ -1,9 +1,36 @@
 module PageObjects
   module Support
+    class SchoolDetailsRow < SitePrism::Section
+      element :key_element, 'dt'
+      element :value_element, 'dd:nth-of-type(1)'
+      element :action_element, 'dd:nth-of-type(2)'
+
+      def key
+        key_element.text
+      end
+
+      def value
+        value_element.text
+      end
+
+      def follow_action_link
+        action_element.find('a').click
+      end
+    end
+
+    class SchoolDetailsSummaryList < SitePrism::Section
+      sections :rows, SchoolDetailsRow, '.govuk-summary-list__row'
+
+      def [](key)
+        rows.find { |row| row.key == key }
+      end
+    end
+
     class SchoolDetailsPage < PageObjects::BasePage
       set_url '/support/schools/{urn}'
 
       elements :school_details_rows, '.school-details-summary-list .govuk-summary-list__row'
+      section :school_details, SchoolDetailsSummaryList, '.school-details-summary-list'
 
       element :contacts, 'table#contacts'
       element :invite_a_new_user, 'a', text: 'Invite a new user'


### PR DESCRIPTION
### Context

In the case that:

1. A school or RB user orders some Chromebooks
2. Post-ordering, Computacenter determine that the school's Chromebook details are missing or wrong
3. They inform the school/RB
4. If the school user writes back into support with their Chromebook details, instead of entering the details into the service

then the support agent has to explain the user to go enter it into the service themselves. This means wasted effort and a delay for the user.

### Changes proposed in this pull request

Allow support agents to update Chromebook details (yes/no on whether the school needs Chromebooks, the domain and recovery email), in case they get a ticket with those details.

### Guidance to review

The wording is a bit off ("when you order", "we", etc) as a result of reusing partials from the RB and school parts of the service, but it felt like a reasonable trade-off to having to duplicate the templates just for the support interface.

#### Screenshots

![image](https://user-images.githubusercontent.com/23801/98874593-74d63880-2472-11eb-8ccd-2d81746df67f.png)

![image](https://user-images.githubusercontent.com/23801/98874635-8586ae80-2472-11eb-937e-45550ce2c231.png)

