### PR TITLE
removes 'go the next school link'

### DIFF
--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -41,7 +41,4 @@
 
 <p class="govuk-body">
   <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-  <% end %>
 </p>


### PR DESCRIPTION
### Context

The schools on the RB’s list of schools page used to be in alphabetical order. 

For example:

**Your schools**
A school
B school
C school

Splitting the schools into different tables means they are in alphabetical order by status.

For example:

**Schools reporting a closure or self-isolation group**
A school
C school

**Schools without a reported closure or self-isolating group**
B school

On the school page, there is a link to 'go to the next school'. This takes the user to the next school alphabetically, which is potentially not the next school on the list of schools the user just saw. In the example, if click 'go to the next school' from A school, they would still go to B School.

### Changes proposed in this pull request

As it doesn't seem like the link was used often, I suggest we remove it.
