### PR TITLE
assets should be cached

### DIFF
--- a/config/initializers/assets_cache_header.rb
+++ b/config/initializers/assets_cache_header.rb
@@ -1,0 +1,8 @@
+# This will affect assets served from /app/assets
+Rails.application.config.static_cache_control = 'public, max-age=31536000'
+
+# This will affect assets in /public, e.g. webpacker assets.
+Rails.application.config.public_file_server.headers = {
+  'Cache-Control' => 'public, max-age=31536000',
+  'Expires' => 1.year.from_now.to_formatted_s(:rfc822),
+}


### PR DESCRIPTION
### Context
This commit adds cache headers to our assets so that a users browser does
not have to download the assets on every page refresh when the assets
have not changed.
### Changes proposed in this pull request

### Guidance to review

Opening the preview app and looking at the network tab all our assets should have a cache-control response header
![image](https://user-images.githubusercontent.com/3441519/100612808-72e1f580-330b-11eb-9a80-d5a13fbcc5bb.png)
