### PR TITLE
Updates delivery message

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -310,7 +310,7 @@
 
           <div class="app-step-nav__panel" id="step-panel-receive-and-distribute-laptops-and-tablets-6">
             <p class="app-step-nav__paragraph">
-              Due to increased levels of demand, devices will be delivered to schools within 5 working days of an order being confirmed, subject to stock availability.
+              Most devices will be delivered to schools within 2 working days of an order being confirmed, subject to stock availability. For large orders (more than 150 devices), we'll call the main delivery contact to arrange delivery.
             </p>
 
             <p class="app-step-nav__paragraph">

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -310,7 +310,7 @@
 
           <div class="app-step-nav__panel" id="step-panel-receive-and-distribute-laptops-and-tablets-6">
             <p class="app-step-nav__paragraph">
-              Most devices will be delivered to schools within 2 working days of an order being confirmed, subject to stock availability. For large orders (more than 150 devices), we'll call the main delivery contact to arrange delivery.
+              Most devices will be delivered to schools within 2 working days of an order being confirmed, subject to stock availability. For large orders (more than 150 devices), we’ll call the main delivery contact to arrange delivery.
             </p>
 
             <p class="app-step-nav__paragraph">

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -30,8 +30,11 @@
     <p class="govuk-body">
       If you try to order more than <%= what_to_order_allocation_list(allocations: @responsible_body.virtual_cap_pools) %> the order will be cancelled.
     </p>
+    <% if @responsible_body.std_device_pool.available_devices_count > 149 %>
+      <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+    <% end %>
     <p class="govuk-body">
-      Devices will be delivered within 2 working days.
+      Most devices will be delivered within 2 working days.
     </p>
     <h3 class="govuk-heading-s">
       Ordering devices for more than one school

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -30,7 +30,7 @@
     <p class="govuk-body">
       If you try to order more than <%= what_to_order_allocation_list(allocations: @responsible_body.virtual_cap_pools) %> the order will be cancelled.
     </p>
-    <% if @responsible_body.std_device_pool.available_devices_count > 149 %>
+    <% if @responsible_body&.std_device_pool&.available_devices_count > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
     <p class="govuk-body">

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -11,7 +11,7 @@
 
     <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order. You cannot order a school’s full allocation yet because no school closures or groups of self-isolating children have been reported.</p>
 
-    <p class="govuk-body">We’re working hard to get devices delivered within 5 working days.</p>
+    <p class="govuk-body">We’re working hard to get devices delivered within 2 working days.</p>
   </div>
 </div>
 <%= render partial: 'place_order_for_schools' %>

--- a/app/views/responsible_body/devices/schools/order_devices.html.erb
+++ b/app/views/responsible_body/devices/schools/order_devices.html.erb
@@ -11,7 +11,10 @@
     <%= render DeviceCountComponent.new(school: @school) %>
 
     <p class="govuk-body">Only order devices for children who cannot attend school and do not have access to a laptop or tablet.</p>
-    <p class="govuk-body">We’re working hard to get devices delivered within 5 working days.</p>
+    <p class="govuk-body">We’re working hard to get devices delivered within 2 working days.</p>
+    <% if @school&.std_device_allocation&.available_devices_count > 149 %>
+      <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+    <% end %>
     <p class="govuk-body">Ordering will close when the school reopens.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -14,7 +14,7 @@
 
     <p class="govuk-body">Order your devices now. Do not delay.</p>
     <p class="govuk-body">Most devices will be delivered within 2 working days.</p>
-    <% if @school.std_device_allocation.available_devices_count > 149 %>
+    <% if @school&.std_device_allocation&.available_devices_count > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
     <p class="govuk-body">Ordering will close when your school reopens.</p>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -12,12 +12,12 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
-    <p class='govuk-body'>Order your devices now. Do not delay.</p>
-    <p class='govuk-body'>Most devices will be delivered within 2 working days.</p>
+    <p class="govuk-body">Order your devices now. Do not delay.</p>
+    <p class="govuk-body">Most devices will be delivered within 2 working days.</p>
     <% if @school.std_device_allocation.available_devices_count > 149 %>
-      <p class='govuk-body'>For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+      <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
-    <p class='govuk-body'>Ordering will close when your school reopens.</p>
+    <p class="govuk-body">Ordering will close when your school reopens.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -14,7 +14,9 @@
 
     <p class='govuk-body'>Order your devices now. Do not delay.</p>
     <p class='govuk-body'>Most devices will be delivered within 2 working days.</p>
-    <p class='govuk-body'>For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+    <% if @school.std_device_allocation.available_devices_count > 149 %>
+      <p class='govuk-body'>For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+    <% end %>
     <p class='govuk-body'>Ordering will close when your school reopens.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -12,9 +12,10 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
-    <p class="govuk-body">Only order devices for children who cannot attend school and do not have access to a laptop or tablet.</p>
-    <p class="govuk-body">We’re working hard to get devices delivered within 5 working days.</p>
-    <p class="govuk-body">Ordering will close when your school reopens.</p>
+    <p class='govuk-body'>Order your devices now. Do not delay.</p>
+    <p class='govuk-body'>Most devices will be delivered within 2 working days.</p>
+    <p class='govuk-body'>For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
+    <p class='govuk-body'>Ordering will close when your school reopens.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -14,7 +14,7 @@
 
     <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', request_devices_school_path(@school) %>, you can go ahead with your order. You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>
 
-    <p class="govuk-body">We’re working hard to get devices delivered within 5 working days.</p>
+    <p class="govuk-body">Most devices will be delivered to schools within 2 working days of an order being confirmed.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>


### PR DESCRIPTION
### Context
https://trello.com/c/oBmUnDoy/1101-update-delivery-content-to-reflect-new-approach-to-large-orders

Computacenter is starting to process large orders and have difficulty doing this within the 48 hours SLA and have experienced issues with schools accepting such large deliveries at short notice. As a result, they are adopting a new approach to fulfilling large orders. 

From the 7th December, where an order is placed on TechSource for 150 or more devices Computacenter will:
- Telephone the delivery contact to arrange delivery via a specialist courier
- Confirm via a ZenDesk email the date of the delivery, we will also explain that the courier link in the dispatch email will not work.

### Changes proposed in this pull request

Everywhere delivery timeline is mentioned it's updated from '5 working days'  to '2 working days'. On the overview guidance and on the order page (where the user has more than 149 devices available to them) we tell the user 'For large orders (more than 150 devices), we’ll call the main delivery contact to arrange delivery'. 

Updates to the RB ordering page will be in a separate PR.
