### PR TITLE
Adds 'right now' to 'available to order'

### DIFF
--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -38,7 +38,7 @@
   <p class="govuk-body"><%= @responsible_body.name %>:</p>
   <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
     <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools</li>
-    <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available</li>
+    <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available to order right now</li>
     <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %></li>
   </ul>
 <% end %>


### PR DESCRIPTION
Makes it clearer what this number means.

### Context
After Kate Thompson spoke to first-line it wasn't clear if 'available' meant 'available to order right now' (the sum of the allocation to schools who have reported disruption) or sum of all the schools had access to their allocation.

### Changes proposed in this pull request
Add 'right now' to 'available to order'.

