### PR TITLE
Redirect a specific incorrect start link

### DIFF
--- a/config/initializers/redirect_incorrect_start.rb
+++ b/config/initializers/redirect_incorrect_start.rb
@@ -1,0 +1,3 @@
+require 'middleware/redirect_incorrect_start'
+
+Rails.application.config.middleware.use Middleware::RedirectIncorrectStart

--- a/lib/middleware/redirect_incorrect_start.rb
+++ b/lib/middleware/redirect_incorrect_start.rb
@@ -1,0 +1,17 @@
+module Middleware
+  class RedirectIncorrectStart
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @req = Rack::Request.new(env)
+
+      if @req.path =~ /^\/start\]$/
+        [302, { 'Location' => '/start' }, []]
+      else
+        @app.call(env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
An email was sent out that contained an incorrect link today. Due to the special character we weren't able to fix the redirect in the Rails routes but instead had to make a middleware to match on the path.

The traffic from the email will drop off very quickly so we will revert this PR in a few days.