### PR TITLE
[1017] enable Rails app logs to be sent to Logit

### DIFF
--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -19,3 +19,4 @@ applications:
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
+    RAILS_LOG_TO_STDOUT: true

--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -19,3 +19,4 @@ applications:
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
+    RAILS_LOG_TO_STDOUT: true

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -19,3 +19,4 @@ applications:
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
+    RAILS_LOG_TO_STDOUT: true


### PR DESCRIPTION
### Context

The logstash set up has been shipping logs from the GOV.UK PaaS platform & routers to Logit, but not the Rails application logs. As PaaS only keeps the current day's application logs on the container (and even that's only if there are no releases in that period) this causes a problem if we need to look back in the application logs for any reason. 

### Changes proposed in this pull request

Most of the configuration needed was already present, it just needed an environment variable (`RAILS_LOG_TO_STDOUT`) setting in all environments. 

Shout out to @saliceti for [this v. useful guide](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2045870109/Configuring+Rails+logger+for+GOVUK+PaaS)

### Guidance to review

