### PR TITLE
[1077] Extend support user search to include users with no associated schools or RBs

### DIFF
--- a/app/components/support/user_search_result_component.html.erb
+++ b/app/components/support/user_search_result_component.html.erb
@@ -6,6 +6,6 @@
   component.slot(:row, key: 'Email address', value: user.email_address)
   component.slot(:row,
                   key: 'Associated with',
-                  value: unordered_list_of_orgs,
+                  value: organisations,
                   action: (Pundit.policy(current_user, user).editable? ? govuk_link_to('Change', associated_organisations_support_user_path(user)) : nil) )
 end %>

--- a/app/components/support/user_search_result_component.rb
+++ b/app/components/support/user_search_result_component.rb
@@ -6,6 +6,14 @@ class Support::UserSearchResultComponent < ViewComponent::Base
     @current_user = current_user
   end
 
+  def organisations
+    if user.organisations.empty?
+      no_organisations
+    else
+      unordered_list_of_orgs
+    end
+  end
+
   def unordered_list_of_orgs
     tag.ul(class: 'govuk-list') do
       safe_join(user.organisations.sort_by(&:name).map do |organisation|
@@ -17,6 +25,10 @@ class Support::UserSearchResultComponent < ViewComponent::Base
   end
 
 private
+
+  def no_organisations
+    '(no schools or responsible bodies)'
+  end
 
   def organisation_link_or_text(organisation)
     case organisation

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -12,7 +12,6 @@ class Support::UsersController < Support::BaseController
     @search_form = Support::UserSearchForm.new(search_params)
     @search_term = @search_form.email_address_or_full_name
     @results = policy_scope(User)
-      .from_responsible_body_or_schools
       .search_by_email_address_or_full_name(@search_term)
       .distinct
       .includes(:responsible_body, :schools)

--- a/spec/components/support/user_search_result_component_spec.rb
+++ b/spec/components/support/user_search_result_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Support::UserSearchResultComponent do
   let(:st_josephs) { create(:school, name: 'St Joseph’s School') }
   let(:coventry) { create(:local_authority, name: 'Coventry') }
   let(:user) { create(:user, schools: [st_marys, st_josephs], responsible_body: coventry, email_address: 'jsmith@school.sch.uk') }
+  let(:unassociated_user) { create(:user, responsible_body: nil, schools: [], email_address: 'fran@free.com', full_name: 'Fran Free') }
   let(:support_user) { create(:support_user) }
 
   subject { described_class.new(user: user, current_user: support_user) }
@@ -35,6 +36,14 @@ RSpec.describe Support::UserSearchResultComponent do
 
     it 'does not render a Change link for the users associated organisations' do
       expect(rendered_result_html).not_to include(associated_organisations_support_user_path(user))
+    end
+  end
+
+  context 'when the user has no associations' do
+    subject { described_class.new(user: unassociated_user, current_user: support_user) }
+
+    it 'shows (no schools or responsible bodies) in the associations' do
+      expect(rendered_result_html).to include('(no schools or responsible bodies)')
     end
   end
 

--- a/spec/features/support/searching_for_school_or_rb_users_spec.rb
+++ b/spec/features/support/searching_for_school_or_rb_users_spec.rb
@@ -35,6 +35,15 @@ RSpec.feature 'Searching for school or RB users' do
     and_i_can_navigate_to_the_support_page_for_their_school
   end
 
+  scenario 'users with no associated organisations are still shown in the results' do
+    given_i_am_signed_in_as_a_support_user
+    and_there_is_a_user_with_no_associations
+
+    when_i_follow_the_links_to_find_users
+    and_i_search_for_the_unassociated_user_by_email
+    then_i_see_the_unassociated_user_on_the_results_page
+  end
+
   def given_i_am_signed_in_as_a_support_user
     sign_in_as support_user
   end
@@ -48,6 +57,10 @@ RSpec.feature 'Searching for school or RB users' do
     create(:school_user, full_name: 'David Jones', email_address: 'djones@another-school.sch.uk', privacy_notice_seen_at: nil)
     create(:local_authority_user, full_name: 'Debbie Barry', email_address: 'dbarry@council.gov.uk', privacy_notice_seen_at: 1.month.ago)
     create(:local_authority_user, full_name: 'Wendy Wilson', email_address: 'wendy.wilson@council.gov.uk', privacy_notice_seen_at: 1.month.ago)
+  end
+
+  def and_there_is_a_user_with_no_associations
+    create(:user, full_name: 'Michelle Michaels', email_address: 'michelle.michaels@example.com', responsible_body_id: nil, schools: [], privacy_notice_seen_at: nil)
   end
 
   def when_i_follow_the_links_to_find_users
@@ -83,6 +96,11 @@ RSpec.feature 'Searching for school or RB users' do
     search_page.submit.click
   end
 
+  def and_i_search_for_the_unassociated_user_by_email
+    search_page.search_term.set 'michelle.michaels'
+    search_page.submit.click
+  end
+
   def then_i_see_the_school_user_on_the_results_page
     expect(results_page).to be_displayed
     expect(results_page.users.size).to eq(1)
@@ -94,6 +112,12 @@ RSpec.feature 'Searching for school or RB users' do
     expect(results_page).to be_displayed
     expect(results_page.users.size).to eq(0)
     expect(results_page).not_to have_text('djones@another-school.sch.uk')
+  end
+
+  def then_i_see_the_unassociated_user_on_the_results_page
+    expect(results_page).to be_displayed
+    expect(results_page.users.size).to eq(1)
+    expect(results_page.users.first).to have_text('michelle.michaels@example.com')
   end
 
   def and_i_can_navigate_to_the_support_page_for_their_school


### PR DESCRIPTION
### Context

[Trello card 1077](https://trello.com/c/Bs8B6yIR/1077-support-find-rb-or-school-users-doesnt-return-users-with-no-associations) - At the moment it's possible for support users to remove all associated schools or responsible bodies from a user, but then be unable to find them again in order to re-associate them. 

### Changes proposed in this pull request

Remove the restriction on the user search which limited it to only users already associated with a school or responsible body.
 
### Guidance to review

Support home > Find responsible body or school users 
Fill in a search term - there is no minimum length, so you can submit something like '@'. 

The search should:
* return the first 100 users matching the term, whether or not they have a responsible body / school
* respond quickly, even when searching the whole database (I've tested this locally against 33k users)
* indicate when users have no associated organisations (see screenshot)

![Screenshot from 2020-12-08 14-01-00](https://user-images.githubusercontent.com/134501/101495161-21b3b080-3960-11eb-9613-4ea42eed577d.png)
