### PR TITLE
[1087] add coms_ numbers to support/performance_data API

### DIFF
--- a/app/controllers/support/performance_data/schools_controller.rb
+++ b/app/controllers/support/performance_data/schools_controller.rb
@@ -32,6 +32,9 @@ private
       allocation: school.std_device_allocation.allocation,
       cap: school.std_device_allocation.cap,
       devices_ordered: school.std_device_allocation.devices_ordered,
+      coms_allocation: school.coms_device_allocation.allocation,
+      coms_cap: school.coms_device_allocation.cap,
+      coms_devices_ordered: school.coms_device_allocation.devices_ordered,
       preorder_info_status: school.preorder_information&.status,
       school_order_state: school.order_state,
     }

--- a/app/controllers/support/performance_data/schools_controller.rb
+++ b/app/controllers/support/performance_data/schools_controller.rb
@@ -32,9 +32,9 @@ private
       allocation: school.std_device_allocation.allocation,
       cap: school.std_device_allocation.cap,
       devices_ordered: school.std_device_allocation.devices_ordered,
-      coms_allocation: school.coms_device_allocation.allocation,
-      coms_cap: school.coms_device_allocation.cap,
-      coms_devices_ordered: school.coms_device_allocation.devices_ordered,
+      coms_allocation: school.coms_device_allocation&.allocation,
+      coms_cap: school.coms_device_allocation&.cap,
+      coms_devices_ordered: school.coms_device_allocation&.devices_ordered,
       preorder_info_status: school.preorder_information&.status,
       school_order_state: school.order_state,
     }

--- a/spec/controllers/support/performance_data/schools_controller_spec.rb
+++ b/spec/controllers/support/performance_data/schools_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
     end
 
     context 'when a valid authentication token is supplied' do
-      let!(:schools) { create_list(:school, 3, :with_preorder_information, :with_std_device_allocation) }
+      let!(:schools) { create_list(:school, 3, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation) }
 
       before do
         setup_auth_token
@@ -44,6 +44,9 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
       'allocation' => school.std_device_allocation.allocation,
       'cap' => school.std_device_allocation.cap,
       'devices_ordered' => school.std_device_allocation.devices_ordered,
+      'coms_allocation' => school.coms_device_allocation.allocation,
+      'coms_cap' => school.coms_device_allocation.cap,
+      'coms_devices_ordered' => school.coms_device_allocation.devices_ordered,
       'preorder_info_status' => school.preorder_information.status,
       'school_order_state' => school.order_state,
     }


### PR DESCRIPTION
### Context

The API at `/support/performance-data/schools.json` has so far only been showing `std_device` allocations/caps/devices_ordered numbers.

The analysts have requested the addition of `coms_device` numbers too. In [this slack thread]() we discussed implementation, and agreed on adding a simple prefix of `coms_` to the coms_device numbers.

### Changes proposed in this pull request

Add coms_device numbers to the API

### Guidance to review

