### PR TITLE
Revert "Bump rails_semantic_logger from 4.4.4 to 4.4.5"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5)
     e2mmap (0.1.0)
-    erubi (1.10.0)
+    erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
     ethon (0.12.0)
@@ -306,7 +306,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_semantic_logger (4.4.5)
+    rails_semantic_logger (4.4.4)
       rack
       railties (>= 3.2)
       semantic_logger (~> 4.4)
@@ -388,7 +388,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    semantic_logger (4.7.4)
+    semantic_logger (4.7.1)
       concurrent-ruby (~> 1.0)
     semantic_range (2.3.0)
     sentry-raven (2.13.0)


### PR DESCRIPTION
### Context

- Revert semantic logger upgrade as seems to be hiding logs at least in dev mode

### Changes proposed in this pull request

- This reverts commit 5bd265f19f0095bc461862ad91d7c72edba09fe6.

### Guidance to review

- Start server in dev mode
- Make some requests
- Should see dev logs and stdout fill up