### PR TITLE
[1115] When adding a school user, devolve ordering to schools if the RB has not decided

### DIFF
--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -8,6 +8,7 @@ class CreateUserService
   end
 
   def self.invite_school_user(user_params = {})
+    devolve_ordering_if_needed!(user_params)
     if user_exists_on_other_school?(user_params) || user_exists_as_responsible_body_user?(user_params)
       invite_to_additional_school!(user_params)
     else
@@ -75,4 +76,11 @@ class CreateUserService
     end
     user
   end
+
+  def self.devolve_ordering_if_needed!(user_params)
+    school = School.find_by(id: user_params[:school_id])
+    school.create_preorder_information!(who_will_order_devices: 'school') if school && school.preorder_information.nil?
+  end
+
+  private_class_method :devolve_ordering_if_needed!
 end


### PR DESCRIPTION
### Context

[Trello card 1115](https://trello.com/c/LXl2jWPJ/1115-devolve-ordering-to-schools-where-trust-decision-is-still-outstanding) - It's possible for a user to be invited to a school before their Responsible Body has made a decision on whether ordering will be central or devolved. As we've had several (> 200) RBs that have still not made a decision despite several 'nudge' emails, and there have been schools which needed devices but were unable to order them because of this, we've decided to let the schools go ahead and order.

However, if the RB has not made a decision, the school will have no `PreorderInformation` record, and this can cause the user journey to end in an error message if they choose to order Chromebooks and go as far as trying to enter the Chromebook domain information.

The fix we decided on was to create a `PreorderInformation` record which devolved ordering to the school at the point of inviting a user to a school, if there was not one already present.

### Changes proposed in this pull request

* At the point of inviting a user to a school (i.e. in the `CreateUserService`), create a `PreorderInformation` record if needed.

### Guidance to review

