### PR TITLE
remove NOINDEX tag to restore public pages to Google

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,6 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', defer: true %>
-    <meta name="robots" content="noindex" />
   </head>
 
   <body class="govuk-template__body ">


### PR DESCRIPTION
### Context

[Trello card 1005](https://trello.com/c/VySvmF3N/1005-remove-noindex-tag-from-all-pages), originally part of the checklist on [card 1005](https://trello.com/c/yTAIXkvu/1004-reindex-ghwt-site-on-search) - we need to un-block search engines from the site, and restore the public-facing pages to search engine results.

### Changes proposed in this pull request

* remove the `noindex` meta tag from all pages

### Guidance to review

