### PR TITLE
1037 build an interface for cc to ship-to and sold-to numbers

### DIFF
--- a/app/components/computacenter/responsible_body_changes_details_component.html.erb
+++ b/app/components/computacenter/responsible_body_changes_details_component.html.erb
@@ -1,0 +1,3 @@
+<div class="responsible-body-changes-details">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/computacenter/responsible_body_changes_details_component.rb
+++ b/app/components/computacenter/responsible_body_changes_details_component.rb
@@ -1,0 +1,37 @@
+class Computacenter::ResponsibleBodyChangesDetailsComponent < ViewComponent::Base
+  attr_accessor :responsible_body
+
+  def initialize(responsible_body:)
+    @responsible_body = responsible_body
+  end
+
+  def rows
+    array = rb_rows
+    array.concat(sold_to_row) if responsible_body.computacenter_reference.present?
+    array
+  end
+
+private
+
+  def rb_rows
+    [{
+      key: 'RB URN',
+      value: responsible_body.computacenter_identifier,
+    },
+     {
+       key: 'RB Name',
+       value: responsible_body.computacenter_name,
+     },
+     {
+       key: 'Address',
+       value: responsible_body.address,
+     }]
+  end
+
+  def sold_to_row
+    [{
+      key: 'Sold To',
+      value: responsible_body.computacenter_reference,
+    }]
+  end
+end

--- a/app/components/computacenter/school_changes_details_component.html.erb
+++ b/app/components/computacenter/school_changes_details_component.html.erb
@@ -1,0 +1,3 @@
+<div class="school-changes-details">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/computacenter/school_changes_details_component.rb
+++ b/app/components/computacenter/school_changes_details_component.rb
@@ -30,7 +30,7 @@ private
       value: school.urn,
     },
      {
-       key: 'School Name',
+       key: 'School name',
        value: school.name,
      },
      {

--- a/app/components/computacenter/school_changes_details_component.rb
+++ b/app/components/computacenter/school_changes_details_component.rb
@@ -1,0 +1,48 @@
+class Computacenter::SchoolChangesDetailsComponent < ViewComponent::Base
+  attr_accessor :school
+
+  def initialize(school:)
+    @school = school
+  end
+
+  def rows
+    array = rb_rows.concat(school_rows)
+    array.concat(ship_to_row) if school.computacenter_reference.present?
+    array
+  end
+
+private
+
+  def rb_rows
+    [{
+      key: 'RB URN',
+      value: school.responsible_body.computacenter_identifier,
+    },
+     {
+       key: 'Sold To',
+       value: school.responsible_body.computacenter_reference,
+     }]
+  end
+
+  def school_rows
+    [{
+      key: 'School URN',
+      value: school.urn,
+    },
+     {
+       key: 'School Name',
+       value: school.name,
+     },
+     {
+       key: 'Address',
+       value: school.address,
+     }]
+  end
+
+  def ship_to_row
+    [{
+      key: 'Ship To',
+      value: school.computacenter_reference,
+    }]
+  end
+end

--- a/app/controllers/computacenter/base_controller.rb
+++ b/app/controllers/computacenter/base_controller.rb
@@ -1,6 +1,4 @@
 class Computacenter::BaseController < ApplicationController
-  include Pundit
-
   before_action :require_cc_user!
 
 private
@@ -12,7 +10,4 @@ private
       redirect_to_sign_in
     end
   end
-
-  attr_reader :current_user
-  helper_method :current_user
 end

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -8,7 +8,7 @@ class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseContr
     respond_to do |format|
       format.html do
         @responsible_bodies = fetch_responsible_bodies
-        @show_download_link = ResponsibleBody.with_changes_relevant_to_computacenter.any?
+        @show_download_link = ResponsibleBody.requiring_a_new_computacenter_reference.any?
       end
       format.csv { send_data csv_generator, filename: "rb-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
@@ -65,11 +65,11 @@ private
   def query_for_view_mode
     case view_mode
     when 'new'
-      new_responsible_bodies
+      ResponsibleBody.requiring_a_new_computacenter_reference.where.not(computacenter_change: :amended)
     when 'amended'
-      amended_responsible_bodies
+      ResponsibleBody.requiring_a_new_computacenter_reference.where(computacenter_change: :amended)
     when 'all'
-      new_responsible_bodies.or(amended_responsible_bodies)
+      ResponsibleBody.requiring_a_new_computacenter_reference
     end
   end
 

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -1,7 +1,10 @@
 class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseController
   before_action :set_responsible_body, except: :index
+  after_action :verify_authorized
+  after_action :verify_policy_scoped, only: :index
 
   def index
+    authorize ResponsibleBody
     respond_to do |format|
       format.html do
         @responsible_bodies = fetch_responsible_bodies
@@ -12,11 +15,13 @@ class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseContr
   end
 
   def edit
+    authorize @responsible_body, :update_computacenter_reference?
     @form = Computacenter::SoldToForm.new(responsible_body: @responsible_body,
                                           sold_to: @responsible_body.computacenter_reference)
   end
 
   def update
+    authorize @responsible_body, :update_computacenter_reference?
     @form = Computacenter::SoldToForm.new(sold_to_params.merge(responsible_body: @responsible_body))
 
     if @form.valid?
@@ -33,6 +38,7 @@ private
 
   def set_responsible_body
     @responsible_body = ResponsibleBody.gias_status_open.find(params[:id])
+    authorize @responsible_body, :show?
   end
 
   def csv_generator
@@ -40,7 +46,8 @@ private
   end
 
   def fetch_responsible_bodies
-    ResponsibleBody.gias_status_open
+    policy_scope(ResponsibleBody)
+      .gias_status_open
       .merge(query_for_view_mode)
       .order(ResponsibleBody.arel_table[:type].asc, ResponsibleBody.arel_table[:name].asc)
   end
@@ -61,7 +68,7 @@ private
       new_responsible_bodies
     when 'amended'
       amended_responsible_bodies
-    else
+    when 'all'
       new_responsible_bodies.or(amended_responsible_bodies)
     end
   end

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -1,0 +1,80 @@
+class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseController
+  before_action :set_responsible_body, except: :index
+
+  def index
+    respond_to do |format|
+      format.html { @responsible_bodies = fetch_responsible_bodies }
+      format.csv { send_data csv_generator, filename: "rb-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
+    end
+  end
+
+  def edit
+    @form = Computacenter::SoldToForm.new(responsible_body: @responsible_body,
+                                          sold_to: @responsible_body.computacenter_reference)
+  end
+
+  def update
+    @form = Computacenter::SoldToForm.new(sold_to_params.merge(responsible_body: @responsible_body))
+
+    if @form.valid?
+      update_sold_to
+      flash[:success] = t(:success, scope: %i[computacenter sold_to update], name: @responsible_body.name)
+      redirect_to computacenter_responsible_body_changes_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_responsible_body
+    @responsible_body = ResponsibleBody.gias_status_open.find(params[:id])
+  end
+
+  def csv_generator
+    ResponsibleBodyExporter.new.export_responsible_bodies(fetch_responsible_bodies)
+  end
+
+  def fetch_responsible_bodies
+    ResponsibleBody.gias_status_open
+      .merge(query_for_view_mode)
+      .order(ResponsibleBody.arel_table[:type].asc, ResponsibleBody.arel_table[:name].asc)
+  end
+
+  def view_mode
+    @view_mode ||= parse_view_mode
+  end
+
+  def parse_view_mode
+    mode = params[:view]
+    mode = 'all' unless mode.in? %w[new amended]
+    mode
+  end
+
+  def query_for_view_mode
+    case view_mode
+    when 'new'
+      new_responsible_bodies
+    when 'amended'
+      amended_responsible_bodies
+    else
+      new_responsible_bodies.or(amended_responsible_bodies)
+    end
+  end
+
+  def new_responsible_bodies
+    ResponsibleBody.where(computacenter_reference: nil).or(ResponsibleBody.computacenter_change_new)
+  end
+
+  def amended_responsible_bodies
+    ResponsibleBody.computacenter_change_amended
+  end
+
+  def sold_to_params
+    params.require(:computacenter_sold_to_form).permit(:sold_to)
+  end
+
+  def update_sold_to
+    @responsible_body.update!(computacenter_reference: @form.sold_to)
+  end
+end

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -5,7 +5,7 @@ class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseContr
     respond_to do |format|
       format.html do
         @responsible_bodies = fetch_responsible_bodies
-        @show_download_link = show_download_link?
+        @show_download_link = ResponsibleBody.with_changes_relevant_to_computacenter.any?
       end
       format.csv { send_data csv_generator, filename: "rb-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
@@ -80,9 +80,5 @@ private
 
   def update_sold_to
     @responsible_body.update!(computacenter_reference: @form.sold_to, computacenter_change: 'none')
-  end
-
-  def show_download_link?
-    ResponsibleBody.gias_status_open.where(computacenter_change: %w[new amended]).count.positive?
   end
 end

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -21,7 +21,8 @@ class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseContr
 
     if @form.valid?
       update_sold_to
-      flash[:success] = t(:success, scope: %i[computacenter sold_to update], name: @responsible_body.name)
+      flash[:success] = t(:success, scope: %i[computacenter sold_to update], name: @responsible_body.name,
+                                    sold_to: @responsible_body.computacenter_reference)
       redirect_to computacenter_responsible_body_changes_path
     else
       render :edit, status: :unprocessable_entity
@@ -74,7 +75,7 @@ private
   end
 
   def sold_to_params
-    params.require(:computacenter_sold_to_form).permit(:sold_to)
+    params.require(:computacenter_sold_to_form).permit(:sold_to, :change_sold_to)
   end
 
   def update_sold_to

--- a/app/controllers/computacenter/responsible_body_changes_controller.rb
+++ b/app/controllers/computacenter/responsible_body_changes_controller.rb
@@ -3,7 +3,10 @@ class Computacenter::ResponsibleBodyChangesController < Computacenter::BaseContr
 
   def index
     respond_to do |format|
-      format.html { @responsible_bodies = fetch_responsible_bodies }
+      format.html do
+        @responsible_bodies = fetch_responsible_bodies
+        @show_download_link = show_download_link?
+      end
       format.csv { send_data csv_generator, filename: "rb-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
   end
@@ -75,6 +78,10 @@ private
   end
 
   def update_sold_to
-    @responsible_body.update!(computacenter_reference: @form.sold_to)
+    @responsible_body.update!(computacenter_reference: @form.sold_to, computacenter_change: 'none')
+  end
+
+  def show_download_link?
+    ResponsibleBody.gias_status_open.where(computacenter_change: %w[new amended]).count.positive?
   end
 end

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -3,7 +3,10 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
 
   def index
     respond_to do |format|
-      format.html { @schools = fetch_schools }
+      format.html do
+        @schools = fetch_schools
+        @show_download_link = show_download_link?
+      end
       format.csv { send_data csv_generator, filename: "school-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
   end
@@ -54,8 +57,6 @@ private
   end
 
   def query_for_view_mode
-    open_schools = School.gias_status_open
-
     case view_mode
     when 'new'
       new_schools
@@ -78,7 +79,11 @@ private
     params.require(:computacenter_ship_to_form).permit(:ship_to)
   end
 
-  def update_references
-    @school.update!(computacenter_reference: @form.ship_to)
+  def update_ship_to
+    @school.update!(computacenter_reference: @form.ship_to, computacenter_change: 'none')
+  end
+
+  def show_download_link?
+    School.gias_status_open.where(computacenter_change: %w[new amended]).count.positive?
   end
 end

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -25,7 +25,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
     @form = Computacenter::ShipToForm.new(ship_to_params.merge(school: @school))
 
     if @form.valid?
-      update_ship_to
+      @school.update_computacenter_reference!(@form.ship_to)
       flash[:success] = t(:success, scope: %i[computacenter ship_to update], name: @school.name, ship_to: @school.computacenter_reference)
       redirect_to computacenter_school_changes_path
     else
@@ -86,9 +86,5 @@ private
 
   def ship_to_params
     params.require(:computacenter_ship_to_form).permit(:ship_to, :change_ship_to)
-  end
-
-  def update_ship_to
-    @school.update!(computacenter_reference: @form.ship_to, computacenter_change: 'none')
   end
 end

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -21,7 +21,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
 
     if @form.valid?
       update_ship_to
-      flash[:success] = t(:success, scope: %i[computacenter ship_to update], name: @school.name)
+      flash[:success] = t(:success, scope: %i[computacenter ship_to update], name: @school.name, ship_to: @school.computacenter_reference)
       redirect_to computacenter_school_changes_path
     else
       render :edit, status: :unprocessable_entity
@@ -76,7 +76,7 @@ private
   end
 
   def ship_to_params
-    params.require(:computacenter_ship_to_form).permit(:ship_to)
+    params.require(:computacenter_ship_to_form).permit(:ship_to, :change_ship_to)
   end
 
   def update_ship_to

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -1,0 +1,84 @@
+class Computacenter::SchoolChangesController < Computacenter::BaseController
+  before_action :set_school, except: :index
+
+  def index
+    respond_to do |format|
+      format.html { @schools = fetch_schools }
+      format.csv { send_data csv_generator, filename: "school-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
+    end
+  end
+
+  def edit
+    @form = Computacenter::ShipToForm.new(school: @school,
+                                          ship_to: @school.computacenter_reference)
+  end
+
+  def update
+    @form = Computacenter::ShipToForm.new(ship_to_params.merge(school: @school))
+
+    if @form.valid?
+      update_ship_to
+      flash[:success] = t(:success, scope: %i[computacenter ship_to update], name: @school.name)
+      redirect_to computacenter_school_changes_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_school
+    @school = School.gias_status_open.find_by(urn: params[:id])
+  end
+
+  def csv_generator
+    SchoolDataExporter.new.export_schools(fetch_schools)
+  end
+
+  def fetch_schools
+    School.joins(:responsible_body)
+      .includes(:responsible_body)
+      .gias_status_open
+      .merge(query_for_view_mode)
+      .order(ResponsibleBody.arel_table[:type].asc, ResponsibleBody.arel_table[:name].asc, School.arel_table[:name].asc)
+  end
+
+  def view_mode
+    @view_mode ||= parse_view_mode
+  end
+
+  def parse_view_mode
+    mode = params[:view]
+    mode = 'all' unless mode.in? %w[new amended]
+    mode
+  end
+
+  def query_for_view_mode
+    open_schools = School.gias_status_open
+
+    case view_mode
+    when 'new'
+      new_schools
+    when 'amended'
+      amended_schools
+    else
+      new_schools.or(amended_schools)
+    end
+  end
+
+  def new_schools
+    School.where(computacenter_reference: nil).or(School.computacenter_change_new)
+  end
+
+  def amended_schools
+    School.computacenter_change_amended
+  end
+
+  def ship_to_params
+    params.require(:computacenter_ship_to_form).permit(:ship_to)
+  end
+
+  def update_references
+    @school.update!(computacenter_reference: @form.ship_to)
+  end
+end

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -5,7 +5,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
     respond_to do |format|
       format.html do
         @schools = fetch_schools
-        @show_download_link = show_download_link?
+        @show_download_link = School.with_changes_relevant_to_computacenter.any?
       end
       format.csv { send_data csv_generator, filename: "school-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
@@ -51,9 +51,11 @@ private
   end
 
   def parse_view_mode
-    mode = params[:view]
-    mode = 'all' unless mode.in? %w[new amended]
-    mode
+    if params[:view].in?(%w[new amended])
+      params[:view]
+    else
+      'all'
+    end
   end
 
   def query_for_view_mode
@@ -81,9 +83,5 @@ private
 
   def update_ship_to
     @school.update!(computacenter_reference: @form.ship_to, computacenter_change: 'none')
-  end
-
-  def show_download_link?
-    School.gias_status_open.where(computacenter_change: %w[new amended]).count.positive?
   end
 end

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -8,7 +8,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
     respond_to do |format|
       format.html do
         @schools = fetch_schools
-        @show_download_link = School.with_changes_relevant_to_computacenter.any?
+        @show_download_link = School.requiring_a_new_computacenter_reference.any?
       end
       format.csv { send_data csv_generator, filename: "school-changes-#{Time.zone.now.strftime('%Y%m%d')}.csv" }
     end
@@ -68,20 +68,12 @@ private
   def query_for_view_mode
     case view_mode
     when 'new'
-      new_schools
+      School.requiring_a_new_computacenter_reference.where.not(computacenter_change: :amended)
     when 'amended'
-      amended_schools
+      School.requiring_a_new_computacenter_reference.where(computacenter_change: :amended)
     else
-      new_schools.or(amended_schools)
+      School.requiring_a_new_computacenter_reference
     end
-  end
-
-  def new_schools
-    School.where(computacenter_reference: nil).or(School.computacenter_change_new)
-  end
-
-  def amended_schools
-    School.computacenter_change_amended
   end
 
   def ship_to_params

--- a/app/controllers/support/base_controller.rb
+++ b/app/controllers/support/base_controller.rb
@@ -1,28 +1,11 @@
 class Support::BaseController < ApplicationController
-  include Pundit
-
-  before_action :require_dfe_user!
+  before_action :require_sign_in!
   after_action :verify_authorized
   after_action :verify_policy_scoped, if: :index_method?
-
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
 private
 
   def index_method?
     %i[index results].include?(action_name)
   end
-
-  def require_dfe_user!
-    unless SessionService.is_signed_in?(session)
-      redirect_to_sign_in
-    end
-  end
-
-  def user_not_authorized
-    render 'errors/forbidden', status: :forbidden
-  end
-
-  attr_reader :current_user
-  helper_method :current_user
 end

--- a/app/form_objects/computacenter/ship_to_form.rb
+++ b/app/form_objects/computacenter/ship_to_form.rb
@@ -1,0 +1,11 @@
+class Computacenter::ShipToForm
+  include ActiveModel::Model
+
+  attr_accessor :ship_to, :school
+
+  validates :ship_to, numericality: { only_integer: true, greater_than: 0, message: 'Ship To must be a number greater than zero' }
+
+  def initialize(params = {})
+    super(params)
+  end
+end

--- a/app/form_objects/computacenter/ship_to_form.rb
+++ b/app/form_objects/computacenter/ship_to_form.rb
@@ -1,9 +1,10 @@
 class Computacenter::ShipToForm
   include ActiveModel::Model
 
-  attr_accessor :ship_to, :school
+  attr_accessor :change_ship_to, :ship_to, :school
 
-  validates :ship_to, numericality: { only_integer: true, greater_than: 0, message: 'Ship To must be a number greater than zero' }
+  validates :ship_to, numericality: { only_integer: true, message: 'Ship To must be a number' }
+  validates :change_ship_to, inclusion: { in: %w[yes no], message: 'Tell us whether the Ship To number needs to change' }
 
   def initialize(params = {})
     super(params)

--- a/app/form_objects/computacenter/sold_to_form.rb
+++ b/app/form_objects/computacenter/sold_to_form.rb
@@ -1,0 +1,12 @@
+class Computacenter::SoldToForm
+  include ActiveModel::Model
+
+  attr_accessor :sold_to, :responsible_body
+
+  validates :sold_to, numericality: { only_integer: true, greater_than: 0, message: 'Sold To must be a number greater than zero' }
+
+  def initialize(params = {})
+    super(params)
+  end
+end
+

--- a/app/form_objects/computacenter/sold_to_form.rb
+++ b/app/form_objects/computacenter/sold_to_form.rb
@@ -1,9 +1,10 @@
 class Computacenter::SoldToForm
   include ActiveModel::Model
 
-  attr_accessor :sold_to, :responsible_body
+  attr_accessor :change_sold_to, :sold_to, :responsible_body
 
-  validates :sold_to, numericality: { only_integer: true, greater_than: 0, message: 'Sold To must be a number greater than zero' }
+  validates :sold_to, numericality: { only_integer: true, message: 'Sold To must be a number' }
+  validates :change_sold_to, inclusion: { in: %w[yes no], message: 'Tell us whether the Sold To number needs to change' }
 
   def initialize(params = {})
     super(params)

--- a/app/form_objects/computacenter/sold_to_form.rb
+++ b/app/form_objects/computacenter/sold_to_form.rb
@@ -9,4 +9,3 @@ class Computacenter::SoldToForm
     super(params)
   end
 end
-

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -1,7 +1,7 @@
 module Computacenter::ResponsibleBodyUrns
   module ClassMethods
-    def with_changes_relevant_to_computacenter
-      gias_status_open.where(computacenter_change: %w[new amended])
+    def requiring_a_new_computacenter_reference
+      gias_status_open.where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
     end
 
     def find_by_computacenter_urn!(cc_urn)

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -40,9 +40,13 @@ module Computacenter::ResponsibleBodyUrns
       when 'LocalAuthority'
         "LEA#{gias_id}"
       when 'Trust'
-        return '' if companies_house_number.blank?
-
-        "t#{companies_house_number.to_i}"
+        if companies_house_number.blank?
+          ''
+        else
+          "t#{companies_house_number.to_i}"
+        end
+      when 'DfE'
+        'DfE'
       end
     end
 
@@ -52,6 +56,8 @@ module Computacenter::ResponsibleBodyUrns
         local_authority_official_name
       when 'Trust'
         name
+      when 'DfE'
+        'Department for Education'
       end
     end
   end

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -1,5 +1,9 @@
 module Computacenter::ResponsibleBodyUrns
   module ClassMethods
+    def with_changes_relevant_to_computacenter
+      gias_status_open.where(computacenter_change: %w[new amended])
+    end
+
     def find_by_computacenter_urn!(cc_urn)
       our_identifier = convert_computacenter_urn(cc_urn)
       # given URNs starting with 't' are for Trusts

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -22,6 +22,13 @@ class ResponsibleBody < ApplicationRecord
     closed: 'closed',
   }, _prefix: 'gias_status'
 
+  enum computacenter_change: {
+    none: 'none',
+    new: 'new',
+    amended: 'amended',
+    closed: 'closed',
+  }, _prefix: true
+
   after_update :maybe_generate_user_changes
 
   def calculate_virtual_caps!
@@ -192,6 +199,10 @@ class ResponsibleBody < ApplicationRecord
       specific_circumstances_schools: schools_by_name.can_order_for_specific_circumstances,
       fully_open_schools: schools_by_name.where(order_state: %w[cannot_order cannot_order_as_reopened]),
     }
+  end
+
+  def address
+    [address_1, address_2, address_3, town, postcode].reject(&:blank?).join(', ')
   end
 
 private

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -17,6 +17,8 @@ class ResponsibleBody < ApplicationRecord
   extend Computacenter::ResponsibleBodyUrns::ClassMethods
   include Computacenter::ResponsibleBodyUrns::InstanceMethods
 
+  before_create :set_computacenter_change
+
   enum status: {
     open: 'open',
     closed: 'closed',
@@ -209,5 +211,9 @@ private
 
   def maybe_generate_user_changes
     users.each(&:generate_user_change_if_needed!)
+  end
+
+  def set_computacenter_change
+    self.computacenter_change = 'new' unless computacenter_change
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -214,6 +214,6 @@ private
   end
 
   def set_computacenter_change
-    self.computacenter_change = 'new' unless computacenter_change
+    self.computacenter_change = 'new'
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -71,8 +71,8 @@ class School < ApplicationRecord
     where(order_state: %w[can_order_for_specific_circumstances can_order])
   end
 
-  def self.with_changes_relevant_to_computacenter
-    gias_status_open.where(computacenter_change: %w[new amended])
+  def self.requiring_a_new_computacenter_reference
+    gias_status_open.where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
   end
 
   def has_ordered?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -174,6 +174,10 @@ class School < ApplicationRecord
     [address_1, address_2, address_3, town, postcode].reject(&:blank?).join(', ')
   end
 
+  def update_computacenter_reference!(new_value)
+    update!(computacenter_reference: new_value, computacenter_change: 'none')
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -177,7 +177,7 @@ private
   end
 
   def set_computacenter_change
-    self.computacenter_change = 'new' unless computacenter_change
+    self.computacenter_change = 'new'
   end
 
   def device_ordering_organisation

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,6 +19,8 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
+  before_create :set_computacenter_change
+
   enum status: {
     open: 'open',
     closed: 'closed',
@@ -47,6 +49,13 @@ class School < ApplicationRecord
     can_order_for_specific_circumstances: 'can_order_for_specific_circumstances',
     can_order: 'can_order',
   }
+
+  enum computacenter_change: {
+    none: 'none',
+    new: 'new',
+    amended: 'amended',
+    closed: 'closed',
+  }, _prefix: true
 
   after_update :maybe_generate_user_changes
 
@@ -157,10 +166,18 @@ class School < ApplicationRecord
     responsible_body.has_school_in_virtual_cap_pools?(self)
   end
 
+  def address
+    [address_1, address_2, address_3, town, postcode].reject(&:blank?).join(', ')
+  end
+
 private
 
   def maybe_generate_user_changes
     users.each(&:generate_user_change_if_needed!)
+  end
+
+  def set_computacenter_change
+    self.computacenter_change = 'added' unless computacenter_change
   end
 
   def device_ordering_organisation

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -71,6 +71,10 @@ class School < ApplicationRecord
     where(order_state: %w[can_order_for_specific_circumstances can_order])
   end
 
+  def self.with_changes_relevant_to_computacenter
+    gias_status_open.where(computacenter_change: %w[new amended])
+  end
+
   def has_ordered?
     device_allocations.to_a.any? { |alloc| alloc.devices_ordered.positive? }
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -177,7 +177,7 @@ private
   end
 
   def set_computacenter_change
-    self.computacenter_change = 'added' unless computacenter_change
+    self.computacenter_change = 'new' unless computacenter_change
   end
 
   def device_ordering_organisation

--- a/app/policies/responsible_body_policy.rb
+++ b/app/policies/responsible_body_policy.rb
@@ -4,4 +4,8 @@ class ResponsibleBodyPolicy < SupportPolicy
       scope.all
     end
   end
+
+  def update_computacenter_reference?
+    user.is_computacenter?
+  end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -1,6 +1,20 @@
 class SchoolPolicy < SupportPolicy
+  class Scope < Scope
+    def resolve
+      if user.is_computacenter? || user.is_support?
+        scope.all
+      else
+        raise 'Unexpected user type in school policy scope'
+      end
+    end
+  end
+
   alias_method :search?, :readable?
   alias_method :results?, :readable?
   alias_method :invite?, :editable?
   alias_method :confirm_invitation?, :editable?
+
+  def update_computacenter_reference?
+    user.is_computacenter?
+  end
 end

--- a/app/services/responsible_body_exporter.rb
+++ b/app/services/responsible_body_exporter.rb
@@ -6,29 +6,39 @@ class ResponsibleBodyExporter
 
   attr_reader :filename
 
-  def initialize(filename)
+  def initialize(filename = nil)
     @filename = filename
   end
 
   def export_responsible_bodies(query = responsible_bodies)
-    CSV.open(filename, 'w') do |csv|
-      csv << headings
-      query.find_each do |rb|
-        csv << [
-          rb.computacenter_identifier,
-          *build_name_fields_for(rb),
-          rb.address_1,
-          rb.address_2,
-          rb.address_3,
-          rb.town,
-          rb.postcode,
-        ]
+    if filename
+      CSV.open(filename, 'w') do |csv|
+        render(csv, query)
+      end
+      nil
+    else
+      CSV.generate(headers: true) do |csv|
+        render(csv, query)
       end
     end
-    nil
   end
 
 private
+
+  def render(csv, query)
+    csv << headings
+    query.find_each do |rb|
+      csv << [
+        rb.computacenter_identifier,
+        *build_name_fields_for(rb),
+        rb.address_1,
+        rb.address_2,
+        rb.address_3,
+        rb.town,
+        rb.postcode,
+      ]
+    end
+  end
 
   def headings
     [

--- a/app/services/school_data_exporter.rb
+++ b/app/services/school_data_exporter.rb
@@ -6,29 +6,40 @@ class SchoolDataExporter
 
   attr_reader :filename
 
-  def initialize(filename)
+  def initialize(filename = nil)
     @filename = filename
   end
 
   def export_schools(query = schools)
-    CSV.open(filename, 'w') do |csv|
-      csv << headings
-      query.find_each do |school|
-        csv << [
-          school.responsible_body.computacenter_identifier,
-          *build_name_fields_for(school),
-          school.address_1,
-          school.address_2,
-          school.address_3,
-          school.town,
-          school.postcode,
-        ]
+    if filename
+      CSV.open(filename, 'w') do |csv|
+        render(csv, query)
+      end
+      nil
+    else
+      CSV.generate(headers: true) do |csv|
+        render(csv, query)
       end
     end
-    nil
   end
 
 private
+
+  def render(csv, query)
+    csv << headings
+    query.find_each do |school|
+      csv << [
+        school.responsible_body.computacenter_identifier,
+        *build_name_fields_for(school),
+        school.address_1,
+        school.address_2,
+        school.address_3,
+        school.town,
+        school.postcode,
+        school.computacenter_change&.capitalize,
+      ]
+    end
+  end
 
   def headings
     [
@@ -40,6 +51,7 @@ private
       'Address line 3',
       'Town/City',
       'Postcode',
+      'New/Amended',
     ].freeze
   end
 

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -28,6 +28,17 @@
 
     <p class="govuk-body">View details of schools with that can place orders.</p>
 
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Changes to schools', computacenter_school_changes_path %>
+    </h2>
+
+    <p class="govuk-body">Review and update Ship To references for schools that have changed.</p>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Changes to responsible bodies', computacenter_responsible_body_changes_path %>
+    </h2>
+
+    <p class="govuk-body">Review and update Sold To references for responsible bodies that have changed.</p>
     <% if policy(:support).readable? %>
       <h2 class="govuk-heading-m">
         <%= govuk_link_to 'Support home', support_home_path %>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -29,7 +29,7 @@
     <p class="govuk-body">View details of schools with that can place orders.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to 'Changes to schools', computacenter_school_changes_path %>
+      <%= govuk_link_to "Changes to schools (#{School.requiring_a_new_computacenter_reference.count})", computacenter_school_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Ship To references for schools that have changed.</p>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -35,7 +35,7 @@
     <p class="govuk-body">Review and update Ship To references for schools that have changed.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to 'Changes to responsible bodies', computacenter_responsible_body_changes_path %>
+      <%= govuk_link_to "Changes to responsible bodies (#{ResponsibleBody.requiring_a_new_computacenter_reference.count})", computacenter_responsible_body_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Sold To references for responsible bodies that have changed.</p>

--- a/app/views/computacenter/responsible_body_changes/edit.html.erb
+++ b/app/views/computacenter/responsible_body_changes/edit.html.erb
@@ -1,0 +1,26 @@
+<%- content_for :before_content, govuk_link_to('Back', computacenter_responsible_body_changes_path(@responsible_body), class: 'govuk-back-link') %>
+<%- title = t('page_titles.computacenter.responsible_body_changes_edit') %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= "#{@responsible_body.name}" %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: computacenter_responsible_body_change_path(@responsible_body), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p class="govuk-body">
+      Confirm the ‘Sold To’ reference is correct or update as appropriate 
+      </p>
+
+      <%= f.govuk_text_field :sold_to,
+                              only_integer: true,
+                              label: {text: 'Sold To'} %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/computacenter/responsible_body_changes/edit.html.erb
+++ b/app/views/computacenter/responsible_body_changes/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', computacenter_responsible_body_changes_path(@responsible_body), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_link_to('Back', computacenter_responsible_body_changes_path, class: 'govuk-back-link') %>
 <%- title = t('page_titles.computacenter.responsible_body_changes_edit') %>
 <%- content_for :title, title %>
 

--- a/app/views/computacenter/responsible_body_changes/edit.html.erb
+++ b/app/views/computacenter/responsible_body_changes/edit.html.erb
@@ -12,15 +12,21 @@
     <%= form_for @form, url: computacenter_responsible_body_change_path(@responsible_body), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <p class="govuk-body">
-      Confirm the ‘Sold To’ reference is correct or update as appropriate 
-      </p>
+      <%= render Computacenter::ResponsibleBodyChangesDetailsComponent.new(responsible_body: @responsible_body) %>
 
-      <%= f.govuk_text_field :sold_to,
-                              only_integer: true,
-                              label: {text: 'Sold To'} %>
+      <%- if @responsible_body.computacenter_change_amended? %>
+        <%= f.govuk_radio_buttons_fieldset(:change_sold_to, legend: { text: 'Does the Sold To number need to change?', size: 'm' }) do %>
+          <%= f.govuk_radio_button :change_sold_to, 'yes', label: { text: 'Yes, change the Sold To number' } do %>
+            <%= f.govuk_text_field  :sold_to, label: { text: 'Sold To number', size: 's' } %>
+          <%- end %>
+          <%= f.govuk_radio_button :change_sold_to, 'no', label: { text: 'No, keep the same Sold To number' } %>
+        <%- end %>
+      <%- else %>
+        <%= f.govuk_text_field :sold_to, label: {text: 'New Sold To number', size: 's'} %>
+        <%= f.hidden_field :change_sold_to, value: 'yes' %>
+      <%- end %>
 
-      <%= f.govuk_submit 'Save' %>
+      <%= f.govuk_submit 'Confirm' %>
     <%- end %>
   </div>
 </div>

--- a/app/views/computacenter/responsible_body_changes/index.html.erb
+++ b/app/views/computacenter/responsible_body_changes/index.html.erb
@@ -10,11 +10,11 @@
   </div>
 </div>
 <%- item_count = @responsible_bodies.count %>
-<% if item_count.positive? %>
+<% if @show_download_link %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-body">
-      <%= govuk_link_to 'Download changes as CSV file', computacenter_responsible_body_changes_path(format: :csv) %>
+      <%= govuk_link_to 'Download changes as a CSV file', computacenter_responsible_body_changes_path(format: :csv) %>
     </div>
   </div>
 </div>
@@ -60,7 +60,7 @@
                 <td class="govuk-table__cell"><%= responsible_body.address %></td>
                 <td class="govuk-table__cell"><%= responsible_body.computacenter_reference %></td>
                 <td class="govuk-table__cell"><%= responsible_body.computacenter_change.capitalize %></td>
-                <td class="govuk-table__cell"><%= govuk_link_to 'Update', edit_computacenter_responsible_body_change_path(responsible_body) %></td>
+                <td class="govuk-table__cell"><%= govuk_link_to "Verify<span class=\"govuk-visually-hidden\"> sold to reference for #{responsible_body.computacenter_name}</span>".html_safe, edit_computacenter_responsible_body_change_path(responsible_body) %></td>
               </tr>
             <%- end %>
           </tbody>

--- a/app/views/computacenter/responsible_body_changes/index.html.erb
+++ b/app/views/computacenter/responsible_body_changes/index.html.erb
@@ -1,0 +1,74 @@
+<% title = t('page_titles.computacenter.responsible_body_changes') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+<%- item_count = @responsible_bodies.count %>
+<% if item_count.positive? %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-body">
+      <%= govuk_link_to 'Download changes as CSV file', computacenter_responsible_body_changes_path(format: :csv) %>
+    </div>
+  </div>
+</div>
+<%- end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <%= render TabComponent.new(
+          label: 'All changes',
+          path: computacenter_responsible_body_changes_path(view: 'all'),
+          selected: @view_mode.blank? || @view_mode == 'all')
+        %>
+        <%= render TabComponent.new(
+          label: 'New responsible bodies',
+          path: computacenter_responsible_body_changes_path(view: 'new'),
+          selected: @view_mode == 'new')
+        %>
+        <%= render TabComponent.new(
+          label: 'Amended responsible bodies',
+          path: computacenter_responsible_body_changes_path(view: 'amended'),
+          selected: @view_mode == 'amended')
+        %>
+      </ul>
+      <div class="govuk-tabs__panel">
+        <table class="govuk-table" id="responsible-body-changes">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">RB URN</th>
+              <th scope="col" class="govuk-table__header">RB Name</th>
+              <th scope="col" class="govuk-table__header">Address</th>
+              <th scope="col" class="govuk-table__header">Sold To</th>
+              <th scope="col" class="govuk-table__header">Change</th>
+              <th scope="col" class="govuk-table__header">Action</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% @responsible_bodies.each do |responsible_body| %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><%= responsible_body.computacenter_identifier %></td>
+                <td class="govuk-table__cell"><%= responsible_body.computacenter_name %></td>
+                <td class="govuk-table__cell"><%= responsible_body.address %></td>
+                <td class="govuk-table__cell"><%= responsible_body.computacenter_reference %></td>
+                <td class="govuk-table__cell"><%= responsible_body.computacenter_change.capitalize %></td>
+                <td class="govuk-table__cell"><%= govuk_link_to 'Update', edit_computacenter_responsible_body_change_path(responsible_body) %></td>
+              </tr>
+            <%- end %>
+          </tbody>
+        </table>
+        <div class="govuk-body">
+          <%= "#{item_count} #{'record'.pluralize(item_count)} found" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/computacenter/responsible_body_changes/index.html.erb
+++ b/app/views/computacenter/responsible_body_changes/index.html.erb
@@ -45,7 +45,7 @@
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header">RB URN</th>
-              <th scope="col" class="govuk-table__header">RB Name</th>
+              <th scope="col" class="govuk-table__header">RB name</th>
               <th scope="col" class="govuk-table__header">Address</th>
               <th scope="col" class="govuk-table__header">Sold To</th>
               <th scope="col" class="govuk-table__header">Change</th>

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', computacenter_school_changes_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_link_to('Back', computacenter_school_changes_path, class: 'govuk-back-link') %>
 <%- title = t('page_titles.computacenter.school_changes_edit') %>
 <%- content_for :title, title %>
 

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -5,22 +5,28 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= "#{@form.school.name} (#{@form.school.urn})" %></span>
+      <span class="govuk-caption-xl"><%= "#{@school.name} (#{@school.urn})" %></span>
       <%= title %>
     </h1>
 
     <%= form_for @form, url: computacenter_school_change_path(@form.school), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <p class="govuk-body">
-      Confirm the ‘Ship To’ reference is correct or update as appropriate 
-      </p>
+      <%= render Computacenter::SchoolChangesDetailsComponent.new(school: @school) %>
 
-      <%= f.govuk_text_field :ship_to,
-                              only_integer: true,
-                              label: {text: 'Ship To'} %>
+      <%- if @school.computacenter_change_amended? %>
+        <%= f.govuk_radio_buttons_fieldset(:change_ship_to, legend: { text: 'Does the Ship To number need to change?', size: 'm' }) do %>
+          <%= f.govuk_radio_button :change_ship_to, 'yes', label: { text: 'Yes, change the Ship To number' } do %>
+            <%= f.govuk_text_field  :ship_to, label: { text: "Ship To number", size: 's' } %>
+          <%- end %>
+          <%= f.govuk_radio_button :change_ship_to, 'no', label: { text: 'No, keep the same Ship To number' } %>
+        <%- end %>
+      <%- else %>
+        <%= f.govuk_text_field :ship_to, label: {text: 'New Ship To number', size: 's'} %>
+        <%= f.hidden_field :change_ship_to, value: 'yes' %>
+      <%- end %>
 
-      <%= f.govuk_submit 'Save' %>
+      <%= f.govuk_submit 'Confirm' %>
     <%- end %>
   </div>
 </div>

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -1,0 +1,26 @@
+<%- content_for :before_content, govuk_link_to('Back', computacenter_school_changes_path(@school), class: 'govuk-back-link') %>
+<%- title = t('page_titles.computacenter.school_changes_edit') %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= "#{@form.school.name} (#{@form.school.urn})" %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: computacenter_school_change_path(@form.school), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p class="govuk-body">
+      Confirm the ‘Ship To’ reference is correct or update as appropriate 
+      </p>
+
+      <%= f.govuk_text_field :ship_to,
+                              only_integer: true,
+                              label: {text: 'Ship To'} %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/computacenter/school_changes/index.html.erb
+++ b/app/views/computacenter/school_changes/index.html.erb
@@ -1,0 +1,79 @@
+<% title = t('page_titles.computacenter.school_changes') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<%- item_count = @schools.count %>
+<% if item_count.positive? %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-body">
+      <%= govuk_link_to 'Download changes as CSV file', computacenter_school_changes_path(format: :csv) %>
+    </div>
+  </div>
+</div>
+<%- end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <%= render TabComponent.new(
+          label: 'All changes',
+          path: computacenter_school_changes_path(view: 'all'),
+          selected: @view_mode.blank? || @view_mode == 'all')
+        %>
+        <%= render TabComponent.new(
+          label: 'New schools',
+          path: computacenter_school_changes_path(view: 'new'),
+          selected: @view_mode == 'new')
+        %>
+        <%= render TabComponent.new(
+          label: 'Amended schools',
+          path: computacenter_school_changes_path(view: 'amended'),
+          selected: @view_mode == 'amended')
+        %>
+      </ul>
+      <div class="govuk-tabs__panel">
+        <table class="govuk-table" id="closed-schools">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">RB URN</th>
+              <th scope="col" class="govuk-table__header">Sold To</th>
+              <th scope="col" class="govuk-table__header">School URN</th>
+              <th scope="col" class="govuk-table__header">School Name</th>
+              <th scope="col" class="govuk-table__header">Address</th>
+              <th scope="col" class="govuk-table__header">Ship To</th>
+              <th scope="col" class="govuk-table__header">Change</th>
+              <th scope="col" class="govuk-table__header">Action</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% @schools.each do |school| %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><%= school.responsible_body.computacenter_identifier %></td>
+                <td class="govuk-table__cell"><%= school.responsible_body.computacenter_reference %></td>
+                <td class="govuk-table__cell"><%= school.urn %></td>
+                <td class="govuk-table__cell"><%= school.name %></td>
+                <td class="govuk-table__cell"><%= school.address %></td>
+                <td class="govuk-table__cell"><%= school.computacenter_reference %></td>
+                <td class="govuk-table__cell"><%= school.computacenter_change.capitalize %></td>
+                <td class="govuk-table__cell"><%= govuk_link_to 'Update', edit_computacenter_school_change_path(school) %></td>
+              </tr>
+            <%- end %>
+          </tbody>
+        </table>
+        <div class="govuk-body">
+          <%= "#{item_count} #{'record'.pluralize(item_count)} found" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/computacenter/school_changes/index.html.erb
+++ b/app/views/computacenter/school_changes/index.html.erb
@@ -11,11 +11,11 @@
 </div>
 
 <%- item_count = @schools.count %>
-<% if item_count.positive? %>
+<% if @show_download_link %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-body">
-      <%= govuk_link_to 'Download changes as CSV file', computacenter_school_changes_path(format: :csv) %>
+      <%= govuk_link_to 'Download changes as a CSV file', computacenter_school_changes_path(format: :csv) %>
     </div>
   </div>
 </div>
@@ -42,7 +42,7 @@
         %>
       </ul>
       <div class="govuk-tabs__panel">
-        <table class="govuk-table" id="closed-schools">
+        <table class="govuk-table" id="school-changes">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header">RB URN</th>
@@ -65,7 +65,7 @@
                 <td class="govuk-table__cell"><%= school.address %></td>
                 <td class="govuk-table__cell"><%= school.computacenter_reference %></td>
                 <td class="govuk-table__cell"><%= school.computacenter_change.capitalize %></td>
-                <td class="govuk-table__cell"><%= govuk_link_to 'Update', edit_computacenter_school_change_path(school) %></td>
+                <td class="govuk-table__cell"><%= govuk_link_to "Verify<span class=\"govuk-visually-hidden\"> ship to reference for #{school.name}</span>".html_safe, edit_computacenter_school_change_path(school) %></td>
               </tr>
             <%- end %>
           </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,9 +611,9 @@ en:
     sold_to:
       update:
         success: "Updated Sold To reference for %{name}"
-    sold_to_ship_to:
+    ship_to:
       update:
-        success: "Updated references for %{name}"
+        success: "Updated Ship To reference for %{name}"
   events:
     default: An event just happened
     sign_in_event: A user from %{organisation} just signed in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,9 +95,9 @@ en:
       techsource: Update TechSource users
       closed_schools: Schools that can order
       school_changes: Changes to schools
-      school_changes_edit: Verify the Ship To reference
+      school_changes_edit: Verify the school details
       responsible_body_changes: Changes to responsible bodies
-      responsible_body_changes_edit: Verify the Sold To reference
+      responsible_body_changes_edit: Verify the responsible body details
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
       schools: Each school will place their own orders
@@ -610,10 +610,10 @@ en:
         create: Generate
     sold_to:
       update:
-        success: "Updated Sold To reference for %{name}"
+        success: "Sold To reference for %{name} is %{sold_to}"
     ship_to:
       update:
-        success: "Updated Ship To reference for %{name}"
+        success: "Ship To reference for %{name} is %{ship_to}"
   events:
     default: An event just happened
     sign_in_event: A user from %{organisation} just signed in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,10 @@ en:
       home: Home
       techsource: Update TechSource users
       closed_schools: Schools that can order
+      school_changes: Changes to schools
+      school_changes_edit: Verify the Ship To reference
+      responsible_body_changes: Changes to responsible bodies
+      responsible_body_changes_edit: Verify the Sold To reference
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
       schools: Each school will place their own orders
@@ -604,6 +608,12 @@ en:
         name: Name
         name_hint: Must be unique, and between 2 and 64 characters long
         create: Generate
+    sold_to:
+      update:
+        success: "Updated Sold To reference for %{name}"
+    sold_to_ship_to:
+      update:
+        success: "Updated references for %{name}"
   events:
     default: An event just happened
     sign_in_event: A user from %{organisation} just signed in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,8 @@ Rails.application.routes.draw do
     get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
     get '/chromebooks', to: 'chromebooks#index', as: :chromebooks
     get '/schools-that-can-order', to: 'closed_schools#index', as: :closed_schools
+    resources :schools, only: %i[index edit update], path: '/school-changes', as: :school_changes, controller: 'school_changes'
+    resources :responsible_bodies, only: %i[index edit update], path: '/responsible-body-changes', as: :responsible_body_changes, controller: 'responsible_body_changes'
     get '/techsource', to: 'techsource#new'
     post '/techsource', to: 'techsource#create'
     resources :api_tokens, path: '/api-tokens'

--- a/db/migrate/20201127103253_add_computacenter_change_to_schools_and_responsible_bodies.rb
+++ b/db/migrate/20201127103253_add_computacenter_change_to_schools_and_responsible_bodies.rb
@@ -1,0 +1,9 @@
+class AddComputacenterChangeToSchoolsAndResponsibleBodies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :computacenter_change, :string, null: false, default: 'none'
+    add_index :schools, :computacenter_change
+
+    add_column :responsible_bodies, :computacenter_change, :string, null: false, default: 'none'
+    add_index :responsible_bodies, :computacenter_change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -186,8 +186,8 @@ ActiveRecord::Schema.define(version: 2020_12_10_140102) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
@@ -272,7 +272,9 @@ ActiveRecord::Schema.define(version: 2020_12_10_140102) do
     t.string "order_state", default: "cannot_order", null: false
     t.string "status", default: "open", null: false
     t.boolean "mno_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
     t.boolean "increased_allocations_feature_flag", default: false
+    t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -187,6 +187,8 @@ ActiveRecord::Schema.define(version: 2020_12_10_140102) do
     t.string "postcode"
     t.string "status", default: "open", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
+    t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
     t.index ["gias_id"], name: "index_responsible_bodies_on_gias_id", unique: true

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
 
     trait :with_preorder_information do
-      preorder_information
+      preorder_information { association :preorder_information, school: instance }
     end
 
     trait :with_headteacher_contact do
@@ -41,11 +41,11 @@ FactoryBot.define do
     end
 
     trait :with_std_device_allocation do
-      association :std_device_allocation, factory: %i[school_device_allocation with_std_allocation]
+      std_device_allocation { association :school_device_allocation, :with_std_allocation, school: instance }
     end
 
     trait :with_coms_device_allocation do
-      association :coms_device_allocation, factory: %i[school_device_allocation with_coms_allocation]
+      coms_device_allocation { association :school_device_allocation, :with_coms_allocation, school: instance }
     end
 
     trait :can_order_for_specific_circumstances do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :school do
     association :responsible_body, factory: %i[local_authority trust].sample
     urn { Faker::Number.unique.number(digits: 6) }
-    name { Faker::Educator.secondary_school }
+    sequence(:name) { |n| "#{Faker::Educator.secondary_school}-#{n}" }
     computacenter_reference { Faker::Number.number(digits: 8) }
     phase { School.phases.values.sample }
     establishment_type { School.establishment_types.values.sample }

--- a/spec/features/computacenter/responsible_body_changes_spec.rb
+++ b/spec/features/computacenter/responsible_body_changes_spec.rb
@@ -1,0 +1,212 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'Administering responsible body changes' do
+  describe 'signed in as a Computacenter user' do
+    let(:user) { create(:computacenter_user) }
+    let!(:new_trusts) { create_list(:trust, 2, computacenter_change: 'new') }
+    let!(:amended_trusts) { create_list(:trust, 2, computacenter_change: 'amended') }
+    let!(:trusts) { create_list(:trust, 2) }
+
+    before do
+      given_i_am_signed_in_as_a_computacenter_user
+    end
+
+    scenario 'navigate to responsible body changes page' do
+      when_i_visit_the_home_page
+      and_i_click_the_changes_to_responsible_bodies_link
+      then_i_see_the_list_of_all_changed_responsible_bodies
+    end
+
+    scenario 'view new responsible bodies' do
+      when_i_visit_the_changes_to_responsible_bodies_page
+      and_i_click_on_the_new_responsible_bodies_tab
+      then_i_see_the_list_of_new_responsible_bodies
+    end
+
+    scenario 'view amended responsible_bodies' do
+      when_i_visit_the_changes_to_responsible_bodies_page
+      and_i_click_on_the_amended_responsible_bodies_tab
+      then_i_see_the_list_of_amended_responsible_bodies
+    end
+
+    scenario 'download csv file' do
+      when_i_visit_the_changes_to_responsible_bodies_page
+      and_i_click_the_download_csv_link
+      then_it_downloads_the_changed_responsible_bodies_as_a_csv_file
+    end
+
+    scenario 'update a Sold To reference' do
+      when_i_visit_the_changes_to_responsible_bodies_page
+      then_i_see_the_list_of_all_changed_responsible_bodies
+      when_i_click_the_verify_link_for_a_responsible_body
+      then_i_see_the_verify_sold_to_form
+      when_i_update_the_sold_to_reference
+      and_i_click_save
+      then_i_see_an_updated_list_of_all_changed_responsible_bodies
+    end
+
+    scenario 'update a Sold To reference with bad data' do
+      when_i_visit_the_changes_to_responsible_bodies_page
+      then_i_see_the_list_of_all_changed_responsible_bodies
+      when_i_click_the_verify_link_for_a_responsible_body
+      then_i_see_the_verify_sold_to_form
+      when_i_update_the_sold_to_reference_with_bad_data
+      and_i_click_save
+      then_i_see_an_error_message
+    end
+
+    def given_i_am_signed_in_as_a_computacenter_user
+      sign_in_as user
+    end
+
+    def when_i_visit_the_home_page
+      visit computacenter_home_path
+      expect(page).to have_text('Home')
+    end
+
+    def and_i_click_the_changes_to_responsible_bodies_link
+      click_on 'Changes to responsible bodies'
+      expect(page).to have_text 'Changes to responsible bodies'
+    end
+
+    def then_i_see_the_list_of_all_changed_responsible_bodies
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New responsible bodies'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended responsible bodies'
+
+      new_trusts.each do |t|
+        expect(page).to have_text(t.computacenter_identifier)
+      end
+
+      amended_trusts.each do |t|
+        expect(page).to have_text(t.computacenter_identifier)
+      end
+
+      trusts.each do |t|
+        expect(page).not_to have_text(t.computacenter_identifier)
+      end
+    end
+
+    def when_i_visit_the_changes_to_responsible_bodies_page
+      visit computacenter_responsible_body_changes_path
+    end
+
+    def and_i_click_on_the_new_responsible_bodies_tab
+      click_on 'New responsible bodies'
+    end
+
+    def then_i_see_the_list_of_new_responsible_bodies
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'New responsible bodies'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended responsible bodies'
+
+      within '#responsible-body-changes' do
+        new_trusts.each do |t|
+          expect(page).to have_text(t.computacenter_identifier)
+        end
+
+        amended_trusts.each do |t|
+          expect(page).not_to have_text(t.computacenter_identifier)
+        end
+
+        trusts.each do |t|
+          expect(page).not_to have_text(t.computacenter_identifier)
+        end
+      end
+    end
+
+    def and_i_click_on_the_amended_responsible_bodies_tab
+      click_on 'Amended responsible bodies'
+    end
+
+    def then_i_see_the_list_of_amended_responsible_bodies
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New responsible bodies'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Amended responsible bodies'
+
+      within '#responsible-body-changes' do
+        new_trusts.each do |t|
+          expect(page).not_to have_text(t.computacenter_identifier)
+        end
+
+        amended_trusts.each do |t|
+          expect(page).to have_text(t.computacenter_identifier)
+        end
+
+        trusts.each do |t|
+          expect(page).not_to have_text(t.computacenter_identifier)
+        end
+      end
+    end
+
+    def and_i_click_the_download_csv_link
+      click_on 'Download changes as a CSV file'
+    end
+
+    def then_it_downloads_the_changed_responsible_bodies_as_a_csv_file
+      expect_download(content_type: 'text/csv')
+
+      new_trusts.each do |t|
+        expect(page.body).to have_text(t.computacenter_identifier)
+      end
+
+      amended_trusts.each do |t|
+        expect(page.body).to have_text(t.computacenter_identifier)
+      end
+
+      trusts.each do |t|
+        expect(page.body).not_to have_text(t.computacenter_identifier)
+      end
+    end
+
+    def when_i_click_the_verify_link_for_a_responsible_body
+      click_on "Verify sold to reference for #{new_trusts.first.computacenter_name}"
+    end
+
+    def then_i_see_the_verify_sold_to_form
+      expect(page).to have_text('Verify the Sold To reference')
+      expect(page).to have_field('Sold To')
+    end
+
+    def when_i_update_the_sold_to_reference
+      fill_in 'Sold To', with: '80129999'
+    end
+
+    def and_i_click_save
+      click_on 'Save'
+    end
+
+    def then_i_see_an_updated_list_of_all_changed_responsible_bodies
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New responsible bodies'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended responsible bodies'
+
+      within '#responsible-body-changes' do
+        new_trusts.each_with_index do |t, i|
+          if i == 0
+            expect(page).not_to have_text(t.computacenter_name)
+          else
+            expect(page).to have_text(t.computacenter_name)
+          end
+        end
+
+        amended_trusts.each do |t|
+          expect(page).to have_text(t.computacenter_name)
+        end
+
+        trusts.each do |t|
+          expect(page).not_to have_text(t.computacenter_name)
+        end
+      end
+    end
+
+    def when_i_update_the_sold_to_reference_with_bad_data
+      fill_in 'Sold To', with: 'Banana'
+    end
+
+    def then_i_see_an_error_message
+      expect(page).to have_text('Sold To must be a number greater than zero')
+    end
+  end
+end

--- a/spec/features/computacenter/responsible_body_changes_spec.rb
+++ b/spec/features/computacenter/responsible_body_changes_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Administering responsible body changes' do
     end
 
     def and_i_click_the_changes_to_responsible_bodies_link
-      click_on 'Changes to responsible bodies'
+      click_on 'Changes to responsible bodies (4)'
       expect(page).to have_text 'Changes to responsible bodies'
     end
 

--- a/spec/features/computacenter/school_changes_spec.rb
+++ b/spec/features/computacenter/school_changes_spec.rb
@@ -1,0 +1,207 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'Administering school changes' do
+  describe 'signed in as a Computacenter user' do
+    let(:user) { create(:computacenter_user) }
+    let!(:new_schools) { create_list(:school, 5, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, computacenter_change: 'new') }
+    let!(:amended_schools) { create_list(:school, 5, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, computacenter_change: 'amended') }
+    let!(:schools) { create_list(:school, 5, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation) }
+
+    before do
+      given_i_am_signed_in_as_a_computacenter_user
+    end
+
+    scenario 'navigate to school changes page' do
+      when_i_visit_the_home_page
+      and_i_click_the_changes_to_schools_link
+      then_i_see_the_list_of_all_changed_schools
+    end
+
+    scenario 'view new schools' do
+      when_i_visit_the_changes_to_schools_page
+      and_i_click_on_the_new_schools_tab
+      then_i_see_the_list_of_new_schools
+    end
+
+    scenario 'view amended schools' do
+      when_i_visit_the_changes_to_schools_page
+      and_i_click_on_the_amended_schools_tab
+      then_i_see_the_list_of_amended_schools
+    end
+
+    scenario 'download csv file' do
+      when_i_visit_the_changes_to_schools_page
+      and_i_click_the_download_csv_link
+      then_it_downloads_the_changed_schools_as_a_csv_file
+    end
+
+    scenario 'update a Ship To reference' do
+      when_i_visit_the_changes_to_schools_page
+      then_i_see_the_list_of_all_changed_schools
+      when_i_click_the_verify_link_for_a_school
+      then_i_see_the_verify_ship_to_form
+      when_i_update_the_ship_to_reference
+      and_i_click_save
+      then_i_see_an_updated_list_of_all_changed_schools
+    end
+
+    scenario 'update a Ship To reference with bad data' do
+      when_i_visit_the_changes_to_schools_page
+      then_i_see_the_list_of_all_changed_schools
+      when_i_click_the_verify_link_for_a_school
+      then_i_see_the_verify_ship_to_form
+      when_i_update_the_ship_to_reference_with_bad_data
+      and_i_click_save
+      then_i_see_an_error_message
+    end
+
+    def given_i_am_signed_in_as_a_computacenter_user
+      sign_in_as user
+    end
+
+    def when_i_visit_the_home_page
+      visit computacenter_home_path
+      expect(page).to have_text('Home')
+    end
+
+    def and_i_click_the_changes_to_schools_link
+      click_on 'Changes to schools'
+      expect(page).to have_text 'Changes to schools'
+    end
+
+    def then_i_see_the_list_of_all_changed_schools
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New schools'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended schools'
+
+      new_schools.each do |s|
+        expect(page).to have_text("#{s.urn} #{s.name}")
+      end
+
+      amended_schools.each do |s|
+        expect(page).to have_text("#{s.urn} #{s.name}")
+      end
+
+      schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+    end
+
+    def when_i_visit_the_changes_to_schools_page
+      visit computacenter_school_changes_path
+    end
+
+    def and_i_click_on_the_new_schools_tab
+      click_on 'New schools'
+    end
+
+    def then_i_see_the_list_of_new_schools
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'New schools'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended schools'
+
+      new_schools.each do |s|
+        expect(page).to have_text("#{s.urn} #{s.name}")
+      end
+
+      amended_schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+
+      schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+    end
+
+    def and_i_click_on_the_amended_schools_tab
+      click_on 'Amended schools'
+    end
+
+    def then_i_see_the_list_of_amended_schools
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New schools'
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'Amended schools'
+
+      new_schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+
+      amended_schools.each do |s|
+        expect(page).to have_text("#{s.urn} #{s.name}")
+      end
+
+      schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+    end
+
+    def and_i_click_the_download_csv_link
+      click_on 'Download changes as a CSV file'
+    end
+
+    def then_it_downloads_the_changed_schools_as_a_csv_file
+      expect_download(content_type: 'text/csv')
+
+      new_schools.each do |s|
+        expect(page.body).to have_text(s.urn)
+      end
+
+      amended_schools.each do |s|
+        expect(page.body).to have_text(s.urn)
+      end
+
+      schools.each do |s|
+        expect(page).not_to have_text(s.urn)
+      end
+    end
+
+    def when_i_click_the_verify_link_for_a_school
+      click_on "Verify ship to reference for #{new_schools.first.name}"
+    end
+
+    def then_i_see_the_verify_ship_to_form
+      expect(page).to have_text('Verify the Ship To reference')
+      expect(page).to have_field('Ship To')
+    end
+
+    def when_i_update_the_ship_to_reference
+      fill_in 'Ship To', with: '80129999'
+    end
+
+    def and_i_click_save
+      click_on 'Save'
+    end
+
+    def then_i_see_an_updated_list_of_all_changed_schools
+      expect(page).to have_selector 'li.govuk-tabs__list-item.govuk-tabs__list-item--selected', text: 'All changes'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'New schools'
+      expect(page).to have_selector 'li.govuk-tabs__list-item', text: 'Amended schools'
+
+      new_schools.each_with_index do |s, i|
+        school_name = "#{s.urn} #{s.name}"
+        if i == 0
+          expect(page).not_to have_text(school_name)
+        else
+          expect(page).to have_text(school_name)
+        end
+      end
+
+      amended_schools.each do |s|
+        expect(page).to have_text("#{s.urn} #{s.name}")
+      end
+
+      schools.each do |s|
+        expect(page).not_to have_text("#{s.urn} #{s.name}")
+      end
+    end
+
+    def when_i_update_the_ship_to_reference_with_bad_data
+      fill_in 'Ship To', with: 'Banana'
+    end
+
+    def then_i_see_an_error_message
+      expect(page).to have_text('Ship To must be a number greater than zero')
+    end
+  end
+end

--- a/spec/features/computacenter/school_changes_spec.rb
+++ b/spec/features/computacenter/school_changes_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Administering school changes' do
     end
 
     def and_i_click_the_changes_to_schools_link
-      click_on 'Changes to schools'
+      click_on 'Changes to schools (4)'
       expect(page).to have_text 'Changes to schools'
     end
 

--- a/spec/policies/responsible_body_policy_spec.rb
+++ b/spec/policies/responsible_body_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe ResponsibleBodyPolicy do
+  subject(:policy) { described_class }
+
+  permissions :update_computacenter_reference? do
+    it 'blocks access to support users' do
+      expect(policy).not_to permit(build(:support_user), :support)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :support)
+    end
+  end
+end

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -22,4 +22,14 @@ describe SchoolPolicy do
       expect(policy).to permit(build(:computacenter_user), :support)
     end
   end
+
+  permissions :update_computacenter_reference? do
+    it 'blocks access to support users' do
+      expect(policy).not_to permit(build(:support_user), :support)
+    end
+
+    it 'grants access to Computacenter users' do
+      expect(policy).to permit(build(:computacenter_user), :support)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
 
   config.before do
     Faker::Number.unique.clear
+    Faker::Educator.unique.clear
     DatabaseCleaner.start
   end
 

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SchoolDataExporter, type: :model do
 
       found = false
       data.each do |row|
-        if row['School URN + School Name'] == "#{school.urn} #{school.name}"
+        if row['School URN + School Name'].start_with?(school.urn.to_s)
           expect(row['Responsible body URN']).to be_blank
           found = true
         end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/ds5m99jv/1037-build-an-interface-for-cc-to-shipto-soldto-numbers)
Add an interface to expose changes to schools and responsible bodies to Computacenter and enable them to adjust the `Sold To` and `Ship To` references for responsible bodies and schools as appropriate.  This will then remove the need to capture this information and send CSV files to CC when changes are made.

### Changes proposed in this pull request
Add `computacenter_change` column to `School` and `ResponsibleBody` and enum to models reflect change state.
Add "Changes to schools" page that lists changes and form to verify `Ship To` references for each school in the list.
Add CSV download of school changes
Add "Changes to responsible bodies" page that lists changes and form to verify `Sold To` references for each responsible body in the list.
Add CSV download of responsible body changes
Add links to pages on home page of Computacenter area.

### Guidance to review
The new `computacenter_change` enum is used to determine which schools or responsible bodies are included in the lists for Computacenter.  When a change is made to a school that needs to be propagated to Computacenter the `computacenter_change` should be updated accordingly.

Currently we expose new and amended schools and responsible bodies to CC via a CSV. Creating a new school or responsible body will set the `computacenter_change` to `new` so these will be automatically included in the list.

If a change is made to a school or responsible body that CC must be made aware of then the `computacenter_change` should be set to `amended`.  Being an enum there are built in helpers for these i.e. `school.computacenter_change_amended!`.

We currently only notify CC of changes to the organisation name or address, or if a school moves to a different trust (and does not change URN)

Once a school or responsible body has been verified by CC and any necessary changes made, the `computacenter_update` is set to `none` and will no longer appear in the list.

![image](https://user-images.githubusercontent.com/333931/100748415-341b7080-33db-11eb-808b-33d97e877a46.png)
![image](https://user-images.githubusercontent.com/333931/100748562-5f9e5b00-33db-11eb-9902-674bcee758a0.png)
![image](https://user-images.githubusercontent.com/333931/100748615-73e25800-33db-11eb-878d-692dd1650567.png)
![image](https://user-images.githubusercontent.com/333931/100748657-7fce1a00-33db-11eb-8e68-00668f87ea42.png)
![image](https://user-images.githubusercontent.com/333931/100895657-b710f980-34b5-11eb-9f0a-65bc2e19d572.png)
![image](https://user-images.githubusercontent.com/333931/100895747-d019aa80-34b5-11eb-8367-eaac781fa9de.png)
![image](https://user-images.githubusercontent.com/333931/100896088-2b4b9d00-34b6-11eb-87ba-89b07b3dd5cc.png)
![image](https://user-images.githubusercontent.com/333931/100896150-3acae600-34b6-11eb-957e-77d30b0cfc92.png)

Responsible Bodies

![image](https://user-images.githubusercontent.com/333931/100748782-b3a93f80-33db-11eb-86f7-cfbb78d50ddd.png)
![image](https://user-images.githubusercontent.com/333931/100748812-c0c62e80-33db-11eb-8c6a-fb996c3c1578.png)
![image](https://user-images.githubusercontent.com/333931/100748863-cf144a80-33db-11eb-9b16-30dc5a733ade.png)
![image](https://user-images.githubusercontent.com/333931/100896611-b462d400-34b6-11eb-82ff-ac107fbbad19.png)
![image](https://user-images.githubusercontent.com/333931/100896686-cb092b00-34b6-11eb-8fe7-5baaffae9091.png)
![image](https://user-images.githubusercontent.com/333931/100896909-0572c800-34b7-11eb-90e9-46c43f1df445.png)

