### PR TITLE
[1064] Add validation to school_or_rb_domain

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -7,6 +7,12 @@ class PreorderInformation < ApplicationRecord
   belongs_to :school_contact, optional: true
 
   validates :status, presence: true
+  validates :school_or_rb_domain,
+            format: { with: /\A[a-z0-9._-]+\z/ },
+            on: :create,
+            if: proc { |pre| pre.will_need_chromebooks? }
+
+  before_validation :prepare_school_or_rb_domain
 
   enum status: {
     needs_contact: 'needs_contact',
@@ -134,6 +140,12 @@ class PreorderInformation < ApplicationRecord
   end
 
 private
+
+  def prepare_school_or_rb_domain
+    if school_or_rb_domain.present?
+      self.school_or_rb_domain = school_or_rb_domain.strip.downcase.gsub(/\/$/, '')
+    end
+  end
 
   def any_school_users?
     school&.users&.any?

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Change school Chromebook information' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith', school: school) }
 
   before do
-    create(:preorder_information, school: school_user.school, who_will_order_devices: 'school', will_need_chromebooks: 'yes')
+    create(:preorder_information, school: school_user.school, who_will_order_devices: 'school', will_need_chromebooks: 'yes', school_or_rb_domain: 'example.com')
     create(:school_device_allocation, school: school_user.school, device_type: 'std_device', allocation: 63)
   end
 

--- a/spec/features/school/view_school_details_spec.rb
+++ b/spec/features/school/view_school_details_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'View school details' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
 
   before do
-    create(:preorder_information, school: school_user.school, who_will_order_devices: 'responsible_body', will_need_chromebooks: 'yes')
+    create(:preorder_information, school: school_user.school, who_will_order_devices: 'responsible_body', will_need_chromebooks: 'yes', school_or_rb_domain: 'example.com')
     create(:school_device_allocation, school: school_user.school, device_type: 'std_device', allocation: 63)
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/Ea9OavT1/1064-improve-google-schoolorrbdomain-data-collection

### Changes proposed in this pull request

- add validation to `PreorderInformation#school_or_rb_domain`
- This should only run on create otherwise existing invalid records cannot be be saved/updated
- in the future if we ever get all records passing validation we can remove this from `on: :create` 

### Guidance to review

- Sign up and follow process
- on prompting for chromebook details do this will assorted domains that are not valid
- Another test, create record with invalid `school_or_rb_domain`
- Update another attribute on this record, should be saved as validation should not run