### PR TITLE
Allow Computacenter to edit Chromebook details

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -97,6 +97,12 @@ private
   end
 
   def remove_change_links_if_read_only(row)
-    Pundit.policy(viewer, @school).edit? ? row : row.except(:change_path, :action, :action_path)
+    if row.in?(chromebook_rows_if_needed) && Pundit.policy(viewer, :chromebook).edit?
+      row
+    elsif Pundit.policy(viewer, @school).edit?
+      row
+    else
+      row.except(:change_path, :action, :action_path)
+    end
   end
 end

--- a/app/controllers/support/schools/devices/chromebooks_controller.rb
+++ b/app/controllers/support/schools/devices/chromebooks_controller.rb
@@ -1,6 +1,6 @@
 class Support::Schools::Devices::ChromebooksController < Support::BaseController
   before_action :set_school
-  before_action { authorize PreorderInformation }
+  before_action { authorize :chromebook }
 
   def edit
     @chromebook_information_form = ChromebookInformationForm.new(

--- a/app/policies/chromebook_policy.rb
+++ b/app/policies/chromebook_policy.rb
@@ -1,0 +1,9 @@
+class ChromebookPolicy < ApplicationPolicy
+  def edit?
+    user.is_support? || user.is_computacenter?
+  end
+
+  def update?
+    user.is_support? || user.is_computacenter?
+  end
+end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -96,7 +96,7 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(result.css('.govuk-summary-list__row')[1].text).to include('The trust orders devices')
     end
 
-    it 'shows the chromebook details' do
+    it 'shows the chromebook details and allows them to be edited' do
       expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we will order Chromebooks')
       expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
@@ -108,6 +108,29 @@ describe Support::SchoolDetailsSummaryListComponent do
 
     it 'does not show the school contact even if the school contact is set' do
       expect(result.css('dl').text).not_to include('School contact')
+    end
+  end
+
+  context 'when a computacenter user is the viewer' do
+    subject(:result) { render_inline(described_class.new(school: school, viewer: build(:computacenter_user))) }
+
+    before do
+      create(:preorder_information,
+             school: school,
+             who_will_order_devices: :responsible_body,
+             school_or_rb_domain: 'school.domain.org',
+             recovery_email_address: 'admin@recovery.org',
+             will_need_chromebooks: 'yes')
+    end
+
+    it 'shows the chromebook details and allows them to be edited' do
+      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we will order Chromebooks')
+      expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
+      expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
+
+      expect(action_for_row(result, 'Ordering Chromebooks?')).to be_present
+      expect(action_for_row(result, 'Domain')).to be_present
+      expect(action_for_row(result, 'Recovery email')).to be_present
     end
   end
 

--- a/spec/controllers/support/schools/devices/chromebooks_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/chromebooks_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Support::Schools::Devices::ChromebooksController do
+  let(:preorder_information) { create(:preorder_information, :school_will_order) }
+  let(:school) { preorder_information.school }
+
+  describe '#edit' do
+    it 'is successful for support users' do
+      expect {
+        get :edit, params: { school_urn: school.urn }
+      }.to receive_status_ok_for(create(:support_user))
+    end
+
+    it 'is successful for computacenter users' do
+      expect {
+        get :edit, params: { school_urn: school.urn }
+      }.to receive_status_ok_for(create(:computacenter_user))
+    end
+  end
+
+  describe '#update' do
+    it 'is successful for support users' do
+      sign_in_as create(:support_user)
+
+      patch :update, params: {
+        school_urn: school.urn,
+        chromebook_information_form: {
+          will_need_chromebooks: 'no',
+        },
+      }
+
+      expect(response).to redirect_to(support_school_path(school))
+    end
+
+    it 'is successful for computacenter users' do
+      sign_in_as create(:computacenter_user)
+
+      patch :update, params: {
+        school_urn: school.urn,
+        chromebook_information_form: {
+          will_need_chromebooks: 'no',
+        },
+      }
+
+      expect(response).to redirect_to(support_school_path(school))
+    end
+  end
+end

--- a/spec/policies/chromebook_policy_spec.rb
+++ b/spec/policies/chromebook_policy_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe ChromebookPolicy do
+  subject(:policy) { described_class }
+
+  permissions :edit?, :update? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), :any)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :any)
+    end
+
+    it 'blocks access to school users' do
+      expect(policy).not_to permit(build(:school_user), :any)
+    end
+
+    it 'blocks access to responsible body users' do
+      expect(policy).not_to permit(build(:trust_user), :any)
+    end
+  end
+end


### PR DESCRIPTION
### Context

CC users need to be able to edit Chromebook details through the support interface.

### Changes proposed in this pull request

Authorise Chromebook editing in the support interface for CC users, and show the link on the school details view.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/99820930-51358100-2b49-11eb-90ee-c8d3dc6eb466.png)
