### PR TITLE
[1008] Add noindex to a specific guide page

### DIFF
--- a/app/controllers/devices_guidance_controller.rb
+++ b/app/controllers/devices_guidance_controller.rb
@@ -29,6 +29,7 @@ private
         title: page_metadata[:title],
         description: page_metadata[:description],
         audience: page_metadata[:audience],
+        noindex: page_metadata[:noindex],
       }
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', defer: true %>
+    <%= yield(:head) %>
   </head>
 
   <body class="govuk-template__body ">

--- a/app/views/layouts/multipage_guide.html.erb
+++ b/app/views/layouts/multipage_guide.html.erb
@@ -1,6 +1,12 @@
 <% content_for :devices_service, true %>
 <%= content_for :title, @page.title %>
 
+<%= content_for :head do %>
+  <% if @page.noindex %>
+    <meta name="robots" content="noindex" />
+  <% end %>
+<% end %>
+
 <%- content_for :before_content do %>
   <% breadcrumbs([{ 'Home' => guidance_page_path },
                   { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
       title: Set up a Google domain for care leavers
       description: Find out how local authorities can set up a Google domain for care leavers and children with a social worker.
       audience: responsible_body_users
+      noindex: true
   guide_to_collecting_mobile_information:
     overview: Overview
     asking_for_network: Asking about mobile network, contracts and Pay-as-you-go (PAYG)

--- a/spec/views/layouts/multipage_guide.html.erb_spec.rb
+++ b/spec/views/layouts/multipage_guide.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/multipage_guide.html.erb' do
+  before do
+    controller.singleton_class.class_eval do
+      def hide_nav_menu?
+        false
+      end
+      helper_method :hide_nav_menu?
+    end
+  end
+
+  context 'when page has noindex set to true' do
+    it 'has meta tag noindex' do
+      assign(:page, OpenStruct.new(page_id: 'google_domain_for_care_leavers_and_children_with_social_worker', noindex: true))
+      render
+      expect(rendered).to include('noindex')
+    end
+  end
+
+  context 'when page has noindex not set' do
+    it 'has meta tag noindex' do
+      assign(:page, OpenStruct.new(page_id: 'google_domain_for_care_leavers_and_children_with_social_worker'))
+      render
+      expect(rendered).not_to include('noindex')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/1uWqx6WZ/1008-apply-noindex-tag-to-specific-page

### Changes proposed in this pull request

- Add ability to noindex a specific device guide page via the i18n strings

### Guidance to review

- visit http://localhost:3000/devices/google-domain-for-care-leavers-and-children-with-social-worker
- should see noindex in the source
- visit another guide page eg http://localhost:3000/devices/enrol-chromebooks-without-user-logins
- should not see noindex in the source