### PR TITLE
makes table columns specified widths

### DIFF
--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -5,7 +5,7 @@
   </caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header app-schools-table__school-column">School</th>
+      <th class="govuk-table__header app-schools-table__column-40">School</th>
       <th class="govuk-table__header">What to order</th>
     </tr>
   </thead>

--- a/app/views/responsible_body/devices/schools/_school_states_table.html.erb
+++ b/app/views/responsible_body/devices/schools/_school_states_table.html.erb
@@ -9,10 +9,10 @@
 <table id="<%= table_id %>" class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header app-schools-table__school-column">School</th>
-      <th class="govuk-table__header">Who will order?</th>
-      <th class="govuk-table__header">Allocation</th>
-      <th class="govuk-table__header"><span class="govuk-visually-hidden">Status</span></th>
+      <th class="govuk-table__header app-schools-table__column-40">School</th>
+      <th class="govuk-table__header app-schools-table__column-20">Who will order?</th>
+      <th class="govuk-table__header app-schools-table__column-20">Allocation</th>
+      <th class="govuk-table__header app-schools-table__column-20"><span class="govuk-visually-hidden">Status</span></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -35,8 +35,12 @@ $govuk-image-url-function: frontend-image-url;
   border-bottom: 1px solid $govuk-border-colour;
 }
 
-.app-schools-table__school-column {
-  width: 50%;
+.app-schools-table__column-40 {
+  width: 40%;
+}
+
+.app-schools-table__column-20 {
+  width: 20%;
 }
 
 .search-results {


### PR DESCRIPTION
### Context

On the schools summary page for responsible bodies, we show multiple tables. If 1 some schools a table have a status and others don't, the tables are misaligned making them harder to read.

### Changes proposed in this pull request

Add classes with percentage widths and add them all columns.

Before:
![localhost_3000_responsible-body_devices_schools (1)](https://user-images.githubusercontent.com/8417288/101476351-87df0a00-3945-11eb-830b-46d96f4dcaee.png)

After:
![localhost_3000_responsible-body_devices_schools](https://user-images.githubusercontent.com/8417288/101476366-90374500-3945-11eb-8168-686b5d721856.png)

