### PR TITLE
add facility for support users to move users between schools and RBs

### DIFF
--- a/app/components/support/user_search_result_component.html.erb
+++ b/app/components/support/user_search_result_component.html.erb
@@ -4,5 +4,8 @@
 
 <%= govuk_summary_list(classes: 'govuk-summary-list--no-border') do |component|
   component.slot(:row, key: 'Email address', value: user.email_address)
-  component.slot(:row, key: 'Associated with', value: unordered_list_of_orgs, action: govuk_link_to('Change', associated_organisations_support_user_path(user)) )
+  component.slot(:row,
+                  key: 'Associated with',
+                  value: unordered_list_of_orgs,
+                  action: (UserPolicy.new(current_user, user).editable? ? govuk_link_to('Change', associated_organisations_support_user_path(user)) : nil) )
 end %>

--- a/app/components/support/user_search_result_component.html.erb
+++ b/app/components/support/user_search_result_component.html.erb
@@ -4,5 +4,5 @@
 
 <%= govuk_summary_list(classes: 'govuk-summary-list--no-border') do |component|
   component.slot(:row, key: 'Email address', value: user.email_address)
-  component.slot(:row, key: 'Associated with', value: unordered_list_of_orgs)
+  component.slot(:row, key: 'Associated with', value: unordered_list_of_orgs, action: govuk_link_to('Change', associated_organisations_support_user_path(user)) )
 end %>

--- a/app/components/support/user_search_result_component.html.erb
+++ b/app/components/support/user_search_result_component.html.erb
@@ -7,5 +7,5 @@
   component.slot(:row,
                   key: 'Associated with',
                   value: unordered_list_of_orgs,
-                  action: (UserPolicy.new(current_user, user).editable? ? govuk_link_to('Change', associated_organisations_support_user_path(user)) : nil) )
+                  action: (Pundit.policy(current_user, user).editable? ? govuk_link_to('Change', associated_organisations_support_user_path(user)) : nil) )
 end %>

--- a/app/components/support/user_search_result_component.rb
+++ b/app/components/support/user_search_result_component.rb
@@ -1,8 +1,9 @@
 class Support::UserSearchResultComponent < ViewComponent::Base
-  attr_reader :user
+  attr_reader :user, :current_user
 
-  def initialize(user)
+  def initialize(user:, current_user:)
     @user = user
+    @current_user = current_user
   end
 
   def unordered_list_of_orgs

--- a/app/controllers/support/users/responsible_bodies_controller.rb
+++ b/app/controllers/support/users/responsible_bodies_controller.rb
@@ -1,0 +1,18 @@
+class Support::Users::ResponsibleBodiesController < Support::BaseController
+  before_action :set_user
+
+  def index
+    @form = Support::UserResponsibleBodyForm.new(user: @user, name: user_responsible_body_params[:name])
+    @responsible_bodies = @form.matching_responsible_bodies
+  end
+
+private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_responsible_body_params(opts = params)
+    opts.fetch('support_user_responsible_body_form').permit(:name)
+  end
+end

--- a/app/controllers/support/users/responsible_bodies_controller.rb
+++ b/app/controllers/support/users/responsible_bodies_controller.rb
@@ -10,7 +10,8 @@ class Support::Users::ResponsibleBodiesController < Support::BaseController
 private
 
   def set_user
-    @user = policy_scope(User).find(params[:id])
+    @user = User.find(params[:id])
+    authorize @user
   end
 
   def user_responsible_body_params(opts = params)

--- a/app/controllers/support/users/responsible_bodies_controller.rb
+++ b/app/controllers/support/users/responsible_bodies_controller.rb
@@ -1,5 +1,6 @@
 class Support::Users::ResponsibleBodiesController < Support::BaseController
   before_action :set_user
+  before_action { authorize User }
 
   def index
     @form = Support::UserResponsibleBodyForm.new(user: @user, name: user_responsible_body_params[:name])
@@ -9,7 +10,7 @@ class Support::Users::ResponsibleBodiesController < Support::BaseController
 private
 
   def set_user
-    @user = User.find(params[:id])
+    @user = policy_scope(User).find(params[:id])
   end
 
   def user_responsible_body_params(opts = params)

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -1,5 +1,6 @@
 class Support::Users::SchoolsController < Support::BaseController
   before_action :set_user, :set_school
+  before_action { authorize User }
 
   def index
     @form = Support::NewUserSchoolForm.new(user: @user, name_or_urn: user_school_params[:name_or_urn])
@@ -26,8 +27,7 @@ class Support::Users::SchoolsController < Support::BaseController
 private
 
   def set_user
-    # @user = User.safe_to_show_to(@current_user).find(params[:id])
-    @user = User.find(params[:id])
+    @user = policy_scope(User).find(params[:id])
   end
 
   def set_school

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -1,0 +1,40 @@
+class Support::Users::SchoolsController < Support::BaseController
+  before_action :set_user, :set_school
+
+  def index
+    @form = Support::NewUserSchoolForm.new(user: @user, name_or_urn: user_school_params[:name_or_urn])
+    @schools = @form.matching_schools
+  end
+
+  def create
+    @user_school = @user.user_schools.build(school_id: @school.id)
+    if @user_school.save
+      flash[:success] = "#{@user.full_name} is now associated with #{@school.name}"
+    else
+      flash[:warning] = @user_school.errors.full_messages.join("\n")
+    end
+    redirect_to associated_organisations_support_user_path(@user.id)
+  end
+
+  def destroy
+    @user_school = @user.user_schools.find_by_school_id(@school.id)
+    @user_school&.destroy!
+    flash[:success] = "#{@user.full_name} is no longer associated with #{@school.name}"
+    redirect_to associated_organisations_support_user_path(@user.id)
+  end
+
+private
+
+  def set_user
+    # @user = User.safe_to_show_to(@current_user).find(params[:id])
+    @user = User.find(params[:id])
+  end
+
+  def set_school
+    @school = School.find_by_urn(params[:urn])
+  end
+
+  def user_school_params(opts = params)
+    opts.fetch('support_new_user_school_form').permit(:name_or_urn)
+  end
+end

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -27,7 +27,8 @@ class Support::Users::SchoolsController < Support::BaseController
 private
 
   def set_user
-    @user = policy_scope(User).find(params[:id])
+    @user = User.find(params[:id])
+    authorize @user
   end
 
   def set_school

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,6 +1,7 @@
 class Support::UsersController < Support::BaseController
   SEARCH_RESULTS_LIMIT = 100
 
+  before_action :set_user, only: %i[associated_organisations update_responsible_body]
   before_action { authorize User }
 
   def search
@@ -21,7 +22,6 @@ class Support::UsersController < Support::BaseController
   end
 
   def associated_organisations
-    @user = User.find(params[:id])
     @schools = @user.schools.order(:name)
     @responsible_body = @user.responsible_body
     @user_responsible_body_form = Support::UserResponsibleBodyForm.new(user: @user)
@@ -29,7 +29,6 @@ class Support::UsersController < Support::BaseController
   end
 
   def update_responsible_body
-    @user = User.find(params[:id])
     @user.update!(responsible_body_id: params[:responsible_body_id])
     flash[:success] = success_message
     redirect_to associated_organisations_support_user_path(@user.id)
@@ -47,5 +46,9 @@ private
     else
       "#{@user.full_name} is no longer associated with a Responsible body"
     end
+  end
+
+  def set_user
+    @user = policy_scope(User).find(params[:id])
   end
 end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -20,9 +20,32 @@ class Support::UsersController < Support::BaseController
     @maximum_search_result_number_reached = (@results.size == SEARCH_RESULTS_LIMIT)
   end
 
+  def associated_organisations
+    @user = User.find(params[:id])
+    @schools = @user.schools.order(:name)
+    @responsible_body = @user.responsible_body
+    @user_responsible_body_form = Support::UserResponsibleBodyForm.new(user: @user)
+    @user_school_form = Support::NewUserSchoolForm.new(user: @user)
+  end
+
+  def update_responsible_body
+    @user = User.find(params[:id])
+    @user.update!(responsible_body_id: params[:responsible_body_id])
+    flash[:success] = success_message
+    redirect_to associated_organisations_support_user_path(@user.id)
+  end
+
 private
 
   def search_params
     params.require(:support_user_search_form).permit(:email_address_or_full_name)
+  end
+
+  def success_message
+    if @user.responsible_body.present?
+      "#{@user.full_name} is now associated with #{@user.responsible_body.name}"
+    else
+      "#{@user.full_name} is no longer associated with a Responsible body"
+    end
   end
 end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -9,7 +9,7 @@ class Support::NewUserSchoolForm
   end
 
   def matching_schools
-    School.includes(:user_schools)
+    School.includes(:responsible_body)
           .where('urn = ? OR LOWER(name) LIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn.downcase}%")
           .order(:name)
   end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -1,0 +1,16 @@
+class Support::NewUserSchoolForm
+  include ActiveModel::Model
+
+  attr_accessor :user, :name_or_urn
+
+  def initialize(user:, name_or_urn: nil)
+    @user = user
+    @name_or_urn = name_or_urn
+  end
+
+  def matching_schools
+    School.includes(:user_schools)
+          .where('urn = ? OR LOWER(name) LIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn.downcase}%")
+          .order(:name)
+  end
+end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -10,7 +10,7 @@ class Support::NewUserSchoolForm
 
   def matching_schools
     School.includes(:responsible_body)
-          .where('urn = ? OR LOWER(name) LIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn.downcase}%")
+          .where('urn = ? OR name ILIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn}%")
           .order(:name)
   end
 end

--- a/app/form_objects/support/user_responsible_body_form.rb
+++ b/app/form_objects/support/user_responsible_body_form.rb
@@ -9,7 +9,7 @@ class Support::UserResponsibleBodyForm
   end
 
   def matching_responsible_bodies
-    ResponsibleBody.where('LOWER(name) LIKE(?)', "%#{@name.downcase}%")
+    ResponsibleBody.where('name ILIKE(?)', "%#{@name}%")
                    .order(:name)
   end
 end

--- a/app/form_objects/support/user_responsible_body_form.rb
+++ b/app/form_objects/support/user_responsible_body_form.rb
@@ -1,0 +1,15 @@
+class Support::UserResponsibleBodyForm
+  include ActiveModel::Model
+
+  attr_accessor :user, :name
+
+  def initialize(user:, name: nil)
+    @user = user
+    @name = name
+  end
+
+  def matching_responsible_bodies
+    ResponsibleBody.where('LOWER(name) LIKE(?)', "%#{@name.downcase}%")
+                   .order(:name)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,7 +142,7 @@ class User < ApplicationRecord
   end
 
   def effective_responsible_bodies
-    user_schools.map { |us| us.school.responsible_body }.prepend(responsible_body).compact.uniq
+    user_schools.map { |us| us.school&.responsible_body }.prepend(responsible_body).compact.uniq
   end
 
   def relevant_to_computacenter?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -13,4 +13,6 @@ class UserPolicy < SupportPolicy
 
   alias_method :search?, :readable?
   alias_method :results?, :readable?
+  alias_method :associated_organisations?, :editable?
+  alias_method :update_responsible_body?, :editable?
 end

--- a/app/views/support/users/associated_organisations.html.erb
+++ b/app/views/support/users/associated_organisations.html.erb
@@ -1,0 +1,106 @@
+<%- title = t('page_titles.support.users.associated_organisations') %>
+<% content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { 'Support home' => support_home_path },
+    { t('page_titles.support.users.search') => search_support_users_path },
+    @user.full_name,
+    title,
+  ]) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Schools</h2>
+    <%- if @schools.present? %>
+      <table class="govuk-table schools">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name and URN</th>
+            <th scope="col" class="govuk-table__header">Responsible body</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @schools.each do |school| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
+                <br>
+                <%= school.type_label %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= govuk_button_to('Remove', support_user_school_path(urn: school.urn, id: @user.id), method: :delete, form_class: 'form-inline')  %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+    <%- else %>
+      <p class="govuk-body">(none)</p>
+    <%- end %>
+
+    <%= form_for @user_school_form, url: support_user_schools_path(@user), method: :get do |f| %>
+      <%= f.govuk_fieldset legend: { text: 'Associate with a school', size: 'm' } do %>
+        <%= f.govuk_text_field :name_or_urn, width: 'one-third' %>
+        <%= f.govuk_submit %>
+      <%- end %>
+    <%- end %>
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Responsible body</h2>
+    <%- if @responsible_body.present? %>
+      <table class="govuk-table responsible-body">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= govuk_link_to @responsible_body.name, support_responsible_body_path(id: @responsible_body.id) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= @responsible_body.humanized_type %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= govuk_button_to('Remove', update_responsible_body_support_user_path(responsible_body_id: nil, id: @user.id), method: :patch) %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    <%- else %>
+      <p class="govuk-body">(none)</p>
+    <%- end %>
+
+    <%= form_for @user_responsible_body_form, url: responsible_bodies_support_user_path(@user), method: :get do |f| %>
+      <%= f.govuk_fieldset legend: { text: 'Associate with a responsible body', size: 'm' } do %>
+        <%= f.govuk_text_field :name, width: 'one-third' %>
+        <%= f.govuk_submit %>
+      <%- end %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/support/users/associated_organisations.html.erb
+++ b/app/views/support/users/associated_organisations.html.erb
@@ -97,7 +97,7 @@
     <%- end %>
 
     <%= form_for @user_responsible_body_form, url: responsible_bodies_support_user_path(@user), method: :get do |f| %>
-      <%= f.govuk_fieldset legend: { text: 'Associate with a responsible body', size: 'm' } do %>
+      <%= f.govuk_fieldset legend: { text: 'Move to a different responsible body', size: 'm' } do %>
         <%= f.govuk_text_field :name, width: 'one-third' %>
         <%= f.govuk_submit %>
       <%- end %>

--- a/app/views/support/users/responsible_bodies/index.html.erb
+++ b/app/views/support/users/responsible_bodies/index.html.erb
@@ -1,0 +1,53 @@
+<%- title = t('page_titles.support.users.responsible_bodies.index') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', associated_organisations_support_user_path(@user), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">
+      Responsible bodies matching <q><%= @form.name %></q>
+    </h2>
+    <%- if @responsible_bodies.present? %>
+      <table class="govuk-table responsible-bodies">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @responsible_bodies.each do |responsible_body| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= responsible_body.humanized_type %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= govuk_link_to responsible_body.name, support_responsible_body_path(id: responsible_body.id) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%- if @user.responsible_body_id == responsible_body.id %>
+                  (already associated)
+                <%- else %>
+                  <%= govuk_button_to('Associate', update_responsible_body_support_user_path(responsible_body_id: responsible_body.id, id: @user.id), method: :patch) %>
+                <%- end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <%- else %>
+      <p class="govuk-body">(none matching)</p>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/support/users/results.html.erb
+++ b/app/views/support/users/results.html.erb
@@ -39,7 +39,7 @@
     <ul class="govuk-list search-results">
       <% @results.each do |user| %>
         <li>
-          <%= render Support::UserSearchResultComponent.new(user) %>
+          <%= render Support::UserSearchResultComponent.new(user: user, current_user: current_user) %>
         </li>
       <%- end %>
     </ul>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -1,0 +1,56 @@
+<%- title = t('page_titles.support.users.schools.index') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', associated_organisations_support_user_path(@user), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">
+      Schools matching <q><%= @form.name_or_urn %></q>
+    </h2>
+
+    <%- if @schools.present? %>
+      <table class="govuk-table schools">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Name and URN</th>
+            <th scope="col" class="govuk-table__header">Responsible body</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @schools.each do |school| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
+                <br>
+                <%= school.type_label %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%- if @user.school_id == school.id %>
+                  (already associated)
+                <%- else %>
+                  <%= govuk_button_to('Associate', support_user_schools_path(urn: school.urn, id: @user.id), method: :post) %>
+                <%- end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <%- else %>
+      <p class="govuk-body">(none matching)</p>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -39,7 +39,7 @@
                 <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
               </td>
               <td class="govuk-table__cell">
-                <%- if @user.school_id == school.id %>
+                <%- if @user.school_ids.include?(school.id) %>
                   (already associated)
                 <%- else %>
                   <%= govuk_button_to('Associate', support_user_schools_path(urn: school.urn, id: @user.id), method: :post) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,8 +70,13 @@ en:
           search: Search for schools by URN
           results: School search results
       users:
+        associated_organisations: Associated organisations
         search: Find responsible body or school users
         results: Users
+        schools:
+          index: Associate with a school
+        responsible_bodies:
+          index: Associate with a responsible body
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact
     support_devices: Devices
@@ -581,3 +586,7 @@ en:
       support_enable_orders_form:
         device_cap: How many devices can they order?
         router_cap: How many routers can they order?
+      support_new_user_school_form:
+        name_or_urn: School name or URN
+      support_user_responsible_body_form:
+        name: Responsible body name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,12 @@ Rails.application.routes.draw do
         get 'search'
         post 'results'
       end
+      member do
+        get 'associated-organisations', as: :associated_organisations
+        get 'responsible-bodies', to: 'users/responsible_bodies#index', as: :responsible_bodies
+        patch 'responsible-body', to: 'users#update_responsible_body', as: :update_responsible_body
+        resources :schools, only: %i[index create destroy], as: :user_schools, controller: 'users/schools', param: :urn
+      end
     end
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin
   end

--- a/spec/components/support/user_search_result_component_spec.rb
+++ b/spec/components/support/user_search_result_component_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Support::UserSearchResultComponent do
   let(:st_josephs) { create(:school, name: 'St Joseph’s School') }
   let(:coventry) { create(:local_authority, name: 'Coventry') }
   let(:user) { create(:user, schools: [st_marys, st_josephs], responsible_body: coventry, email_address: 'jsmith@school.sch.uk') }
+  let(:support_user) { create(:support_user) }
 
-  subject { described_class.new(user) }
+  subject { described_class.new(user: user, current_user: support_user) }
 
   it 'renders the user’s email address' do
     expect(rendered_result_text).to include('jsmith@school.sch.uk')
@@ -21,6 +22,20 @@ RSpec.describe Support::UserSearchResultComponent do
   it 'renders links to the school support pages' do
     expect(rendered_result_html).to include(support_school_path(urn: st_marys.urn))
     expect(rendered_result_html).to include(support_school_path(urn: st_josephs.urn))
+  end
+
+  context 'when the current_user is a support user' do
+    it 'renders a Change link for the users associated organisations' do
+      expect(rendered_result_html).to include(associated_organisations_support_user_path(user))
+    end
+  end
+
+  context 'when the current_user is a Computacenter user' do
+    subject { described_class.new(user: user, current_user: create(:computacenter_user)) }
+
+    it 'does not render a Change link for the users associated organisations' do
+      expect(rendered_result_html).not_to include(associated_organisations_support_user_path(user))
+    end
   end
 
   def rendered_result_html

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Changing a users associated organisations' do
   let(:other_school) { create(:school, name: 'CCC school') }
   let(:responsible_body_user_with_multiple_schools) { create(:trust_user, responsible_body: trust, schools: [trust_school_1, trust_school_2]) }
   let(:other_trust) { create(:trust) }
-  let(:other_local_authority) { create(:local_authority) }
+  let(:other_local_authority) { create(:local_authority, name: 'AN ALL-UPPERCASE LA') }
   let(:search_page) { PageObjects::Support::Users::SearchPage.new }
   let(:results_page) { PageObjects::Support::Users::ResultsPage.new }
   let(:associated_organisations_page) { PageObjects::Support::Users::AssociatedOrganisationsPage.new }
@@ -59,7 +59,7 @@ RSpec.feature 'Changing a users associated organisations' do
   scenario 'entering a partial school name lets me associate schools matching that name' do
     given_i_am_logged_in_as_a_support_user
     when_i_visit_a_users_associated_organisations_page
-    and_i_enter_a_partial_school_name
+    and_i_enter_a_partial_school_name_in_any_case
     then_i_see_schools_matching_that_name
     and_i_see_an_associate_button_next_to_each_school
     when_i_click_the_associate_button
@@ -78,7 +78,7 @@ RSpec.feature 'Changing a users associated organisations' do
   scenario 'entering a partial responsible body name lets me associate responsible bodies matching that name' do
     given_i_am_logged_in_as_a_support_user
     when_i_visit_a_users_associated_organisations_page
-    and_i_enter_a_partial_responsible_body_name
+    and_i_enter_a_partial_responsible_body_name_in_any_case
     then_i_see_responsible_bodies_matching_that_name
     and_i_see_an_associate_button_next_to_each_responsible_body
     when_i_click_the_associate_button_next_to_the_responsible_body
@@ -180,8 +180,8 @@ RSpec.feature 'Changing a users associated organisations' do
     expect(associated_organisations_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is no longer associated with a Responsible body")
   end
 
-  def and_i_enter_a_partial_school_name
-    fill_in 'School name or URN', with: other_school.name.first(3)
+  def and_i_enter_a_partial_school_name_in_any_case
+    fill_in 'School name or URN', with: other_school.name.first(3).downcase
     associated_organisations_page.submit_school_name_or_urn.click
   end
 
@@ -222,8 +222,8 @@ RSpec.feature 'Changing a users associated organisations' do
     expect(matching_schools_page.schools[0]).not_to have_button('Associate')
   end
 
-  def and_i_enter_a_partial_responsible_body_name
-    fill_in 'Responsible body name', with: other_local_authority.name.first(3)
+  def and_i_enter_a_partial_responsible_body_name_in_any_case
+    fill_in 'Responsible body name', with: other_local_authority.name.first(3).downcase
     associated_organisations_page.submit_responsible_body_name.click
   end
 

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -1,0 +1,250 @@
+require 'rails_helper'
+
+RSpec.feature 'Changing a users associated organisations' do
+  let(:support_user) { create(:dfe_user) }
+  let(:school_user) { create(:school_user) }
+  let(:trust) { create(:trust) }
+  let(:trust_school_1) { create(:school, responsible_body: trust, name: 'AAA school') }
+  let(:trust_school_2) { create(:school, responsible_body: trust, name: 'BBB school') }
+  let(:other_school) { create(:school, name: 'CCC school') }
+  let(:responsible_body_user_with_multiple_schools) { create(:trust_user, responsible_body: trust, schools: [trust_school_1, trust_school_2]) }
+  let(:other_trust) { create(:trust) }
+  let(:other_local_authority) { create(:local_authority) }
+  let(:search_page) { PageObjects::Support::Users::SearchPage.new }
+  let(:results_page) { PageObjects::Support::Users::ResultsPage.new }
+  let(:associated_organisations_page) { PageObjects::Support::Users::AssociatedOrganisationsPage.new }
+  let(:matching_schools_page) { PageObjects::Support::Users::MatchingSchoolsPage.new }
+  let(:matching_responsible_bodies_page) { PageObjects::Support::Users::MatchingResponsibleBodiesPage.new }
+
+  scenario 'a support user sees a Change link next to the users assocations' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_search_for_an_existing_user_by_email
+    then_i_see_their_associated_organisations
+    and_i_see_a_link_to_change_their_associated_organisations
+  end
+
+  scenario 'clicking the Change link shows the  associated organisations' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_search_for_an_existing_user_by_email
+    and_i_click_the_link_to_change_their_associated_organisations
+    then_i_see_their_associated_schools_and_responsible_body
+    and_i_see_a_link_to_remove_each_school
+    and_i_see_a_link_to_remove_the_responsible_body
+  end
+
+  scenario 'clicking a school Remove link removes the school' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_click_the_remove_link_next_to_a_school
+    then_i_no_longer_see_the_removed_school_in_their_schools
+    and_i_see_a_message_telling_me_the_school_has_been_removed
+  end
+
+  scenario 'clicking the responsible body Remove link removes the responsible_body' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_click_the_remove_link_next_to_the_responsible_body
+    then_i_see_the_user_has_no_responsible_body
+    and_i_see_a_message_telling_me_the_responsible_body_has_been_removed
+  end
+
+  scenario 'entering a partial school name lets me associate schools matching that name' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_enter_a_partial_school_name
+    then_i_see_schools_matching_that_name
+    and_i_see_an_associate_button_next_to_each_school
+    when_i_click_the_associate_button
+    then_i_see_the_school_added_to_their_schools
+    and_i_see_a_message_telling_me_the_school_has_been_associated
+  end
+
+  scenario 'entering the URN of a school that is already associated shows it as already associated' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_enter_a_school_urn_that_the_user_already_has
+    then_i_see_the_school_is_already_associated
+    and_i_dont_see_a_button_to_associate_the_school
+  end
+
+  scenario 'entering a partial responsible body name lets me associate responsible bodies matching that name' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_enter_a_partial_responsible_body_name
+    then_i_see_responsible_bodies_matching_that_name
+    and_i_see_an_associate_button_next_to_each_responsible_body
+    when_i_click_the_associate_button_next_to_the_responsible_body
+    then_i_see_the_new_responsible_body_replaces_their_existing_responsible_body
+    and_i_see_a_message_telling_me_the_responsible_body_has_been_associated
+  end
+
+  scenario 'entering the name of a responsible_body that is already associated shows it as already associated' do
+    given_i_am_logged_in_as_a_support_user
+    when_i_visit_a_users_associated_organisations_page
+    and_i_enter_a_responsible_body_name_that_the_user_already_has
+    then_i_see_the_responsible_body_is_already_associated
+    and_i_dont_see_a_button_to_associate_the_responsible_body
+  end
+
+  def given_i_am_logged_in_as_a_support_user
+    sign_in_as support_user
+  end
+
+  def when_i_search_for_an_existing_user_by_email
+    visit '/support'
+    click_on 'Find users'
+    fill_in 'Enter an email address or name', with: responsible_body_user_with_multiple_schools.email_address
+    click_on 'Search'
+  end
+
+  def then_i_see_their_associated_organisations
+    expect(results_page).to be_displayed
+    expect(results_page.users.first).to have_text(responsible_body_user_with_multiple_schools.email_address)
+    expect(results_page.users.first).to have_text(trust_school_1.name)
+    expect(results_page.users.first).to have_text(trust_school_2.name)
+  end
+
+  def and_i_see_a_link_to_change_their_associated_organisations
+    expect(results_page.users.first).to have_link('Change')
+  end
+
+  def and_i_click_the_link_to_change_their_associated_organisations
+    within(results_page.users.first) do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_see_their_associated_schools_and_responsible_body
+    expect(associated_organisations_page).to be_displayed
+    expect(associated_organisations_page.schools.size).to eq(2)
+    expect(associated_organisations_page.schools[0]).to have_text(trust_school_1.name)
+    expect(associated_organisations_page.schools[1]).to have_text(trust_school_2.name)
+    expect(associated_organisations_page.responsible_body).to have_text(trust.name)
+  end
+
+  def and_i_see_a_link_to_remove_each_school
+    expect(associated_organisations_page.schools[0]).to have_css('input[type=submit][value=Remove]')
+    expect(associated_organisations_page.schools[1]).to have_css('input[type=submit][value=Remove]')
+  end
+
+  def and_i_see_a_link_to_remove_the_responsible_body
+    expect(associated_organisations_page.responsible_body).to have_css('input[type=submit][value=Remove]')
+  end
+
+  def when_i_visit_a_users_associated_organisations_page
+    visit(associated_organisations_support_user_path(responsible_body_user_with_multiple_schools))
+  end
+
+  def and_i_click_the_remove_link_next_to_a_school
+    within(associated_organisations_page.schools[0]) do
+      click_on('Remove')
+    end
+  end
+
+  def then_i_no_longer_see_the_removed_school_in_their_schools
+    expect(associated_organisations_page.schools.size).to eq(1)
+    expect(associated_organisations_page.schools[0]).to have_text(trust_school_2.name)
+  end
+
+  def and_i_see_a_message_telling_me_the_school_has_been_removed
+    expect(associated_organisations_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is no longer associated with #{trust_school_1.name}")
+  end
+
+  def then_i_see_the_user_has_no_responsible_body
+    expect(associated_organisations_page).not_to have_responsible_body
+  end
+
+  def and_i_click_the_remove_link_next_to_the_responsible_body
+    within(associated_organisations_page.responsible_body) do
+      click_on('Remove')
+    end
+  end
+
+  def and_i_see_a_message_telling_me_the_responsible_body_has_been_removed
+    expect(associated_organisations_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is no longer associated with a Responsible body")
+  end
+
+  def and_i_enter_a_partial_school_name
+    fill_in 'School name or URN', with: other_school.name.first(3)
+    associated_organisations_page.submit_school_name_or_urn.click
+  end
+
+  def then_i_see_schools_matching_that_name
+    expect(matching_schools_page).to be_displayed
+    expect(matching_schools_page.school_names).to all(have_text(other_school.name.first(3)))
+  end
+
+  def and_i_see_an_associate_button_next_to_each_school
+    expect(matching_schools_page.schools).to all(have_button('Associate'))
+  end
+
+  def when_i_click_the_associate_button
+    matching_schools_page.associate_school_link.click
+  end
+
+  def then_i_see_the_school_added_to_their_schools
+    expect(associated_organisations_page.schools.size).to eq(3)
+    expect(associated_organisations_page.schools[2]).to have_text(other_school.name)
+  end
+
+  def and_i_see_a_message_telling_me_the_school_has_been_associated
+    expect(associated_organisations_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is now associated with #{other_school.name}")
+  end
+
+  def and_i_enter_a_school_urn_that_the_user_already_has
+    fill_in 'School name or URN', with: trust_school_1.urn
+    associated_organisations_page.submit_school_name_or_urn.click
+  end
+
+  def then_i_see_the_school_is_already_associated
+    expect(matching_schools_page).to be_displayed
+    expect(matching_schools_page.school_names).to all(have_text(trust_school_1.name))
+    expect(matching_schools_page.schools[0]).to have_text('already associated')
+  end
+
+  def and_i_dont_see_a_button_to_associate_the_school
+    expect(matching_schools_page.schools[0]).not_to have_button('Associate')
+  end
+
+  def and_i_enter_a_partial_responsible_body_name
+    fill_in 'Responsible body name', with: other_local_authority.name.first(3)
+    associated_organisations_page.submit_responsible_body_name.click
+  end
+
+  def then_i_see_responsible_bodies_matching_that_name
+    expect(matching_responsible_bodies_page).to be_displayed
+    expect(matching_responsible_bodies_page.responsible_body_names).to all(have_text(other_school.name.first(3)))
+  end
+
+  def and_i_see_an_associate_button_next_to_each_responsible_body
+    expect(matching_responsible_bodies_page.responsible_bodies).to all(have_button('Associate'))
+  end
+
+  def when_i_click_the_associate_button_next_to_the_responsible_body
+    matching_responsible_bodies_page.associate_responsible_body_link.click
+  end
+
+  def then_i_see_the_new_responsible_body_replaces_their_existing_responsible_body
+    expect(associated_organisations_page.responsible_body).not_to have_text(trust.name)
+    expect(associated_organisations_page.responsible_body).to have_text(other_local_authority.name)
+  end
+
+  def and_i_see_a_message_telling_me_the_responsible_body_has_been_associated
+    expect(associated_organisations_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is now associated with #{other_local_authority.name}")
+  end
+
+  def and_i_enter_a_responsible_body_name_that_the_user_already_has
+    fill_in 'Responsible body name', with: trust.name
+    associated_organisations_page.submit_responsible_body_name.click
+  end
+
+  def then_i_see_the_responsible_body_is_already_associated
+    expect(matching_responsible_bodies_page).to be_displayed
+    expect(matching_responsible_bodies_page.responsible_body_names).to all(have_text(trust.name))
+    expect(matching_responsible_bodies_page.responsible_bodies[0]).to have_text('already associated')
+  end
+
+  def and_i_dont_see_a_button_to_associate_the_responsible_body
+    expect(matching_responsible_bodies_page.responsible_bodies[0]).not_to have_button('Associate')
+  end
+end

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Changing a users associated organisations' do
   let(:support_user) { create(:dfe_user) }
+  let(:computacenter_support_user) { create(:computacenter_user) }
   let(:school_user) { create(:school_user) }
   let(:trust) { create(:trust) }
   let(:trust_school_1) { create(:school, responsible_body: trust, name: 'AAA school') }
@@ -21,6 +22,13 @@ RSpec.feature 'Changing a users associated organisations' do
     when_i_search_for_an_existing_user_by_email
     then_i_see_their_associated_organisations
     and_i_see_a_link_to_change_their_associated_organisations
+  end
+
+  scenario 'a Computacenter support user does not see a Change link next to the users assocations' do
+    given_i_am_logged_in_as_a_computacenter_support_user
+    when_i_search_for_an_existing_user_by_email
+    then_i_see_their_associated_organisations
+    and_i_do_not_see_a_link_to_change_their_associated_organisations
   end
 
   scenario 'clicking the Change link shows the  associated organisations' do
@@ -90,6 +98,10 @@ RSpec.feature 'Changing a users associated organisations' do
     sign_in_as support_user
   end
 
+  def given_i_am_logged_in_as_a_computacenter_support_user
+    sign_in_as computacenter_support_user
+  end
+
   def when_i_search_for_an_existing_user_by_email
     visit '/support'
     click_on 'Find users'
@@ -106,6 +118,10 @@ RSpec.feature 'Changing a users associated organisations' do
 
   def and_i_see_a_link_to_change_their_associated_organisations
     expect(results_page.users.first).to have_link('Change')
+  end
+
+  def and_i_do_not_see_a_link_to_change_their_associated_organisations
+    expect(results_page.users.first).not_to have_link('Change')
   end
 
   def and_i_click_the_link_to_change_their_associated_organisations

--- a/spec/page_objects/support/users/associated_organisations_page.rb
+++ b/spec/page_objects/support/users/associated_organisations_page.rb
@@ -1,0 +1,21 @@
+module PageObjects
+  module Support
+    module Users
+      class AssociatedOrganisationsPage < PageObjects::BasePage
+        set_url '/support/users/{id}/associated-organisations'
+
+        element :school_name_or_urn, 'input#support-new-user-school-form-name-or-urn-field'
+        element :submit_school_name_or_urn, '#new_support_new_user_school_form input[value=Continue]'
+        elements :schools, 'table.schools tbody tr'
+
+        element :responsible_body_name, 'input#support-user-responsible-body-form-name-field'
+        element :submit_responsible_body_name, '#new_support_user_responsible_body_form input[value=Continue]'
+        element :responsible_body, 'table.responsible-body tbody tr'
+
+        def has_responsible_body?
+          has_selector?(responsible_body)
+        end
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/users/matching_responsible_bodies_page.rb
+++ b/spec/page_objects/support/users/matching_responsible_bodies_page.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Support
+    module Users
+      class MatchingResponsibleBodiesPage < PageObjects::BasePage
+        set_url '/support/users/{id}/responsible-bodies'
+
+        element :associate_responsible_body_link, 'table.responsible-bodies tbody tr input[type=submit][value=Associate]'
+        elements :responsible_bodies, 'table.responsible-bodies tbody tr'
+        elements :responsible_body_names, 'table.responsible-bodies tbody tr td:first-child a'
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/users/matching_schools_page.rb
+++ b/spec/page_objects/support/users/matching_schools_page.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Support
+    module Users
+      class MatchingSchoolsPage < PageObjects::BasePage
+        set_url '/support/users/{id}/schools'
+
+        element :associate_school_link, 'table.schools tbody tr input[type=submit][value=Associate]'
+        elements :schools, 'table.schools tbody tr'
+        elements :school_names, 'table.schools tbody tr td:first-child a'
+      end
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe UserPolicy do
   subject(:policy) { described_class }
 
-  permissions :new?, :create?, :edit?, :update?, :destroy? do
+  permissions :new?, :create?, :edit?, :update?, :destroy?, :associated_organisations?, :update_responsible_body? do
     it 'grants access to support users' do
       expect(policy).to permit(build(:support_user), :support)
     end


### PR DESCRIPTION
### Context

[Trello card 1021](https://trello.com/c/swcEUVuq/1021-allow-support-to-move-users-between-schools-and-or-rbs) - requests to change users' associated organisations are fairly regular now, and each time the support team member has to ask a dev to do it for them from the console.

### Changes proposed in this pull request

* add UI to allow support users to make those changes themselves

### Guidance to review

This was very much a 'whatever works' UI, with more of an eye on speed of implementation rather than elegance. As such, it could really do with a checkover from @fofr or @ralph-hawkins 

Screenshots:

**Point of entry - new 'Change' link on (existing) user search results**
![Screenshot from 2020-11-19 11-21-31](https://user-images.githubusercontent.com/134501/99659892-78ad2080-2a59-11eb-8687-f88a688089bf.png)

**New page - users' associated organisations**
![Screenshot from 2020-11-19 11-22-34](https://user-images.githubusercontent.com/134501/99659958-94b0c200-2a59-11eb-9762-86cd4804012c.png)

**New page - finding a school to associate**
![Screenshot from 2020-11-19 11-26-28](https://user-images.githubusercontent.com/134501/99660359-29b3bb00-2a5a-11eb-9cff-e8c7e448f957.png)

**New page - finding a responsible body to associate**
![Screenshot from 2020-11-19 11-28-31](https://user-images.githubusercontent.com/134501/99660555-6b446600-2a5a-11eb-939b-e82ae9d01ca2.png)


