### PR TITLE
1108 virtual cap update your schools page

### DIFF
--- a/app/components/conditional_school_preorder_status_tag_component.html.erb
+++ b/app/components/conditional_school_preorder_status_tag_component.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::Tag.new(text: text, colour: type.to_s) if should_show_status? %>

--- a/app/components/conditional_school_preorder_status_tag_component.rb
+++ b/app/components/conditional_school_preorder_status_tag_component.rb
@@ -8,7 +8,7 @@ class ConditionalSchoolPreorderStatusTagComponent < SchoolPreorderStatusTagCompo
     when 'responsible_body'
       status.in? statuses_to_display
     when 'school'
-      status.in? (statuses_to_display + ['ordered'])
+      status.in?(statuses_to_display + %w[ordered])
     else
       true
     end

--- a/app/components/conditional_school_preorder_status_tag_component.rb
+++ b/app/components/conditional_school_preorder_status_tag_component.rb
@@ -1,0 +1,22 @@
+class ConditionalSchoolPreorderStatusTagComponent < SchoolPreorderStatusTagComponent
+  def initialize(school:, viewer: nil)
+    super
+  end
+
+  def should_show_status?
+    case @school.preorder_information&.who_will_order_devices
+    when 'responsible_body'
+      status.in? statuses_to_display
+    when 'school'
+      status.in? (statuses_to_display + ['ordered'])
+    else
+      true
+    end
+  end
+
+private
+
+  def statuses_to_display
+    %w[needs_contact needs_info school_contacted school_will_be_contacted].freeze
+  end
+end

--- a/app/components/display_allocations_component.html.erb
+++ b/app/components/display_allocations_component.html.erb
@@ -1,0 +1,1 @@
+<%= allocations.join('<br/>').html_safe %>

--- a/app/components/display_allocations_component.rb
+++ b/app/components/display_allocations_component.rb
@@ -6,8 +6,8 @@ class DisplayAllocationsComponent < ViewComponent::Base
   end
 
   def allocations
-    std_devices_count = school&.std_device_allocation.allocation.to_i
-    coms_devices_count = school&.coms_device_allocation.allocation.to_i
+    std_devices_count = school.std_device_allocation&.raw_allocation.to_i
+    coms_devices_count = school.coms_device_allocation&.raw_allocation.to_i
     [
       build_text(std_devices_count, 'device'),
       build_text(coms_devices_count, 'router'),

--- a/app/components/display_allocations_component.rb
+++ b/app/components/display_allocations_component.rb
@@ -1,0 +1,22 @@
+class DisplayAllocationsComponent < ViewComponent::Base
+  attr_reader :school
+
+  def initialize(school:)
+    @school = school
+  end
+
+  def allocations
+    std_devices_count = school&.std_device_allocation.allocation.to_i
+    coms_devices_count = school&.coms_device_allocation.allocation.to_i
+    [
+      build_text(std_devices_count, 'device'),
+      build_text(coms_devices_count, 'router'),
+    ]
+  end
+
+private
+
+  def build_text(count, name)
+    "#{count}&nbsp;#{name.pluralize(count)}"
+  end
+end

--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -59,18 +59,20 @@ private
   end
 
   def device_allocation_row
+    allocation = @school.std_device_allocation&.raw_allocation.to_i
     {
       key: 'Device allocation',
-      value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
+      value: pluralize(allocation, 'device'),
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query <span class="govuk-visually-hidden">device</span> allocation'.html_safe,
     }
   end
 
   def router_allocation_row
+    allocation = @school.coms_device_allocation&.raw_allocation.to_i
     {
       key: 'Router allocation',
-      value: pluralize(@school.coms_device_allocation&.allocation.to_i, 'router'),
+      value: pluralize(allocation, 'router'),
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query <span class="govuk-visually-hidden">router</span> allocation'.html_safe,
     }
@@ -88,7 +90,7 @@ private
   end
 
   def display_router_allocation_row?
-    @school.coms_device_allocation&.allocation.to_i.positive?
+    @school.coms_device_allocation&.raw_allocation.to_i.positive?
   end
 
   def order_status_row

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -1,10 +1,14 @@
 class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseController
   def index
-    @schools = @responsible_body.schools
-                                .includes(:preorder_information)
-                                .includes(:std_device_allocation)
-                                .gias_status_open
-                                .order(name: :asc)
+    schools = @responsible_body.schools
+      .includes(:preorder_information)
+      .includes(:std_device_allocation)
+      .gias_status_open
+      .order(name: :asc)
+
+    @ordering_schools = schools.can_order
+    @specific_circumstances_schools = schools.can_order_for_specific_circumstances
+    @fully_open_schools = schools.where(order_state: %w[cannot_order cannot_order_as_reopened])
   end
 
   def show

--- a/app/views/responsible_body/devices/schools/_school_states_table.html.erb
+++ b/app/views/responsible_body/devices/schools/_school_states_table.html.erb
@@ -6,7 +6,7 @@
     <%- end %>
   </div>
 </div>
-<table id="specific-circumstances-schools" class="govuk-table">
+<table id="<%= table_id %>" class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header app-schools-table__school-column">School</th>

--- a/app/views/responsible_body/devices/schools/_school_states_table.html.erb
+++ b/app/views/responsible_body/devices/schools/_school_states_table.html.erb
@@ -1,0 +1,38 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margine-top-4">
+    <h3 class="govuk-heading-m"><%= heading %></h3>
+    <% if local_assigns[:heading_text] %>
+      <p class="govuk-body"><%= heading_text %></p>
+    <%- end %>
+  </div>
+</div>
+<table id="specific-circumstances-schools" class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header app-schools-table__school-column">School</th>
+      <th class="govuk-table__header">Who will order?</th>
+      <th class="govuk-table__header">Allocation</th>
+      <th class="govuk-table__header"><span class="govuk-visually-hidden">Status</span></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% schools.each do |school| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= govuk_link_to "#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn) %>
+          <br>
+          <%= school.type_label %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= (school.preorder_information || school.responsible_body).who_will_order_devices_label %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= render DisplayAllocationsComponent.new(school: school) %>
+        </td>
+        <td class="govuk-table__cell govuk-table__cell--nowrap">
+          <%= render ConditionalSchoolPreorderStatusTagComponent.new(school: school, viewer: @responsible_body) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      <%= pluralize(@schools.size, 'school') %>
+      <%= title %>
     </h1>
 
     <%= render GovukComponent::Details.new(summary: 'Is this list wrong?') do %>
@@ -26,33 +26,18 @@
   </div>
 </div>
 
-<table id="schools" class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header app-schools-table__school-column">School and URN</th>
-      <th class="govuk-table__header">Allocation</th>
-      <th class="govuk-table__header">Who will order?</th>
-      <th class="govuk-table__header">Status</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @schools.each do |school| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <%= govuk_link_to "#{school.name} (#{school.urn})", responsible_body_devices_school_path(school.urn) %>
-          <br>
-          <%= school.type_label %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= school.std_device_allocation&.allocation.to_i %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= (school.preorder_information || school.responsible_body).who_will_order_devices_label %>
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--nowrap">
-          <%= render SchoolPreorderStatusTagComponent.new(school: school, viewer: @responsible_body) %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<% if @specific_circumstances_schools.count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @specific_circumstances_schools,
+    heading: t('.specific_circumstances_heading') } %>
+<%- end %>
+
+<% if @ordering_schools.count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @ordering_schools,
+    heading: t('.ordering_schools_heading'),
+    heading_text: t('.ordering_schools_heading_text') } %>
+<%- end %>
+
+<% if @fully_open_schools.count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @fully_open_schools,
+    heading: t('.fully_open_schools_heading') } %>
+<%- end %>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -36,16 +36,19 @@
 
 <% if @specific_circumstances_schools.count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @specific_circumstances_schools,
-    heading: t('.specific_circumstances_heading') } %>
+                                                       table_id: 'specific-circumstances-schools',
+                                                       heading: t('.specific_circumstances_heading') } %>
 <%- end %>
 
 <% if @ordering_schools.count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @ordering_schools,
-    heading: t('.ordering_schools_heading'),
-    heading_text: t('.ordering_schools_heading_text') } %>
+                                                       table_id: 'ordering-schools',
+                                                       heading: t('.ordering_schools_heading'),
+                                                       heading_text: t('.ordering_schools_heading_text') } %>
 <%- end %>
 
 <% if @fully_open_schools.count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @fully_open_schools,
-    heading: t('.fully_open_schools_heading') } %>
+                                                       table_id: 'fully-open-schools',
+                                                       heading: t('.fully_open_schools_heading') } %>
 <%- end %>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -26,6 +26,14 @@
   </div>
 </div>
 
+<% if @responsible_body.has_virtual_cap_feature_flags? %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
+  </div>
+</div>
+<%- end %>
+
 <% if @specific_circumstances_schools.count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @specific_circumstances_schools,
     heading: t('.specific_circumstances_heading') } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,11 @@ en:
         update:
           success: We’ve saved your choice
       schools:
+        index:
+          ordering_schools_heading: Schools reporting a closure or self-isolation group
+          ordering_schools_heading_text: When a school has reported either a closure or a group of 15 or more pupils self-isolating at the same time, you can order its allocation of devices or routers
+          specific_circumstances_heading: Schools with approved requests for specific circumstances
+          fully_open_schools_heading: Schools without a reported closure or self-isolating group
         who_to_contact:
           create:
             failure: "Saved. We will email %{email_address} shortly"
@@ -620,11 +625,3 @@ en:
         name_or_urn: School name or URN
       support_user_responsible_body_form:
         name: Responsible body name
-  responsible_body:
-    devices:
-      schools:
-        index:
-          ordering_schools_heading: Schools reporting a closure or self-isolation group
-          ordering_schools_heading_text: When a school has reported either a closure or a group of 15 or more pupils self-isolating at the same time, you can order its allocation of devices or routers
-          specific_circumstances_heading: Schools with approved requests for specific circumstances
-          fully_open_schools_heading: Schools without a reported closure or self-isolating group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
     responsible_body_changed_allocations: We’ve changed how we allocate devices
     new_responsible_body_user: Invite a new user
     edit_responsible_body_user: Edit user
-    responsible_body_schools_list: List of schools
+    responsible_body_schools_list: Your schools
     requests_for_extra_mobile_data: Requests for extra mobile data
     suggested_email_to_schools: A suggested email for you to send to schools
     request_extra_mobile_data: Request extra data for mobile devices
@@ -620,3 +620,11 @@ en:
         name_or_urn: School name or URN
       support_user_responsible_body_form:
         name: Responsible body name
+  responsible_body:
+    devices:
+      schools:
+        index:
+          ordering_schools_heading: Schools reporting a closure or self-isolation group
+          ordering_schools_heading_text: When a school has reported either a closure or a group of 15 or more pupils self-isolating at the same time, you can order its allocation of devices or routers
+          specific_circumstances_heading: Schools with approved requests for specific circumstances
+          fully_open_schools_heading: Schools without a reported closure or self-isolating group

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -186,7 +186,9 @@ ActiveRecord::Schema.define(version: 2020_11_30_111700) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
+    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
     t.index ["gias_id"], name: "index_responsible_bodies_on_gias_id", unique: true
@@ -270,6 +272,8 @@ ActiveRecord::Schema.define(version: 2020_11_30_111700) do
     t.string "order_state", default: "cannot_order", null: false
     t.string "status", default: "open", null: false
     t.boolean "mno_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
+    t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/components/display_allocations_component_spec.rb
+++ b/spec/components/display_allocations_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DisplayAllocationsComponent, type: :component do
   let(:trust) { create(:trust, :manages_centrally, :vcap_feature_flag) }
   let(:school) { create(:school, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: trust) }
   let(:another_school) { create(:school, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: trust) }
+
   subject(:component) { described_class.new(school: school) }
 
   before do
@@ -42,9 +43,9 @@ RSpec.describe DisplayAllocationsComponent, type: :component do
     end
   end
 
-  def put_school_in_pool(rb, pool_school)
+  def put_school_in_pool(responsible_body, pool_school)
     pool_school.preorder_information.responsible_body_will_order_devices!
     pool_school.can_order!
-    rb.add_school_to_virtual_cap_pools!(pool_school)
+    responsible_body.add_school_to_virtual_cap_pools!(pool_school)
   end
 end

--- a/spec/components/display_allocations_component_spec.rb
+++ b/spec/components/display_allocations_component_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe DisplayAllocationsComponent, type: :component do
+  let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789', body: '<xml>test-request</xml>') }
+  let(:response) { OpenStruct.new(body: '<xml>test-response</xml>') }
+
+  let(:trust) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+  let(:school) { create(:school, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: trust) }
+  let(:another_school) { create(:school, :with_preorder_information, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: trust) }
+  subject(:component) { described_class.new(school: school) }
+
+  before do
+    allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
+    allow(mock_request).to receive(:post!).and_return(response)
+    school.std_device_allocation.update!(allocation: 24)
+    school.coms_device_allocation.update!(allocation: 33)
+    put_school_in_pool(trust, another_school)
+  end
+
+  context 'when in a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
+    before do
+      put_school_in_pool(trust, school)
+      school.reload
+    end
+
+    it 'renders the original device allocations' do
+      render_inline(component)
+      expect(rendered_component).to include('24&nbsp;devices')
+      expect(rendered_component).to include('33&nbsp;routers')
+    end
+  end
+
+  context 'when not in a virtual pool', with_feature_flags: { virtual_caps: 'inactive' } do
+    before do
+      trust.update!(vcap_feature_flag: false)
+    end
+
+    it 'renders the original device allocations' do
+      render_inline(component)
+      expect(rendered_component).to include('24&nbsp;devices')
+      expect(rendered_component).to include('33&nbsp;routers')
+    end
+  end
+
+  def put_school_in_pool(rb, pool_school)
+    pool_school.preorder_information.responsible_body_will_order_devices!
+    pool_school.can_order!
+    rb.add_school_to_virtual_cap_pools!(pool_school)
+  end
+end

--- a/spec/controllers/responsible_body/devices/schools_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/schools_controller_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe ResponsibleBody::Devices::SchoolsController do
   describe '#index' do
     it 'excludes closed schools' do
       get :index
-      expect(assigns(:schools)).not_to include(closed_school)
+      expect(assigns(:ordering_schools)).not_to include(closed_school)
+      expect(assigns(:specific_circumstances_schools)).not_to include(closed_school)
+      expect(assigns(:fully_open_schools)).not_to include(closed_school)
     end
   end
 end

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Setting up the devices ordering' do
       given_the_responsible_body_has_decided_to_order_centrally
       when_i_visit_the_responsible_body_homepage
       when_i_follow_the_get_devices_link
-      and_i_follow_the_list_of_schools_link
+      and_i_follow_the_your_schools_link
       then_i_see_a_list_of_the_schools_i_am_responsible_for
 
       when_i_click_on_the_first_school_name
@@ -202,8 +202,8 @@ RSpec.feature 'Setting up the devices ordering' do
     click_on 'Get laptops and tablets'
   end
 
-  def and_i_follow_the_list_of_schools_link
-    click_on 'List of schools'
+  def and_i_follow_the_your_schools_link
+    click_on 'Your schools'
   end
 
   def then_i_see_guidance_for_a_trust
@@ -247,34 +247,34 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def then_i_see_a_list_of_the_schools_i_am_responsible_for
-    expect(page).to have_content('2 schools')
-    expect(responsible_body_schools_page.school_rows[0].title)
+    expect(page).to have_content('Your schools')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].title)
       .to have_content('Aardvark Primary School (456654) Primary school')
-    expect(responsible_body_schools_page.school_rows[1].title)
+    expect(responsible_body_schools_page.fully_open_school_rows[1].title)
       .to have_content('Zebra Secondary School (123321) Secondary school')
   end
 
   def then_i_see_a_list_of_the_academies_i_am_responsible_for
-    expect(page).to have_content('2 schools')
-    expect(responsible_body_schools_page.school_rows[0].title)
+    expect(page).to have_content('Your schools')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].title)
       .to have_content('Koala Academy')
-    expect(responsible_body_schools_page.school_rows[1].title)
+    expect(responsible_body_schools_page.fully_open_school_rows[1].title)
       .to have_content('Pangolin Primary Academy')
   end
 
   def and_each_school_needs_a_contact
-    expect(responsible_body_schools_page.school_rows[0].status).to have_content('Needs a contact')
-    expect(responsible_body_schools_page.school_rows[1].status).to have_content('Needs a contact')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].status).to have_content('Needs a contact')
+    expect(responsible_body_schools_page.fully_open_school_rows[1].status).to have_content('Needs a contact')
   end
 
   def and_each_school_needs_information
-    expect(responsible_body_schools_page.school_rows[0].status).to have_content('Needs information')
-    expect(responsible_body_schools_page.school_rows[1].status).to have_content('Needs information')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].status).to have_content('Needs information')
+    expect(responsible_body_schools_page.fully_open_school_rows[1].status).to have_content('Needs information')
   end
 
   def and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
-    expect(responsible_body_schools_page.school_rows[0].allocation).to have_content('42')
-    expect(responsible_body_schools_page.school_rows[1].allocation).to have_content('0')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].allocation).to have_content('42')
+    expect(responsible_body_schools_page.fully_open_school_rows[1].allocation).to have_content('0')
   end
 
   def given_the_responsible_body_has_decided_to_order_centrally
@@ -289,13 +289,13 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_the_list_shows_that_schools_will_place_all_orders
-    expect(responsible_body_schools_page.school_rows[0].who_will_order_devices).to have_content('School')
-    expect(responsible_body_schools_page.school_rows[1].who_will_order_devices).to have_content('School')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('School')
+    expect(responsible_body_schools_page.fully_open_school_rows[1].who_will_order_devices).to have_content('School')
   end
 
   def and_the_list_shows_that_the_responsible_body_will_place_all_orders
-    expect(responsible_body_schools_page.school_rows[0].who_will_order_devices).to have_content('Local authority')
-    expect(responsible_body_schools_page.school_rows[1].who_will_order_devices).to have_content('Local authority')
+    expect(responsible_body_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('Local authority')
+    expect(responsible_body_schools_page.fully_open_school_rows[1].who_will_order_devices).to have_content('Local authority')
   end
 
   def when_i_click_on_the_first_school_name

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
 
   def then_i_see_the_get_laptops_and_tablets_page
     expect(page).to have_css('h1', text: 'Get laptops and tablets')
-    expect(page).to have_link('List of schools')
+    expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
     expect(page).to have_link('Request devices for specific circumstances')
   end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature 'Ordering devices' do
 
   def then_i_see_the_get_laptops_and_tablets_page
     expect(page).to have_css('h1', text: 'Get laptops and tablets')
-    expect(page).to have_link('List of schools')
+    expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
     expect(page).to have_link('Request devices for specific circumstances')
   end

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing your schools' do
+  let(:responsible_body) { create(:trust, :manages_centrally) }
+  let(:schools) { create_list(:school, 3, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body) }
+  let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }
+
+  let(:your_schools_page) { PageObjects::ResponsibleBody::SchoolsPage.new }
+
+  before do
+    stub_computacenter_outgoing_api_calls
+    given_i_am_signed_in_as_a_responsible_body_user
+    given_my_order_information_is_up_to_date
+  end
+
+  scenario 'navigate to your schools page' do
+    when_i_visit_the_responsible_body_home_page
+    and_i_follow_the_get_laptops_and_tablets_link
+    then_i_see_the_get_laptops_and_tablets_page
+
+    when_i_follow_the_your_schools_link
+    then_i_see_the_your_schools_page
+  end
+
+  scenario 'see a school that is able to fully order' do
+    given_a_school_can_order
+    when_i_visit_the_your_schools_page
+    then_i_see_the_school_in_the_schools_reporting_closure_list
+  end
+
+  scenario 'see a school that is able to order for specific circumstances' do
+    given_a_school_can_order_for_specific_circumstances
+    when_i_visit_the_your_schools_page
+    then_i_see_the_school_in_the_schools_with_approved_requests_list
+  end
+
+  scenario 'see a schools that is fully open' do
+    given_a_school_is_fully_open
+    when_i_visit_the_your_schools_page
+    then_i_see_the_school_in_the_fully_open_schools_list
+  end
+
+  scenario 'when the virtual caps are enabled and the trust manages centrally', with_feature_flags: { virtual_caps: 'active' } do
+    given_there_are_schools_in_the_pool
+    when_i_visit_the_your_schools_page
+    then_i_see_the_summary_pooled_device_count_card
+  end
+
+  def given_i_am_signed_in_as_a_responsible_body_user
+    sign_in_as user
+  end
+
+  def given_my_order_information_is_up_to_date
+    responsible_body.update!(who_will_order_devices: 'responsible_body', vcap_feature_flag: true)
+    PreorderInformation.where(school_id: responsible_body.schools).update_all(will_need_chromebooks: 'no')
+    schools[0].preorder_information.responsible_body_will_order_devices!
+    schools[1].preorder_information.responsible_body_will_order_devices!
+    schools[2].preorder_information.school_will_order_devices!
+  end
+
+  def given_a_school_can_order
+    schools.first.can_order!
+  end
+
+  def given_a_school_can_order_for_specific_circumstances
+    schools.second.can_order_for_specific_circumstances!
+  end
+
+  def given_a_school_is_fully_open
+    schools.first.can_order!
+    schools.second.can_order_for_specific_circumstances!
+    schools.third.cannot_order!
+  end
+
+  def given_there_are_schools_in_the_pool
+    schools.first.can_order!
+    schools.first.std_device_allocation.update!(cap: 5, allocation: 5, devices_ordered: 2)
+    responsible_body.add_school_to_virtual_cap_pools!(schools.first)
+    schools.second.can_order_for_specific_circumstances!
+    schools.second.std_device_allocation.update!(cap: 5, allocation: 20, devices_ordered: 0)
+    responsible_body.add_school_to_virtual_cap_pools!(schools.second)
+  end
+
+  def when_i_visit_the_responsible_body_home_page
+    visit responsible_body_home_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def when_i_visit_the_your_schools_page
+    visit responsible_body_devices_schools_path
+    expect(page).to have_http_status(:ok)
+  end
+
+  def and_i_follow_the_get_laptops_and_tablets_link
+    click_link 'Get laptops and tablets'
+  end
+
+  def when_i_follow_the_your_schools_link
+    click_link 'Your schools'
+  end
+
+  def then_i_see_the_get_laptops_and_tablets_page
+    expect(page).to have_css('h1', text: 'Get laptops and tablets')
+    expect(page).to have_link('Your schools')
+    expect(page).to have_link('Order devices')
+    expect(page).to have_link('Request devices for specific circumstances')
+  end
+
+  def then_i_see_the_your_schools_page
+    expect(page).to have_css('h1', text: 'Your schools')
+  end
+
+  def then_i_see_the_school_in_the_schools_reporting_closure_list
+    school = schools.first
+    expect(your_schools_page.ordering_school_rows[0].title).to have_content(school.name)
+    expect(your_schools_page.ordering_school_rows[0].who_will_order_devices).to have_content('Trust')
+    expect(your_schools_page.ordering_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} devices")
+    expect(your_schools_page.ordering_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} routers")
+  end
+
+  def then_i_see_the_school_in_the_schools_with_approved_requests_list
+    school = schools.second
+    expect(your_schools_page.specific_circumstances_school_rows[0].title).to have_content(school.name)
+    expect(your_schools_page.specific_circumstances_school_rows[0].who_will_order_devices).to have_content('Trust')
+    expect(your_schools_page.specific_circumstances_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} devices")
+    expect(your_schools_page.specific_circumstances_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} routers")
+  end
+
+  def then_i_see_the_school_in_the_fully_open_schools_list
+    school = schools.third
+    expect(your_schools_page.fully_open_school_rows[0].title).to have_content(school.name)
+    expect(your_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('School')
+    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} devices")
+    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} routers")
+  end
+
+  def then_i_see_the_summary_pooled_device_count_card
+    expect(page).to have_content("#{responsible_body.name} has:")
+    std_count = responsible_body.std_device_pool.cap - responsible_body.std_device_pool.devices_ordered
+    coms_count = responsible_body.coms_device_pool.cap - responsible_body.coms_device_pool.devices_ordered
+    expected = "#{std_count} #{'device'.pluralize(std_count)} and #{coms_count} #{'router'.pluralize(coms_count)} available to order"
+    expect(page).to have_content(expected)
+  end
+end

--- a/spec/page_objects/responsible_body/schools_page.rb
+++ b/spec/page_objects/responsible_body/schools_page.rb
@@ -2,13 +2,15 @@ module PageObjects
   module ResponsibleBody
     class SchoolRow < SitePrism::Section
       element :title, 'td:nth-of-type(1)'
-      element :allocation, 'td:nth-of-type(2)'
-      element :who_will_order_devices, 'td:nth-of-type(3)'
+      element :who_will_order_devices, 'td:nth-of-type(2)'
+      element :allocation, 'td:nth-of-type(3)'
       element :status, 'td:nth-of-type(4)'
     end
 
     class SchoolsPage < PageObjects::BasePage
-      sections :school_rows, SchoolRow, '#schools tbody tr'
+      sections :specific_circumstances_school_rows, SchoolRow, '#specific-circumstances-schools tbody tr'
+      sections :ordering_school_rows, SchoolRow, '#ordering-schools tbody tr'
+      sections :fully_open_school_rows, SchoolRow, '#fully-open-schools tbody tr'
     end
   end
 end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/Gvsyoype/1108-virtual-cap-update-your-schools-page)
Update list of schools page for responsible body to support virtual caps.

### Changes proposed in this pull request
Updated school list page to new content, 3 separate lists to split schools by order state.
Only show statuses for schools that are not ready to order or additionally, that have ordered in the case of devolved schools
Available devices pooled summary card only visible when responsible body orders centrally and feature flags for virtual caps enabled.

### Guidance to review
As a RB user, where the RB manages centrally, with a mix of schools that can order/can_order_for_specific_circumstances and cannot order. From the Responsible Body home page visit the Get laptops and tablets -> Your Schools links. You should then see a list of schools divided into 3 tables.  There will be no available devices summary card at the top of the page.
![image](https://user-images.githubusercontent.com/333931/101203997-6d661180-3663-11eb-994b-01e74c224f6e.png)

Enable the feature flags for virtual caps (`FEATURES_virtual_caps=active bundle exec rails s`) and `responsible_body.udpate!(vcap_feature_flag: true)`
Repeat the journey, the summary card should now be visible at the top of the list.
![image](https://user-images.githubusercontent.com/333931/101203921-4e677f80-3663-11eb-9d7e-53ff77ed147d.png)

In both cases, the school allocation figures displayed use the 'raw' original value from the `SchoolDeviceAllocation` not the value from the virtual pool.
