### PR TITLE
add allocation to virtual cap pool

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -67,6 +67,19 @@ class SchoolDeviceAllocation < ApplicationRecord
     self[:devices_ordered]
   end
 
+  def allocation
+    if FeatureFlag.active? :virtual_caps
+      school_virtual_cap&.allocation || super
+    else
+      Rails.logger.info("Virtual allocation: #{school_virtual_cap&.allocation}") if is_in_virtual_cap_pool?
+      super
+    end
+  end
+
+  def raw_allocation
+    self[:allocation]
+  end
+
   def is_in_virtual_cap_pool?
     school_virtual_cap.present?
   end

--- a/app/models/school_virtual_cap.rb
+++ b/app/models/school_virtual_cap.rb
@@ -1,5 +1,5 @@
 class SchoolVirtualCap < ApplicationRecord
   belongs_to :virtual_cap_pool, touch: true
   belongs_to :school_device_allocation
-  delegate :cap, :devices_ordered, to: :virtual_cap_pool
+  delegate :allocation, :cap, :devices_ordered, to: :virtual_cap_pool
 end

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -6,6 +6,8 @@ class VirtualCapPool < ApplicationRecord
 
   after_touch :recalculate_caps!
 
+  validates :device_type, uniqueness: { scope: :responsible_body_id }
+
   enum device_type: {
     'coms_device': 'coms_device',
     'std_device': 'std_device',
@@ -14,6 +16,7 @@ class VirtualCapPool < ApplicationRecord
   def recalculate_caps!
     self.cap = school_device_allocations.sum(:cap)
     self.devices_ordered = school_device_allocations.sum(:devices_ordered)
+    self.allocation = school_device_allocations.sum(:allocation)
     save!
     # TODO: trigger events for CC here?
   end
@@ -30,20 +33,19 @@ private
 
   def school_can_be_added_to_pool?(school)
     school.responsible_body_id == responsible_body_id &&
+      school&.preorder_information&.responsible_body_will_order_devices? &&
       (school.can_order? || school.can_order_for_specific_circumstances?) &&
       school.device_allocations.exists?(device_type: device_type) &&
       !school_virtual_caps.exists?(school_device_allocation: school.device_allocations.find_by(device_type: device_type))
   end
 
-  def add_school_allocation(allocation)
+  def add_school_allocation(device_allocation)
     transaction do
-      school_virtual_caps.create!(school_device_allocation: allocation)
-      update_caps!(cap_change: allocation.raw_cap, devices_ordered_change: allocation.raw_devices_ordered)
+      school_virtual_caps.create!(school_device_allocation: device_allocation)
+      update!(cap: cap + device_allocation.raw_cap,
+              devices_ordered: devices_ordered + device_allocation.raw_devices_ordered,
+              allocation: allocation + device_allocation.raw_allocation)
+      # TODO: trigger events for CC here?
     end
-  end
-
-  def update_caps!(cap_change: 0, devices_ordered_change: 0)
-    update!(cap: cap + cap_change, devices_ordered: devices_ordered + devices_ordered_change)
-    # TODO: trigger events for CC here?
   end
 end

--- a/db/migrate/20201120145136_add_allocation_to_virtual_pool.rb
+++ b/db/migrate/20201120145136_add_allocation_to_virtual_pool.rb
@@ -1,0 +1,6 @@
+class AddAllocationToVirtualPool < ActiveRecord::Migration[6.0]
+  def change
+    add_column :virtual_cap_pools, :allocation, :integer, null: false, default: 0
+    add_index :virtual_cap_pools, %i[device_type responsible_body_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_110109) do
+ActiveRecord::Schema.define(version: 2020_11_20_145136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -383,6 +383,8 @@ ActiveRecord::Schema.define(version: 2020_11_19_110109) do
     t.integer "devices_ordered", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "allocation", default: 0, null: false
+    t.index ["device_type", "responsible_body_id"], name: "index_virtual_cap_pools_on_device_type_and_responsible_body_id", unique: true
     t.index ["responsible_body_id"], name: "index_virtual_cap_pools_on_responsible_body_id"
   end
 

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
     before do
       schools.each do |s|
+        s.preorder_information.responsible_body_will_order_devices!
         s.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
         s.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
       end
@@ -267,8 +268,10 @@ RSpec.describe ResponsibleBody, type: :model do
     it 'adds the schools cap and devices_ordered to the relevant pool' do
       schools.each { |s| responsible_body.add_school_to_virtual_cap_pools!(s) }
       responsible_body.reload
+      expect(responsible_body.std_device_pool.allocation).to eq(30)
       expect(responsible_body.std_device_pool.cap).to eq(30)
       expect(responsible_body.std_device_pool.devices_ordered).to eq(6)
+      expect(responsible_body.coms_device_pool.allocation).to eq(60)
       expect(responsible_body.coms_device_pool.cap).to eq(15)
       expect(responsible_body.coms_device_pool.devices_ordered).to eq(9)
     end
@@ -286,6 +289,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
     before do
       schools.each do |s|
+        s.preorder_information.responsible_body_will_order_devices!
         s.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
         s.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
         responsible_body.add_school_to_virtual_cap_pools!(s)


### PR DESCRIPTION
### Context
Add `:allocation` to virtual cap pool. This could help smooth out any potential issues with validations and devices_ordered appearing as being greater than the allocation at school level.

### Changes proposed in this pull request
Add allocation to `VirtualCapPool`
Provide `allocation` accessor for `SchoolDeviceAllocation` that determines which value to use (pool/local) and is FeatureFlag-ged with `:virtual_caps`
Added unique constraint to ensure there is only one virtual cap pool per `device_type` for a responsible body (as suggested by @aldavidson in the previous PR).
Added an additional check so that a school must also be centrally managed to be added to a pool

### Guidance to review

