### PR TITLE
Update 'Order devices' page for virtual cap RBs

### DIFF
--- a/app/components/responsible_body/pooled_device_count_component.html.erb
+++ b/app/components/responsible_body/pooled_device_count_component.html.erb
@@ -1,0 +1,14 @@
+<div class="app-card app-card__order">
+  <h2 class="govuk-!-margin-0 govuk-!-margin-bottom-6">
+    <span class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-24">
+      <%= name_string.html_safe -%>
+    </span>
+    <span class="govuk-panel__title govuk-!-font-size-36">
+      <%= availablility_string.html_safe -%>
+    </span>
+  </h2>
+
+  <div class="govuk-panel__body govuk-!-font-size-24">
+    <%= ordered_string -%>
+  </div>
+</div>

--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -1,0 +1,35 @@
+class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :responsible_body
+
+  def initialize(responsible_body:)
+    @responsible_body = responsible_body
+  end
+
+  def name_string
+    "#{responsible_body.name} has:"
+  end
+
+  def availablility_string
+    if @responsible_body.has_devices_available_to_order?
+      allocations.map { |allocation|
+        "#{allocation.available_devices_count} #{allocation.device_type_name.pluralize(allocation.available_devices_count)}"
+      }.join(' and <br/>') + ' available to order'
+    else
+      'All devices ordered'
+    end
+  end
+
+  def ordered_string
+    'You ordered ' + allocations.map { |allocation|
+      "#{allocation.devices_ordered} #{allocation.device_type_name.pluralize(allocation.cap)}"
+    }.join(' and ')
+  end
+
+private
+
+  def allocations
+    responsible_body.virtual_cap_pools.order(Arel.sql("device_type = 'coms_device' ASC"))
+  end
+end

--- a/app/concerns/device_count.rb
+++ b/app/concerns/device_count.rb
@@ -1,0 +1,13 @@
+module DeviceCount
+  extend ActiveSupport::Concern
+
+  included do
+    def has_devices_available_to_order?
+      available_devices_count.positive?
+    end
+
+    def available_devices_count
+      [0, (cap.to_i - devices_ordered.to_i)].max
+    end
+  end
+end

--- a/app/concerns/device_type.rb
+++ b/app/concerns/device_type.rb
@@ -1,0 +1,19 @@
+module DeviceType
+  extend ActiveSupport::Concern
+
+  included do
+    enum device_type: {
+      'coms_device': 'coms_device',
+      'std_device': 'std_device',
+    }
+
+    def device_type_name
+      case device_type
+      when 'coms_device'
+        'router'
+      else
+        'device'
+      end
+    end
+  end
+end

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -6,7 +6,11 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::BaseControll
         # or mix of centrally managed and devolved
         @schools = @responsible_body.schools.gias_status_open.that_are_centrally_managed.that_can_order_now.order(name: :asc)
 
-        if @schools.can_order.count.positive?
+        @schools_can_order = @schools.can_order
+        @schools_can_order_for_specific_circumstances = @schools.can_order_for_specific_circumstances
+
+        # There is no seperate 'specific circumstances' page if we're using virtual caps.
+        if @responsible_body.has_virtual_cap_feature_flags? || @schools.can_order.count.positive?
           render 'order_devices'
         else
           render 'specific_circumstances'

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -143,13 +143,17 @@ module ViewHelper
     now >= window_start && now <= window_end
   end
 
+  def what_to_order_allocation_list(allocations:)
+    allocations.map { |alloc|
+      "#{alloc.available_devices_count} #{alloc.device_type_name.pluralize(alloc.available_devices_count)}"
+    }.join(' and ')
+  end
+
   def what_to_order_availability(school:)
     suffix = (school.can_order_for_specific_circumstances? ? ' for specific circumstances' : nil)
 
     if school.has_devices_available_to_order?
-      string = school.device_allocations.map { |alloc|
-        "#{alloc.available_devices_count} #{alloc.device_type_name.pluralize(alloc.available_devices_count)}"
-      }.join(' and ')
+      string = what_to_order_allocation_list(allocations: school.device_allocations)
 
       "Order #{string}#{suffix}"
     else

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -35,6 +35,10 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
+  def has_devices_available_to_order?
+    virtual_cap_pools.any?(&:has_devices_available_to_order?)
+  end
+
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -1,4 +1,7 @@
 class SchoolDeviceAllocation < ApplicationRecord
+  include DeviceType
+  include DeviceCount
+
   has_paper_trail
 
   belongs_to :school
@@ -9,20 +12,6 @@ class SchoolDeviceAllocation < ApplicationRecord
   has_many :cap_update_calls
 
   validates_with CapAndAllocationValidator
-
-  enum device_type: {
-    'coms_device': 'coms_device',
-    'std_device': 'std_device',
-  }
-
-  def device_type_name
-    case device_type
-    when 'coms_device'
-      'router'
-    else
-      'device'
-    end
-  end
 
   def self.can_order_std_devices_now
     by_device_type('std_device').where('cap > devices_ordered')
@@ -105,14 +94,6 @@ class SchoolDeviceAllocation < ApplicationRecord
 
   def is_in_virtual_cap_pool?
     school_virtual_cap.present?
-  end
-
-  def has_devices_available_to_order?
-    available_devices_count.positive?
-  end
-
-  def available_devices_count
-    [0, (cap.to_i - devices_ordered.to_i)].max
   end
 
   def computacenter_cap_type

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -1,5 +1,7 @@
 class VirtualCapPool < ApplicationRecord
   include Computacenter::CapChangeNotifier
+  include DeviceType
+  include DeviceCount
 
   belongs_to :responsible_body
   has_many :school_virtual_caps, dependent: :destroy
@@ -9,11 +11,6 @@ class VirtualCapPool < ApplicationRecord
   after_touch :recalculate_caps!
 
   validates :device_type, uniqueness: { scope: :responsible_body_id }
-
-  enum device_type: {
-    'coms_device': 'coms_device',
-    'std_device': 'std_device',
-  }
 
   def recalculate_caps!
     self.cap = school_device_allocations.sum(:cap)

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -8,16 +8,16 @@
         The number of devices you can order is the remaining allocation of devices for:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>approved requests for specific circumstances</li>
-        <li>schools that have reported a closure or 15 or more pupils self-isolating at the same time</li>
+        <li>approved requests <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %></li>
+        <li><%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time</li>
       </ul>
     <% elsif @schools_can_order.any? %>
       <p class="govuk-body">
-        The number of devices you can order is the remaining allocation of devices for schools that have reported a closure or 15 or more pupils self-isolating at the same time.
+        The number of devices you can order is the remaining allocation of devices for <%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time.
       </p>
     <% elsif @schools_can_order_for_specific_circumstances.any? %>
       <p class="govuk-body">
-        The number of devices you can order is the remaining allocation of devices where a request for specific circumstances has been approved.
+        The number of devices you can order is the remaining allocation of devices where a request <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %> has been approved.
       </p>
     <% end %>
 

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -21,13 +21,6 @@
       </p>
     <% end %>
 
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      The number of devices you can order is:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the total devices allocated to <%= govuk_link_to "schools that have reported a closure or a self&#8209;isolating group".html_safe, responsible_body_devices_schools_path %></li>
-      <li><%= govuk_link_to 'devices requested for specific circumstances', responsible_body_devices_request_devices_path %></li>
-    </ul>
     <h2 class="govuk-heading-m">
       How to order
     </h2>

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -1,0 +1,56 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
+
+    <% if @schools_can_order.any? && @schools_can_order_for_specific_circumstances.any? %>
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        The number of devices you can order is the remaining allocation of devices for:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>approved requests for specific circumstances</li>
+        <li>schools that have reported a closure or 15 or more pupils self-isolating at the same time</li>
+      </ul>
+    <% elsif @schools_can_order.any? %>
+      <p class="govuk-body">
+        The number of devices you can order is the remaining allocation of devices for schools that have reported a closure or 15 or more pupils self-isolating at the same time.
+      </p>
+    <% elsif @schools_can_order_for_specific_circumstances.any? %>
+      <p class="govuk-body">
+        The number of devices you can order is the remaining allocation of devices where a request for specific circumstances has been approved.
+      </p>
+    <% end %>
+
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      The number of devices you can order is:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the total devices allocated to <%= govuk_link_to "schools that have reported a closure or a self&#8209;isolating group".html_safe, responsible_body_devices_schools_path %></li>
+      <li><%= govuk_link_to 'devices requested for specific circumstances', responsible_body_devices_request_devices_path %></li>
+    </ul>
+    <h2 class="govuk-heading-m">
+      How to order
+    </h2>
+    <p class="govuk-body">
+      You need to place orders on a website called TechSource.
+    </p>
+    <p class="govuk-body">
+      If you try to order more than <%= what_to_order_allocation_list(allocations: @responsible_body.virtual_cap_pools) %> the order will be cancelled.
+    </p>
+    <p class="govuk-body">
+      Devices will be delivered within 2 working days.
+    </p>
+    <h3 class="govuk-heading-s">
+      Ordering devices for more than one school
+    </h3>
+    <p class="govuk-body">
+      You can combine allocations for all your schools, and have all devices delivered to one place. If you want different schools to get devices directly, place a separate order for each delivery address.
+    </p>
+    <p class="govuk-body">
+      When using TechSource, you will be asked for a URN. Use any URN for one of the schools you manage.
+    </p>
+
+    <h3 class="govuk-heading-s">Using TechSource for the first time</h3>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address } %>
+  </div>
+</div>

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -3,13 +3,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.order_devices.order_devices_now') %>
+      <%= t('page_titles.order_devices.title') %>
     </h1>
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
-
-    <p class="govuk-body">We’re working hard to get devices delivered within 5 working days.</p>
   </div>
 </div>
 
-<%= render partial: 'place_order_for_schools' %>
+<% if @responsible_body.has_virtual_cap_feature_flags? %>
+  <%= render partial: 'place_order_for_virtual_pool' %>
+<% else %>
+  <%= render partial: 'place_order_for_schools' %>
+<% end %>

--- a/spec/components/responsible_body/pooled_device_count_component_spec.rb
+++ b/spec/components/responsible_body/pooled_device_count_component_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::PooledDeviceCountComponent, type: :component do
+  context 'when no devices available' do
+    let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation]) }
+    let(:pooled_allocation) { VirtualCapPool.new(devices_ordered: 0, cap: 0, device_type: 'std_device') }
+
+    subject(:component) { described_class.new(responsible_body: responsible_body) }
+
+    it 'renders availability' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'All devices ordered'
+    end
+
+    it 'renders state' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'ordered 0 devices'
+    end
+  end
+
+  context 'when devices available' do
+    let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation]) }
+    let(:pooled_allocation) { VirtualCapPool.new(devices_ordered: 1, cap: 5, device_type: 'std_device') }
+
+    subject(:component) { described_class.new(responsible_body: responsible_body) }
+
+    it 'renders availability' do
+      html = render_inline(component).to_html
+
+      expect(html).to include '4 devices available to order'
+    end
+
+    it 'renders state' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'ordered 1 devices'
+    end
+  end
+
+  context 'when all devices ordered' do
+    let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation]) }
+    let(:pooled_allocation) { VirtualCapPool.new(devices_ordered: 5, cap: 5, device_type: 'std_device') }
+
+    subject(:component) { described_class.new(responsible_body: responsible_body) }
+
+    it 'renders availability' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'All devices ordered'
+    end
+
+    it 'renders state' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'ordered 5 devices'
+    end
+  end
+
+  context 'with different allocations present' do
+    let(:pooled_allocation1) { VirtualCapPool.new(device_type: 'std_device', devices_ordered: 1, cap: 3) }
+    let(:pooled_allocation2) { VirtualCapPool.new(device_type: 'coms_device', devices_ordered: 2, cap: 5) }
+    let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation1, pooled_allocation2]) }
+
+    subject(:component) { described_class.new(responsible_body: responsible_body) }
+
+    it 'renders availability' do
+      content = render_inline(component).content
+
+      expect(content).to include '2 devices and 3 routers available to order'
+    end
+
+    it 'renders state' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'ordered 1 devices and 2 routers'
+    end
+  end
+end

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
+  let(:responsible_body) { create(:trust, :manages_centrally) }
+  let(:schools) { create_list(:school, 3, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body) }
+  let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }
+
+  before do
+    stub_computacenter_outgoing_api_calls
+    given_i_am_signed_in_as_a_responsible_body_user
+    given_my_order_information_is_up_to_date
+  end
+
+  scenario 'navigate to order devices page' do
+    when_i_visit_the_responsible_body_home_page
+    and_i_follow_the_get_laptops_and_tablets_link
+    then_i_see_the_get_laptops_and_tablets_page
+
+    when_i_follow_the_order_devices_link
+    then_i_see_the_cannot_order_devices_yet_page
+  end
+
+  scenario 'a centrally managed school that can order for local restrictions' do
+    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_1_school_in_local_restrictions_that_i_need_to_place_orders_for
+    and_is_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
+    and_i_see_where_my_allocation_has_come_from_for_the_1_school_in_local_restrictions
+  end
+
+  scenario 'a centrally managed school that can order for specific circumstances' do
+    given_a_centrally_managed_school_within_a_pool_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_1_school_with_specific_circumstances_that_i_need_to_place_orders_for
+    and_is_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
+    and_i_see_where_my_allocation_has_come_from_for_the_1_school_with_specific_circumstances
+  end
+
+  scenario 'centrally managed schools that can order for local restrictions and specific circumstances' do
+    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+    given_a_centrally_managed_school_within_a_pool_can_order_for_specific_circumstances
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_2_schools_that_i_need_to_place_orders_for
+    and_i_see_2_schools_that_i_have_already_placed_orders_for
+    and_i_see_where_my_allocation_has_come_from_for_the_2_schools
+  end
+
+  def given_i_am_signed_in_as_a_responsible_body_user
+    sign_in_as user
+  end
+
+  def given_my_order_information_is_up_to_date
+    responsible_body.update!(who_will_order_devices: 'responsible_body', vcap_feature_flag: true)
+    PreorderInformation.where(school_id: responsible_body.schools).update_all(will_need_chromebooks: 'no')
+    schools[0].preorder_information.responsible_body_will_order_devices!
+    schools[1].preorder_information.responsible_body_will_order_devices!
+  end
+
+  def given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+    schools[0].can_order!
+    schools[0].std_device_allocation.update!(cap: 3, allocation: 20, devices_ordered: 1) # 2 left
+    schools[0].coms_device_allocation.update!(cap: 5, allocation: 10, devices_ordered: 2) # 3 left
+
+    add_school_to_virtual_cap(school: schools[0])
+  end
+
+  def given_a_centrally_managed_school_within_a_pool_can_order_for_specific_circumstances
+    schools[1].can_order_for_specific_circumstances!
+    schools[1].std_device_allocation.update!(cap: 3, allocation: 20, devices_ordered: 1) # 2 left
+    schools[1].coms_device_allocation.update!(cap: 0, allocation: 0, devices_ordered: 0) # 0 left
+
+    add_school_to_virtual_cap(school: schools[1])
+  end
+
+  def when_i_visit_the_responsible_body_home_page
+    visit responsible_body_home_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def when_i_visit_the_order_devices_page
+    visit responsible_body_devices_order_devices_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def when_i_follow_the_order_devices_link
+    click_link('Order devices')
+  end
+
+  def and_i_follow_the_get_laptops_and_tablets_link
+    click_link 'Get laptops and tablets'
+  end
+
+  def then_i_see_the_get_laptops_and_tablets_page
+    expect(page).to have_css('h1', text: 'Get laptops and tablets')
+    expect(page).to have_link('List of schools')
+    expect(page).to have_link('Order devices')
+    expect(page).to have_link('Request devices for specific circumstances')
+  end
+
+  def then_i_see_the_cannot_order_devices_yet_page
+    expect(page).to have_css('h1', text: 'You cannot order devices yet')
+  end
+
+  def then_i_see_the_order_now_page
+    expect(page).to have_css('h1', text: 'Order devices')
+  end
+
+  def and_i_see_1_school_in_local_restrictions_that_i_need_to_place_orders_for
+    expect(page).to have_text('2 devices and 3 routers available to order')
+  end
+
+  def and_is_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
+    expect(page).to have_text('You ordered 1 devices and 2 routers')
+  end
+
+  def and_i_see_1_school_with_specific_circumstances_that_i_need_to_place_orders_for
+    expect(page).to have_text('2 devices and 0 routers available to order')
+  end
+
+  def and_is_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
+    expect(page).to have_text('You ordered 1 devices and 0 routers')
+  end
+
+  def and_i_see_2_schools_that_i_need_to_place_orders_for
+    expect(page).to have_text('4 devices and 3 routers available to order')
+  end
+
+  def and_i_see_2_schools_that_i_have_already_placed_orders_for
+    expect(page).to have_text('You ordered 2 devices and 2 routers')
+  end
+
+  def and_i_see_where_my_allocation_has_come_from_for_the_1_school_in_local_restrictions
+    expect(page).to have_text('remaining allocation of devices for schools that have reported a closure or')
+  end
+
+  def and_i_see_where_my_allocation_has_come_from_for_the_1_school_with_specific_circumstances
+    expect(page).to have_text('remaining allocation of devices where a request for specific circumstances')
+  end
+
+  def and_i_see_where_my_allocation_has_come_from_for_the_2_schools
+    expect(page).to have_text('remaining allocation of devices for:')
+    expect(page).to have_text('approved requests for specific circumstances')
+    expect(page).to have_text('schools that have reported a closure or 15')
+  end
+
+  def add_school_to_virtual_cap(school:)
+    responsible_body.add_school_to_virtual_cap_pools!(school)
+    responsible_body.calculate_virtual_caps!
+  end
+end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Ordering devices' do
   let(:responsible_body) { create(:local_authority) }
-  let(:schools) { create_list(:school, 5, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, responsible_body: responsible_body) }
+  let(:schools) { create_list(:school, 6, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, responsible_body: responsible_body) }
   let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }
 
   before do
@@ -148,7 +148,7 @@ RSpec.feature 'Ordering devices' do
   end
 
   def then_i_see_the_order_now_page
-    expect(page).to have_css('h1', text: 'Order devices now')
+    expect(page).to have_css('h1', text: 'Order devices')
   end
 
   def and_i_see_1_school_that_i_need_to_place_orders_for

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -3,6 +3,48 @@ require 'rails_helper'
 RSpec.describe ViewHelper do
   let(:school) { School.new(device_allocations: allocations) }
 
+  describe '#what_to_order_allocation_list' do
+    context 'with school device allocations' do
+      context 'when devices available to order' do
+        let(:allocations) { [SchoolDeviceAllocation.new(cap: 4, devices_ordered: 1)] }
+
+        it 'returns X devices' do
+          expect(helper.what_to_order_allocation_list(allocations: allocations)).to eql('3 devices')
+        end
+      end
+
+      context 'when devices and routers available to order' do
+        let(:allocation1) { SchoolDeviceAllocation.new(device_type: :std_device, cap: 10, devices_ordered: 3) }
+        let(:allocation2) { SchoolDeviceAllocation.new(device_type: :coms_device, cap: 4, devices_ordered: 1) }
+        let(:allocations) { [allocation1, allocation2] }
+
+        it 'X devices and X routers' do
+          expect(helper.what_to_order_allocation_list(allocations: allocations)).to eql('7 devices and 3 routers')
+        end
+      end
+    end
+
+    context 'with virtual cap pool allocations' do
+      context 'when devices available to order' do
+        let(:allocations) { [VirtualCapPool.new(cap: 4, devices_ordered: 1)] }
+
+        it 'returns X devices' do
+          expect(helper.what_to_order_allocation_list(allocations: allocations)).to eql('3 devices')
+        end
+      end
+
+      context 'when devices and routers available to order' do
+        let(:allocation1) { VirtualCapPool.new(device_type: :std_device, cap: 10, devices_ordered: 3) }
+        let(:allocation2) { VirtualCapPool.new(device_type: :coms_device, cap: 4, devices_ordered: 1) }
+        let(:allocations) { [allocation1, allocation2] }
+
+        it 'X devices and X routers' do
+          expect(helper.what_to_order_allocation_list(allocations: allocations)).to eql('7 devices and 3 routers')
+        end
+      end
+    end
+  end
+
   describe '#what_to_order_availability' do
     context 'when devices available to order' do
       let(:allocations) { [SchoolDeviceAllocation.new(cap: 4, devices_ordered: 1)] }

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -139,4 +139,40 @@ RSpec.describe VirtualCapPool, type: :model do
       end
     end
   end
+
+  describe '#available_devices_count' do
+    subject(:allocation) { described_class.new(cap: 100, devices_ordered: 200) }
+
+    context 'when negative' do
+      it 'returns zero' do
+        expect(allocation.available_devices_count).to be_zero
+      end
+    end
+  end
+
+  describe '#has_devices_available_to_order?' do
+    context 'when used full allocation' do
+      let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 100) }
+
+      it 'returns false' do
+        expect(allocation.has_devices_available_to_order?).to be false
+      end
+    end
+
+    context 'when partially used allocation' do
+      let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 75) }
+
+      it 'returns true' do
+        expect(allocation.has_devices_available_to_order?).to be true
+      end
+    end
+
+    context 'when no devices ordered' do
+      let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 0) }
+
+      it 'returns true' do
+        expect(allocation.has_devices_available_to_order?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/VxiaDLtN/1082-virtual-cap-update-ordered-devices-page

Prototype page: https://ghwt-prototype.herokuapp.com/responsible-body/devices/order-lockdown

### Changes proposed in this pull request

- Add a new 'Order devices' page for responsible bodies that are ordering centrally and are in the virtual cap feature
- This page shows regardless of whether RB has schools ordering for specific circumstances or not. We have added copy to explain where their device counts come from in each case: schools closed, schools with specific circumstances and a mix of both.
- Nothing should change for RBs ordering centrally outside of the feature.

### Guidance to review

To make sure nothing has changed with existing functionality:

1. Log in as RB ordering centrally
2. Set a school to `can_order`
3. Existing 'Order devices' page should be shown
4. Set school to 'can_order_for_specific_circumstances`
5. Existing 'specific circumstances' page should show

With these changes:

1. Log in as RB ordering centrally, with `FEATURES_virtual_caps=active` and the `vcap_feature_flag` flag set to true on the RB.
2. New page should be shown regardless of having schools in specific circumstances or closed normally
3. The [page should look like this ](https://ghwt-prototype.herokuapp.com/responsible-body/devices/order-lockdown)with an additional conditional paragraph at the top
4. The new device count component should correctly render the devices available to order and the devices already ordered.

### Screenshot

![screencapture-localhost-3000-responsible-body-devices-order-devices-2020-12-02-12_04_54](https://user-images.githubusercontent.com/31316/100870503-9eddb200-3496-11eb-9309-d8e319776659.png)


