### PR TITLE
make FactoryBot school URNs unique in tests

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :school do
     association :responsible_body, factory: %i[local_authority trust].sample
-    urn { Faker::Number.number(digits: 6) }
+    urn { Faker::Number.unique.number(digits: 6) }
     name { Faker::Educator.secondary_school }
     computacenter_reference { Faker::Number.number(digits: 8) }
     phase { School.phases.values.sample }


### PR DESCRIPTION
### Context

When performing full test runs, we occasionally get collisions in the randomly-generated URNs for schools. These make the test run fail with an error like:
```
ActiveRecord::RecordNotUnique:
       PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_schools_on_urn"
       DETAIL:  Key (urn)=(441405) already exists.
```

Although we've always been able to successfully re-run the workflow, this is still a source of frustration and lost time.
 
### Changes proposed in this pull request

Make schools URNs unique

### Guidance to review

Difficult to prove that you've fixed an intermittent PRNG collision..... :man_shrugging: 

