### PR TITLE
remove Devices ordered line from school details if RB has VirtualCaps enabled

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -84,7 +84,7 @@ private
   end
 
   def display_devices_ordered_row?
-    @school.std_device_allocation&.devices_ordered.to_i.positive?
+    !@school.responsible_body.has_virtual_cap_feature_flags? && @school.std_device_allocation&.devices_ordered.to_i.positive?
   end
 
   def display_router_allocation_row?

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -49,6 +49,8 @@ RSpec.feature 'Ordering via a school' do
         when_i_view_a_school(school)
         then_i_see_status_of('You can order')
         and_i_see 'You’ve ordered 3 of 12 devices'
+        and_i_see 'Devices ordered'
+        and_i_see '3 devices'
 
         when_i_click_on('Order devices')
         then_i_see_the_school_order_devices_page
@@ -92,6 +94,8 @@ RSpec.feature 'Ordering via a school' do
 
         when_i_view_a_school(school)
         then_i_do_not_see 'You’ve ordered 3 of 10 devices'
+        and_i_do_not_see 'Devices ordered'
+        and_i_do_not_see '3 devices'
         and_i_see_an_order_devices_now_link
       end
     end


### PR DESCRIPTION
### Context

Following on from [this Slack thread](https://ukgovernmentdfe.slack.com/archives/C01A7DVKE9J/p1606824548032000), another instance of 'Devices ordered' not catered for in the previous PR #877

### Changes proposed in this pull request

Don't show the 'Devices ordered' line in the `ResponsibleBody::SchoolDetailsSummaryListComponent` if the Responsible Body has virtual caps enabled

### Guidance to review

Before:

![Screenshot from 2020-12-02 10-40-24](https://user-images.githubusercontent.com/134501/100862236-d6466180-348a-11eb-9e5e-636cb8fdf68e.png)

After:
![Screenshot from 2020-12-02 10-40-59](https://user-images.githubusercontent.com/134501/100862287-e8280480-348a-11eb-9437-c12571f4d50f.png)


