### PR TITLE
Update support responsible body page for virtual caps

### DIFF
--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -30,6 +30,6 @@ class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
 private
 
   def allocations
-    responsible_body.virtual_cap_pools.order(Arel.sql("device_type = 'coms_device' ASC"))
+    responsible_body.virtual_cap_pools.with_std_device_first
   end
 end

--- a/app/components/school_preorder_status_tag_component.rb
+++ b/app/components/school_preorder_status_tag_component.rb
@@ -7,7 +7,7 @@ class SchoolPreorderStatusTagComponent < ViewComponent::Base
   end
 
   def text
-    I18n.t!(status, scope: [:components, :school_preorder_status_tag_component, :status, text_key])
+    I18n.t!(status, scope: [:components, :school_preorder_status_tag_component, :status, who_will_order_devices_key, text_key])
   end
 
   def type
@@ -33,6 +33,14 @@ private
 
   def status
     @status ||= school.preorder_status_or_default
+  end
+
+  def who_will_order_devices_key
+    if school.who_will_order_devices == 'responsible_body'
+      :responsible_body
+    else
+      :school
+    end
   end
 
   def text_key

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -13,6 +13,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
 
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
+    @virtual_cap_pools = @responsible_body.virtual_cap_pools.with_std_device_first
     @users = policy_scope(@responsible_body.users).not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
     @schools = @responsible_body
       .schools

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -161,12 +161,25 @@ module ViewHelper
     end
   end
 
-  def what_to_order_state(school:)
-    string = school.device_allocations.map { |alloc|
+  def what_to_order_state_list(allocations:)
+    allocations.map { |alloc|
       "#{alloc.devices_ordered} #{alloc.device_type_name.pluralize(alloc.devices_ordered)}"
     }.join(' and ')
+  end
+
+  def what_to_order_state(school:)
+    string = what_to_order_state_list(allocations: school.device_allocations)
 
     "You’ve ordered #{string}"
+  end
+
+  def centrally_managing_count_or_all_schools(responsible_body:)
+    schools = responsible_body.schools.gias_status_open
+    if responsible_body.is_ordering_for_all_schools?
+      'all'
+    else
+      "#{schools.that_are_centrally_managed.count} of #{schools.count}"
+    end
   end
 
   def link_to_ed_settings_form

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -39,6 +39,10 @@ class ResponsibleBody < ApplicationRecord
     virtual_cap_pools.any?(&:has_devices_available_to_order?)
   end
 
+  def has_school_in_virtual_cap_pools?(school)
+    virtual_cap_pools.any? { |pool| pool.has_school?(school) }
+  end
+
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end
@@ -81,6 +85,10 @@ class ResponsibleBody < ApplicationRecord
 
   def has_virtual_cap_feature_flags?
     FeatureFlag.active?(:virtual_caps) && vcap_feature_flag?
+  end
+
+  def has_virtual_cap_feature_flags_and_centrally_managed_schools?
+    has_virtual_cap_feature_flags? && has_centrally_managed_schools?
   end
 
   def self.in_connectivity_pilot
@@ -145,6 +153,14 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def is_ordering_for_schools?
+    schools.gias_status_open.that_are_centrally_managed.any?
+  end
+
+  def is_ordering_for_all_schools?
+    schools.gias_status_open.count == schools.gias_status_open.that_are_centrally_managed.count
+  end
+
+  def has_centrally_managed_schools?
     schools.gias_status_open.that_are_centrally_managed.any?
   end
 

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -12,6 +12,10 @@ class VirtualCapPool < ApplicationRecord
 
   validates :device_type, uniqueness: { scope: :responsible_body_id }
 
+  def self.with_std_device_first
+    order(Arel.sql("device_type = 'coms_device' ASC"))
+  end
+
   def recalculate_caps!
     self.cap = school_device_allocations.sum(:cap)
     self.devices_ordered = school_device_allocations.sum(:devices_ordered)
@@ -26,6 +30,10 @@ class VirtualCapPool < ApplicationRecord
     else
       raise VirtualCapPoolError, "Cannot add school to virtual pool #{school.urn} #{school.name}"
     end
+  end
+
+  def has_school?(school)
+    schools.exists?(school.id)
   end
 
 private

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -33,14 +33,38 @@
   <p class="govuk-body">None</p>
 <% end %>
 
-<table id="responsible-body-schools" class="govuk-table govuk-!-margin-top-9">
-  <caption class="govuk-table__caption govuk-heading-l">Schools</caption>
+<% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools</h2>
+  <p class="govuk-body"><%= @responsible_body.name %>:</p>
+  <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
+    <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools</li>
+    <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available</li>
+    <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %></li>
+  </ul>
+<% end %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Schools</h2>
+
+<% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        For centrally managed schools, device allocations are combined. We only know how many devices <%= @responsible_body.name %> has ordered, not how many devices went to which school.
+      </p>
+    </div>
+  </div>
+<% end %>
+
+<table id="responsible-body-schools" class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
+
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
       <th scope="col" class="govuk-table__header">Status</th>
       <th scope="col" class="govuk-table__header">Devices</th>
       <th scope="col" class="govuk-table__header">Routers</th>
+      <th scope="col" class="govuk-table__header">Who is ordering</th>          
       <th scope="col" class="govuk-table__header">Actions</th>
     </tr>
   </thead>
@@ -49,17 +73,24 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
         <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
-        <%- device_allocations_data = school.device_allocations.detect(&:std_device?) %>
+        <%- device_allocations_data = school.std_device_allocation %>
         <td class="govuk-table__cell">
           <%= device_allocations_data&.allocation || 0 %> allocated<br>
-          <%= device_allocations_data&.cap || 0 %> caps<br>
-          <%= device_allocations_data&.devices_ordered || 0 %> ordered
+          <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+            <%= device_allocations_data&.cap || 0 %> caps<br>
+            <%= device_allocations_data&.devices_ordered || 0 %> ordered
+          <% end %>
         </td>
-        <%- dongles_allocations_data = school.device_allocations.detect(&:coms_device?) %>
+        <%- dongles_allocations_data = school.coms_device_allocation %>
         <td class="govuk-table__cell">
           <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
-          <%= dongles_allocations_data&.cap || 0 %> caps<br>
-          <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+          <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+            <%= dongles_allocations_data&.cap || 0 %> caps<br>
+            <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+          <% end %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
         </td>
         <td class="govuk-table__cell">
           <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,26 +363,48 @@ en:
   components:
     school_preorder_status_tag_component:
       status:
+        school:
+          responsible_body:
+            needs_contact: Needs a contact
+            needs_info: Needs information
+            ready: Ready
+            school_contacted: School contacted
+            school_will_be_contacted: School will be contacted
+            school_ready: School ready
+            rb_can_order: You can order
+            school_can_order: School can order
+            ordered: School has ordered
+          default:
+            needs_contact: Needs a contact
+            needs_info: Needs information
+            ready: Ready
+            school_contacted: School contacted
+            school_will_be_contacted: School will be contacted
+            school_ready: School ready
+            rb_can_order: Responsible body can order
+            school_can_order: School can order
+            ordered: School has ordered
         responsible_body:
-          needs_contact: Needs a contact
-          needs_info: Needs information
-          ready: Ready
-          school_contacted: School contacted
-          school_will_be_contacted: School will be contacted
-          school_ready: School ready
-          rb_can_order: You can order
-          school_can_order: School can order
-          ordered: School has ordered
-        default:
-          needs_contact: Needs a contact
-          needs_info: Needs information
-          ready: Ready
-          school_contacted: School contacted
-          school_will_be_contacted: School will be contacted
-          school_ready: School ready
-          rb_can_order: Responsible body can order
-          school_can_order: School can order
-          ordered: School has ordered
+          responsible_body:
+            needs_contact: Needs a contact
+            needs_info: Needs information
+            ready: Ready
+            school_contacted: School contacted
+            school_will_be_contacted: School will be contacted
+            school_ready: School ready
+            rb_can_order: You can order
+            school_can_order: School can order
+            ordered: You have ordered
+          default:
+            needs_contact: Needs a contact
+            needs_info: Needs information
+            ready: Ready
+            school_contacted: School contacted
+            school_will_be_contacted: School will be contacted
+            school_ready: School ready
+            rb_can_order: Responsible body can order
+            school_can_order: School can order
+            ordered: Responsible body has ordered
   activemodel:
     errors:
       models:

--- a/spec/components/school_preorder_status_tag_component_spec.rb
+++ b/spec/components/school_preorder_status_tag_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SchoolPreorderStatusTagComponent do
   subject(:component) { described_class.new(school: school, viewer: viewer) }
 
-  let(:school) { instance_double('School', preorder_status_or_default: 'rb_can_order') }
+  let(:school) { instance_double('School', preorder_status_or_default: 'rb_can_order', who_will_order_devices: 'responsible_body') }
   let(:viewer) { nil }
 
   describe '#text' do
@@ -13,11 +13,31 @@ RSpec.describe SchoolPreorderStatusTagComponent do
       end
 
       context 'when viewer is an RB' do
-        let(:school) { instance_double('School', preorder_status_or_default: 'rb_can_order') }
+        let(:school) { instance_double('School', preorder_status_or_default: 'rb_can_order', who_will_order_devices: 'responsible_body') }
         let(:viewer) { LocalAuthority.new }
 
         it 'returns You can order' do
           expect(component.text).to eql('You can order')
+        end
+      end
+    end
+
+    context 'when school is managed centrally' do
+      context 'when the RB has ordered' do
+        let(:school) { instance_double('School', preorder_status_or_default: 'ordered', who_will_order_devices: 'responsible_body') }
+
+        it 'returns RB has ordered' do
+          expect(component.text).to eql('Responsible body has ordered')
+        end
+      end
+    end
+
+    context 'when school manages orders' do
+      let(:school) { instance_double('School', preorder_status_or_default: 'ordered', who_will_order_devices: 'school') }
+
+      context 'when the school has ordered' do
+        it 'returns school has ordered' do
+          expect(component.text).to eql('School has ordered')
         end
       end
     end

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -1,32 +1,96 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing responsible body information in the support area', type: :feature do
-  let(:local_authority) { create(:local_authority, name: 'Coventry') }
+  let(:local_authority) { create(:local_authority, :devolves_management, name: 'Coventry') }
+  let(:local_authority_managing_centrally) { create(:trust, :manages_centrally, :vcap_feature_flag, name: 'Manchester') }
+
   let(:responsible_bodies_page) { PageObjects::Support::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::ResponsibleBodyPage.new }
 
-  scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
-    given_a_responsible_body_with_users
-    and_it_has_some_schools
-
-    when_i_sign_in_as_a_dfe_user
-    and_i_visit_the_support_responsible_bodies_page
-    and_i_visit_a_support_responsible_body_page
-
-    then_i_can_see_the_users_assigned_to_that_responsible_body
-    and_i_can_see_the_schools_managed_by_that_responsible_body
+  before do
+    stub_computacenter_outgoing_api_calls
   end
 
-  scenario 'Computacenter users see the on-boarded responsible bodies and stats about them' do
-    given_a_responsible_body_with_users
-    and_it_has_some_schools
+  context 'when no schools are centrally managed' do
+    scenario 'DfE users see the on-boarded responsible bodies and stats about them' do
+      given_a_responsible_body_with_users
+      and_it_has_some_schools
 
-    when_i_sign_in_as_a_computacenter_user
-    and_i_visit_the_support_responsible_bodies_page
-    and_i_visit_a_support_responsible_body_page
+      when_i_sign_in_as_a_dfe_user
+      and_i_visit_the_support_responsible_bodies_page
+      and_i_visit_a_support_responsible_body_page
 
-    then_i_only_see_the_users_assigned_to_that_responsible_body_who_have_seen_the_privacy_notice
-    and_i_can_see_the_schools_managed_by_that_responsible_body
+      then_i_can_see_the_users_assigned_to_that_responsible_body
+      and_i_can_see_the_schools_managed_by_that_responsible_body
+    end
+
+    scenario 'Computacenter users see the on-boarded responsible bodies and stats about them' do
+      given_a_responsible_body_with_users
+      and_it_has_some_schools
+
+      when_i_sign_in_as_a_computacenter_user
+      and_i_visit_the_support_responsible_bodies_page
+      and_i_visit_a_support_responsible_body_page
+
+      then_i_only_see_the_users_assigned_to_that_responsible_body_who_have_seen_the_privacy_notice
+      and_i_can_see_the_schools_managed_by_that_responsible_body
+    end
+  end
+
+  context 'with virtual caps enabled', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when some schools are centrally managed' do
+      scenario 'DfE users see the centrally managed schools' do
+        given_a_centrally_managed_responsible_body_with_users
+        and_it_has_some_centrally_managed_schools
+
+        when_i_sign_in_as_a_dfe_user
+        and_i_visit_the_support_responsible_bodies_page
+        and_i_visit_a_support_responsible_body_that_is_centrally_managed_page
+
+        and_i_can_see_a_mix_of_centrally_managed_and_devolved_schools_by_that_responsible_body
+        and_i_see_details_of_some_of_the_centrally_managed_schools_in_the_responsible_body
+      end
+
+      scenario 'Computacenter users see the centrally managed schools' do
+        given_a_centrally_managed_responsible_body_with_users
+        and_it_has_some_centrally_managed_schools
+
+        when_i_sign_in_as_a_computacenter_user
+        and_i_visit_the_support_responsible_bodies_page
+        and_i_visit_a_support_responsible_body_that_is_centrally_managed_page
+
+        then_i_only_see_the_users_assigned_to_that_responsible_body_who_have_seen_the_privacy_notice
+        and_i_can_see_a_mix_of_centrally_managed_and_devolved_schools_by_that_responsible_body
+        and_i_see_details_of_some_of_the_centrally_managed_schools_in_the_responsible_body
+      end
+    end
+
+    context 'when all schools are centrally managed' do
+      scenario 'DfE users see the centrally managed schools' do
+        given_a_centrally_managed_responsible_body_with_users
+        and_it_has_all_centrally_managed_schools
+
+        when_i_sign_in_as_a_dfe_user
+        and_i_visit_the_support_responsible_bodies_page
+        and_i_visit_a_support_responsible_body_that_is_centrally_managed_page
+
+        and_i_can_see_the_schools_that_are_all_centrally_managed_by_that_responsible_body
+        and_i_see_details_of_all_the_centrally_managed_schools_in_the_responsible_body
+      end
+
+      scenario 'Computacenter users see the centrally managed schools' do
+        given_a_centrally_managed_responsible_body_with_users
+        and_it_has_all_centrally_managed_schools
+
+        when_i_sign_in_as_a_computacenter_user
+        and_i_visit_the_support_responsible_bodies_page
+        and_i_visit_a_support_responsible_body_that_is_centrally_managed_page
+
+        then_i_only_see_the_users_assigned_to_that_responsible_body_who_have_seen_the_privacy_notice
+        and_i_can_see_the_schools_that_are_all_centrally_managed_by_that_responsible_body
+        and_i_see_details_of_all_the_centrally_managed_schools_in_the_responsible_body
+      end
+    end
   end
 
   def given_a_responsible_body_with_users
@@ -45,6 +109,24 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
            last_signed_in_at: Date.new(2020, 7, 1),
            privacy_notice_seen_at: Date.new(2020, 7, 1),
            responsible_body: local_authority)
+  end
+
+  def given_a_centrally_managed_responsible_body_with_users
+    create(:user,
+           full_name: 'Amy Adams',
+           email_address: 'amy.adams@coventry.gov.uk',
+           sign_in_count: 0,
+           last_signed_in_at: nil,
+           privacy_notice_seen_at: nil,
+           responsible_body: local_authority_managing_centrally)
+
+    create(:user,
+           full_name: 'Zeta Zane',
+           email_address: 'zeta.zane@coventry.gov.uk',
+           sign_in_count: 2,
+           last_signed_in_at: Date.new(2020, 7, 1),
+           privacy_notice_seen_at: Date.new(2020, 7, 1),
+           responsible_body: local_authority_managing_centrally)
   end
 
   def and_it_has_some_schools
@@ -70,6 +152,95 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
            responsible_body: local_authority)
   end
 
+  def and_it_has_some_centrally_managed_schools
+    alpha = create(:school, :primary,
+                   :with_std_device_allocation, :with_coms_device_allocation,
+                   urn: 567_891,
+                   name: 'Alpha Primary School',
+                   responsible_body: local_authority_managing_centrally)
+    create(:preorder_information, :rb_will_order, school: alpha)
+
+    alpha.std_device_allocation.update!(
+      allocation: 5,
+      cap: 3,
+      devices_ordered: 1,
+    )
+    alpha.coms_device_allocation.update!(
+      allocation: 4,
+      cap: 2,
+      devices_ordered: 0,
+    )
+    alpha.can_order!
+
+    local_authority_managing_centrally.add_school_to_virtual_cap_pools!(alpha)
+    local_authority_managing_centrally.calculate_virtual_caps!
+
+    # Devolved:
+    beta = create(:school, :secondary,
+                  :with_std_device_allocation, :with_coms_device_allocation,
+                  urn: 123_457,
+                  name: 'Beta Secondary School',
+                  responsible_body: local_authority_managing_centrally)
+    create(:preorder_information, :school_will_order, school: beta)
+
+    beta.std_device_allocation.update!(
+      allocation: 5,
+      cap: 3,
+      devices_ordered: 1,
+    )
+    beta.coms_device_allocation.update!(
+      allocation: 4,
+      cap: 2,
+      devices_ordered: 0,
+    )
+    beta.can_order!
+  end
+
+  def and_it_has_all_centrally_managed_schools
+    alpha = create(:school, :primary,
+                   :with_std_device_allocation, :with_coms_device_allocation,
+                   urn: 567_891,
+                   name: 'Alpha Primary School',
+                   responsible_body: local_authority_managing_centrally)
+    create(:preorder_information, :rb_will_order, school: alpha)
+
+    alpha.std_device_allocation.update!(
+      allocation: 5,
+      cap: 3,
+      devices_ordered: 1,
+    )
+    alpha.coms_device_allocation.update!(
+      allocation: 4,
+      cap: 2,
+      devices_ordered: 0,
+    )
+
+    beta = create(:school, :secondary,
+                  :with_std_device_allocation, :with_coms_device_allocation,
+                  urn: 123_457,
+                  name: 'Beta Secondary School',
+                  responsible_body: local_authority_managing_centrally)
+    create(:preorder_information, :rb_will_order, school: beta)
+
+    beta.std_device_allocation.update!(
+      allocation: 5,
+      cap: 3,
+      devices_ordered: 1,
+    )
+    beta.coms_device_allocation.update!(
+      allocation: 4,
+      cap: 2,
+      devices_ordered: 0,
+    )
+
+    alpha.can_order!
+    beta.can_order!
+    local_authority_managing_centrally.add_school_to_virtual_cap_pools!(alpha)
+    local_authority_managing_centrally.add_school_to_virtual_cap_pools!(beta)
+
+    local_authority_managing_centrally.calculate_virtual_caps!
+  end
+
   def when_i_sign_in_as_a_dfe_user
     sign_in_as create(:dfe_user)
   end
@@ -84,6 +255,10 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
 
   def and_i_visit_a_support_responsible_body_page
     click_on local_authority.name
+  end
+
+  def and_i_visit_a_support_responsible_body_that_is_centrally_managed_page
+    click_on local_authority_managing_centrally.name
   end
 
   def then_i_can_see_the_users_assigned_to_that_responsible_body
@@ -128,6 +303,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     expect(first_row).to have_text('4 allocated')
     expect(first_row).to have_text('2 caps')
     expect(first_row).to have_text('0 ordered')
+    expect(first_row).to have_text('School')
 
     second_row = responsible_body_page.school_rows[1]
     expect(second_row).to have_text('Needs a contact')
@@ -135,5 +311,85 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     expect(second_row).to have_text('0 allocated')
     expect(second_row).to have_text('0 caps')
     expect(second_row).to have_text('0 ordered')
+    expect(second_row).to have_text('School')
+  end
+
+  # some:
+  def and_i_can_see_a_mix_of_centrally_managed_and_devolved_schools_by_that_responsible_body
+    expect(responsible_body_page.school_rows.size).to eq(2)
+
+    first_row = responsible_body_page.school_rows[0]
+    expect(first_row).to have_text('Alpha Primary School (567891)')
+    # devices
+    expect(first_row).to have_text('5 allocated')
+    expect(first_row).not_to have_text('3 caps')
+    expect(first_row).not_to have_text('1 ordered')
+    # dongles
+    expect(first_row).to have_text('4 allocated')
+    expect(first_row).not_to have_text('2 caps')
+    expect(first_row).not_to have_text('0 ordered')
+
+    expect(first_row).to have_text('Trust')
+
+    second_row = responsible_body_page.school_rows[1]
+    expect(second_row).to have_text('Beta Secondary School (123457)')
+
+    # devices
+    expect(second_row).to have_text('5 allocated')
+    expect(second_row).to have_text('3 caps')
+    expect(second_row).to have_text('1 ordered')
+    # dongles
+    expect(second_row).to have_text('4 allocated')
+    expect(second_row).to have_text('2 caps')
+    expect(second_row).to have_text('0 ordered')
+
+    expect(second_row).to have_text('School')
+  end
+
+  def and_i_see_details_of_some_of_the_centrally_managed_schools_in_the_responsible_body
+    stats = responsible_body_page.centrally_managed_stats
+
+    expect(stats[0]).to have_text('manages ordering for 1 of 2 of its schools')
+    expect(stats[1]).to have_text('has 2 devices and 2 routers available')
+    expect(stats[2]).to have_text('has ordered 1 device and 0 routers')
+  end
+
+  # all:
+  def and_i_can_see_the_schools_that_are_all_centrally_managed_by_that_responsible_body
+    expect(responsible_body_page.school_rows.size).to eq(2)
+
+    first_row = responsible_body_page.school_rows[0]
+    expect(first_row).to have_text('Alpha Primary School (567891)')
+    # devices
+    expect(first_row).to have_text('10 allocated')
+    expect(first_row).not_to have_text('3 caps')
+    expect(first_row).not_to have_text('1 ordered')
+    # dongles
+    expect(first_row).to have_text('8 allocated')
+    expect(first_row).not_to have_text('2 caps')
+    expect(first_row).not_to have_text('0 ordered')
+    expect(first_row).to have_text('Trust')
+
+    second_row = responsible_body_page.school_rows[1]
+    expect(second_row).to have_text('Beta Secondary School (123457)')
+
+    # devices
+    expect(second_row).to have_text('10 allocated')
+    expect(second_row).not_to have_text('3 caps')
+    expect(second_row).not_to have_text('1 ordered')
+    # dongles
+    expect(second_row).to have_text('8 allocated')
+    expect(second_row).not_to have_text('2 caps')
+    expect(second_row).not_to have_text('0 ordered')
+
+    expect(second_row).to have_text('Trust')
+  end
+
+  def and_i_see_details_of_all_the_centrally_managed_schools_in_the_responsible_body
+    stats = responsible_body_page.centrally_managed_stats
+
+    expect(stats[0]).to have_text('manages ordering for all of its schools')
+    expect(stats[1]).to have_text('has 4 devices and 4 routers available')
+    expect(stats[2]).to have_text('has ordered 2 devices and 0 routers')
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe ViewHelper do
     end
   end
 
+  describe '#what_to_order_state_list' do
+    context 'when devices available to order' do
+      let(:allocations) { [SchoolDeviceAllocation.new(cap: 4, devices_ordered: 2)] }
+
+      it 'returns X devices' do
+        expect(helper.what_to_order_state_list(allocations: allocations)).to eql('2 devices')
+      end
+    end
+
+    context 'when devices and routers available to order' do
+      let(:allocation1) { SchoolDeviceAllocation.new(device_type: :std_device, cap: 10, devices_ordered: 3) }
+      let(:allocation2) { SchoolDeviceAllocation.new(device_type: :coms_device, cap: 4, devices_ordered: 2) }
+      let(:allocations) { [allocation1, allocation2] }
+
+      it 'returns X devices and X routers' do
+        expect(helper.what_to_order_state_list(allocations: allocations)).to eql('3 devices and 2 routers')
+      end
+    end
+  end
+
   describe '#what_to_order_state' do
     context 'when devices available to order' do
       let(:allocations) { [SchoolDeviceAllocation.new(cap: 4, devices_ordered: 2)] }

--- a/spec/page_objects/support/responsible_body_page.rb
+++ b/spec/page_objects/support/responsible_body_page.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       elements :users, '.user'
       elements :school_rows, '#responsible-body-schools tbody tr'
+      elements :centrally_managed_stats, '#responsible-body-centrally-managed-stats li'
     end
   end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/az8uLtni/1076-update-admin-app-for-virtual-caps

### Changes proposed in this pull request

1. Update support area to show details of any centrally managed schools and virtual cap data
2. Hide cap and devices ordered data for schools within the virtual cap

### Guidance to review

1. Find RB without virtual cap enabled
2. Centrally managed section should not show
3. Table should show all data fields: allocation, cap and devices ordered

With 1 school in virtual cap:

1. Enable virtual cap and find RB
2. Add school to virtual cap
3. Centrally managed section should show with v-cap devices ordered and available, and a '1 of 2 schools' are centrally managed message
4. School within virtual cap should not show cap and devices ordered in table

With all schools in virtual cap:

1. Enable virtual cap and find RB
2. Add both schools to virtual cap
3. Centrally managed section should show with v-cap devices ordered and available, and a 'all' schools are centrally managed message
4. No schools within virtual cap should show cap and devices ordered in table

### Screenshot

![screencapture-localhost-3000-support-responsible-bodies-88-2020-12-04-10_50_20](https://user-images.githubusercontent.com/31316/101155047-87313580-361e-11eb-9863-35edad9f9bb8.png)


