### PR TITLE
[1122] Fix intermittent duplicate-key spec failures

### DIFF
--- a/spec/services/responsible_body_exporter_spec.rb
+++ b/spec/services/responsible_body_exporter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ResponsibleBodyExporter, type: :model do
       sat
       exporter.export_responsible_bodies
     end
-    
+
     after do
       remove_file(filename)
     end

--- a/spec/services/responsible_body_exporter_spec.rb
+++ b/spec/services/responsible_body_exporter_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ResponsibleBodyExporter, type: :model do
   subject(:exporter) { described_class.new(filename) }
 
   context 'when exporting responsible_body data' do
-    around do |example|
+    before do
       responsible_body
       exporter.export_responsible_bodies
+    end
 
-      example.run
-
+    after do
       remove_file(filename)
     end
 
@@ -29,10 +29,12 @@ RSpec.describe ResponsibleBodyExporter, type: :model do
   context 'when exporting single academy trusts' do
     let(:sat) { create(:trust, :single_academy_trust, companies_house_number: nil) }
 
-    around do |example|
+    before do
       sat
       exporter.export_responsible_bodies
-      example.run
+    end
+    
+    after do
       remove_file(filename)
     end
 

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe SchoolDataExporter, type: :model do
   subject(:exporter) { described_class.new(filename) }
 
   context 'when exporting school data' do
-    around do |example|
+    before do
       school
       exporter.export_schools
-      example.run
+    end
+
+    after do
       remove_file(filename)
     end
 
@@ -27,10 +29,12 @@ RSpec.describe SchoolDataExporter, type: :model do
   context 'when exporting single academy trusts' do
     let(:sat) { create(:trust, :single_academy_trust, companies_house_number: nil) }
 
-    around do |example|
+    before do
       school.update!(responsible_body: sat)
       exporter.export_schools
-      example.run
+    end
+
+    after do
       remove_file(filename)
     end
 


### PR DESCRIPTION
### Context

While investigating [intermittent ActiveRecord::RecordNotUnique errors in our test suite](https://trello.com/c/KIkSSDVf/1122-fix-intermittent-duplicate-key-spec-failures), I isolated the problem down to test data leaking, specifically two examples which created their data in `around` hooks. 

This is outside of the per-test transaction scope, so DatabaseCleaner's `:transaction` strategy is unable to roll it back, and the record persists into all subsequent examples.

This can occasionally cause a unique constraint violation even on values created with Faker::(type).unique, as Faker does not
use the database for existence checking.

### Changes proposed in this pull request

* restructure the two `around` hooks as `before`/`after` pairs

### Guidance to review

