### PR TITLE
[1083] replace devices ordered panel with 'Order devices now' link when VCaps are enabled

### DIFF
--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -7,23 +7,29 @@
       <%= @school.name %>
     </h1>
 
-    <%- if @school.has_std_device_allocation? %>
-      <%= render DeviceCountComponent.new(
-        school: @school,
-        show_action: @school.std_device_allocation.devices_ordered < @school.std_device_allocation.cap,
-        action: { 'Order devices' => order_devices_responsible_body_devices_school_path(urn: @school.urn) }) %>
-    <% else %>
-      <%= render partial: 'shared/school_without_allocation' %>
-    <%- end %>
+    <%- if FeatureFlag.active?(:virtual_caps) && @responsible_body.vcap_feature_flag %>
+      <%- if @school.can_order? || @school.can_order_for_specific_circumstances? %>
+        <p class="govuk-body"><%= govuk_link_to 'Order devices now', responsible_body_devices_order_devices_path %></p>
+      <%- end %>
+    <%- else %>
+      <%- if @school.has_std_device_allocation? %>
+        <%= render DeviceCountComponent.new(
+          school: @school,
+          show_action: @school.std_device_allocation.devices_ordered < @school.std_device_allocation.cap,
+          action: { 'Order devices' => order_devices_responsible_body_devices_school_path(urn: @school.urn) }) %>
+      <% else %>
+        <%= render partial: 'shared/school_without_allocation' %>
+      <%- end %>
 
-    <%- if @school.preorder_information.orders_managed_centrally? %>
-      <%- unless @school.preorder_information.chromebook_information_complete? %>
-        <h2 class="govuk-heading-l">Before you can order, we need more information</h2>
-        <%= render partial: 'shared/chromebook_information_intro' %>
-        <%= render partial: 'shared/chromebook_information_form', locals: {
-          legend_text: 'Will the school’s order include Chromebooks?',
-          url: responsible_body_devices_school_chromebooks_path(@school.urn),
-          form_object: @chromebook_information_form } %>
+      <%- if @school.preorder_information.orders_managed_centrally? %>
+        <%- unless @school.preorder_information.chromebook_information_complete? %>
+          <h2 class="govuk-heading-l">Before you can order, we need more information</h2>
+          <%= render partial: 'shared/chromebook_information_intro' %>
+          <%= render partial: 'shared/chromebook_information_form', locals: {
+            legend_text: 'Will the school’s order include Chromebooks?',
+            url: responsible_body_devices_school_chromebooks_path(@school.urn),
+            form_object: @chromebook_information_form } %>
+        <%- end %>
       <%- end %>
     <%- end %>
   </div>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -7,7 +7,7 @@
       <%= @school.name %>
     </h1>
 
-    <%- if FeatureFlag.active?(:virtual_caps) && @responsible_body.vcap_feature_flag %>
+    <%- if @responsible_body.has_virtual_cap_feature_flags? %>
       <%- if @school.can_order? || @school.can_order_for_specific_circumstances? %>
         <p class="govuk-body"><%= govuk_link_to 'Order devices now', responsible_body_devices_order_devices_path %></p>
       <%- end %>

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -17,39 +17,83 @@ RSpec.feature 'Ordering via a school' do
     school_that_cannot_order_as_reopened.update!(preorder_information: another_preorder, std_device_allocation: another_allocation)
   end
 
-  context 'when school has no devices to order' do
-    scenario 'cannot order devices' do
+  context 'when the responsible body does not the vcap_feature_flag enabled' do
+    context 'when school has no devices to order' do
+      scenario 'cannot order devices' do
+        given_i_am_signed_in_as_rb_user
+
+        when_i_view_a_school(school)
+        then_i_see_status_of('Ready')
+        and_i_see_the_no_allocation_message
+      end
+    end
+
+    scenario 'when the school has reopened' do
       given_i_am_signed_in_as_rb_user
 
-      when_i_view_a_school(school)
-      then_i_see_status_of('Ready')
+      when_i_view_a_school(school_that_cannot_order_as_reopened)
+      then_i_see('You ordered 3 of 12 devices')
+    end
+
+    context 'when school has devices to order' do
+      let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, cap: 12, devices_ordered: 3) }
+
+      before do
+        school.update!(std_device_allocation: allocation, order_state: 'can_order')
+        school.preorder_information.refresh_status!
+      end
+
+      scenario 'can order devices' do
+        given_i_am_signed_in_as_rb_user
+
+        when_i_view_a_school(school)
+        then_i_see_status_of('You can order')
+        and_i_see 'You’ve ordered 3 of 12 devices'
+
+        when_i_click_on('Order devices')
+        then_i_see_the_school_order_devices_page
+        and_i_see_the_techsource_button
+      end
     end
   end
 
-  scenario 'when the school has reopened' do
-    given_i_am_signed_in_as_rb_user
+  context 'when the virtual_caps feature flag is active and responsible body does have the vcap_feature_flag enabled', with_feature_flags: { virtual_caps: 'active' } do
+    let(:rb) { create(:trust, :vcap_feature_flag, schools: [school, school_that_cannot_order_as_reopened]) }
 
-    when_i_view_a_school(school_that_cannot_order_as_reopened)
-    then_i_see('You ordered 3 of 12 devices')
-  end
+    context 'when school has no devices to order' do
+      scenario 'cannot order devices' do
+        given_i_am_signed_in_as_rb_user
 
-  context 'when school has devices to order' do
-    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
-
-    before do
-      school.update!(std_device_allocation: allocation, order_state: 'can_order')
-      school.preorder_information.refresh_status!
+        when_i_view_a_school(school)
+        then_i_see_status_of('Ready')
+        and_i_do_not_see 'This school has no allocation'
+        and_i_do_not_see 'Order devices now'
+      end
     end
 
-    scenario 'can order devices' do
+    scenario 'when the school has reopened' do
       given_i_am_signed_in_as_rb_user
 
-      when_i_view_a_school(school)
-      then_i_see_status_of('You can order')
+      when_i_view_a_school(school_that_cannot_order_as_reopened)
+      and_i_do_not_see('You ordered 3 of 12 devices')
+      and_i_do_not_see 'Order devices now'
+    end
 
-      when_i_click_on('Order devices')
-      then_i_see_the_school_order_devices_page
-      and_i_see_the_techsource_button
+    context 'when the school can order devices and has an allocation' do
+      let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, allocation: 12, cap: 10, devices_ordered: 3) }
+
+      before do
+        school.update!(std_device_allocation: allocation, order_state: 'can_order')
+        school.preorder_information.refresh_status!
+      end
+
+      scenario 'I do not see the number of devices' do
+        given_i_am_signed_in_as_rb_user
+
+        when_i_view_a_school(school)
+        then_i_do_not_see 'You’ve ordered 3 of 10 devices'
+        and_i_see_an_order_devices_now_link
+      end
     end
   end
 
@@ -79,5 +123,27 @@ RSpec.feature 'Ordering via a school' do
 
   def then_i_see(content)
     expect(page).to have_content(content)
+  end
+  alias_method :and_i_see, :then_i_see
+
+  def then_i_do_not_see(content)
+    expect(page).not_to have_content(content)
+  end
+  alias_method :and_i_do_not_see, :then_i_do_not_see
+
+  def and_i_do_not_see_an_order_devices_link
+    expect(page).not_to have_link('Order devices')
+  end
+
+  def and_i_see_that_all_devices_are_ordered
+    expect(page).to have_content('All devices ordered')
+  end
+
+  def and_i_see_the_no_allocation_message
+    expect(page).to have_content 'This school has no allocation'
+  end
+
+  def and_i_see_an_order_devices_now_link
+    expect(page).to have_link('Order devices now')
   end
 end


### PR DESCRIPTION
### Context

[Trello card 1083](https://trello.com/c/2mIHtMV8/1083-virtual-cap-update-school-page) - as part of the [Virtual Cap Pools epic](https://trello.com/c/Blj9SZ65/1007-virtual-cap), we need to update the Responsible Body school page according to the [updated design](https://ghwt-design-history.herokuapp.com/rbs-ordering-for-groups-of-schools/#simplified-school-page).

### Changes proposed in this pull request

* When the `virtual_caps` feature flag is enabled AND the current responsible body has the `vcap_feature_flag` attribute set to true, remove the panel which would normally show how many devices have been ordered from their cap.

This is because we cannot accurately know the numbers per school if the school is part of a pool, so we need to defer to a central place for ordering.  

### Guidance to review

* set the `:virtual_caps` feature flag to `'active'`
* choose a Responsible Body with some schools, and set `vcap_feature_flag: true` on it
* log in as a user from that Responsible Body, go to 'Get laptops and tables' > 'List of schools' and click on a school 
