### PR TITLE
Send different invite email when a RB ordering centrally is using virtual caps

### DIFF
--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -9,6 +9,16 @@ class CanOrderDevicesMailer < ApplicationMailer
                           personalisation: personalisation)
   end
 
+  def user_can_order_in_virtual_cap
+    @user = params[:user]
+    @school = params[:school]
+
+    tracked_template_mail('can_order_in_virtual_cap',
+                          can_order_devices_in_virtual_cap_template_id,
+                          to: @user.email_address,
+                          personalisation: personalisation)
+  end
+
   def user_can_order_but_action_needed
     @user = params[:user]
     @school = params[:school]
@@ -76,6 +86,10 @@ private
 
   def can_order_devices_template_id
     Settings.govuk_notify.templates.devices.can_order_devices
+  end
+
+  def can_order_devices_in_virtual_cap_template_id
+    Settings.govuk_notify.templates.devices.can_order_devices_in_virtual_cap
   end
 
   def can_order_but_action_needed_template_id

--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -48,6 +48,8 @@ private
       :user_can_order_but_action_needed
     elsif status?('rb_can_order', 'school_can_order', school: school) && user.orders_devices? && !user.seen_privacy_notice?
       :nudge_user_to_read_privacy_policy
+    elsif status?('rb_can_order', school: school) && school.responsible_body.has_virtual_cap_feature_flags? && user.in?(school.order_users_with_active_techsource_accounts)
+      :user_can_order_in_virtual_cap
     elsif status?('ready', 'school_ready', 'rb_can_order', 'school_can_order', school: school) && user.in?(school.order_users_with_active_techsource_accounts)
       :user_can_order
     end

--- a/app/models/user_can_order_devices_notifications.rb
+++ b/app/models/user_can_order_devices_notifications.rb
@@ -32,7 +32,9 @@ private
   end
 
   def message_type_for_school(school)
-    if %w[rb_can_order school_can_order].include?(school.preorder_information&.status)
+    if %w[rb_can_order].include?(school.preorder_information&.status) && school.responsible_body.has_virtual_cap_feature_flags?
+      :user_can_order_in_virtual_cap
+    elsif %w[rb_can_order school_can_order].include?(school.preorder_information&.status)
       :user_can_order
     elsif %w[needs_info].include?(school.preorder_information&.status)
       :user_can_order_but_action_needed

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,6 +46,7 @@ govuk_notify:
       nominate_contacts: 'ef964a6f-d984-4f35-a074-6f3cb79bfec7'
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
       can_order_devices: '9df2c08a-c457-4b13-9270-c5a20687d168'
+      can_order_devices_in_virtual_cap: 'ab40ae48-6086-4fd7-b391-b29883572d86'
       user_added_to_additional_school: 'f3ec0c69-17f8-424d-9c33-f17438355c2c'
       can_order_but_action_needed: '9096f09c-0b36-486c-9395-a6626198fd86'
       user_added_to_additional_school: 'f3ec0c69-17f8-424d-9c33-f17438355c2c'

--- a/spec/mailers/can_order_devices_mailer_spec.rb
+++ b/spec/mailers/can_order_devices_mailer_spec.rb
@@ -53,6 +53,51 @@ RSpec.describe CanOrderDevicesMailer, type: :mailer do
     end
   end
 
+  describe '#user_can_order_in_virtual_cap' do
+    it 'adds an email audit record' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_now
+      }.to change { EmailAudit.count }.by(1)
+    end
+
+    it 'sets the correct values on the email audit record' do
+      described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_now
+      expect(EmailAudit.last).to have_attributes(message_type: 'can_order_in_virtual_cap',
+                                                 template: Settings.govuk_notify.templates.devices.can_order_devices_in_virtual_cap,
+                                                 user_id: user.id,
+                                                 school_id: school.id,
+                                                 email_address: user.email_address)
+    end
+
+    it 'enqueues mailer job with #deliver_later' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_later
+      }.to have_enqueued_job.on_queue('mailers')
+    end
+
+    it 'sends mail with #deliver_now' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_now
+      }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+
+    context 'when user is deleted' do
+      let(:user) { create(:school_user, deleted_at: 1.second.ago) }
+
+      it 'enqueues mailer job with #deliver_later' do
+        expect {
+          described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_later
+        }.to have_enqueued_job.on_queue('mailers')
+      end
+
+      it 'does not send mail with #deliver_now' do
+        expect {
+          described_class.with(user: user, school: school).user_can_order_in_virtual_cap.deliver_now
+        }.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+    end
+  end
+
   describe '#user_can_order_but_action_is_needed' do
     it 'adds an email audit record' do
       expect {


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/HyeLDn5U/1102-virtual-caps-update-automatic-email-which-is-sent-when-a-trust-ordering-centrally-is-invited-to-order-when-a-school-reports-disr

> We currently send an automated email out when we raise the cap for a school having reported disruption. This sends a generic message inviting them to order which is the same for both schools ordering directly and trusts ordering on behalf of schools. 

> When we implement virtual caps we will no longer know if that school has received their allocation of devices only how many are remaining within the trusts 'virtual cap' as a result we need to adapt our communications for trusts ordering centrally to reflect this. 

### Changes proposed in this pull request

Use a different email template when the RB of a school ready to order is ordering centrally _and_ in the virtual cap feature.

### Guidance to review

Is a preorder status of `rb_can_order` enough to qualify that it is 1) centrally managed, and 2) ready to order - even after placing an initial order?

1. Enable global virtual caps feature flag 
2. Find RB that is ordering centrally and toggle the feature flag on
3. Open school for ordering
4. Email should be sent