### PR TITLE
Simplify schools list page

### DIFF
--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -18,9 +18,9 @@
     <p class="govuk-body">Use this section to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>tell us who will place orders for schools</li>
-      <li>give schools access to the services they need</li>
-      <li>see your list of schools and their allocations</li>
+      <li>see your list of schools and their device allocations</li>
+      <li>tell us if the school will place their own orders</li>
+      <li>give contacts and technical information for each school</li>
     </ul>
 
     <% if @responsible_body.is_ordering_for_schools? %>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -10,21 +10,18 @@
                  ]) %>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Get laptops and tablets</span>
-  <%= title %>
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-margin-bottom-2"><%= pluralize(@schools.size, 'school') %></h2>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= pluralize(@schools.size, 'school') %>
+    </h1>
 
     <%= render GovukComponent::Details.new(summary: 'Is this list wrong?') do %>
       <% if @responsible_body.is_a_local_authority? %>
         <p>This is a list of all local authority maintained and special schools.</p>
       <% end %>
       <p>Email <%= ghwt_contact_mailto(subject: 'Problem with list of schools') %>
-        and tell us what to change.</p>
+        and tell us what to&nbsp;change.</p>
     <%- end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
     responsible_body_changed_allocations: We’ve changed how we allocate devices
     new_responsible_body_user: Invite a new user
     edit_responsible_body_user: Edit user
-    responsible_body_schools_list: Get schools ready
+    responsible_body_schools_list: List of schools
     requests_for_extra_mobile_data: Requests for extra mobile data
     suggested_email_to_schools: A suggested email for you to send to schools
     request_extra_mobile_data: Request extra data for mobile devices

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Setting up the devices ordering' do
       given_the_responsible_body_has_decided_to_order_centrally
       when_i_visit_the_responsible_body_homepage
       when_i_follow_the_get_devices_link
-      and_i_choose_to_get_schools_ready
+      and_i_follow_the_list_of_schools_link
       then_i_see_a_list_of_the_schools_i_am_responsible_for
 
       when_i_click_on_the_first_school_name
@@ -202,8 +202,8 @@ RSpec.feature 'Setting up the devices ordering' do
     click_on 'Get laptops and tablets'
   end
 
-  def and_i_choose_to_get_schools_ready
-    click_on 'Get schools ready'
+  def and_i_follow_the_list_of_schools_link
+    click_on 'List of schools'
   end
 
   def then_i_see_guidance_for_a_trust

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature 'Ordering devices' do
 
   def then_i_see_the_get_laptops_and_tablets_page
     expect(page).to have_css('h1', text: 'Get laptops and tablets')
-    expect(page).to have_link('Get schools ready')
+    expect(page).to have_link('List of schools')
     expect(page).to have_link('Order devices')
     expect(page).to have_link('Request devices for specific circumstances')
   end


### PR DESCRIPTION
Update to match https://ghwt-design-history.herokuapp.com/rbs-ordering-for-groups-of-schools/#simplified-schools-list

- ‘Get schools ready’ and ‘17 schools’ has been consolidated into a single title
- Title updated from ‘Get schools ready’ to 'List of schools' and an updated ‘use this section’ list

https://trello.com/c/MaiG7Jha/1084-virtual-cap-update-schools-list-page
https://trello.com/c/vsHiB2yY/1085-virtual-cap-update-get-laptops-and-tablets-page