### PR TITLE
[1071] allow existing non-RB-users to be invited to an RB

### DIFF
--- a/app/controllers/support/responsible_bodies/users_controller.rb
+++ b/app/controllers/support/responsible_bodies/users_controller.rb
@@ -10,9 +10,9 @@ class Support::ResponsibleBodies::UsersController < Support::BaseController
     @user = CreateUserService.invite_responsible_body_user(
       user_params.merge(responsible_body_id: params[:responsible_body_id]),
     )
-    # If anything goes wrong, the service will return a non-persisted user
+    # If anything goes wrong, the service will return a  user
     # object so that we can inspect the errors
-    if @user.persisted?
+    if @user.errors.empty?
       redirect_to return_path
     else
       render :new, status: :unprocessable_entity

--- a/app/mailers/invite_existing_user_to_responsible_body_mailer.rb
+++ b/app/mailers/invite_existing_user_to_responsible_body_mailer.rb
@@ -1,0 +1,25 @@
+class InviteExistingUserToResponsibleBodyMailer < ApplicationMailer
+  def invite_existing_user_to_responsible_body_email
+    @user = params[:user]
+    @responsible_body = params[:responsible_body]
+
+    template_mail(
+      invite_existing_user_to_responsible_body_template_id,
+      to: @user.email_address,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def personalisation
+    {
+      email_address: @user.email_address,
+      responsible_body_name: @responsible_body.name,
+    }
+  end
+
+  def invite_existing_user_to_responsible_body_template_id
+    Settings.govuk_notify.templates.devices.invite_existing_user_to_responsible_body
+  end
+end

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -58,7 +58,8 @@ class CreateUserService
     user = User.find_by_email_address(user_params[:email_address])
     if user.responsible_body_id.present?
       user.assign_attributes(user_params)
-      user.errors.add(:base, 'That email address is already a user on another responsible body')
+      user.errors.add(:base, :existing_responsible_body_user)
+      user.errors.add(:email_address, :belongs_to_existing_responsible_body_user)
     elsif user.update(user_params.select { |key, _value| user.send(key).blank? })
       InviteExistingUserToResponsibleBodyMailer.with(user: user, responsible_body: user.responsible_body).invite_existing_user_to_responsible_body_email.deliver_later
     end

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -1,10 +1,10 @@
 class CreateUserService
   def self.invite_responsible_body_user(user_params = {})
-    user = User.new(user_params.merge(orders_devices: true))
-    if user.save
-      InviteResponsibleBodyUserMailer.with(user: user).invite_user_email.deliver_later
+    if user_exists?(user_params)
+      invite_existing_user_to_responsible_body!(user_params)
+    else
+      invite_new_user_to_responsible_body!(user_params)
     end
-    user
   end
 
   def self.invite_school_user(user_params = {})
@@ -13,6 +13,10 @@ class CreateUserService
     else
       create_new_school_user!(user_params)
     end
+  end
+
+  def self.user_exists?(user_params)
+    User.where(email_address: user_params[:email_address]).exists?
   end
 
   def self.user_exists_on_other_school?(user_params)
@@ -49,4 +53,25 @@ class CreateUserService
   end
 
   private_class_method :invite_to_additional_school!
+
+  def self.invite_existing_user_to_responsible_body!(user_params)
+    user = User.find_by_email_address(user_params[:email_address])
+    if user.responsible_body_id.present?
+      user.assign_attributes(user_params)
+      user.errors.add(:base, 'That email address is already a user on another responsible body')
+    elsif user.update(user_params.select { |key, _value| user.send(key).blank? })
+      InviteExistingUserToResponsibleBodyMailer.with(user: user, responsible_body: user.responsible_body).invite_existing_user_to_responsible_body_email.deliver_later
+    end
+    user
+  end
+
+  private_class_method :invite_existing_user_to_responsible_body!
+
+  def self.invite_new_user_to_responsible_body!(user_params)
+    user = User.new(user_params.merge(orders_devices: true))
+    if user.save
+      InviteResponsibleBodyUserMailer.with(user: user).invite_user_email.deliver_later
+    end
+    user
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -512,6 +512,9 @@ en:
               gte_devices_ordered: can’t be less than devices ordered
         user:
           attributes:
+            base:
+              existing_responsible_body_user:
+                That email address belongs to a user for another responsible body.
             full_name:
               blank: Enter the user’s full name
               length: Enter a name that is between 2 and 1024 characters
@@ -520,6 +523,7 @@ en:
               taken: Email address has already been used
               too_short: Enter an email address that is at least %{count} characters
               invalid: Enter an email address in the correct format, like name@example.com
+              belongs_to_existing_responsible_body_user: Enter an email address for someone who isn't already a user for another responsible body
             orders_devices:
               inclusion: Tell us whether the user will order devices
               user_limit: There are already 3 users who can order devices. Change or remove another user.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ govuk_notify:
       mno_not_in_scheme_sms: '401aed7e-83ac-4e90-abac-3e2f9bc45a95'
     devices:
       invite_responsible_body_user: '42e5cd7a-deaa-4234-bdea-db63b7c4ad90'
+      invite_existing_user_to_responsible_body: 'a8fe1f78-85b3-43e8-87b7-77e64fe56fc1'
       nominate_contacts: 'ef964a6f-d984-4f35-a074-6f3cb79bfec7'
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
       can_order_devices: '9df2c08a-c457-4b13-9270-c5a20687d168'

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -101,10 +101,11 @@ RSpec.describe CreateUserService do
           expect { perform_enqueued_jobs { result } }.not_to change(ActionMailer::Base.deliveries, :size)
         end
 
-        it 'returns the user unpersisted, with an error on the base' do
+        it 'returns the user unpersisted, with errors on the base and the email_address' do
           expect(result).to be_a(User)
           expect(result).to have_attributes(valid_params)
           expect(result.errors[:base]).not_to be_empty
+          expect(result.errors[:email_address]).not_to be_empty
         end
       end
     end


### PR DESCRIPTION
### Context

[Trello card 1071](https://trello.com/c/WQSvtsY2/1071-support-add-a-user-form-cant-add-an-existing-user-to-a-new-school) - although it was possible to add an existing user to an additional school, it was not possible to add an existing user to a Responsible Body.

### Changes proposed in this pull request

* allow an existing user to be added to a Responsible Body from the support UI, as along as they are not already associated with a Responsible Body
* add a new email template (content approved by @emmajhf )
* if the entered email address _is_ already a Responsible Body user, show a more meaningful error message 

### Guidance to review

* go to Support > Support Home > Responsible Bodies
* click on a Responsible Body
* click on 'Invite user'
* enter an email address that already exists as a non-RB user - this should work
* enter an email address that already exists as an RB user - this should not work, and should show you a meaningful error message (see screenshot)

![Screenshot from 2020-11-26 14-37-34](https://user-images.githubusercontent.com/134501/100363917-5127fc00-2ff5-11eb-9e72-823d5564eea3.png)

