### PR TITLE
[926] Log devices ordered updates against school

### DIFF
--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -13,6 +13,7 @@ class Computacenter::API::CapUsageUpdate
   end
 
   def apply!
+    log_to_devices_ordered_updates
     school = School.find_by_computacenter_reference!(ship_to)
     allocation = school.device_allocations.find_by_device_type!(Computacenter::CapTypeConverter.to_dfe_type(cap_type))
     CapMismatch.new(school, allocation).warn(cap_amount) if cap_amount != allocation.allocation
@@ -50,5 +51,16 @@ class Computacenter::API::CapUsageUpdate
     def cap_mismatch_message(cap_amount)
       "CapUsage mismatch: given capAmount: #{cap_amount}, school URN: #{school.urn}, SchoolDeviceAllocation: #{allocation.inspect}"
     end
+  end
+
+private
+
+  def log_to_devices_ordered_updates
+    Computacenter::DevicesOrderedUpdate.create!(
+      cap_type: cap_type,
+      ship_to: ship_to,
+      cap_amount: cap_amount,
+      cap_used: cap_used,
+    )
   end
 end

--- a/app/models/computacenter/devices_ordered_update.rb
+++ b/app/models/computacenter/devices_ordered_update.rb
@@ -1,0 +1,9 @@
+module Computacenter
+  class DevicesOrderedUpdate < ApplicationRecord
+    self.table_name = 'computacenter_devices_ordered_updates'
+
+    belongs_to :school, primary_key: :computacenter_reference,
+                        foreign_key: :ship_to,
+                        optional: true
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,6 +12,9 @@ class School < ApplicationRecord
   has_one :preorder_information
   has_many :email_audits
   has_many :extra_mobile_data_requests
+  has_many :devices_ordered_updates, class_name: 'Computacenter::DevicesOrderedUpdate',
+                                     primary_key: :computacenter_reference,
+                                     foreign_key: :ship_to
 
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true

--- a/db/migrate/20201116150859_create_devices_ordered_updates.rb
+++ b/db/migrate/20201116150859_create_devices_ordered_updates.rb
@@ -1,0 +1,14 @@
+class CreateDevicesOrderedUpdates < ActiveRecord::Migration[6.0]
+  def change
+    create_table :computacenter_devices_ordered_updates do |t|
+      t.string :cap_type
+      t.string :ship_to
+      t.integer :cap_amount
+      t.integer :cap_used
+
+      t.timestamps
+    end
+
+    add_index :computacenter_devices_ordered_updates, :ship_to
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_103917) do
+ActiveRecord::Schema.define(version: 2020_11_16_150859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,16 @@ ActiveRecord::Schema.define(version: 2020_11_10_103917) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["school_device_allocation_id"], name: "index_cap_update_calls_on_school_device_allocation_id"
+  end
+
+  create_table "computacenter_devices_ordered_updates", force: :cascade do |t|
+    t.string "cap_type"
+    t.string "ship_to"
+    t.integer "cap_amount"
+    t.integer "cap_used"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ship_to"], name: "index_computacenter_devices_ordered_updates_on_ship_to"
   end
 
   create_table "computacenter_user_changes", force: :cascade do |t|

--- a/spec/models/computacenter/api/cap_usage_update_spec.rb
+++ b/spec/models/computacenter/api/cap_usage_update_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
       }.to change { school.preorder_information.reload.status }.from('ready').to('ordered')
     end
 
+    it 'logs to devices_ordered_updates' do
+      expect {
+        cap_usage_update.apply!
+      }.to change { Computacenter::DevicesOrderedUpdate.count }.by(1)
+
+      log = Computacenter::DevicesOrderedUpdate.last
+
+      expect(log.cap_type).to eql(args['capType'])
+      expect(log.ship_to).to eql(args['shipTo'])
+      expect(log.cap_amount).to eql(args['capAmount'])
+      expect(log.cap_used).to eql(args['usedCap'])
+
+      expect(log.school).to eql(school)
+      expect(school.devices_ordered_updates).to include(log)
+    end
+
     context 'if the given cap_amount does not match the stored allocation' do
       let(:mock_mismatch) { instance_double(Computacenter::API::CapUsageUpdate::CapMismatch) }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/xdUha5ih/926-fix-number-of-ordered-devices-including-over-orders

### Changes proposed in this pull request

- Add a new table and log CC devices ordered updates to this table

### Guidance to review

- Emulate a incoming CC request to update devices ordered
- Should see this now being logged to new table