### PR TITLE
[1032] Update TechSource unavailable banner to reflect upcoming maintenance window

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -138,8 +138,8 @@ module ViewHelper
 
   def techsource_unavailable?
     now = Time.zone.now
-    window_start = Time.zone.local(2020, 9, 26, 7, 0, 0)
-    window_end = Time.zone.local(2020, 9, 26, 23, 0, 0)
+    window_start = Time.zone.local(2020, 11, 28, 7, 0, 0)
+    window_end = Time.zone.local(2020, 11, 28, 23, 0, 0)
     now >= window_start && now <= window_end
   end
 

--- a/app/views/shared/_techsource_unavailable_banner.html.erb
+++ b/app/views/shared/_techsource_unavailable_banner.html.erb
@@ -1,3 +1,3 @@
-<% if Time.zone.now < Time.zone.local(2020,9,27,0,0,0) %>
-<%= render GovukComponent::Warning.new(text: 'The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.') %>
+<% if Time.zone.now < Time.zone.local(2020,11,29,0,0,0) %>
+<%= render GovukComponent::Warning.new(text: 'The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.') %>
 <%- end %>

--- a/app/views/techsource_launcher/unavailable.html.erb
+++ b/app/views/techsource_launcher/unavailable.html.erb
@@ -8,6 +8,6 @@
     </h1>
 
     <p class="govuk-body">The TechSource website is closed for maintenance.</p>
-    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 27 September.</p>
+    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 29 November.</p>
   </div>
 </div>

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TechsourceLauncherController, type: :controller do
   describe '#start' do
     context 'before techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+        Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
         sign_in_as user
       end
 
@@ -20,7 +20,7 @@ RSpec.describe TechsourceLauncherController, type: :controller do
 
     context 'during techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+        Timecop.travel(Time.zone.local(2020, 11, 28, 8, 0, 0))
         sign_in_as user
       end
 
@@ -37,7 +37,7 @@ RSpec.describe TechsourceLauncherController, type: :controller do
 
     context 'after techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+        Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
         sign_in_as user
       end
 

--- a/spec/features/techsource_availability_for_responsible_body_spec.rb
+++ b/spec/features/techsource_availability_for_responsible_body_spec.rb
@@ -53,23 +53,23 @@ RSpec.feature 'TechSource availability for responsible body' do
   end
 
   def given_it_is_before_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
   end
 
   def given_it_is_during_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 28, 8, 0, 0))
   end
 
   def given_it_is_after_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
   end
 
   def then_i_see_a_warning_notice
-    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
   end
 
   def then_i_do_not_see_a_warning_notice
-    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
   end
 
   def when_i_click_the_start_now_button

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -57,23 +57,23 @@ RSpec.feature 'TechSource availability for school' do
   end
 
   def given_it_is_before_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 25, 23, 0, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
   end
 
   def given_it_is_during_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 26, 8, 0, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 28, 8, 0, 0))
   end
 
   def given_it_is_after_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 9, 27, 3, 1, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
   end
 
   def then_i_see_a_warning_notice
-    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
   end
 
   def then_i_do_not_see_a_warning_notice
-    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 26 September. You can order devices when it reopens on Sunday 27 September.')
+    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
   end
 
   def when_i_click_the_start_now_button


### PR DESCRIPTION
### Context

> Please be aware that there is a planned maintenance slot for the TechSource Ordering Portal on Saturday 28th November 2020 from 07:00 to 23:00 GMT, for the purposes of the deployment of the latest release.

### Changes proposed in this pull request

Update the dates to reflect the maintenance window on Saturday.

### Guidance to review

Please check that the dates are correct.
