### PR TITLE
Improvements to the process of adding missing schools

### DIFF
--- a/app/models/data_stage/responsible_body.rb
+++ b/app/models/data_stage/responsible_body.rb
@@ -1,0 +1,16 @@
+class DataStage::ResponsibleBody
+  RB_NAME_MAP = {
+    'Bristol, City of' => 'City of Bristol',
+    'Dorset' => 'Dorset Council',
+    'Herefordshire, County of' => 'Herefordshire',
+    'Kingston upon Hull, City of' => 'Kingston upon Hull',
+  }.freeze
+
+  def self.find_by_name(responsible_body_name)
+    ::ResponsibleBody.find_by(name: translated(responsible_body_name))
+  end
+
+  def self.translated(responsible_body_name)
+    RB_NAME_MAP.fetch(responsible_body_name, responsible_body_name)
+  end
+end

--- a/app/models/data_stage/school.rb
+++ b/app/models/data_stage/school.rb
@@ -11,6 +11,10 @@ class DataStage::School < ApplicationRecord
   has_many :school_links, dependent: :destroy, class_name: 'DataStage::SchoolLink',
                           foreign_key: :staged_school_id
 
+  has_one :counterpart_school, class_name: '::School',
+                               foreign_key: :urn,
+                               primary_key: :urn
+
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
   validates :responsible_body_name, presence: true

--- a/app/models/data_stage/school.rb
+++ b/app/models/data_stage/school.rb
@@ -1,6 +1,13 @@
 class DataStage::School < ApplicationRecord
   self.table_name = 'staged_schools'
 
+  RB_NAME_MAP = {
+    'Bristol, City of' => 'City of Bristol',
+    'Dorset' => 'Dorset Council',
+    'Herefordshire, County of' => 'Herefordshire',
+    'Kingston upon Hull, City of' => 'Kingston upon Hull',
+  }.freeze
+
   has_many :school_links, dependent: :destroy, class_name: 'DataStage::SchoolLink',
                           foreign_key: :staged_school_id
 
@@ -31,4 +38,22 @@ class DataStage::School < ApplicationRecord
     special: 'special',
     other_type: 'other_type',
   }, _suffix: true
+
+  def responsible_body
+    ResponsibleBody.find_by(name: translated_responsible_body_name)
+  end
+
+  def staged_attributes
+    Rails.logger.error("Did not find responsible body: #{responsible_body_name}") if responsible_body.blank?
+
+    attributes
+      .except('id', 'responsible_body_name', 'created_at', 'updated_at')
+      .merge(responsible_body: responsible_body)
+  end
+
+private
+
+  def translated_responsible_body_name
+    RB_NAME_MAP.fetch(responsible_body_name, responsible_body_name)
+  end
 end

--- a/app/models/data_stage/school.rb
+++ b/app/models/data_stage/school.rb
@@ -1,13 +1,6 @@
 class DataStage::School < ApplicationRecord
   self.table_name = 'staged_schools'
 
-  RB_NAME_MAP = {
-    'Bristol, City of' => 'City of Bristol',
-    'Dorset' => 'Dorset Council',
-    'Herefordshire, County of' => 'Herefordshire',
-    'Kingston upon Hull, City of' => 'Kingston upon Hull',
-  }.freeze
-
   has_many :school_links, dependent: :destroy, class_name: 'DataStage::SchoolLink',
                           foreign_key: :staged_school_id
 
@@ -44,7 +37,7 @@ class DataStage::School < ApplicationRecord
   }, _suffix: true
 
   def responsible_body
-    ResponsibleBody.find_by(name: translated_responsible_body_name)
+    DataStage::ResponsibleBody.find_by_name(responsible_body_name)
   end
 
   def staged_attributes
@@ -53,11 +46,5 @@ class DataStage::School < ApplicationRecord
     attributes
       .except('id', 'responsible_body_name', 'created_at', 'updated_at')
       .merge(responsible_body: responsible_body)
-  end
-
-private
-
-  def translated_responsible_body_name
-    RB_NAME_MAP.fetch(responsible_body_name, responsible_body_name)
   end
 end

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -5,11 +5,7 @@ class SchoolUpdateService
 
     # attribute updates for schools
     DataStage::School.updated_since(last_update).find_each(batch_size: 100) do |staged_school|
-      school = School.find_by(urn: staged_school.urn)
-
-      next unless school
-
-      update_school(school, staged_school)
+      update_school(staged_school) if staged_school.counterpart_school.present?
     end
 
     DataStage::DataUpdateRecord.updated!(:schools)
@@ -17,9 +13,8 @@ class SchoolUpdateService
 
 private
 
-  def update_school(school, staged_school)
-    # update school details
-    school.update!(staged_school.staged_attributes)
+  def update_school(staged_school)
+    staged_school.counterpart_school.update!(staged_school.staged_attributes)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e.record.errors)
   end

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -11,14 +11,6 @@ class SchoolUpdateService
     DataStage::DataUpdateRecord.updated!(:schools)
   end
 
-private
-
-  def update_school(staged_school)
-    staged_school.counterpart_school.update!(staged_school.staged_attributes)
-  rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error(e.record.errors)
-  end
-
   def create_school(staged_school)
     Rails.logger.info("Adding school #{staged_school.urn} #{staged_school.name} (#{staged_school.status})")
     school = School.create!(staged_school.staged_attributes)
@@ -27,6 +19,14 @@ private
       school.device_allocations.create!(device_type: 'std_device', allocation: 0)
     end
     school
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error(e.record.errors)
+  end
+
+private
+
+  def update_school(staged_school)
+    staged_school.counterpart_school.update!(staged_school.staged_attributes)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e.record.errors)
   end

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -1,11 +1,4 @@
 class SchoolUpdateService
-  RB_NAME_MAP = {
-    'Bristol, City of' => 'City of Bristol',
-    'Dorset' => 'Dorset Council',
-    'Herefordshire, County of' => 'Herefordshire',
-    'Kingston upon Hull, City of' => 'Kingston upon Hull',
-  }.freeze
-
   def update_schools
     # look at the schools that have changed since the last update
     last_update = DataStage::DataUpdateRecord.last_update_for(:schools)
@@ -26,15 +19,14 @@ private
 
   def update_school(school, staged_school)
     # update school details
-    attrs = staged_attributes(staged_school)
-    school.update!(attrs)
+    school.update!(staged_school.staged_attributes)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e.record.errors)
   end
 
   def create_school(staged_school)
     Rails.logger.info("Adding school #{staged_school.urn} #{staged_school.name} (#{staged_school.status})")
-    school = School.create!(staged_attributes(staged_school))
+    school = School.create!(staged_school.staged_attributes)
     unless school.responsible_body.who_will_order_devices.nil?
       school.create_preorder_information!(who_will_order_devices: school.responsible_body.who_will_order_devices.singularize)
       school.device_allocations.create!(device_type: 'std_device', allocation: 0)
@@ -42,23 +34,5 @@ private
     school
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e.record.errors)
-  end
-
-  def staged_attributes(staged_school)
-    attrs = staged_school.attributes.except('id', 'responsible_body_name', 'created_at', 'updated_at')
-    attrs['responsible_body_id'] = responsible_body_id(staged_school.responsible_body_name)
-    attrs
-  end
-
-  def responsible_body_id(name)
-    rb_id = ResponsibleBody.find_by(name: rb_name(name))&.id
-
-    Rails.logger.error("Did not find responsible body: #{name}") unless rb_id
-
-    rb_id
-  end
-
-  def rb_name(name)
-    RB_NAME_MAP.fetch(name, name)
   end
 end

--- a/docs/support/add_missing_school.md
+++ b/docs/support/add_missing_school.md
@@ -9,7 +9,7 @@ ss = DataStage::School.find_by(urn: 123456)
 Check that the responsible body exists (if it does not then that will need to be added first)
 
 ```ruby
-t = ResponsibleBody.find_by(name: ss.responsible_body_name)
+ss.responsible_body
 ```
 
 Add the school using the `SchoolUpdateService`
@@ -32,7 +32,7 @@ Check whether the school was added as the result of 'closing' and 'reopening' an
 ss.school_links
 ```
 
-If there's a predecessor link, look up the school using the`link_urn` and if it exists in the system check its device allocations
+If there’s a predecessor link, look up the school using the `link_urn` and if it exists in the system check its device allocations:
 
 ```ruby
 School.find_by(urn: 123436)&.device_allocations
@@ -56,7 +56,7 @@ If there is an existing allocation, move the values to the new school (I've only
 
 If you change/move the allocation you need to inform Charlotte/Anya know so that the allocations spreadsheet can be updated.
 
-If there were no links and the school is in the allocations spreadsheet, use the allocation from the there and update the `std_device_allocation.allocation`with the value.
+If there were no links and the school is in the allocations spreadsheet, use the allocation from the there and update the `std_device_allocation.allocation` with the value.
 
 #### Moving Users
 

--- a/docs/support/add_missing_school.md
+++ b/docs/support/add_missing_school.md
@@ -12,14 +12,10 @@ Check that the responsible body exists (if it does not then that will need to be
 ss.responsible_body
 ```
 
-Add the school using the `SchoolUpdateService`
+Add the school:
 
 ```ruby
-sus = SchoolUpdateService.new
-```
-
-```ruby
-s = sus.send(:create_school, ss)
+SchoolUpdateService.new.create_school(ss)
 ```
 
 This will create the school based on the attributes in the `DataStage::School`. If the responsible body has answered the 'who will order' question, this will also create `preorder_information` and a `std_device_allocation` with a zero allocation.


### PR DESCRIPTION
### Context

There is operational documentation on how to add missing schools from the data staging area into the main `schools` table.

### Changes proposed in this pull request

Refactor some existing code to simplify/eliminate certain steps in the documentation, as a stepping stone to automating them with service objects.

### Guidance to review

Does it make sense for `DataStage::School` to be aware of `School`, even if it's just an association?