### PR TITLE
[1096] fix local docker build, by ignoring local node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,4 @@
 ./public/packs
 .byebug_history
 .git
-npm-debug.log
 node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@
 ./public/packs
 .byebug_history
 .git
+npm-debug.log
+node_modules


### PR DESCRIPTION
### Context

While building a Docker image locally, I encountered an error saying that node sass lacked a binding for the current environment.
On investigation, it's because [the asset precompilation stage is using the node_modules copied from the host](https://github.com/sass/node-sass/issues/2165), which may or may not be compatible with the 64-bit Alpine linux environment within the container. 

This isn't typically a problem when the container is built on CI, because that's run in a fresh container and there are no existing node_modules. But it could prevent a developer building the container locally (as it did with me).

### Changes proposed in this pull request

Add node_modules to .dockerignore, so they are not copied into the container
  
### Guidance to review

`make dev build` should now work
