### PR TITLE
Computacenter Support access: fixes and tweaks

### DIFF
--- a/app/components/nav_component.rb
+++ b/app/components/nav_component.rb
@@ -30,7 +30,7 @@ class NavComponent < ViewComponent::Base
     if @user&.is_support?
       support_links
     elsif @user&.is_computacenter?
-      computacenter_links
+      computacenter_links + support_links
     elsif @user&.is_mno_user?
       mno_links
     elsif @user&.is_responsible_body_user?

--- a/app/controllers/computacenter/base_controller.rb
+++ b/app/controllers/computacenter/base_controller.rb
@@ -1,4 +1,6 @@
 class Computacenter::BaseController < ApplicationController
+  include Pundit
+
   before_action :require_cc_user!
 
 private
@@ -10,4 +12,7 @@ private
       redirect_to_sign_in
     end
   end
+
+  attr_reader :current_user
+  helper_method :current_user
 end

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -28,10 +28,12 @@
 
     <p class="govuk-body">View details of schools with that can place orders.</p>
 
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to 'Support home', support_home_path %>
-    </h2>
+    <% if policy(:support).readable? %>
+      <h2 class="govuk-heading-m">
+        <%= govuk_link_to 'Support home', support_home_path %>
+      </h2>
 
-    <p class="govuk-body">Use this section to browse responsible bodies, find users and find schools.</p>
+      <p class="govuk-body">Use this section to browse responsible bodies, find users and find schools.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -27,5 +27,11 @@
     </h2>
 
     <p class="govuk-body">View details of schools with that can place orders.</p>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Support home', support_home_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to browse responsible bodies, find users and find schools.</p>
   </div>
 </div>

--- a/app/views/support/home/schools.html.erb
+++ b/app/views/support/home/schools.html.erb
@@ -16,12 +16,14 @@
       <%= govuk_link_to 'Find schools', search_support_schools_path %>
     </h2>
 
-    <p class="govuk-body">Use this section to find one or more schools by URN
+    <p class="govuk-body">Use this section to find one or more schools by URN.</p>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Enable orders for many schools', devices_enable_orders_for_many_schools_support_schools_path %>
-    </h2>
+    <% if policy(School).edit? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Enable orders for many schools', devices_enable_orders_for_many_schools_support_schools_path %>
+      </h2>
 
-    <p class="govuk-body">Use this section to allow schools to order their full allocation</p>
+      <p class="govuk-body">Use this section to allow schools to order their full allocation</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -20,15 +20,23 @@
 
     <p class="govuk-body">Use this section to find school and responsible body users by name or email address</p>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Find and manage schools', support_schools_path %>
-    </h2>
+    <% if policy(School).edit? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Find and manage schools', support_schools_path %>
+      </h2>
 
-    <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>search for schools</li>
-      <li>enable orders for many schools</li>
-    </ul>
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>search for schools</li>
+        <li>enable orders for many schools</li>
+      </ul>
+    <% else %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Find schools', support_schools_path %>
+      </h2>
+
+      <p class="govuk-body">Use this section to search for schools.</p>
+    <% end %>
 
     <% if policy(Support::ServicePerformance).index? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">


### PR DESCRIPTION
### Context

#809 gave support console access to Computacenter users. However this PR:

- didn't include any links to the support console from the CC area
- still linked to/mentioned some functions that CC users don't have access to

### Changes proposed in this pull request

- Add navigation and section links from the CC area to the support area
- Hide some functions in the support area if the user doesn't have those authorisations

### Guidance to review

**New nav link:**

![image](https://user-images.githubusercontent.com/23801/99821819-63fc8580-2b4a-11eb-8b73-d816122ccd97.png)

----

**New 'Support home' section in the Computacenter home screen:**

![image](https://user-images.githubusercontent.com/23801/99822103-b63da680-2b4a-11eb-8782-36dd5b7599fd.png)

----

**Support home no longer mentions enabling orders for schools to CC users:**

![image](https://user-images.githubusercontent.com/23801/99821884-78d91900-2b4a-11eb-9784-963b020adfbd.png)

![image](https://user-images.githubusercontent.com/23801/99822205-d79e9280-2b4a-11eb-8394-6a14dd554d00.png)


