### PR TITLE
[1040] Hide closed schools

### DIFF
--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -4,7 +4,7 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::BaseControll
       if @responsible_body.has_centrally_managed_schools_that_can_order_now?
         # at least 1 centrally managed school can order now
         # or mix of centrally managed and devolved
-        @schools = @responsible_body.schools.that_are_centrally_managed.that_can_order_now.order(name: :asc)
+        @schools = @responsible_body.schools.gias_status_open.that_are_centrally_managed.that_can_order_now.order(name: :asc)
 
         if @schools.can_order.count.positive?
           render 'order_devices'

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -3,6 +3,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
     @schools = @responsible_body.schools
                                 .includes(:preorder_information)
                                 .includes(:std_device_allocation)
+                                .gias_status_open
                                 .order(name: :asc)
   end
 

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -15,6 +15,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
     @schools = @responsible_body
       .schools
       .includes(:device_allocations, :preorder_information)
+      .gias_status_open
       .order(name: :asc)
   end
 end

--- a/app/form_objects/bulk_urn_search_form.rb
+++ b/app/form_objects/bulk_urn_search_form.rb
@@ -20,7 +20,7 @@ class BulkUrnSearchForm
   end
 
   def schools
-    @schools ||= School.where(urn: array_of_urns)
+    @schools ||= School.gias_status_open.where(urn: array_of_urns)
   end
 
   def missing_urns

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -137,19 +137,19 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def is_ordering_for_schools?
-    schools.that_are_centrally_managed.any?
+    schools.gias_status_open.that_are_centrally_managed.any?
   end
 
   def has_centrally_managed_schools_that_can_order_now?
-    schools.that_are_centrally_managed.that_can_order_now.any?
+    schools.gias_status_open.that_are_centrally_managed.that_can_order_now.any?
   end
 
   def has_schools_that_can_order_devices_now?
-    schools.that_will_order_devices.that_can_order_now.any?
+    schools.gias_status_open.that_will_order_devices.that_can_order_now.any?
   end
 
   def has_any_schools_that_can_order_now?
-    schools.that_can_order_now.any?
+    schools.gias_status_open.that_can_order_now.any?
   end
 
 private

--- a/spec/controllers/responsible_body/devices/orders_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/orders_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::OrdersController do
+  let(:user) { create(:trust_user) }
+  let(:rb) { user.responsible_body }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#show' do
+    let!(:closed_school) { create(:school, responsible_body: rb, status: :closed, order_state: :can_order) }
+
+    before do
+      create(:preorder_information, school: closed_school, who_will_order_devices: :responsible_body)
+    end
+
+    it 'excludes closed schools' do
+      get :show, params: { id: rb.id }
+      expect(assigns(:schools)).to be_nil
+    end
+  end
+end

--- a/spec/controllers/responsible_body/devices/schools_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/schools_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::SchoolsController do
+  let(:user) { create(:trust_user) }
+  let(:rb) { user.responsible_body }
+  let!(:closed_school) { create(:school, status: 'closed', responsible_body: rb) }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#index' do
+    it 'excludes closed schools' do
+      get :index
+      expect(assigns(:schools)).not_to include(closed_school)
+    end
+  end
+end

--- a/spec/controllers/support/responsible_bodies_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Support::ResponsibleBodiesController, type: :controller do
-  describe 'index' do
+  describe '#index' do
     it 'is forbidden for MNO users' do
       sign_in_as create(:mno_user)
 
@@ -22,6 +22,24 @@ RSpec.describe Support::ResponsibleBodiesController, type: :controller do
       get :index
 
       expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  describe '#show' do
+    let(:user) { create(:support_user) }
+    let!(:trust_user) { create(:trust_user) }
+    let!(:rb) { trust_user.responsible_body }
+    let!(:school) { create(:school, responsible_body: rb) }
+    let!(:closed_school) { create(:school, responsible_body: rb, status: :closed) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'excludes closed schools' do
+      get :show, params: { id: rb.id }
+      expect(assigns(:schools)).to include(school)
+      expect(assigns(:schools)).not_to include(closed_school)
     end
   end
 end

--- a/spec/form_objects/bulk_urn_search_form_spec.rb
+++ b/spec/form_objects/bulk_urn_search_form_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe BulkUrnSearchForm do
   let(:school) { create(:school) }
+  let(:closed_school) { create(:school, status: :closed) }
 
   describe '#array_of_urns' do
     subject(:form) do
@@ -20,6 +21,17 @@ RSpec.describe BulkUrnSearchForm do
 
     it 'returns array of urns with no matches' do
       expect(form.missing_urns).to eql(%w[456])
+    end
+  end
+
+  describe '#schools' do
+    subject(:form) do
+      described_class.new(urns: "#{school.urn}\r\n#{closed_school.urn}\r\n")
+    end
+
+    it 'does not include closed schools' do
+      expect(form.schools).to include(school)
+      expect(form.schools).not_to include(closed_school)
     end
   end
 end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#is_ordering_for_schools?' do
     subject(:responsible_body) { create(:trust) }
 
-    let(:schools) { create_list(:school, 2, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     context 'when some schools are centrally managed' do
       before do
         schools[0].preorder_information.responsible_body_will_order_devices!
         schools[1].preorder_information.school_will_order_devices!
+        schools[2].update!(status: :closed)
       end
 
       it 'returns true' do
@@ -89,6 +90,7 @@ RSpec.describe ResponsibleBody, type: :model do
       before do
         schools[0].preorder_information.school_will_order_devices!
         schools[1].preorder_information.school_will_order_devices!
+        schools[2].update!(status: :closed)
       end
 
       it 'returns false' do
@@ -100,19 +102,21 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#has_centrally_managed_schools_that_can_order_now?' do
     subject(:responsible_body) { create(:trust) }
 
-    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     context 'when some schools are centrally managed' do
       before do
         schools[0].preorder_information.responsible_body_will_order_devices!
         schools[1].preorder_information.responsible_body_will_order_devices!
         schools[2].preorder_information.school_will_order_devices!
+        schools[3].update!(status: :closed)
       end
 
       context 'and some managed schools have covid restrictions' do
         before do
           schools[0].can_order!
           schools[2].can_order!
+          schools[3].update!(status: :closed)
         end
 
         it 'returns true' do
@@ -124,6 +128,7 @@ RSpec.describe ResponsibleBody, type: :model do
         before do
           schools[0].cannot_order!
           schools[2].can_order!
+          schools[3].update!(status: :closed)
         end
 
         it 'returns false' do
@@ -137,6 +142,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[0].preorder_information.school_will_order_devices!
         schools[1].preorder_information.school_will_order_devices!
         schools[2].preorder_information.school_will_order_devices!
+        schools[3].update!(status: :closed)
       end
 
       context 'and no schools have covid restrictions' do
@@ -144,6 +150,7 @@ RSpec.describe ResponsibleBody, type: :model do
           schools[0].cannot_order!
           schools[1].cannot_order!
           schools[2].cannot_order!
+          schools[3].update!(status: :closed)
         end
 
         it 'returns false' do
@@ -156,6 +163,7 @@ RSpec.describe ResponsibleBody, type: :model do
           schools[0].cannot_order!
           schools[1].can_order_for_specific_circumstances!
           schools[2].can_order!
+          schools[3].update!(status: :closed)
         end
 
         it 'returns false' do
@@ -168,7 +176,7 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#has_schools_that_can_order_devices_now?' do
     subject(:responsible_body) { create(:trust) }
 
-    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     context 'when some schools that will order are able to order devices' do
       before do
@@ -193,6 +201,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[0].can_order!
         schools[1].cannot_order!
         schools[2].cannot_order!
+        schools[3].update!(status: :closed)
       end
 
       it 'returns false' do
@@ -204,7 +213,7 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#has_any_schools_that_can_order_now?' do
     subject(:responsible_body) { create(:trust) }
 
-    let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     context 'when some centrally managed schools are able to order devices' do
       before do
@@ -214,6 +223,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[0].can_order!
         schools[1].cannot_order!
         schools[2].cannot_order!
+        schools[3].update!(status: :closed)
       end
 
       it 'returns true' do
@@ -229,6 +239,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[0].cannot_order!
         schools[1].cannot_order!
         schools[2].can_order_for_specific_circumstances!
+        schools[3].update!(status: :closed)
       end
 
       it 'returns true' do
@@ -244,6 +255,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[0].cannot_order!
         schools[1].cannot_order!
         schools[2].cannot_order!
+        schools[3].update!(status: :closed)
       end
 
       it 'returns false' do


### PR DESCRIPTION
### Context

- https://trello.com/c/XuWAZaBb/1040-hide-closed-schools-on-service

### Changes proposed in this pull request

- Hide closed schools from views
- hidden from RB users and support users
- schools can still be accessed directly in url via urn
- but they are hidden from index views and support search

### Guidance to review

- Login as RB user viewing list of schools
- Close one of the schools
- School should no longer be visible to RB user
- Login as support user
- Close a school
- School should no longer be return via urn search
- View the RB of the closed school
- Should no longer see school in list of school for RB