### PR TITLE
[1015] Add schools in mno rollout to dashboard

### DIFF
--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -74,4 +74,12 @@ class Support::ServicePerformance
       .sort_by { |_k, v| v }
       .reverse
   end
+
+  def mno_schools_count
+    @mno_schools_count ||= School.where(mno_feature_flag: true).count
+  end
+
+  def mno_schools
+    @mno_schools ||= School.where(mno_feature_flag: true).includes(:responsible_body)
+  end
 end

--- a/app/views/support/service_performance/_mno_rollout.html.erb
+++ b/app/views/support/service_performance/_mno_rollout.html.erb
@@ -1,0 +1,27 @@
+<h2 class="govuk-heading-l">MNO rollout</h2>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <%= render Support::TileComponent.new(
+                 count: @stats.mno_schools_count,
+                 label: pluralize(@stats.mno_schools_count, 'school'),
+                 colour: :blue) %>
+  </div>
+</div>
+
+<table class="govuk-table govuk-!-margin-top-4">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
+      <th scope="col" class="govuk-table__header">Responsible body</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @stats.mno_schools.each do |school| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
+        <td class="govuk-table__cell"><%= govuk_link_to school.responsible_body.name, support_responsible_body_path(school.responsible_body) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -22,4 +22,8 @@
   <% component.slot(:tab, title: 'Connectivity') do %>
     <%= render partial: 'mobile_data_requests' %>
   <% end %>
+
+  <% component.slot(:tab, title: 'MNO rollout') do %>
+    <%= render partial: 'mno_rollout' %>
+  <% end %>
 <%- end %>

--- a/spec/models/support/service_performance_spec.rb
+++ b/spec/models/support/service_performance_spec.rb
@@ -163,4 +163,28 @@ RSpec.describe Support::ServicePerformance, type: :model do
       end
     end
   end
+
+  describe '#mno_schools_count' do
+    before do
+      create(:school, mno_feature_flag: true)
+      create(:school, mno_feature_flag: false)
+      create(:school, mno_feature_flag: false)
+    end
+
+    it 'returns number of school with mno_feature_flag enabled' do
+      expect(stats.mno_schools_count).to be(1)
+    end
+  end
+
+  describe '#mno_schools' do
+    let!(:included_school) { create(:school, mno_feature_flag: true) }
+    let!(:excluded_school_1) { create(:school, mno_feature_flag: false) }
+    let!(:excluded_school_2) { create(:school, mno_feature_flag: false) }
+
+    it 'returns schools with mno_feature_flag enabled' do
+      expect(stats.mno_schools).to include(included_school)
+      expect(stats.mno_schools).not_to include(excluded_school_1)
+      expect(stats.mno_schools).not_to include(excluded_school_2)
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/nlAkop98/1015-show-which-schools-have-get-the-internet-enabled-in-support-while-its-less-than-all-onboarded-schools

### Changes proposed in this pull request

- In support dashboard add extra tab for schools in mno rollout

### Screenshots

![image](https://user-images.githubusercontent.com/92580/99085346-f8ea0680-25bf-11eb-8e26-468557587c38.png)

### Guidance to review

- Enable some schools with `mno_feature_flag` set to `true` on their `School`
- Should see these schools in the dashboard