### PR TITLE
[1080] Add ability to flag specific RBs to have virtual cap enabled

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -75,6 +75,10 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
+  def has_virtual_cap_feature_flags?
+    FeatureFlag.active?(:virtual_caps) && vcap_feature_flag?
+  end
+
   def self.in_connectivity_pilot
     where(in_connectivity_pilot: true)
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -53,7 +53,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def cap
-    if FeatureFlag.active? :virtual_caps
+    if has_virtual_cap_feature_flags?
       if is_in_virtual_cap_pool?
         school_virtual_cap.cap
       else
@@ -70,7 +70,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def devices_ordered
-    if FeatureFlag.active? :virtual_caps
+    if has_virtual_cap_feature_flags?
       if is_in_virtual_cap_pool?
         school_virtual_cap.devices_ordered
       else
@@ -87,7 +87,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def allocation
-    if FeatureFlag.active? :virtual_caps
+    if has_virtual_cap_feature_flags?
       if is_in_virtual_cap_pool?
         school_virtual_cap.allocation
       else
@@ -131,6 +131,10 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
 private
+
+  def has_virtual_cap_feature_flags?
+    school&.responsible_body&.has_virtual_cap_feature_flags? || false
+  end
 
   def cap_lte_allocation
     if cap > allocation

--- a/db/migrate/20201130111700_add_vcap_feature_flag_to_responsible_body.rb
+++ b/db/migrate/20201130111700_add_vcap_feature_flag_to_responsible_body.rb
@@ -1,0 +1,5 @@
+class AddVcapFeatureFlagToResponsibleBody < ActiveRecord::Migration[6.0]
+  def change
+    add_column :responsible_bodies, :vcap_feature_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_145136) do
+ActiveRecord::Schema.define(version: 2020_11_30_111700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_145136) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
     t.index ["gias_id"], name: "index_responsible_bodies_on_gias_id", unique: true

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     trait :devolves_management do
       who_will_order_devices      { 'schools' }
     end
+
+    trait :vcap_feature_flag do
+      vcap_feature_flag           { true }
+    end
   end
 
   factory :trust do
@@ -44,6 +48,10 @@ FactoryBot.define do
 
     trait :manages_centrally do
       who_will_order_devices      { 'responsible_body' }
+    end
+
+    trait :vcap_feature_flag do
+      vcap_feature_flag           { true }
     end
 
     trait :devolves_management do

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -319,4 +319,48 @@ RSpec.describe ResponsibleBody, type: :model do
       expect(responsible_body.coms_device_pool.devices_ordered).to eq(31)
     end
   end
+
+  describe '#has_virtual_cap_feature_flags?' do
+    subject(:responsible_body) { create(:trust, :manages_centrally) }
+
+    context 'without any feature flags', with_feature_flags: { virtual_caps: 'inactive' } do
+      before do
+        responsible_body.update!(vcap_feature_flag: false)
+      end
+
+      it 'returns false' do
+        expect(responsible_body.has_virtual_cap_feature_flags?).to be false
+      end
+    end
+
+    context 'when global feature flag is enabled', with_feature_flags: { virtual_caps: 'active' } do
+      before do
+        responsible_body.update!(vcap_feature_flag: false)
+      end
+
+      it 'returns false' do
+        expect(responsible_body.has_virtual_cap_feature_flags?).to be false
+      end
+    end
+
+    context 'when responsible body flag is enabled', with_feature_flags: { virtual_caps: 'inactive' } do
+      before do
+        responsible_body.update!(vcap_feature_flag: true)
+      end
+
+      it 'returns false' do
+        expect(responsible_body.has_virtual_cap_feature_flags?).to be false
+      end
+    end
+
+    context 'when responsible body flag and global feature flag are enabled', with_feature_flags: { virtual_caps: 'active' } do
+      before do
+        responsible_body.update!(vcap_feature_flag: true)
+      end
+
+      it 'returns true' do
+        expect(responsible_body.has_virtual_cap_feature_flags?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
   end
 
   context 'when in a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
-    let(:responsible_body) { create(:trust, :manages_centrally) }
+    let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
     let(:school) { create(:school, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
     let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789', body: '<xml>test-request</xml>') }
     let(:response) { OpenStruct.new(body: '<xml>test-response</xml>') }


### PR DESCRIPTION
### Context

Like the MNO offer, we would like to roll out virtual caps in small batches of RBs so that we limit the risk of the rollout. In addition to the global virtual cap feature flag we're adding a per-RB flag.

### Changes proposed in this pull request

1. By default, all trusts are excluded from the virtual cap rollout, even if the global feature flag is enabled.
2. Only use the `SchoolVirtualCap` and `VirtualCapPool` is the global feature is on and the individual RB flag is enabled.

### Guidance to review

1. Find school
2. Toggle global virtual cap feature on: no change to cap/allocation/device_ordered
3. Toggle `vcap_feature_flag` enabled on its RB: virtual cap enabled for all the schools within that RB that are eligible

