### PR TITLE
Virtual pool caps for cc

### DIFF
--- a/app/models/computacenter/cap_change_notifier.rb
+++ b/app/models/computacenter/cap_change_notifier.rb
@@ -1,0 +1,32 @@
+module Computacenter
+  module CapChangeNotifier
+    def notify_computacenter_of_cap_changes?
+      Settings.computacenter.outgoing_api.endpoint.present?
+    end
+
+    def notify_computacenter_by_email(device_type, new_cap_value)
+      mailer = ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
+
+      if device_type == 'std_device'
+        mailer.notify_of_devices_cap_change.deliver_later
+      else
+        mailer.notify_of_comms_cap_change.deliver_later
+      end
+    end
+
+    def update_cap_on_computacenter!(allocation_ids)
+      ids = Array(allocation_ids)
+      api_request = Computacenter::OutgoingAPI::CapUpdateRequest.new(allocation_ids: ids)
+      response = api_request.post!
+
+      SchoolDeviceAllocation.where(id: ids).each do |allocation|
+        allocation.update!(
+          cap_update_request_timestamp: api_request.timestamp,
+          cap_update_request_payload_id: api_request.payload_id,
+        )
+        allocation.cap_update_calls << CapUpdateCall.new(request_body: api_request.body, response_body: response.body)
+      end
+      response
+    end
+  end
+end

--- a/app/models/computacenter/cap_change_notifier.rb
+++ b/app/models/computacenter/cap_change_notifier.rb
@@ -4,8 +4,8 @@ module Computacenter
       Settings.computacenter.outgoing_api.endpoint.present?
     end
 
-    def notify_computacenter_by_email(device_type, new_cap_value)
-      mailer = ComputacenterMailer.with(school: @school, new_cap_value: new_cap_value)
+    def notify_computacenter_by_email(school, device_type, new_cap_value)
+      mailer = ComputacenterMailer.with(school: school, new_cap_value: new_cap_value)
 
       if device_type == 'std_device'
         mailer.notify_of_devices_cap_change.deliver_later

--- a/app/models/computacenter/cap_change_notifier.rb
+++ b/app/models/computacenter/cap_change_notifier.rb
@@ -19,7 +19,7 @@ module Computacenter
       api_request = Computacenter::OutgoingAPI::CapUpdateRequest.new(allocation_ids: ids)
       response = api_request.post!
 
-      SchoolDeviceAllocation.where(id: ids).each do |allocation|
+      SchoolDeviceAllocation.where(id: ids).find_each do |allocation|
         allocation.update!(
           cap_update_request_timestamp: api_request.timestamp,
           cap_update_request_payload_id: api_request.payload_id,

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -65,7 +65,7 @@ class SchoolDeviceAllocation < ApplicationRecord
         super
       end
     else
-      Rails.logger.info("Virtual cap: #{school_virtual_cap.adjusted_cap_for_school}") if is_in_virtual_cap_pool?
+      Rails.logger.info("Virtual cap: #{school_virtual_cap.cap}") if is_in_virtual_cap_pool?
       super
     end
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -41,11 +41,31 @@ class SchoolDeviceAllocation < ApplicationRecord
     by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type))
   end
 
+  def computacenter_cap
+    # value to pass to computacenter
+    if FeatureFlag.active? :virtual_caps
+      if is_in_virtual_cap_pool?
+        # set the cap so the whole remaining pool amount could be ordered against this school
+        # CC keep track of devices ordered by school. Assume devices_ordered has been correctly sync'd
+        school_virtual_cap.adjusted_cap
+      else
+        raw_cap
+      end
+    else
+      Rails.logger.info("Computacenter adjusted cap: #{school_virtual_cap.adjusted_cap}") if is_in_virtual_cap_pool?
+      raw_cap
+    end
+  end
+
   def cap
     if FeatureFlag.active? :virtual_caps
-      school_virtual_cap&.cap || super
+      if is_in_virtual_cap_pool?
+        school_virtual_cap.cap
+      else
+        super
+      end
     else
-      Rails.logger.info("Virtual cap: #{school_virtual_cap&.cap}") if is_in_virtual_cap_pool?
+      Rails.logger.info("Virtual cap: #{school_virtual_cap.adjusted_cap_for_school}") if is_in_virtual_cap_pool?
       super
     end
   end
@@ -56,9 +76,13 @@ class SchoolDeviceAllocation < ApplicationRecord
 
   def devices_ordered
     if FeatureFlag.active? :virtual_caps
-      school_virtual_cap&.devices_ordered || super
+      if is_in_virtual_cap_pool?
+        school_virtual_cap.devices_ordered
+      else
+        super
+      end
     else
-      Rails.logger.info("Virtual devices_ordered: #{school_virtual_cap&.devices_ordered}") if is_in_virtual_cap_pool?
+      Rails.logger.info("Virtual devices_ordered: #{school_virtual_cap.devices_ordered}") if is_in_virtual_cap_pool?
       super
     end
   end
@@ -69,9 +93,13 @@ class SchoolDeviceAllocation < ApplicationRecord
 
   def allocation
     if FeatureFlag.active? :virtual_caps
-      school_virtual_cap&.allocation || super
+      if is_in_virtual_cap_pool?
+        school_virtual_cap.allocation
+      else
+        super
+      end
     else
-      Rails.logger.info("Virtual allocation: #{school_virtual_cap&.allocation}") if is_in_virtual_cap_pool?
+      Rails.logger.info("Virtual allocation: #{school_virtual_cap.allocation}") if is_in_virtual_cap_pool?
       super
     end
   end

--- a/app/models/school_virtual_cap.rb
+++ b/app/models/school_virtual_cap.rb
@@ -2,4 +2,8 @@ class SchoolVirtualCap < ApplicationRecord
   belongs_to :virtual_cap_pool, touch: true
   belongs_to :school_device_allocation
   delegate :allocation, :cap, :devices_ordered, to: :virtual_cap_pool
+
+  def adjusted_cap
+    cap - devices_ordered + school_device_allocation.raw_devices_ordered
+  end
 end

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -42,13 +42,8 @@ private
   end
 
   def add_school_allocation(device_allocation)
-    transaction do
-      school_virtual_caps.create!(school_device_allocation: device_allocation)
-      update!(cap: cap + device_allocation.raw_cap,
-              devices_ordered: devices_ordered + device_allocation.raw_devices_ordered,
-              allocation: allocation + device_allocation.raw_allocation)
-      notify_computacenter!
-    end
+    school_virtual_caps.create!(school_device_allocation: device_allocation)
+    recalculate_caps!
   end
 
   def notify_computacenter!

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -54,7 +54,7 @@ private
   def notify_computacenter!
     if FeatureFlag.active? :virtual_caps
       if notify_computacenter_of_cap_changes?
-        allocation_ids = school_device_allocations.joins(:school).where(schools: { order_state: %w[can_order can_order_for_specific_circumstances]}).pluck(:id)
+        allocation_ids = school_device_allocations.joins(:school).where(schools: { order_state: %w[can_order can_order_for_specific_circumstances] }).pluck(:id)
         update_cap_on_computacenter!(allocation_ids)
       end
     else

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -1,4 +1,6 @@
 class VirtualCapPool < ApplicationRecord
+  include Computacenter::CapChangeNotifier
+
   belongs_to :responsible_body
   has_many :school_virtual_caps, dependent: :destroy
   has_many :school_device_allocations, through: :school_virtual_caps
@@ -18,7 +20,7 @@ class VirtualCapPool < ApplicationRecord
     self.devices_ordered = school_device_allocations.sum(:devices_ordered)
     self.allocation = school_device_allocations.sum(:allocation)
     save!
-    # TODO: trigger events for CC here?
+    notify_computacenter!
   end
 
   def add_school!(school)
@@ -45,7 +47,18 @@ private
       update!(cap: cap + device_allocation.raw_cap,
               devices_ordered: devices_ordered + device_allocation.raw_devices_ordered,
               allocation: allocation + device_allocation.raw_allocation)
-      # TODO: trigger events for CC here?
+      notify_computacenter!
+    end
+  end
+
+  def notify_computacenter!
+    if FeatureFlag.active? :virtual_caps
+      if notify_computacenter_of_cap_changes?
+        allocation_ids = school_device_allocations.joins(:school).where(schools: { order_state: %w[can_order can_order_for_specific_circumstances]}).pluck(:id)
+        update_cap_on_computacenter!(allocation_ids)
+      end
+    else
+      Rails.logger.info("VirtualCapPool #{id}: (not) Notifying CC of changes (cap: #{cap}, devices_ordered: #{devices_ordered})")
     end
   end
 end

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -23,11 +23,11 @@ class SchoolOrderStateAndCapUpdateService
           # don't send updates as they will happen when the pool is updated and the caps adjusted
           unless allocation.is_in_virtual_pool?
             update_cap_on_computacenter!(allocation.id)
-            notify_computacenter_by_email(allocation.device_type, allocation.cap)
+            notify_computacenter_by_email(@school, allocation.device_type, allocation.cap)
           end
         else
           update_cap_on_computacenter!(allocation.id)
-          notify_computacenter_by_email(allocation.device_type, allocation.cap)
+          notify_computacenter_by_email(@school, allocation.device_type, allocation.cap)
         end
       end
     end

--- a/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
+++ b/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
@@ -3,6 +3,6 @@ xml.CapAdjustmentRequest(payloadID: assigns[:payload_id], dateTime: assigns[:tim
   assigns[:allocations].each do |allocation|
     xml.Record(capType: allocation.computacenter_cap_type,
                shipTo: allocation.school.computacenter_reference,
-               capAmount: allocation.cap)
+               capAmount: allocation.computacenter_cap)
   end
 end

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
+    context 'when a school is centrally managed and the school is not in the virtual cap pool' do
+      before do
+        school.preorder_information.responsible_body_will_order_devices!
+      end
+
+      it 'adds the school to the virtual cap pool of the responsible body' do
+        service.update!
+        expect(school.responsible_body.std_device_pool.schools).to include(school)
+      end
+    end
+
     context 'changing order_state to can_order_for_specific_circumstances' do
       let!(:allocation) { create(:school_device_allocation, :with_std_allocation, allocation: 7, school: school) }
       let!(:router_allocation) { create(:school_device_allocation, :with_coms_allocation, allocation: 5, school: school) }


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/1mHZtH0E/990-virtual-cap-sending-virtual-cap-to-cc) Notify Computacenter of changes to caps in the virtual cap pool

### Changes proposed in this pull request
Refactored Computacenter cap notifications out of `SchoolOrderStateAndCapUpdateService` and into a module
Added cap notifications for all ordering schools in the pool when changes occur to the VirtualCapPool
Added `computacenter_cap` accessor for `SchoolDeviceAllocation` and referenced this in the XML builder that constructs the payload for the Computacenter API.  When in a virtual cap pool this calculates the schools cap based on the available devices in the pool plus the local devices_ordered for that allocation. When not in a virtual pool this just returns the local cap.
School's are added to the pool as part of being enabled for ordering

### Guidance to review
When the `cap` or `devices_ordered` changes in the pool as a result of a change to a school or a school has been added to the pool, cap changes should be sent for all schools in the pool.
When ordering is enabled for a school via the `SchoolOrderStateAnCapUpdateService`, the school should be added to the virtual cap pool for its responsible_body if it is being centrally managed.