### PR TITLE
[1107] Notify MNOs if there are new requests

### DIFF
--- a/app/jobs/notify_mnos_job.rb
+++ b/app/jobs/notify_mnos_job.rb
@@ -2,14 +2,10 @@ class NotifyMnosJob < ApplicationJob
   queue_as :default
 
   def perform
-    MobileNetwork
-      .joins(:extra_mobile_data_requests)
-      .where(extra_mobile_data_requests: { status: %w[requested] })
-      .where('extra_mobile_data_requests.created_at > ?', since_last_email)
-      .having('COUNT(mobile_networks.id) > 0')
-      .group('mobile_networks.id').each do |mno|
-      number_of_new_requests = mno.extra_mobile_data_requests.requested.where('created_at > ?', since_last_email).count
-      mno.users.each do |user|
+    users.each do |user|
+      number_of_new_requests = user.mobile_network.extra_mobile_data_requests.requested.where('created_at > ?', since_last_email_for_user(user)).count
+
+      if number_of_new_requests.positive?
         MnoMailer.notify_new_requests(user: user, number_of_new_requests: number_of_new_requests).deliver_now
       end
     end
@@ -17,13 +13,11 @@ class NotifyMnosJob < ApplicationJob
 
 private
 
-  def since_last_email
-    now = Time.zone.now
+  def since_last_email_for_user(user)
+    user.email_audits.where(message_type: 'notify_new_requests').last&.created_at || 72.hours.ago
+  end
 
-    if now.monday?
-      now - 72.hours
-    else
-      now - 24.hours
-    end
+  def users
+    @users ||= User.joins(:mobile_network)
   end
 end

--- a/app/jobs/notify_mnos_job.rb
+++ b/app/jobs/notify_mnos_job.rb
@@ -1,0 +1,16 @@
+class NotifyMnosJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    MobileNetwork
+      .joins(:extra_mobile_data_requests)
+      .where(extra_mobile_data_requests: { status: %w[requested] })
+      .having('COUNT(mobile_networks.id) > 0')
+      .group('mobile_networks.id').each do |mno|
+      number_of_new_requests = mno.extra_mobile_data_requests.requested.count
+      mno.users.each do |user|
+        MnoMailer.notify_new_requests(user: user, number_of_new_requests: number_of_new_requests).deliver_now
+      end
+    end
+  end
+end

--- a/app/jobs/notify_mnos_job.rb
+++ b/app/jobs/notify_mnos_job.rb
@@ -5,12 +5,25 @@ class NotifyMnosJob < ApplicationJob
     MobileNetwork
       .joins(:extra_mobile_data_requests)
       .where(extra_mobile_data_requests: { status: %w[requested] })
+      .where('extra_mobile_data_requests.created_at > ?', since_last_email)
       .having('COUNT(mobile_networks.id) > 0')
       .group('mobile_networks.id').each do |mno|
-      number_of_new_requests = mno.extra_mobile_data_requests.requested.count
+      number_of_new_requests = mno.extra_mobile_data_requests.requested.where('created_at > ?', since_last_email).count
       mno.users.each do |user|
         MnoMailer.notify_new_requests(user: user, number_of_new_requests: number_of_new_requests).deliver_now
       end
+    end
+  end
+
+private
+
+  def since_last_email
+    now = Time.zone.now
+
+    if now.monday?
+      now - 72.hours
+    else
+      now - 24.hours
     end
   end
 end

--- a/app/mailers/mno_mailer.rb
+++ b/app/mailers/mno_mailer.rb
@@ -5,9 +5,18 @@ class MnoMailer < ApplicationMailer
       to: user.email_address,
       personalisation: personalisation(user, number_of_new_requests),
     )
+
+    audit_email(user: user)
   end
 
 private
+
+  def audit_email(user:)
+    EmailAudit.create!(message_type: 'notify_new_requests',
+                       template: notify_new_requests_template_id,
+                       email_address: user.email_address,
+                       user: user)
+  end
 
   def personalisation(user, number_of_new_requests)
     {

--- a/app/mailers/mno_mailer.rb
+++ b/app/mailers/mno_mailer.rb
@@ -1,0 +1,23 @@
+class MnoMailer < ApplicationMailer
+  def notify_new_requests(user:, number_of_new_requests:)
+    template_mail(
+      notify_new_requests_template_id,
+      to: user.email_address,
+      personalisation: personalisation(user, number_of_new_requests),
+    )
+  end
+
+private
+
+  def personalisation(user, number_of_new_requests)
+    {
+      full_name: user.full_name,
+      brand: user.mobile_network.brand,
+      number: number_of_new_requests,
+    }
+  end
+
+  def notify_new_requests_template_id
+    Settings.govuk_notify.templates.mno.notify_new_requests
+  end
+end

--- a/app/models/email_audit.rb
+++ b/app/models/email_audit.rb
@@ -1,6 +1,6 @@
 class EmailAudit < ApplicationRecord
   belongs_to :user
-  belongs_to :school
+  belongs_to :school, optional: true
 
   validates :message_type, presence: true
   validates :template, presence: true

--- a/app/models/mobile_network.rb
+++ b/app/models/mobile_network.rb
@@ -1,5 +1,6 @@
 class MobileNetwork < ApplicationRecord
   has_many :extra_mobile_data_requests, dependent: :destroy
+  has_many :users
 
   validates :brand, presence: true, uniqueness: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
   has_many :school_welcome_wizards, dependent: :destroy
+  has_many :email_audits
 
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,6 +56,8 @@ govuk_notify:
       device_cap_change: '6e00f2bf-d373-436d-a2c0-2910f20ef521'
       comms_cap_change: '01f1b2a3-a216-44cc-a567-704bfd0a3c56'
       school_can_order: '90df56c1-997b-4a73-ba97-4220328a1917'
+    mno:
+      notify_new_requests: '934c7ca4-3782-4e8a-b2d8-dd6f6d128371'
 
 # Hostname used for generating URLs in emails
 hostname_for_urls: http://localhost:3000

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,6 +11,10 @@
     queue: scheduler
     description: Stage GIAS school data
   StageTrustDataJob:
-    cron: '30 5 * * * Europe/London' # every daya at 5:30am
+    cron: '30 5 * * * Europe/London' # every day at 5:30am
     queue: scheduler
     description: Stage GIAS trust data
+  NotifyMnosJob:
+    cron: '0 8 * * 1-5 Europe/London'  # every weekday at 8:00am
+    queue: scheduler
+    description: Notify MNOs of requests

--- a/spec/jobs/notify_mnos_job_spec.rb
+++ b/spec/jobs/notify_mnos_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe NotifyMnosJob do
+  let(:mno_1_user) { create(:user) }
+  let(:mno_2_user) { create(:user) }
+
+  let(:mno1) { create(:mobile_network, users: [mno_1_user]) }
+  let(:mno2) { create(:mobile_network, users: [mno_2_user]) }
+
+  describe '#perform' do
+    before do
+      create(:extra_mobile_data_request, mobile_network: mno1)
+      create(:extra_mobile_data_request, mobile_network: mno1)
+      create(:extra_mobile_data_request, mobile_network: mno1, status: :in_progress)
+      create(:extra_mobile_data_request, mobile_network: mno2, status: :in_progress)
+    end
+
+    it 'emails relevant mno users' do
+      allow(MnoMailer).to receive(:notify_new_requests).and_call_original
+
+      expect {
+        described_class.perform_now
+      }.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      expect(MnoMailer).to have_received(:notify_new_requests).with(user: mno_1_user, number_of_new_requests: 2)
+    end
+  end
+end

--- a/spec/jobs/notify_mnos_job_spec.rb
+++ b/spec/jobs/notify_mnos_job_spec.rb
@@ -6,13 +6,20 @@ RSpec.describe NotifyMnosJob do
 
   let(:mno1) { create(:mobile_network, users: [mno_1_user]) }
   let(:mno2) { create(:mobile_network, users: [mno_2_user]) }
+  let(:now) { Time.zone.local(2020, 12, 7, 8) }
+
+  around do |example|
+    Timecop.freeze(now) do
+      example.run
+    end
+  end
 
   describe '#perform' do
     before do
-      create(:extra_mobile_data_request, mobile_network: mno1)
-      create(:extra_mobile_data_request, mobile_network: mno1)
-      create(:extra_mobile_data_request, mobile_network: mno1, status: :in_progress)
-      create(:extra_mobile_data_request, mobile_network: mno2, status: :in_progress)
+      create(:extra_mobile_data_request, mobile_network: mno1, created_at: 6.hours.ago) # in scope
+      create(:extra_mobile_data_request, mobile_network: mno1, created_at: 1.week.ago) # not in scope
+      create(:extra_mobile_data_request, mobile_network: mno1, created_at: 1.week.ago) # not in scope
+      create(:extra_mobile_data_request, mobile_network: mno2, status: :in_progress, created_at: 6.hours.ago) # not in scope
     end
 
     it 'emails relevant mno users' do
@@ -22,7 +29,7 @@ RSpec.describe NotifyMnosJob do
         described_class.perform_now
       }.to change { ActionMailer::Base.deliveries.size }.by(1)
 
-      expect(MnoMailer).to have_received(:notify_new_requests).with(user: mno_1_user, number_of_new_requests: 2)
+      expect(MnoMailer).to have_received(:notify_new_requests).with(user: mno_1_user, number_of_new_requests: 1)
     end
   end
 end

--- a/spec/mailers/mno_mailer_spec.rb
+++ b/spec/mailers/mno_mailer_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe MnoMailer, type: :mailer do
 
       expect(mail[:personalisation].unparsed_value).to eq(expected_personalisation)
     end
+
+    it 'audits the email' do
+      expect { mail.deliver_now }.to change(EmailAudit, :count).by(1)
+
+      audit = EmailAudit.last
+      expect(audit.message_type).to eql('notify_new_requests')
+      expect(audit.template).to eql(Settings.govuk_notify.templates.mno.notify_new_requests)
+      expect(audit.email_address).to eql(user.email_address)
+      expect(audit.user).to eql(user)
+    end
   end
 end

--- a/spec/mailers/mno_mailer_spec.rb
+++ b/spec/mailers/mno_mailer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe MnoMailer, type: :mailer do
+  let(:user) { build(:mno_user) }
+
+  describe '#notify_new_requests' do
+    subject(:mail) { MnoMailer.notify_new_requests(user: user, number_of_new_requests: 3) }
+
+    it 'sends to user with correct personalisation' do
+      expect(mail.to).to eq([user.email_address])
+
+      expected_personalisation = {
+        full_name: user.full_name,
+        brand: user.mobile_network.brand,
+        number: 3,
+      }
+
+      expect(mail[:personalisation].unparsed_value).to eq(expected_personalisation)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/TprR7Aph/1107-build-automatic-notification-for-mnos-when-they-receive-a-request

### Changes proposed in this pull request

- Notify MNO users if they have new requests
- Emails are sent every weekday at 8am

### Screenshots

![image](https://user-images.githubusercontent.com/92580/101061680-a41b2980-3588-11eb-99d4-80d10c020ead.png)

### Guidance to review

- Ensure there is an MobileNetwork with a user
- Create a request for this mno
- Trigger job
- User should see email