### PR TITLE
Authorise /support with pundit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,12 +54,14 @@ RSpec/EmptyLineAfterSubject:
   Exclude:
     - 'spec/factories.rb'
 
-# the Pundit RSpec DSL triggers this cop false positively
+# The Pundit RSpec DSL triggers this cop false positively
+# Although this may be resolved fairly soon, see https://github.com/rubocop-hq/rubocop-rspec/issues/333
 RSpec/RepeatedExample:
   Exclude:
     - 'spec/policies/**/*'
 
-# the Pundit RSpec DSL triggers this cop false positively
+# The Pundit RSpec DSL triggers this cop false positively
+# Although this may be resolved fairly soon, see https://github.com/rubocop-hq/rubocop-rspec/issues/333
 RSpec/RepeatedDescription:
   Exclude:
     - 'spec/policies/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,16 @@ RSpec/EmptyLineAfterSubject:
   Exclude:
     - 'spec/factories.rb'
 
+# the Pundit RSpec DSL triggers this cop false positively
+RSpec/RepeatedExample:
+  Exclude:
+    - 'spec/policies/**/*'
+
+# the Pundit RSpec DSL triggers this cop false positively
+RSpec/RepeatedDescription:
+  Exclude:
+    - 'spec/policies/**/*'
+
 Naming/MethodParameterName:
   AllowedNames:
     - e

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'pry-rails'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 
+# Use Pundit for authorisation
+gem 'pundit'
+
 # Rate-limiting
 gem 'rack-throttle'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.0.4)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
@@ -514,6 +516,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.0)
+  pundit
   rack-throttle
   rails (>= 6.0.3.1)
   rails-controller-testing

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -3,7 +3,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
     array = super
     array << headteacher_row if headteacher.present?
     array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row) if @school.mno_feature_flag?
-    array
+    array.map { |row| remove_change_links_if_read_only(row) }
   end
 
 private
@@ -94,5 +94,9 @@ private
 
   def display_router_allocation_row?
     true
+  end
+
+  def remove_change_links_if_read_only(row)
+    Pundit.policy(viewer, @school).edit? ? row : row.except(:change_path, :action, :action_path)
   end
 end

--- a/app/controllers/support/base_controller.rb
+++ b/app/controllers/support/base_controller.rb
@@ -1,13 +1,23 @@
 class Support::BaseController < ApplicationController
+  include Pundit
+
   before_action :require_dfe_user!
+  after_action :verify_authorized
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
 private
 
   def require_dfe_user!
-    if !SessionService.is_signed_in?(session)
+    unless SessionService.is_signed_in?(session)
       redirect_to_sign_in
-    elsif !@current_user.is_support?
-      render 'errors/forbidden', status: :forbidden
     end
   end
+
+  def user_not_authorized
+    render 'errors/forbidden', status: :forbidden
+  end
+
+  attr_reader :current_user
+  helper_method :current_user
 end

--- a/app/controllers/support/base_controller.rb
+++ b/app/controllers/support/base_controller.rb
@@ -3,6 +3,7 @@ class Support::BaseController < ApplicationController
 
   before_action :require_dfe_user!
   after_action :verify_authorized
+  after_action :verify_policy_scoped, only: %i[index results] # # rubocop:disable Rails/LexicallyScopedActionFilter
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/app/controllers/support/base_controller.rb
+++ b/app/controllers/support/base_controller.rb
@@ -3,11 +3,15 @@ class Support::BaseController < ApplicationController
 
   before_action :require_dfe_user!
   after_action :verify_authorized
-  after_action :verify_policy_scoped, only: %i[index results] # # rubocop:disable Rails/LexicallyScopedActionFilter
+  after_action :verify_policy_scoped, if: :index_method?
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
 private
+
+  def index_method?
+    %i[index results].include?(action_name)
+  end
 
   def require_dfe_user!
     unless SessionService.is_signed_in?(session)

--- a/app/controllers/support/home_controller.rb
+++ b/app/controllers/support/home_controller.rb
@@ -1,4 +1,6 @@
 class Support::HomeController < Support::BaseController
+  before_action { authorize :support }
+
   def show; end
 
   def schools; end

--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -20,11 +20,11 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
   end
 
   def edit
-    @user = @responsible_body.users.safe_to_show_to(@current_user).find(params[:id])
+    @user = policy_scope(@responsible_body.users).find(params[:id])
   end
 
   def update
-    @user = @responsible_body.users.safe_to_show_to(@current_user).find(params[:id])
+    @user = policy_scope(@responsible_body.users).find(params[:id])
 
     if @user.update(user_params)
       flash[:success] = 'User has been updated'
@@ -35,7 +35,7 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
   end
 
   def destroy
-    @user = @responsible_body.users.safe_to_show_to(@current_user).find(params[:id])
+    @user = policy_scope(@responsible_body.users).find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
     flash[:success] = 'User has been deleted'

--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -1,5 +1,6 @@
 class Support::ResponsibleBodies::UsersController < Support::BaseController
   before_action :set_responsible_body
+  before_action { authorize User }
 
   def new
     @user = @responsible_body.users.build
@@ -58,5 +59,6 @@ private
 
   def set_responsible_body
     @responsible_body = ResponsibleBody.find(params[:responsible_body_id])
+    authorize @responsible_body, :show?
   end
 end

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -1,4 +1,6 @@
 class Support::ResponsibleBodiesController < Support::BaseController
+  before_action { authorize ResponsibleBody }
+
   def index
     @responsible_bodies = ResponsibleBody
       .select('responsible_bodies.*')

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -2,7 +2,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
   before_action { authorize ResponsibleBody }
 
   def index
-    @responsible_bodies = ResponsibleBody
+    @responsible_bodies = policy_scope(ResponsibleBody)
       .select('responsible_bodies.*')
       .excluding_department_for_education
       .with_users_who_have_signed_in_at_least_once(privacy_notice_required: @current_user.is_computacenter?)

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -13,7 +13,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
 
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
-    @users = @responsible_body.users.safe_to_show_to(@current_user).not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
+    @users = policy_scope(@responsible_body.users).not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
     @schools = @responsible_body
       .schools
       .includes(:device_allocations, :preorder_information)

--- a/app/controllers/support/schools/devices/allocation_controller.rb
+++ b/app/controllers/support/schools/devices/allocation_controller.rb
@@ -29,7 +29,9 @@ private
 
   def set_school_and_allocation
     @school = School.find_by_urn(params[:school_urn])
+    authorize @school, :show?
     @allocation = SchoolDeviceAllocation.find_or_initialize_by(school: @school, device_type: device_type)
+    authorize @allocation
   end
 
   def allocation_params

--- a/app/controllers/support/schools/devices/chromebooks_controller.rb
+++ b/app/controllers/support/schools/devices/chromebooks_controller.rb
@@ -1,5 +1,6 @@
 class Support::Schools::Devices::ChromebooksController < Support::BaseController
   before_action :set_school
+  before_action { authorize PreorderInformation }
 
   def edit
     @chromebook_information_form = ChromebookInformationForm.new(
@@ -28,6 +29,7 @@ private
 
   def set_school
     @school = School.find_by_urn(params[:school_urn])
+    authorize @school, :show?
   end
 
   def chromebook_params

--- a/app/controllers/support/schools/devices/order_status_controller.rb
+++ b/app/controllers/support/schools/devices/order_status_controller.rb
@@ -1,5 +1,5 @@
 class Support::Schools::Devices::OrderStatusController < Support::BaseController
-  before_action :set_school
+  before_action :set_school, except: %i[collect_urns_to_allow_many_schools_to_order allow_ordering_for_many_schools]
 
   def edit
     @form = Support::EnableOrdersForm.new(existing_params.merge(enable_orders_form_params))
@@ -46,10 +46,12 @@ class Support::Schools::Devices::OrderStatusController < Support::BaseController
   end
 
   def collect_urns_to_allow_many_schools_to_order
+    authorize School, :edit?
     @form = Support::BulkAllocationForm.new
   end
 
   def allow_ordering_for_many_schools
+    authorize School, :edit?
     @form = Support::BulkAllocationForm.new(restriction_params)
 
     if @form.valid?
@@ -64,6 +66,7 @@ private
 
   def set_school
     @school = School.find_by_urn(params[:school_urn])
+    authorize @school, :show?
   end
 
   def existing_params

--- a/app/controllers/support/schools/users_controller.rb
+++ b/app/controllers/support/schools/users_controller.rb
@@ -1,11 +1,12 @@
 class Support::Schools::UsersController < Support::BaseController
+  before_action :set_school
+  before_action { authorize User }
+
   def new
-    @school = School.find_by(urn: params[:school_urn])
     @user = @school.users.build
   end
 
   def create
-    @school = School.find_by(urn: params[:school_urn])
     user_attributes = @school.users.build(user_params).attributes.merge(school_id: @school.id).symbolize_keys!
     @user = CreateUserService.invite_school_user(user_attributes)
 
@@ -17,12 +18,10 @@ class Support::Schools::UsersController < Support::BaseController
   end
 
   def edit
-    @school = School.find_by(urn: params[:school_urn])
     @user = present(@school.users.safe_to_show_to(@current_user).find(params[:id]))
   end
 
   def update
-    @school = School.find_by(urn: params[:school_urn])
     @user = @school.users.safe_to_show_to(@current_user).find(params[:id])
 
     if @user.update(user_params)
@@ -35,7 +34,6 @@ class Support::Schools::UsersController < Support::BaseController
   end
 
   def destroy
-    @school = School.find_by(urn: params[:school_urn])
     @user = @school.users.safe_to_show_to(@current_user).find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
@@ -45,6 +43,11 @@ class Support::Schools::UsersController < Support::BaseController
   end
 
 private
+
+  def set_school
+    @school = School.find_by(urn: params[:school_urn])
+    authorize @school, :show?
+  end
 
   def present(user)
     SchoolUserPresenter.new(user)

--- a/app/controllers/support/schools/users_controller.rb
+++ b/app/controllers/support/schools/users_controller.rb
@@ -18,11 +18,11 @@ class Support::Schools::UsersController < Support::BaseController
   end
 
   def edit
-    @user = present(@school.users.safe_to_show_to(@current_user).find(params[:id]))
+    @user = present(policy_scope(@school.users).find(params[:id]))
   end
 
   def update
-    @user = @school.users.safe_to_show_to(@current_user).find(params[:id])
+    @user = policy_scope(@school.users).find(params[:id])
 
     if @user.update(user_params)
       flash[:success] = 'User has been updated'
@@ -34,7 +34,7 @@ class Support::Schools::UsersController < Support::BaseController
   end
 
   def destroy
-    @user = @school.users.safe_to_show_to(@current_user).find(params[:id])
+    @user = policy_scope(@school.users).find(params[:id])
     @user.update!(deleted_at: Time.zone.now)
 
     flash[:success] = 'User has been deleted'

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -1,4 +1,6 @@
 class Support::SchoolsController < Support::BaseController
+  before_action { authorize School }
+
   def search
     @search_form = BulkUrnSearchForm.new
   end

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -12,7 +12,7 @@ class Support::SchoolsController < Support::BaseController
 
   def show
     @school = School.find_by!(urn: params[:urn])
-    @users = @school.users.safe_to_show_to(@current_user).not_deleted
+    @users = policy_scope(@school.users).not_deleted
     @email_audits = @school.email_audits.order(created_at: :desc)
   end
 

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -7,7 +7,7 @@ class Support::SchoolsController < Support::BaseController
 
   def results
     @search_form = BulkUrnSearchForm.new(search_params)
-    @schools = @search_form.schools.includes(:preorder_information, :responsible_body)
+    @schools = policy_scope(@search_form.schools).includes(:preorder_information, :responsible_body)
   end
 
   def show

--- a/app/controllers/support/service_performance_controller.rb
+++ b/app/controllers/support/service_performance_controller.rb
@@ -1,4 +1,6 @@
 class Support::ServicePerformanceController < Support::BaseController
+  before_action { authorize :support }
+
   def index
     @stats = Support::ServicePerformance.new
   end

--- a/app/controllers/support/service_performance_controller.rb
+++ b/app/controllers/support/service_performance_controller.rb
@@ -1,7 +1,8 @@
 class Support::ServicePerformanceController < Support::BaseController
-  before_action { authorize :support }
+  before_action { authorize Support::ServicePerformance }
 
   def index
+    skip_policy_scope
     @stats = Support::ServicePerformance.new
   end
 end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -10,9 +10,8 @@ class Support::UsersController < Support::BaseController
   def results
     @search_form = Support::UserSearchForm.new(search_params)
     @search_term = @search_form.email_address_or_full_name
-    @results = User
+    @results = policy_scope(User)
       .from_responsible_body_or_schools
-      .safe_to_show_to(@current_user)
       .search_by_email_address_or_full_name(@search_term)
       .distinct
       .includes(:responsible_body, :schools)

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,6 +1,8 @@
 class Support::UsersController < Support::BaseController
   SEARCH_RESULTS_LIMIT = 100
 
+  before_action { authorize User }
+
   def search
     @search_form = Support::UserSearchForm.new
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,12 +35,6 @@ class User < ApplicationRecord
   scope :search_by_email_address_or_full_name, lambda { |search_term|
     where('email_address ILIKE ? OR full_name ILIKE ?', "%#{search_term}%", "%#{search_term}%")
   }
-  # used in /support/ to avoid showing user contact info to third parties if the
-  # user hasn't accepted the privacy notice
-  scope :safe_to_show_to, lambda { |user|
-    # TODO: update this check once we have a proper authorization system in place
-    user.is_computacenter? ? where.not(privacy_notice_seen_at: nil) : all
-  }
 
   validates :full_name,
             presence: true,

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, 'must be logged in' unless user
+
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      raise Pundit::NotAuthorizedError, 'must be logged in' unless user
+
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/local_authority_policy.rb
+++ b/app/policies/local_authority_policy.rb
@@ -1,0 +1,2 @@
+class LocalAuthorityPolicy < ResponsibleBodyPolicy
+end

--- a/app/policies/preorder_information_policy.rb
+++ b/app/policies/preorder_information_policy.rb
@@ -1,0 +1,2 @@
+class PreorderInformationPolicy < SupportPolicy
+end

--- a/app/policies/responsible_body_policy.rb
+++ b/app/policies/responsible_body_policy.rb
@@ -1,2 +1,7 @@
 class ResponsibleBodyPolicy < SupportPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
 end

--- a/app/policies/responsible_body_policy.rb
+++ b/app/policies/responsible_body_policy.rb
@@ -1,0 +1,2 @@
+class ResponsibleBodyPolicy < SupportPolicy
+end

--- a/app/policies/school_device_allocation_policy.rb
+++ b/app/policies/school_device_allocation_policy.rb
@@ -1,0 +1,2 @@
+class SchoolDeviceAllocationPolicy < SupportPolicy
+end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -1,0 +1,6 @@
+class SchoolPolicy < SupportPolicy
+  alias_method :search?, :readable?
+  alias_method :results?, :readable?
+  alias_method :invite?, :editable?
+  alias_method :confirm_invitation?, :editable?
+end

--- a/app/policies/support/service_performance_policy.rb
+++ b/app/policies/support/service_performance_policy.rb
@@ -1,0 +1,5 @@
+class Support::ServicePerformancePolicy < ApplicationPolicy
+  def index?
+    user.is_support?
+  end
+end

--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -1,0 +1,20 @@
+class SupportPolicy < ApplicationPolicy
+  def readable?
+    user.is_support? || user.is_computacenter?
+  end
+
+  def editable?
+    user.is_support?
+  end
+
+  alias_method :index?, :readable?
+  alias_method :show?, :readable?
+  alias_method :schools?, :readable?
+
+  alias_method :new?, :editable?
+  alias_method :create?, :editable?
+  alias_method :edit?, :editable?
+  alias_method :update?, :editable?
+  alias_method :destroy?, :editable?
+  alias_method :technical_support?, :editable?
+end

--- a/app/policies/trust_policy.rb
+++ b/app/policies/trust_policy.rb
@@ -1,0 +1,2 @@
+class TrustPolicy < ResponsibleBodyPolicy
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,16 @@
 class UserPolicy < SupportPolicy
+  class Scope < Scope
+    def resolve
+      if user.is_computacenter?
+        scope.where.not(privacy_notice_seen_at: nil)
+      elsif user.is_support?
+        scope.all
+      else
+        raise 'Unexpected user type in user policy scope'
+      end
+    end
+  end
+
   alias_method :search?, :readable?
   alias_method :results?, :readable?
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,4 @@
+class UserPolicy < SupportPolicy
+  alias_method :search?, :readable?
+  alias_method :results?, :readable?
+end

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -30,15 +30,17 @@
       <li>enable orders for many schools</li>
     </ul>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Service performance', support_service_performance_path %>
-    </h2>
+    <% if policy(Support::ServicePerformance).index? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Service performance', support_service_performance_path %>
+      </h2>
 
-    <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>see the service performance for the device reserve</li>
-      <li>see the service performance for the connectivity offers</li>
-    </ul>
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>see the service performance for the device reserve</li>
+        <li>see the service performance for the connectivity offers</li>
+      </ul>
+    <% end %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Technical support', support_technical_support_path %>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -42,10 +42,12 @@
       </ul>
     <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Technical support', support_technical_support_path %>
-    </h2>
+    <% if policy(:support).technical_support? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Technical support', support_technical_support_path %>
+      </h2>
 
-    <p class="govuk-body">Use this section to see the background queues and jobs running on the service</p>
+      <p class="govuk-body">Use this section to see the background queues and jobs running on the service</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -13,15 +13,19 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
 
-<%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
+<% if policy(User).new? %>
+  <%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
+<% end %>
 
 <% if @users.present? %>
   <% @users.each do |user| %>
     <div class="user">
       <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-1"><%= user.full_name %></h3>
-      <p class="govuk-body">
-        <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user, pilot: 'devices') %>
-      </p>
+      <% if policy(user).edit? %>
+        <p class="govuk-body">
+          <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user) %>
+        </p>
+      <% end %>
       <%= render Support::UserSummaryListComponent.new(user: user) %>
     </div>
   <% end %>
@@ -58,7 +62,7 @@
           <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
         </td>
         <td class="govuk-table__cell">
-          <% if school&.preorder_information&.school_will_be_contacted? %>
+          <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>
             <%= govuk_link_to 'Invite', support_school_confirm_invitation_path(school_urn: school.urn) %>
           <% end %>
         </td>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -17,10 +17,13 @@
   </div>
 </div>
 
-<%= render Support::SchoolDetailsSummaryListComponent.new(school: @school) %>
+<%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: current_user) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
-<%= govuk_button_link_to t('page_titles.new_school_user'), new_support_school_user_path(school_urn: @school.urn) %>
+
+<% if policy(User).new? %>
+  <%= govuk_button_link_to t('page_titles.new_school_user'), new_support_school_user_path(school_urn: @school.urn) %>
+<% end %>
 
 <% if @users.present? %>
   <% @users.each do |user| %>

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -8,8 +8,9 @@ describe Support::SchoolDetailsSummaryListComponent do
            email_address: 'davy.jones@school.sch.uk',
            phone_number: '12345')
   end
+  let(:support_user) { build(:support_user) }
 
-  subject(:result) { render_inline(described_class.new(school: school)) }
+  subject(:result) { render_inline(described_class.new(school: school, viewer: support_user)) }
 
   def row_for_key(doc, key)
     doc.css('.govuk-summary-list__row').find { |row| row.css('dt').text.strip == key }

--- a/spec/controllers/support/responsible_bodies/users_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies/users_controller_spec.rb
@@ -2,19 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
   let(:dfe_user) { create(:dfe_user) }
+  let(:responsible_body) { create(:local_authority) }
 
   describe '#create' do
     context 'for support users', versioning: true do
-      let(:responsible_body) { create(:local_authority) }
-
       before do
         sign_in_as dfe_user
       end
 
       def perform_create!
         post :create, params: { responsible_body_id: responsible_body.id,
-                                user: attributes_for(:user),
-                                pilot: 'devices' }
+                                user: attributes_for(:user) }
       end
 
       it 'creates users' do
@@ -45,7 +43,7 @@ RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
     it 'is forbidden for MNO users' do
       sign_in_as create(:mno_user)
 
-      post :create, params: { responsible_body_id: 1, user: { some: 'data' } }
+      post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -53,13 +51,13 @@ RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
     it 'is forbidden for responsible body users' do
       sign_in_as create(:trust_user)
 
-      post :create, params: { responsible_body_id: 1, user: { some: 'data' } }
+      post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
 
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'redirects to / for unauthenticated users' do
-      post :create, params: { responsible_body_id: 1, user: { some: 'data' } }
+      post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
 
       expect(response).to redirect_to(sign_in_path)
     end

--- a/spec/controllers/support/responsible_bodies/users_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies/users_controller_spec.rb
@@ -41,19 +41,15 @@ RSpec.describe Support::ResponsibleBodies::UsersController, type: :controller do
     end
 
     it 'is forbidden for MNO users' do
-      sign_in_as create(:mno_user)
-
-      post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
-
-      expect(response).to have_http_status(:forbidden)
+      expect {
+        post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
+      }.to be_forbidden_for(create(:mno_user))
     end
 
     it 'is forbidden for responsible body users' do
-      sign_in_as create(:trust_user)
-
-      post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
-
-      expect(response).to have_http_status(:forbidden)
+      expect {
+        post :create, params: { responsible_body_id: responsible_body.id, user: { some: 'data' } }
+      }.to be_forbidden_for(create(:trust_user))
     end
 
     it 'redirects to / for unauthenticated users' do

--- a/spec/controllers/support/responsible_bodies_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies_controller_spec.rb
@@ -3,19 +3,11 @@ require 'rails_helper'
 RSpec.describe Support::ResponsibleBodiesController, type: :controller do
   describe 'index' do
     it 'is forbidden for MNO users' do
-      sign_in_as create(:mno_user)
-
-      get :index
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :index }.to be_forbidden_for(create(:mno_user))
     end
 
     it 'is forbidden for responsible body users' do
-      sign_in_as create(:trust_user)
-
-      get :index
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :index }.to be_forbidden_for(create(:trust_user))
     end
 
     it 'redirects to / for unauthenticated users' do

--- a/spec/controllers/support/schools/users_controller_spec.rb
+++ b/spec/controllers/support/schools/users_controller_spec.rb
@@ -3,20 +3,28 @@ require 'rails_helper'
 RSpec.describe Support::Schools::UsersController do
   let(:support_user) { create(:support_user) }
   let(:school) { create(:school) }
-
-  before do
-    sign_in_as support_user
-  end
+  let(:existing_user) { create(:school_user, school: school) }
 
   describe '#new' do
-    it 'loads' do
+    it 'is successful for support users' do
+      sign_in_as support_user
       get :new, params: { school_urn: school.urn }
       expect(response).to be_successful
+    end
+
+    it 'is forbidden for computacenter users' do
+      expect {
+        get :new, params: { school_urn: school.urn }
+      }.to be_forbidden_for(create(:computacenter_user))
     end
   end
 
   describe '#create' do
-    context 'happy path' do
+    context 'for a support user, with valid new user details' do
+      before do
+        sign_in_as support_user
+      end
+
       def post!
         post :create, params: {
           school_urn: school.urn,
@@ -56,7 +64,11 @@ RSpec.describe Support::Schools::UsersController do
       end
     end
 
-    context 'when there is an error' do
+    context 'for a support user, when there is an error' do
+      before do
+        sign_in_as support_user
+      end
+
       def post!
         post :create, params: {
           school_urn: school.urn,
@@ -77,24 +89,89 @@ RSpec.describe Support::Schools::UsersController do
         expect(response).to render_template(:new)
       end
     end
+
+    it 'is forbidden for a computacenter user' do
+      expect {
+        post :create, params: {
+          school_urn: school.urn,
+          user: {
+            full_name: 'John Doe',
+            email_address: 'john@example.com',
+            orders_devices: '0',
+          },
+        }
+      }.to be_forbidden_for(create(:computacenter_user))
+    end
+  end
+
+  describe '#edit' do
+    it 'is successful for support users' do
+      expect {
+        get :edit, params: { school_urn: school.urn, id: existing_user.id }
+      }.to receive_status_ok_for(support_user)
+    end
+
+    it 'is forbidden for computacenter users' do
+      expect {
+        get :edit, params: { school_urn: school.urn, id: existing_user.id }
+      }.to be_forbidden_for(create(:computacenter_user))
+    end
+  end
+
+  describe '#update' do
+    it 'is successful for support users' do
+      sign_in_as support_user
+
+      put :update, params: {
+        school_urn: school.urn,
+        id: existing_user.id,
+        user: {
+          full_name: 'someone_else',
+        },
+      }
+
+      expect(response).to redirect_to(support_school_path(school))
+    end
+
+    it 'is forbidden for computacenter users' do
+      expect {
+        put :update, params: {
+          school_urn: school.urn,
+          id: existing_user.id,
+          user: {
+            full_name: 'someone_else',
+          },
+        }
+      }.to be_forbidden_for(create(:computacenter_user))
+    end
   end
 
   describe '#destroy' do
     let(:user) { create(:school_user) }
     let(:school) { user.school }
 
-    before do
-      sign_in_as support_user
+    context 'for support users' do
+      before do
+        sign_in_as support_user
+      end
+
+      it 'sets user deleted_at timestamp' do
+        delete :destroy, params: { school_urn: school.urn, id: user.id }
+        expect(user.reload.deleted_at).to be_present
+      end
+
+      it 'redirects back to the school' do
+        delete :destroy, params: { school_urn: school.urn, id: user.id }
+        expect(response).to redirect_to(support_school_path(school))
+      end
     end
 
-    it 'sets user deleted_at timestamp' do
-      delete :destroy, params: { school_urn: school.urn, id: user.id }
-      expect(user.reload.deleted_at).to be_present
-    end
-
-    it 'redirects back to the school' do
-      delete :destroy, params: { school_urn: school.urn, id: user.id }
-      expect(response).to redirect_to(support_school_path(school))
+    context 'for computacenter users' do
+      it 'is forbidden' do
+        expect {
+          delete :destroy, params: { school_urn: school.urn, id: user.id }
+        }.to be_forbidden_for(create(:computacenter_user))
+      end
     end
   end
 end

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -31,19 +31,11 @@ RSpec.describe Support::SchoolsController, type: :controller do
 
   describe 'show' do
     it 'is forbidden for MNO users' do
-      sign_in_as create(:mno_user)
-
-      get :show, params: { urn: school.urn }
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :show, params: { urn: school.urn } }.to be_forbidden_for(create(:mno_user))
     end
 
     it 'is forbidden for responsible body users' do
-      sign_in_as create(:trust_user)
-
-      get :show, params: { urn: school.urn }
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :show, params: { urn: school.urn } }.to be_forbidden_for(create(:trust_user))
     end
 
     it 'redirects to / for unauthenticated users' do

--- a/spec/controllers/support/service_performance_controller_spec.rb
+++ b/spec/controllers/support/service_performance_controller_spec.rb
@@ -11,19 +11,11 @@ RSpec.describe Support::ServicePerformanceController, type: :controller do
     end
 
     it 'is forbidden for MNO users' do
-      sign_in_as create(:mno_user)
-
-      get :index
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :index }.to be_forbidden_for(create(:mno_user))
     end
 
     it 'is forbidden for responsible body users' do
-      sign_in_as create(:trust_user)
-
-      get :index
-
-      expect(response).to have_http_status(:forbidden)
+      expect { get :index }.to be_forbidden_for(create(:trust_user))
     end
 
     it 'redirects to / for unauthenticated users' do

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Support::UsersController do
       sign_in_as support_user
       post :results, params: { support_user_search_form: { email_address_or_full_name: 'Smith' } }
 
-      expect(assigns[:results]).to contain_exactly(user_who_has_seen_privacy_notice,  user_who_has_not_seen_privacy_notice)
+      expect(assigns[:results]).to contain_exactly(user_who_has_seen_privacy_notice, user_who_has_not_seen_privacy_notice)
     end
 
     it 'returns all matching school and RB users who have seen the privacy notice for Computacenter users' do

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Support::UsersController do
+  let(:support_user) { create(:support_user) }
+  let(:user_who_has_seen_privacy_notice) { create(:school_user, :has_seen_privacy_notice, full_name: 'Jane Smith') }
+  let(:user_who_has_not_seen_privacy_notice) { create(:school_user, :has_not_seen_privacy_notice, full_name: 'John Smith') }
+
+  describe '#search' do
+    it 'is successful for support users' do
+      expect {
+        get :search
+      }.to receive_status_ok_for(support_user)
+    end
+
+    it 'is successful for computacenter users' do
+      expect {
+        get :search
+      }.to receive_status_ok_for(create(:computacenter_user))
+    end
+  end
+
+  describe '#results' do
+    before do
+      user_who_has_seen_privacy_notice
+      user_who_has_not_seen_privacy_notice
+    end
+
+    it 'returns all matching school and RB users for support users' do
+      sign_in_as support_user
+      post :results, params: { support_user_search_form: { email_address_or_full_name: 'Smith' } }
+
+      expect(assigns[:results]).to contain_exactly(user_who_has_seen_privacy_notice,  user_who_has_not_seen_privacy_notice)
+    end
+
+    it 'returns all matching school and RB users who have seen the privacy notice for Computacenter users' do
+      sign_in_as create(:computacenter_user)
+      post :results, params: { support_user_search_form: { email_address_or_full_name: 'Smith' } }
+
+      expect(assigns[:results]).to contain_exactly(user_who_has_seen_privacy_notice)
+    end
+  end
+end

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe SchoolPolicy do
+  subject(:policy) { described_class }
+
+  permissions :invite?, :confirm_invitation? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'blocks access to Computacenter users' do
+      expect(policy).not_to permit(build(:computacenter_user), :support)
+    end
+  end
+
+  permissions :search?, :results? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :support)
+    end
+  end
+end

--- a/spec/policies/support_policy_spec.rb
+++ b/spec/policies/support_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe SupportPolicy do
+  subject(:policy) { described_class }
+
+  permissions :new?, :create?, :edit?, :update?, :destroy?, :technical_support? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'blocks access to Computacenter users' do
+      expect(policy).not_to permit(build(:computacenter_user), :support)
+    end
+  end
+
+  permissions :index?, :show?, :schools? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :support)
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe UserPolicy do
+  subject(:policy) { described_class }
+
+  permissions :new?, :create?, :edit?, :update?, :destroy? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'blocks access to Computacenter users' do
+      expect(policy).not_to permit(build(:computacenter_user), :support)
+    end
+  end
+
+  permissions :index?, :show?, :search?, :results? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :support)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :support)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'simplecov'
 require "capybara"
 require "capybara/rspec"
 require "site_prism"
+require 'pundit/rspec'
 
 SimpleCov.start
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -13,3 +13,15 @@ end
 RSpec.configure do |c|
   c.include ControllerHelper, type: :controller
 end
+
+RSpec::Matchers.define :be_forbidden_for do |user|
+  match do |actual|
+    sign_in_as user
+
+    actual.call
+
+    response.status == 403
+  end
+
+  supports_block_expectations
+end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -25,3 +25,15 @@ RSpec::Matchers.define :be_forbidden_for do |user|
 
   supports_block_expectations
 end
+
+RSpec::Matchers.define :receive_status_ok_for do |user|
+  match do |actual|
+    sign_in_as user
+
+    actual.call
+
+    response.status == 200
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
### Context

We wish to introduce more fine-grained authorisation for various parts of the support interface. This will immediately allow us to add a read-only view for Computacenter users.

### Changes proposed in this pull request

Introduce [Pundit](https://github.com/varvet/pundit), a library/DSL for encapsulating authorisation.
Hide any parts of the UI if a user is unable to access the area.

### Guidance to review

* I've disabled a couple of Rubocop cops in a couple of places, where it felt appropriate – would like to hear thoughts if others agree
* I'm not 100% sure about the right way to split testing between controller and policy specs.