### PR TITLE
Support layout tweaks

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -25,7 +25,7 @@ private
       "Unavailable: #{@school.extra_mobile_data_requests.unavailable.count}",
     ].join('<br>').html_safe
 
-    govuk_details(summary: pluralize(@school.extra_mobile_data_requests.count, 'request'), description: description)
+    govuk_details(summary: pluralize(@school.extra_mobile_data_requests.count, 'request'), description: description, classes: 'app-details-in-summary-list')
   end
 
   def who_will_order_row

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -8,7 +8,6 @@
 <% end %>
 
 <h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Devices pilot</span>
   <%= @responsible_body.name %>
 </h1>
 

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -12,29 +12,25 @@
   <%= @responsible_body.name %>
 </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
 
-    <h2 class="govuk-heading-l">Users</h2>
+<%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
 
-    <% if @users.present? %>
-      <% @users.each do |user| %>
-        <div class="user">
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
-          <p class="govuk-body">
-            <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user, pilot: 'devices') %>
-          </p>
-          <%= render Support::UserSummaryListComponent.new(user: user) %>
-        </div>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">None</p>
-    <% end %>
-  </div>
-</div>
+<% if @users.present? %>
+  <% @users.each do |user| %>
+    <div class="user">
+      <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+      <p class="govuk-body">
+        <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user, pilot: 'devices') %>
+      </p>
+      <%= render Support::UserSummaryListComponent.new(user: user) %>
+    </div>
+  <% end %>
+<% else %>
+  <p class="govuk-body">None</p>
+<% end %>
 
-<table id="responsible-body-schools" class="govuk-table govuk-!-margin-top-6">
+<table id="responsible-body-schools" class="govuk-table govuk-!-margin-top-9">
   <caption class="govuk-table__caption govuk-heading-l">Schools</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/support/schools/confirm_invitation.html.erb
+++ b/app/views/support/schools/confirm_invitation.html.erb
@@ -4,7 +4,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">Devices pilot</span>
       Invite <%= @school.name %>
     </h1>
 

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -19,36 +19,26 @@
 
 <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= govuk_button_link_to t('page_titles.new_school_user'), new_support_school_user_path(school_urn: @school.urn) %>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
+<%= govuk_button_link_to t('page_titles.new_school_user'), new_support_school_user_path(school_urn: @school.urn) %>
 
-    <h2 class="govuk-heading-l">Users</h2>
+<% if @users.present? %>
+  <% @users.each do |user| %>
+    <div class="user">
+      <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+      <p class="govuk-body">
+        <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_school_user_path(school_urn: @school.urn, id: user.id) %>
+      </p>
+      <%= render Support::UserSummaryListComponent.new(user: user) %>
+    </div>
+  <% end %>
+<% else %>
+  <p class="govuk-body">None</p>
+<% end %>
 
-    <% if @users.present? %>
-      <% @users.each do |user| %>
-        <div class="user">
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= user.full_name %></h3>
-          <p class="govuk-body">
-            <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_school_user_path(school_urn: @school.urn, id: user.id) %>
-          </p>
-          <%= render Support::UserSummaryListComponent.new(user: user) %>
-        </div>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">None</p>
-    <% end %>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-margin-top-4">Notifications sent</h2>
-
-    <% if @email_audits.present? %>
-      <%= render Support::EmailAuditListComponent.new(@email_audits) %>
-    <% else %>
-      <p class="govuk-body">None</p>
-    <% end %>
-  </div>
-</div>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Notifications sent</h2>
+<% if @email_audits.present? %>
+  <%= render Support::EmailAuditListComponent.new(@email_audits) %>
+<% else %>
+  <p class="govuk-body">None</p>
+<% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -57,3 +57,9 @@ $govuk-image-url-function: frontend-image-url;
     float: right;
   }
 }
+
+.app-details-in-summary-list {
+  .govuk-details__summary {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
### Context

- Make user lists and notifications full width to make content more readable
- Move invite user button to beneath the "Users" heading
- Tweak styling of details to match row height of summary list
- Remove "Devices pilot" caption

(Ignore whitespace when reviewing)

![localhost_3000_support_schools_100000](https://user-images.githubusercontent.com/319055/99646327-40e9ad00-2a48-11eb-936e-ba6bfb07103c.png)
