### PR TITLE
Add papertrail to PreorderInformation

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -1,4 +1,6 @@
 class PreorderInformation < ApplicationRecord
+  has_paper_trail
+
   self.table_name = 'preorder_information'
 
   belongs_to :school

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PreorderInformation, type: :model do
+  it { is_expected.to be_versioned }
+
   describe 'status' do
     context 'when the school orders devices and the school contact is missing' do
       subject do


### PR DESCRIPTION
### Context

We don't have an easy way to analyse when Chromebook details are changed, or whether anyone is changing whether school ordering is devolved or not.

https://trello.com/c/x4uZNNZ0/1042-switch-changing-who-can-order-devices-at-the-school-level-to-a-support-task

### Changes proposed in this pull request

Add `paper_trail` to `PreorderInformation` – this will allow to easily track Chromebook detail changes, and `who_will_order_devices` information.


