### PR TITLE
Fix wrongly named virtual cap query method

### DIFF
--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -21,7 +21,7 @@ class SchoolOrderStateAndCapUpdateService
       if notify_computacenter_of_cap_changes?
         if FeatureFlag.active? :virtual_caps
           # don't send updates as they will happen when the pool is updated and the caps adjusted
-          unless allocation.is_in_virtual_pool?
+          unless allocation.is_in_virtual_cap_pool?
             update_cap_on_computacenter!(allocation.id)
             notify_computacenter_by_email(@school, allocation.device_type, allocation.cap)
           end

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
+    context 'when a school is not in the virtual cap pool', with_feature_flags: { virtual_caps: 'active' } do
+      it 'triggers notifications that the school can order' do
+        service.update!
+        expect(notifications).to have_received(:call)
+      end
+    end
+
     context 'when a school is centrally managed and the school is not in the virtual cap pool' do
       before do
         school.preorder_information.responsible_body_will_order_devices!


### PR DESCRIPTION
### Context
@jamesrose found a wrongly named method that wasn't being exercised in the tests but was found locally as he had the virtual caps feature flag enabled.

### Changes proposed in this pull request
Rename method from `is_in_virtual_pool?` to `is_in_virtual_cap_pool?` and added test that hits this.

### Guidance to review

