### PR TITLE
Initial virtual pool implementation

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -28,10 +28,10 @@ class ResponsibleBody < ApplicationRecord
     virtual_cap_pools.each(&:recalculate_caps!)
   end
 
-  def add_school_to_virtual_cap_pools(school)
+  def add_school_to_virtual_cap_pools!(school)
     school.device_allocations.each do |allocation|
       pool = virtual_cap_pools.send(allocation.device_type).first_or_create!
-      pool.add_school(school)
+      pool.add_school!(school)
     end
   end
 

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -8,7 +8,7 @@ class ResponsibleBody < ApplicationRecord
   has_many :extra_mobile_data_requests
   has_many :schools
 
-  has_many :virtual_cap_pools
+  has_many :virtual_cap_pools, dependent: :destroy
   has_one :std_device_pool, -> { std_device }, class_name: 'VirtualCapPool'
   has_one :coms_device_pool, -> { coms_device }, class_name: 'VirtualCapPool'
 

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -4,6 +4,8 @@ class SchoolDeviceAllocation < ApplicationRecord
   belongs_to :school
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :last_updated_by_user, class_name: 'User', optional: true
+  has_one :school_virtual_cap
+
   has_many :cap_update_calls
 
   validates_with CapAndAllocationValidator
@@ -37,6 +39,22 @@ class SchoolDeviceAllocation < ApplicationRecord
 
   def self.by_computacenter_device_type(cc_device_type)
     by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type))
+  end
+
+  def cap
+    school_virtual_cap&.cap || super
+  end
+
+  def raw_cap
+    self[:cap]
+  end
+
+  def devices_ordered
+    school_virtual_cap&.devices_ordered || super
+  end
+
+  def raw_devices_ordered
+    self[:devices_ordered]
   end
 
   def has_devices_available_to_order?

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -4,7 +4,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   belongs_to :school
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :last_updated_by_user, class_name: 'User', optional: true
-  has_one :school_virtual_cap, dependent: :destroy
+  has_one :school_virtual_cap, touch: true, dependent: :destroy
 
   has_many :cap_update_calls
 

--- a/app/models/school_virtual_cap.rb
+++ b/app/models/school_virtual_cap.rb
@@ -1,5 +1,5 @@
 class SchoolVirtualCap < ApplicationRecord
-  belongs_to :virtual_cap_pool
+  belongs_to :virtual_cap_pool, touch: true
   belongs_to :school_device_allocation
   delegate :cap, :devices_ordered, to: :virtual_cap_pool
 end

--- a/app/models/school_virtual_cap.rb
+++ b/app/models/school_virtual_cap.rb
@@ -1,0 +1,5 @@
+class SchoolVirtualCap < ApplicationRecord
+  belongs_to :virtual_cap_pool
+  belongs_to :school_device_allocation
+  delegate :cap, :devices_ordered, to: :virtual_cap_pool
+end

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -1,0 +1,41 @@
+class VirtualCapPool < ApplicationRecord
+  belongs_to :responsible_body
+  has_many :school_virtual_caps, dependent: :destroy
+  has_many :school_device_allocations, through: :school_virtual_caps
+  has_many :schools, through: :school_device_allocations
+
+  enum device_type: {
+    'coms_device': 'coms_device',
+    'std_device': 'std_device',
+  }
+
+  def recalculate_caps!
+    self.cap = school_device_allocations.sum(:cap)
+    self.devices_ordered = school_device_allocations.sum(:devices_ordered)
+    save!
+    # TODO: trigger events for CC here?
+  end
+
+  def add_school(school)
+    if school.responsible_body_id == responsible_body_id
+      allocation = school.device_allocations.find_by(device_type: device_type)
+      if allocation && !school_virtual_caps.exists?(school_device_allocation: allocation)
+        add_school_allocation(allocation)
+      end
+    end
+  end
+
+private
+
+  def add_school_allocation(allocation)
+    transaction do
+      school_virtual_caps.create!(school_device_allocation: allocation)
+      update_caps!(cap_change: allocation.raw_cap, devices_ordered_change: allocation.raw_devices_ordered)
+    end
+  end
+
+  def update_caps!(cap_change: 0, devices_ordered_change: 0)
+    update!(cap: cap + cap_change, devices_ordered: devices_ordered + devices_ordered_change)
+    # TODO: trigger events for CC here?
+  end
+end

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -4,6 +4,8 @@ class VirtualCapPool < ApplicationRecord
   has_many :school_device_allocations, through: :school_virtual_caps
   has_many :schools, through: :school_device_allocations
 
+  after_touch :recalculate_caps!
+
   enum device_type: {
     'coms_device': 'coms_device',
     'std_device': 'std_device',

--- a/app/models/virtual_cap_pool_error.rb
+++ b/app/models/virtual_cap_pool_error.rb
@@ -1,0 +1,1 @@
+class VirtualCapPoolError < StandardError; end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -7,6 +7,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %i[
     mno_offer
     reduced_allocations
+    virtual_caps
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/db/migrate/20201112160714_create_virtual_cap_pool.rb
+++ b/db/migrate/20201112160714_create_virtual_cap_pool.rb
@@ -1,0 +1,19 @@
+class CreateVirtualCapPool < ActiveRecord::Migration[6.0]
+  def change
+    create_table :virtual_cap_pools do |t|
+      t.string :device_type, null: false
+      t.bigint :responsible_body_id, null: false
+      t.integer :cap, null: false, default: 0
+      t.integer :devices_ordered, null: false, default: 0
+      t.timestamps
+    end
+
+    add_foreign_key :virtual_cap_pools, :responsible_bodies, column: :responsible_body_id
+
+    create_table :school_virtual_caps do |t|
+      t.references :virtual_cap_pool, foreign_key: true
+      t.references :school_device_allocation, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201119110109_add_index_to_virtual_cap_pool.rb
+++ b/db/migrate/20201119110109_add_index_to_virtual_cap_pool.rb
@@ -1,0 +1,5 @@
+class AddIndexToVirtualCapPool < ActiveRecord::Migration[6.0]
+  def change
+    add_index :virtual_cap_pools, :responsible_body_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_150859) do
+ActiveRecord::Schema.define(version: 2020_11_19_110109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -383,6 +383,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_150859) do
     t.integer "devices_ordered", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["responsible_body_id"], name: "index_virtual_cap_pools_on_responsible_body_id"
   end
 
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,6 +225,15 @@ ActiveRecord::Schema.define(version: 2020_11_16_150859) do
     t.index ["school_id"], name: "index_school_device_allocations_on_school_id"
   end
 
+  create_table "school_virtual_caps", force: :cascade do |t|
+    t.bigint "virtual_cap_pool_id"
+    t.bigint "school_device_allocation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_device_allocation_id"], name: "index_school_virtual_caps_on_school_device_allocation_id"
+    t.index ["virtual_cap_pool_id"], name: "index_school_virtual_caps_on_virtual_cap_pool_id"
+  end
+
   create_table "school_welcome_wizards", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "step", default: "allocation", null: false
@@ -367,6 +376,15 @@ ActiveRecord::Schema.define(version: 2020_11_16_150859) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "virtual_cap_pools", force: :cascade do |t|
+    t.string "device_type", null: false
+    t.bigint "responsible_body_id", null: false
+    t.integer "cap", default: 0, null: false
+    t.integer "devices_ordered", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
   add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
@@ -374,6 +392,9 @@ ActiveRecord::Schema.define(version: 2020_11_16_150859) do
   add_foreign_key "preorder_information", "school_contacts"
   add_foreign_key "responsible_bodies", "users", column: "key_contact_id"
   add_foreign_key "school_device_allocations", "schools"
+  add_foreign_key "school_virtual_caps", "school_device_allocations"
+  add_foreign_key "school_virtual_caps", "virtual_cap_pools"
   add_foreign_key "school_welcome_wizards", "users", column: "invited_user_id"
   add_foreign_key "schools", "responsible_bodies"
+  add_foreign_key "virtual_cap_pools", "responsible_bodies"
 end

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -11,6 +11,14 @@ FactoryBot.define do
     trait :in_connectivity_pilot do
       in_connectivity_pilot       { true }
     end
+
+    trait :manages_centrally do
+      who_will_order_devices      { 'responsible_body' }
+    end
+
+    trait :devolves_management do
+      who_will_order_devices      { 'schools' }
+    end
   end
 
   factory :trust do
@@ -32,6 +40,14 @@ FactoryBot.define do
 
     trait :in_connectivity_pilot do
       in_connectivity_pilot       { true }
+    end
+
+    trait :manages_centrally do
+      who_will_order_devices      { 'responsible_body' }
+    end
+
+    trait :devolves_management do
+      who_will_order_devices      { 'schools' }
     end
   end
 end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#add_school_to_virtual_cap_pools' do
     subject(:responsible_body) { create(:trust, :manages_centrally) }
 
-    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
 
     before do
       schools.each do |s|
@@ -265,7 +265,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
 
     it 'adds the schools cap and devices_ordered to the relevant pool' do
-      schools.each { |s| responsible_body.add_school_to_virtual_cap_pools(s) }
+      schools.each { |s| responsible_body.add_school_to_virtual_cap_pools!(s) }
       responsible_body.reload
       expect(responsible_body.std_device_pool.cap).to eq(30)
       expect(responsible_body.std_device_pool.devices_ordered).to eq(6)
@@ -274,21 +274,21 @@ RSpec.describe ResponsibleBody, type: :model do
     end
 
     it 'creates the virtual pool for the device type if it does not exists' do
-      expect { responsible_body.add_school_to_virtual_cap_pools(schools.first) }.to change { VirtualCapPool.count }.by(2)
-      expect { responsible_body.add_school_to_virtual_cap_pools(schools.second) }.not_to(change { VirtualCapPool.count })
+      expect { responsible_body.add_school_to_virtual_cap_pools!(schools.first) }.to change { VirtualCapPool.count }.by(2)
+      expect { responsible_body.add_school_to_virtual_cap_pools!(schools.second) }.not_to(change { VirtualCapPool.count })
     end
   end
 
   describe '#calculate_virtual_caps!' do
     subject(:responsible_body) { create(:trust, :manages_centrally) }
 
-    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
 
     before do
       schools.each do |s|
         s.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
         s.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
-        responsible_body.add_school_to_virtual_cap_pools(s)
+        responsible_body.add_school_to_virtual_cap_pools!(s)
       end
     end
 

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -251,4 +251,56 @@ RSpec.describe ResponsibleBody, type: :model do
       end
     end
   end
+
+  describe '#add_school_to_virtual_cap_pools' do
+    subject(:responsible_body) { create(:trust, :manages_centrally) }
+
+    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
+    before do
+      schools.each do |s|
+        s.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
+        s.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
+      end
+    end
+
+    it 'adds the schools cap and devices_ordered to the relevant pool' do
+      schools.each { |s| responsible_body.add_school_to_virtual_cap_pools(s) }
+      responsible_body.reload
+      expect(responsible_body.std_device_pool.cap).to eq(30)
+      expect(responsible_body.std_device_pool.devices_ordered).to eq(6)
+      expect(responsible_body.coms_device_pool.cap).to eq(15)
+      expect(responsible_body.coms_device_pool.devices_ordered).to eq(9)
+    end
+
+    it 'creates the virtual pool for the device type if it does not exists' do
+      expect { responsible_body.add_school_to_virtual_cap_pools(schools.first) }.to change { VirtualCapPool.count }.by(2)
+      expect { responsible_body.add_school_to_virtual_cap_pools(schools.second) }.not_to(change { VirtualCapPool.count })
+    end
+  end
+
+  describe '#calculate_virtual_caps!' do
+    subject(:responsible_body) { create(:trust, :manages_centrally) }
+
+    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
+    before do
+      schools.each do |s|
+        s.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
+        s.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
+        responsible_body.add_school_to_virtual_cap_pools(s)
+      end
+    end
+
+    it 'calculates the virtual cap for all device types' do
+      schools.first.std_device_allocation.update!(cap: 100, allocation: 100, devices_ordered: 75)
+      schools.last.coms_device_allocation.update!(cap: 50, allocation: 100, devices_ordered: 25)
+
+      responsible_body.calculate_virtual_caps!
+      expect(responsible_body.std_device_pool.cap).to eq(120)
+      expect(responsible_body.std_device_pool.devices_ordered).to eq(79)
+      expect(responsible_body.coms_device_pool.cap).to eq(60)
+      expect(responsible_body.coms_device_pool.devices_ordered).to eq(31)
+    end
+  end
 end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -113,5 +113,12 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       expect(allocation.devices_ordered).to eq(145)
       expect(allocation.raw_devices_ordered).to eq(87)
     end
+
+    it 'propagates changes up to the pool' do
+      allocation.update!(allocation: 400, cap: 300, devices_ordered: 200)
+      responsible_body.std_device_pool.reload
+      expect(responsible_body.std_device_pool.cap).to eq(300)
+      expect(responsible_body.std_device_pool.devices_ordered).to eq(200)
+    end
   end
 end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -89,11 +89,19 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
 
     subject(:allocation) { described_class.create!(device_type: 'std_device', cap: 100, devices_ordered: 87, allocation: 100, school: school) }
 
+    ### moving this into an around block causes test fails elsewhere in the suite?!?
     before do
       allocation
       responsible_body.add_school_to_virtual_cap_pools!(school)
       responsible_body.std_device_pool.update!(cap: 256, devices_ordered: 145)
       allocation.reload
+
+      @original_state = FeatureFlag.active?(:virtual_caps)
+      FeatureFlag.activate(:virtual_caps) unless @original_state
+    end
+
+    after do
+      FeatureFlag.deactivate(:virtual_caps) unless @original_state
     end
 
     it ':cap refers to the pool cap instead of local version' do

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -83,25 +83,17 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
     end
   end
 
-  context 'when in a virtual pool' do
+  context 'when in a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
     let(:responsible_body) { create(:trust, :manages_centrally) }
     let(:school) { create(:school, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
 
     subject(:allocation) { described_class.create!(device_type: 'std_device', cap: 100, devices_ordered: 87, allocation: 100, school: school) }
 
-    ### moving this into an around block causes test fails elsewhere in the suite?!?
     before do
       allocation
       responsible_body.add_school_to_virtual_cap_pools!(school)
       responsible_body.std_device_pool.update!(cap: 256, devices_ordered: 145)
       allocation.reload
-
-      @original_state = FeatureFlag.active?(:virtual_caps)
-      FeatureFlag.activate(:virtual_caps) unless @original_state
-    end
-
-    after do
-      FeatureFlag.deactivate(:virtual_caps) unless @original_state
     end
 
     it ':cap refers to the pool cap instead of local version' do

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
 
   context 'when in a virtual pool' do
     let(:responsible_body) { create(:trust, :manages_centrally) }
-    let(:school) { create(:school, :with_preorder_information, responsible_body: responsible_body) }
+    let(:school) { create(:school, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
 
     subject(:allocation) { described_class.create!(device_type: 'std_device', cap: 100, devices_ordered: 87, allocation: 100, school: school) }
 
     before do
       allocation
-      responsible_body.add_school_to_virtual_cap_pools(school)
+      responsible_body.add_school_to_virtual_cap_pools!(school)
       responsible_body.std_device_pool.update!(cap: 256, devices_ordered: 145)
       allocation.reload
     end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -82,4 +82,28 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       end
     end
   end
+
+  context 'when in a virtual pool' do
+    let(:responsible_body) { create(:trust, :manages_centrally) }
+    let(:school) { create(:school, :with_preorder_information, responsible_body: responsible_body) }
+
+    subject(:allocation) { described_class.create!(device_type: 'std_device', cap: 100, devices_ordered: 87, allocation: 100, school: school) }
+
+    before do
+      allocation
+      responsible_body.add_school_to_virtual_cap_pools(school)
+      responsible_body.std_device_pool.update!(cap: 256, devices_ordered: 145)
+      allocation.reload
+    end
+
+    it ':cap refers to the pool cap instead of local version' do
+      expect(allocation.cap).to eq(256)
+      expect(allocation.raw_cap).to eq(100)
+    end
+
+    it ':devices_ordered refers to the pool devices_ordered instead of the local version' do
+      expect(allocation.devices_ordered).to eq(145)
+      expect(allocation.raw_devices_ordered).to eq(87)
+    end
+  end
 end

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe VirtualCapPool, type: :model do
 
   subject(:pool) { local_authority.virtual_cap_pools.std_device.create! }
 
-  describe '#add_school' do
-    context 'when school belongs to the responsible body' do
-      let(:schools) { create_list(:school, 2, :with_std_device_allocation, responsible_body: local_authority) }
+  describe '#add_school!' do
+    context 'when a school can be added to the pool' do
+      let(:schools) { create_list(:school, 2, :with_std_device_allocation, :in_lockdown, responsible_body: local_authority) }
 
       before do
         schools.first.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
@@ -15,25 +15,39 @@ RSpec.describe VirtualCapPool, type: :model do
       end
 
       it 'adds the allocation values to the pool' do
-        pool.add_school(schools.first)
+        pool.add_school!(schools.first)
         expect(pool.cap).to eq(20)
         expect(pool.devices_ordered).to eq(10)
 
-        pool.add_school(schools.last)
+        pool.add_school!(schools.last)
         expect(pool.cap).to eq(30)
         expect(pool.devices_ordered).to eq(11)
       end
     end
 
     context 'when the school does not belong to the responsible body' do
-      let(:non_rb_school) { create(:school, :with_std_device_allocation) }
+      let(:non_rb_school) { create(:school, :in_lockdown, :with_std_device_allocation) }
 
       before do
         non_rb_school.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
       end
 
       it 'does not add the schools allocation to the pool' do
-        pool.add_school(non_rb_school)
+        expect { pool.add_school!(non_rb_school) }.to raise_error VirtualCapPoolError
+        expect(pool.cap).to eq(0)
+        expect(pool.devices_ordered).to eq(0)
+      end
+    end
+
+    context 'when the school is not in an ordering state' do
+      let(:non_ordering_school) { create(:school, :with_std_device_allocation, responsible_body: local_authority) }
+
+      before do
+        non_ordering_school.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
+      end
+
+      it 'does not add the schools allocation to the pool' do
+        expect { pool.add_school!(non_ordering_school) }.to raise_error VirtualCapPoolError
         expect(pool.cap).to eq(0)
         expect(pool.devices_ordered).to eq(0)
       end
@@ -41,12 +55,12 @@ RSpec.describe VirtualCapPool, type: :model do
   end
 
   describe '#recalculate_caps!' do
-    let(:schools) { create_list(:school, 2, :with_std_device_allocation, responsible_body: local_authority) }
+    let(:schools) { create_list(:school, 2, :with_std_device_allocation, :in_lockdown, responsible_body: local_authority) }
 
     before do
       schools.first.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
       schools.last.std_device_allocation.update!(cap: 10, allocation: 30, devices_ordered: 1)
-      schools.each { |s| pool.add_school(s) }
+      schools.each { |s| pool.add_school!(s) }
     end
 
     it 'recalculates the cap and devices_ordered totals for the schools in the pool' do

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe VirtualCapPool, type: :model do
+  let(:local_authority) { create(:local_authority) }
+
+  subject(:pool) { local_authority.virtual_cap_pools.std_device.create! }
+
+  describe '#add_school' do
+    context 'when school belongs to the responsible body' do
+      let(:schools) { create_list(:school, 2, :with_std_device_allocation, responsible_body: local_authority) }
+
+      before do
+        schools.first.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
+        schools.last.std_device_allocation.update!(cap: 10, allocation: 30, devices_ordered: 1)
+      end
+
+      it 'adds the allocation values to the pool' do
+        pool.add_school(schools.first)
+        expect(pool.cap).to eq(20)
+        expect(pool.devices_ordered).to eq(10)
+
+        pool.add_school(schools.last)
+        expect(pool.cap).to eq(30)
+        expect(pool.devices_ordered).to eq(11)
+      end
+    end
+
+    context 'when the school does not belong to the responsible body' do
+      let(:non_rb_school) { create(:school, :with_std_device_allocation) }
+
+      before do
+        non_rb_school.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
+      end
+
+      it 'does not add the schools allocation to the pool' do
+        pool.add_school(non_rb_school)
+        expect(pool.cap).to eq(0)
+        expect(pool.devices_ordered).to eq(0)
+      end
+    end
+  end
+
+  describe '#recalculate_caps!' do
+    let(:schools) { create_list(:school, 2, :with_std_device_allocation, responsible_body: local_authority) }
+
+    before do
+      schools.first.std_device_allocation.update!(cap: 20, allocation: 30, devices_ordered: 10)
+      schools.last.std_device_allocation.update!(cap: 10, allocation: 30, devices_ordered: 1)
+      schools.each { |s| pool.add_school(s) }
+    end
+
+    it 'recalculates the cap and devices_ordered totals for the schools in the pool' do
+      schools.first.std_device_allocation.update!(cap: 40, allocation: 40, devices_ordered: 26)
+
+      pool.recalculate_caps!
+
+      expect(pool.cap).to eq(50)
+      expect(pool.devices_ordered).to eq(27)
+    end
+  end
+end

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
 
     context 'when a std SchoolDeviceAllocation does not exist' do
       before do
-        SchoolDeviceAllocation.delete_all
+        SchoolDeviceAllocation.destroy_all
       end
 
       context 'when no device_type was given' do


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/Nj7Thku9/988-virtual-cap-calculate-virtual-cap)
Calculate virtual caps. This is a first iteration of a virtual pool for devices for us to kick about and poke holes in.

### Changes proposed in this pull request
Adds `VirtualCapPool` model to hold `:cap` and `:devices_ordered` pooled amounts for specific a `:device_type`
Adds `SchoolVirtualCap` model as a join table between `SchoolDeviceAllocation` and `VirtualCapPool`
Implements accessors for `:cap` and `:devices_ordered` on `SchoolDeviceAllocation` that determine whether to return the pool values or the local object values
'Raw' accessor methods `:raw_cap` and `:raw_devices_ordered` added to access local model values so original values can be accessed when in a pool (e.g. for pool calculation)
Feature flagged using the virtual pool cap and devices ordered values from the `SchoolDeviceAllocation` so enable `:virtual_caps` to use the values directly, otherwise the pool amounts are just logged to the Rails logger when these are accessed and the local values returned.
Added `touch: true` to pass changes up the `SchoolDeviceAllocation` -> `SchoolVirtualCap` -> `VirtualCapPool` chain to trigger a recalculation of the pool amounts (which in turn, down the line, can push changes to CC).

### Guidance to review

There is a migration to run to add the new tables.
A school can be added to its responsible body's virtual cap pool by calling `responsible_body.add_school_to_virtual_cap_pool(school)`
This will iterate the `device_allocations` on the school and add them to the virtual pool for the correct device type ('std_device' or 'coms_device' currently).
The `:cap` and `:devices_ordered` values remain unchanged on the `SchoolDeviceAllocation` object.
The `SchoolDeviceAllocation` uses a new association `:school_virtual_cap` to determine whether it is in a pool or not.
The pool `:cap` and `:devices_ordered` are updated when adding a school.  They can also be updated by invoking `responsible_body.calculate_virtual_caps!` or for a specific pool by `responsible_body.std_device_pool.recalculate_caps!` or `responsible_body.coms_device_pool.recalculate_caps!`.  This methods sums up the `:cap` and `:devices_ordered` for all allocations in the pool.
Once in a pool, changes to a school's `SchoolDeviceAllocation` will trigger a recalculation of the pool's amounts.