### PR TITLE
[1094] re-do schools performance data endpoint in raw SQL, for huge speedup

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -25,8 +25,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def self.included_in_performance_analysis
-    t = SchoolDeviceAllocation.arel_table
-    std_device.where(t[:cap].gt(0).or(t[:allocation].gt(0)))
+    where('cap > 0 OR allocation > 0')
   end
 
   def self.can_order_std_devices_now

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -24,10 +24,6 @@ class SchoolDeviceAllocation < ApplicationRecord
     end
   end
 
-  def self.included_in_performance_analysis
-    where('cap > 0 OR allocation > 0')
-  end
-
   def self.can_order_std_devices_now
     by_device_type('std_device').where('cap > devices_ordered')
   end

--- a/spec/controllers/support/performance_data/schools_controller_spec.rb
+++ b/spec/controllers/support/performance_data/schools_controller_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
       before do
         setup_auth_token
         schools[0].std_device_allocation.update!(allocation: 0, cap: 0)
+        schools[0].coms_device_allocation.update!(allocation: 0, cap: 0)
+
         schools[1].std_device_allocation.update!(allocation: 10, cap: 10)
-        schools[2].std_device_allocation.update!(allocation: 10, cap: 0)
+        schools[2].coms_device_allocation.update!(allocation: 10, cap: 0)
       end
 
       it 'does not return an unauthorized status' do
@@ -27,6 +29,7 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
       it 'lists schools with allocations or caps in JSON format' do
         get :index
         payload = JSON.parse(response.body)
+
         expect(payload.count).to eq(2)
         expect(payload.first).to eql(school_data(schools[1]))
         expect(payload.last).to eql(school_data(schools[2]))


### PR DESCRIPTION
### Context

[Trello card 1094](https://trello.com/c/IxhghLAA/1094-performance-data-api-now-takes-7min-to-render-and-download) - The `/support/support/performance-data/schools.json` endpoint has become unsustainably slow since the release of the [virtual cap pool work](https://github.com/DFE-Digital/get-help-with-tech/pull/843) and [expanding the endpoint's dataset to also include comms devices](https://github.com/DFE-Digital/get-help-with-tech/pull/860). It's now taking almost 7 minutes to render and stream the response on production. 

### Changes proposed in this pull request

* re-implement the endpoint in raw SQL, to optimise query performance
* use `connection.select_all` to return the records. `select_all` returns results from the database as an array of Hashes, thus removing the need to instantiate ActiveRecord objects.
 
### Guidance to review

Results from staging, where the number of `SchoolDeviceAllocation` records is comparable to prod:

```
> SchoolDeviceAllocation.where('cap > 0 OR allocation > 0').group('device_type').count
=> {"std_device"=>20008, "coms_device"=>21965}
```

#### Before:
```
time curl -s -H 'Authorization: Bearer (...)' https://get-help-with-tech-staging.london.cloudapps.digital/support/performance-data/schools.json
real	1m47.018s
```

#### After:

```
time curl -s -H 'Authorization: Bearer (...)' https://get-help-with-tech-staging.london.cloudapps.digital/support/performance-data/schools.json
real	0m4.204s
```
