### PR TITLE
[1006] Support can see mno request counts

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -2,7 +2,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
   def rows
     array = super
     array << headteacher_row if headteacher.present?
-    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row)
+    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row) if @school.mno_feature_flag?
     array
   end
 

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -1,10 +1,31 @@
 class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetailsSummaryListComponent
   def rows
-    super +
-      (headteacher.present? ? [headteacher_row] : [])
+    array = super
+    array << headteacher_row if headteacher.present?
+    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row)
+    array
   end
 
 private
+
+  def mno_row
+    {
+      key: 'Extra mobile data',
+      value: mno_value,
+    }
+  end
+
+  def mno_value
+    [
+      "Total: #{@school.extra_mobile_data_requests.count}",
+      "Requested: #{@school.extra_mobile_data_requests.requested.count}",
+      "In progress: #{@school.extra_mobile_data_requests.in_progress.count}",
+      "Queried: #{@school.extra_mobile_data_requests.queried.count}",
+      "Complete: #{@school.extra_mobile_data_requests.complete.count}",
+      "Cancelled: #{@school.extra_mobile_data_requests.cancelled.count}",
+      "Unavailable: #{@school.extra_mobile_data_requests.unavailable.count}",
+    ].join('<br>').html_safe
+  end
 
   def who_will_order_row
     super.except(:change_path, :action, :action_path)

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -16,8 +16,7 @@ private
   end
 
   def mno_value
-    [
-      "Total: #{@school.extra_mobile_data_requests.count}",
+    description = [
       "Requested: #{@school.extra_mobile_data_requests.requested.count}",
       "In progress: #{@school.extra_mobile_data_requests.in_progress.count}",
       "Queried: #{@school.extra_mobile_data_requests.queried.count}",
@@ -25,6 +24,8 @@ private
       "Cancelled: #{@school.extra_mobile_data_requests.cancelled.count}",
       "Unavailable: #{@school.extra_mobile_data_requests.unavailable.count}",
     ].join('<br>').html_safe
+
+    govuk_details(summary: "Total: #{@school.extra_mobile_data_requests.count}", description: description)
   end
 
   def who_will_order_row

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -10,7 +10,7 @@ private
 
   def mno_row
     {
-      key: 'Extra mobile data',
+      key: 'Extra mobile data requests',
       value: mno_value,
     }
   end

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -25,7 +25,7 @@ private
       "Unavailable: #{@school.extra_mobile_data_requests.unavailable.count}",
     ].join('<br>').html_safe
 
-    govuk_details(summary: "Total: #{@school.extra_mobile_data_requests.count}", description: description)
+    govuk_details(summary: pluralize(@school.extra_mobile_data_requests.count, 'request'), description: description)
   end
 
   def who_will_order_row

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -170,7 +170,7 @@ describe Support::SchoolDetailsSummaryListComponent do
       let(:school) { build(:school, mno_feature_flag: true) }
 
       it 'shows Extra mobile data row with 0 requests' do
-        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Total: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('0 requests')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('Requested: 0')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('In progress: 0')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('Queried: 0')
@@ -190,7 +190,7 @@ describe Support::SchoolDetailsSummaryListComponent do
       end
 
       it 'shows Extra mobile data row with 0 requests' do
-        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Total: 3')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('3 requests')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('Requested: 2')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('In progress: 0')
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('Queried: 0')

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -156,4 +156,40 @@ describe Support::SchoolDetailsSummaryListComponent do
       end
     end
   end
+
+  describe 'extra mobile data' do
+    context 'when there are no requests' do
+      let(:school) { build(:school) }
+
+      it 'shows Extra mobile data row with 0 requests' do
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Total: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Requested: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('In progress: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Queried: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Complete: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Cancelled: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Unavailable: 0')
+      end
+    end
+
+    context 'when there are requests' do
+      let(:school) { create(:school) }
+
+      before do
+        school.extra_mobile_data_requests << create(:extra_mobile_data_request)
+        school.extra_mobile_data_requests << create(:extra_mobile_data_request)
+        school.extra_mobile_data_requests << create(:extra_mobile_data_request, status: 'complete')
+      end
+
+      it 'shows Extra mobile data row with 0 requests' do
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Total: 3')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Requested: 2')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('In progress: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Queried: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Complete: 1')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Cancelled: 0')
+        expect(value_for_row(result, 'Extra mobile data').text).to include('Unavailable: 0')
+      end
+    end
+  end
 end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -162,7 +162,7 @@ describe Support::SchoolDetailsSummaryListComponent do
       let(:school) { build(:school, mno_feature_flag: false) }
 
       it 'does not display row' do
-        expect(result.text).not_to include('Extra mobile data')
+        expect(result.text).not_to include('Extra mobile data requests')
       end
     end
 
@@ -170,13 +170,13 @@ describe Support::SchoolDetailsSummaryListComponent do
       let(:school) { build(:school, mno_feature_flag: true) }
 
       it 'shows Extra mobile data row with 0 requests' do
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Total: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Requested: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('In progress: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Queried: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Complete: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Cancelled: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Unavailable: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Total: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Requested: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('In progress: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Queried: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Complete: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Cancelled: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Unavailable: 0')
       end
     end
 
@@ -190,13 +190,13 @@ describe Support::SchoolDetailsSummaryListComponent do
       end
 
       it 'shows Extra mobile data row with 0 requests' do
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Total: 3')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Requested: 2')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('In progress: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Queried: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Complete: 1')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Cancelled: 0')
-        expect(value_for_row(result, 'Extra mobile data').text).to include('Unavailable: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Total: 3')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Requested: 2')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('In progress: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Queried: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Complete: 1')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Cancelled: 0')
+        expect(value_for_row(result, 'Extra mobile data requests').text).to include('Unavailable: 0')
       end
     end
   end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -158,8 +158,16 @@ describe Support::SchoolDetailsSummaryListComponent do
   end
 
   describe 'extra mobile data' do
+    context 'when school is not using mno_feature' do
+      let(:school) { build(:school, mno_feature_flag: false) }
+
+      it 'does not display row' do
+        expect(result.text).not_to include('Extra mobile data')
+      end
+    end
+
     context 'when there are no requests' do
-      let(:school) { build(:school) }
+      let(:school) { build(:school, mno_feature_flag: true) }
 
       it 'shows Extra mobile data row with 0 requests' do
         expect(value_for_row(result, 'Extra mobile data').text).to include('Total: 0')
@@ -173,7 +181,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     context 'when there are requests' do
-      let(:school) { create(:school) }
+      let(:school) { create(:school, mno_feature_flag: true) }
 
       before do
         school.extra_mobile_data_requests << create(:extra_mobile_data_request)

--- a/spec/features/support/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/enabling_orders_for_a_school_spec.rb
@@ -177,22 +177,18 @@ RSpec.feature 'Enabling orders for a school from the support area' do
 
   def then_the_ordering_for_specific_circumstances_is_confirmed
     expect(school_details_page).to have_text('We’ve saved your choices')
-    expect(school_details_page.school_details_rows[4]).to have_text 'Can place orders?'
-    expect(school_details_page.school_details_rows[4]).to have_text 'Yes, for specific circumstances'
+    expect(school_details_page.school_details['Can place orders?']).to have_text 'Yes, for specific circumstances'
   end
 
   def then_ordering_is_confirmed
     expect(school_details_page).to have_text('We’ve saved your choices')
-    expect(school_details_page.school_details_rows[4]).to have_text 'Can place orders?'
-    expect(school_details_page.school_details_rows[4]).to have_text 'Yes'
+    expect(school_details_page.school_details['Can place orders?']).to have_text 'Yes'
   end
 
   def then_i_see_a_confirmation_that_the_school_cannot_order
     expect(school_details_page).to have_text('We’ve saved your choices')
-    expect(school_details_page.school_details_rows[4]).to have_text 'Devices ordered'
-    expect(school_details_page.school_details_rows[4]).to have_text '25'
-    expect(school_details_page.school_details_rows[5]).to have_text 'Can place orders?'
-    expect(school_details_page.school_details_rows[5]).to have_text 'No'
+    expect(school_details_page.school_details['Devices ordered']).to have_text '25'
+    expect(school_details_page.school_details['Can place orders?']).to have_text 'No'
   end
 
   def and_the_school_order_users_have_been_informed_that_they_can_order


### PR DESCRIPTION
### Context

- https://trello.com/c/eNgLhIpl/1006-show-mno-requests-per-school-in-support-dont-show-personal-info

### Changes proposed in this pull request

- In support when viewing a school show extra mobile data request counts and breakdown

### Screenshots

![image](https://user-images.githubusercontent.com/92580/99060979-c4af1f80-2598-11eb-91ea-00afa0417a91.png)

![image](https://user-images.githubusercontent.com/92580/99061029-d55f9580-2598-11eb-9553-88222b1ea8c9.png)

### Guidance to review

- Login as support user
- Find a school with no extra data requests and view the school
- Should see 0 requests
- Find a school with extra data requests - or may have to setup this data
- Should see extra data request counts and breakdown