### PR TITLE
Remove "if shielding not recommended in your area" text

### DIFF
--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -50,8 +50,6 @@
       </ul>
     <% end %>
 
-    <p class="govuk-body">If shielding is not recommended in your area (see the <%= govuk_link_to 'guidance on local restrictions', 'https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19' %>), you’ll need to show evidence that children have received official advice to continue shielding outside of national guidelines.</p>
-
     <h2 class="govuk-heading-m">Where to send your request</h2>
 
     <p class="govuk-body">


### PR DESCRIPTION
Shielding policy is now national, not based on areas. We do not need this evidence.

Originally removed in #762, but we did not need to remove all shielding references and that PR was closed.