### PR TITLE
Add 'Order devices' link to 'Your Schools' page when within the virtual pool

### DIFF
--- a/app/components/responsible_body/pooled_device_count_component.html.erb
+++ b/app/components/responsible_body/pooled_device_count_component.html.erb
@@ -11,4 +11,8 @@
   <div class="govuk-panel__body govuk-!-font-size-24">
     <%= ordered_string -%>
   </div>
+  
+  <% if show_action && action.present? %>
+    <%= govuk_button_link_to action.first[0], action.first[1], class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-1' %>
+  <% end %>
 </div>

--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -1,10 +1,12 @@
 class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
   include ViewHelper
 
-  attr_reader :responsible_body
+  attr_reader :responsible_body, :action, :show_action
 
-  def initialize(responsible_body:)
+  def initialize(responsible_body:, show_action: true, action: {})
     @responsible_body = responsible_body
+    @action = action
+    @show_action = show_action
   end
 
   def name_string

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -29,7 +29,10 @@
 <% if @responsible_body.has_virtual_cap_feature_flags? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
+    <%= render ResponsibleBody::PooledDeviceCountComponent.new(
+      responsible_body: @responsible_body,
+      show_action: @responsible_body.has_any_schools_that_can_order_now? && @responsible_body.has_devices_available_to_order?,
+      action: { 'Order devices' => responsible_body_devices_order_devices_path } ) %>
   </div>
 </div>
 <%- end %>

--- a/spec/components/responsible_body/pooled_device_count_component_spec.rb
+++ b/spec/components/responsible_body/pooled_device_count_component_spec.rb
@@ -20,6 +20,47 @@ RSpec.describe ResponsibleBody::PooledDeviceCountComponent, type: :component do
     end
   end
 
+  context 'with an action' do
+    let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation]) }
+    let(:pooled_allocation) { VirtualCapPool.new(devices_ordered: 0, cap: 0, device_type: 'std_device') }
+
+    subject(:component) { described_class.new(responsible_body: responsible_body, action: { 'hello' => 'https://example.com' }) }
+
+    it 'renders action button' do
+      doc = render_inline(component)
+
+      expect(doc.css("a[href='https://example.com']")[0].text).to eql('hello')
+    end
+
+    context 'when show action is true' do
+      subject(:component) do
+        described_class.new(responsible_body: responsible_body,
+                            show_action: true,
+                            action: { 'hello' => 'https://example.com' })
+      end
+
+      it 'renders the action' do
+        doc = render_inline(component)
+
+        expect(doc.css("a[href='https://example.com']")[0].text).to eql('hello')
+      end
+    end
+
+    context 'when show action is false' do
+      subject(:component) do
+        described_class.new(responsible_body: responsible_body,
+                            show_action: false,
+                            action: { 'hello' => 'https://example.com' })
+      end
+
+      it 'does not render the action' do
+        html = render_inline(component).to_html
+
+        expect(html).not_to include 'hello'
+      end
+    end
+  end
+
   context 'when devices available' do
     let(:responsible_body) { create(:trust, :manages_centrally, virtual_cap_pools: [pooled_allocation]) }
     let(:pooled_allocation) { VirtualCapPool.new(devices_ordered: 1, cap: 5, device_type: 'std_device') }


### PR DESCRIPTION
### Context

I missed the action functionality of the pooled device count component that I build as part of https://trello.com/c/VxiaDLtN/1082-virtual-cap-update-ordered-devices-page. The action is used on the schools page that was build as part of https://trello.com/c/Gvsyoype/1108-virtual-cap-update-your-schools-page

### Changes proposed in this pull request

1. Add link to 'Order devices' for RBs that can order now within a virtual cap.
2. It takes you back to the previous page so that you can click through to order via TechSource.

### Guidance to review

### Screenshots
![screencapture-localhost-3000-responsible-body-devices-schools-2020-12-07-17_46_20](https://user-images.githubusercontent.com/31316/101385765-23c03580-38b4-11eb-9bca-633fc89ef2b7.png)

