### PR TITLE
Hide 'Who will order?' change link to RBs using virtual caps

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -39,19 +39,25 @@ private
   end
 
   def who_will_order_row
-    who = (@school.preorder_information || @school.responsible_body).who_will_order_devices_label
+    responsible_body = @school.responsible_body
+    who = (@school.preorder_information || responsible_body).who_will_order_devices_label
 
     if who.present?
-      {
+      detail = {
         key: 'Who will order?',
         value: "The #{who.downcase} orders devices",
-        change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
         action: 'who will order',
       }
+      unless responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?
+        detail.merge!(
+          change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+        )
+      end
+      detail
     else
       {
         key: 'Who will order?',
-        value: "#{@school.responsible_body.name} hasn’t decided this yet",
+        value: "#{responsible_body.name} hasn’t decided this yet",
         action_path: responsible_body_devices_who_will_order_edit_path,
         action: 'Decide who will order',
       }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -153,6 +153,10 @@ class School < ApplicationRecord
     device_allocations.any?(&:has_devices_available_to_order?)
   end
 
+  def in_virtual_cap_pool?
+    responsible_body.has_school_in_virtual_cap_pools?(self)
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -156,6 +156,16 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     it 'does not show the school contact even if the school contact is set' do
       expect(result.css('dl').text).not_to include('School contact')
     end
+
+    context 'when the responsible body has virtual caps enabled', with_feature_flags: { virtual_caps: 'active' } do
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+      let(:school) { create(:school, :primary, :academy, responsible_body: responsible_body) }
+
+      it 'confirms that fact but does not allow changes' do
+        expect(value_for_row(result, 'Who will order?').text).to include('The trust orders devices')
+        expect(action_for_row(result, 'Who will order?')).to be_nil
+      end
+    end
   end
 
   context 'when the responsible body has not made a decision about who will order' do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -411,4 +411,26 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe '#in_virtual_cap_pool?' do
+    subject(:responsible_body) { create(:trust, :manages_centrally) }
+
+    let(:schools) { create_list(:school, 2, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
+
+    before do
+      first_school = schools.first
+      first_school.preorder_information.responsible_body_will_order_devices!
+      first_school.std_device_allocation.update!(allocation: 10, cap: 10, devices_ordered: 2)
+      first_school.coms_device_allocation.update!(allocation: 20, cap: 5, devices_ordered: 3)
+      responsible_body.add_school_to_virtual_cap_pools!(first_school)
+    end
+
+    it 'returns true for a school within the pool' do
+      expect(schools.first.in_virtual_cap_pool?).to be true
+    end
+
+    it 'returns false for a school outside the pool' do
+      expect(schools.last.in_virtual_cap_pool?).to be false
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/x4uZNNZ0/1042-switch-changing-who-can-order-devices-at-the-school-level-to-a-support-task

It is currently a developer task to back out of using virtual caps. We need to at least hide the link in the UI that allows RBs to change who will order when it is enabled.

### Changes proposed in this pull request

Hide 'Change' link for RBs using virtual caps

### Guidance to review

1. Find RB using virtual caps and managing centrally
2. Navigate to school page
3. You should not see the 'Change' link for 'Who can order?'

---

1. Find RB with devolved ordering
2. Navigate to school page
3. You should see the 'Change' link for 'Who can order?'
