### PR TITLE
[1063] Fix request count spanning over 2 lines

### DIFF
--- a/app/views/support/service_performance/_mno_rollout.html.erb
+++ b/app/views/support/service_performance/_mno_rollout.html.erb
@@ -22,7 +22,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
         <td class="govuk-table__cell"><%= govuk_link_to school.responsible_body.name, support_responsible_body_path(school.responsible_body) %></td>
-        <td class="govuk-table__cell"><%= pluralize(school.extra_mobile_data_requests.count(:id), 'request') %></td>
+        <td class="govuk-table__cell"><%= pluralize(school.extra_mobile_data_requests.count(:id), 'request').gsub(' ', '&nbsp;').html_safe %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
### Context

![image](https://user-images.githubusercontent.com/92580/99987918-eda98e80-2da8-11eb-96cf-fecda1ae0916.png)

### Changes proposed in this pull request

- Replace space with `nbsp`

### Guidance to review

- Under MNO rollout dashboard make a school or RB have a super long name
- Requests should never span over 2 lines