### PR TITLE
[1063] Add request count to mno rollout dashboard

### DIFF
--- a/app/views/support/service_performance/_mno_rollout.html.erb
+++ b/app/views/support/service_performance/_mno_rollout.html.erb
@@ -14,6 +14,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
       <th scope="col" class="govuk-table__header">Responsible body</th>
+      <th scope="col" class="govuk-table__header">Requests</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -21,6 +22,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
         <td class="govuk-table__cell"><%= govuk_link_to school.responsible_body.name, support_responsible_body_path(school.responsible_body) %></td>
+        <td class="govuk-table__cell"><%= pluralize(school.extra_mobile_data_requests.count(:id), 'request') %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
     and_i_follow_links_to_the_service_performance_page
 
     then_i_see_stats_about_extra_mobile_data_requests
+    and_i_see_stats_about_mno_rollout
   end
 
   def given_there_have_been_sign_ins_from_responsible_body_and_mno_users
@@ -34,6 +35,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
     rb = local_authority
     school_requester = create(:school_user)
     school = school_requester.school
+    school.update!(mno_feature_flag: true)
 
     create_list(:extra_mobile_data_request, 1,
                 status: :requested,
@@ -87,5 +89,11 @@ RSpec.feature 'Viewing service performance', type: :feature do
   def then_i_see_stats_about_responsible_body_user_engagement
     expect(page).to have_text('2 responsible body users have signed in')
     expect(page).to have_text('1 responsible body')
+  end
+
+  def and_i_see_stats_about_mno_rollout
+    within('#mno-rollout') do
+      expect(page).to have_content('4 requests')
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/i4gRgvIv/1063-show-which-schools-are-making-mno-requests-on-dashboard-page

### Changes proposed in this pull request

- Add request count per school to mno rollout dashboard 

### Screenshots

![image](https://user-images.githubusercontent.com/92580/99952656-e3bb6780-2d77-11eb-9ad0-d0b07d4455fa.png)

### Guidance to review

- Enable a school with feature flag `mno_feature_flag`
- Make that school make mno requests
- Should see mno rollout dashboard updated with request count