### PR TITLE
Make 'go to next school' link consistent with schools grouped by status

### DIFF
--- a/app/components/responsible_body/next_school_link_component.html.erb
+++ b/app/components/responsible_body/next_school_link_component.html.erb
@@ -1,0 +1,3 @@
+<%- if next_school.present? %>
+  or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(next_school.urn) %>
+<%- end %>

--- a/app/components/responsible_body/next_school_link_component.rb
+++ b/app/components/responsible_body/next_school_link_component.rb
@@ -1,0 +1,26 @@
+class ResponsibleBody::NextSchoolLinkComponent < ViewComponent::Base
+  attr_accessor :current_school, :recordsets
+
+  def initialize(current_school:, recordsets:)
+    @current_school = current_school
+    @recordsets = recordsets
+  end
+
+  def next_school
+    next_school_in_recordset(recordset_containing_school)
+  end
+
+private
+
+  def recordset_containing_school(school = @current_school)
+    @recordsets.find do |recordset|
+      recordset.pluck(:id).include?(school.id)
+    end
+  end
+
+  def next_school_in_recordset(recordset, school = @current_school)
+    if (index_of_school = recordset.pluck(:id).index(school.id))
+      recordset[index_of_school + 1]
+    end
+  end
+end

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -8,6 +8,7 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
       school_or_rb_domain: @school.preorder_information&.school_or_rb_domain,
       recovery_email_address: @school.preorder_information&.recovery_email_address,
     )
+    load_schools_by_order_status
   end
 
   def update
@@ -19,6 +20,7 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
       @preorder_info.update_chromebook_information_and_status!(chromebook_params)
       redirect_to responsible_body_devices_school_path(urn: @school.urn)
     else
+      load_schools_by_order_status
       render :edit, status: :unprocessable_entity
     end
   end
@@ -35,5 +37,9 @@ private
       :school_or_rb_domain,
       :recovery_email_address,
     )
+  end
+
+  def load_schools_by_order_status
+    @schools = @responsible_body.schools_by_order_status
   end
 end

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -1,15 +1,7 @@
 class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseController
-  def index
-    schools = @responsible_body.schools
-      .includes(:preorder_information)
-      .includes(:std_device_allocation)
-      .gias_status_open
-      .order(name: :asc)
+  before_action :load_schools_by_order_status, only: %i[show index]
 
-    @ordering_schools = schools.can_order
-    @specific_circumstances_schools = schools.can_order_for_specific_circumstances
-    @fully_open_schools = schools.where(order_state: %w[cannot_order cannot_order_as_reopened])
-  end
+  def index; end
 
   def show
     @school = @responsible_body.schools.find_by!(urn: params[:urn])
@@ -22,5 +14,11 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
 
   def order_devices
     @school = @responsible_body.schools.find_by!(urn: params[:urn])
+  end
+
+private
+
+  def load_schools_by_order_status
+    @schools = @responsible_body.schools_by_order_status
   end
 end

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -2,6 +2,7 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::BaseCo
   before_action :find_school!
 
   def new
+    load_schools_by_order_status
     @form = ResponsibleBody::Devices::WhoToContactForm.new(school: @school)
   end
 
@@ -50,5 +51,9 @@ private
     params
       .require(:responsible_body_devices_who_to_contact_form)
       .permit(:who_to_contact, :full_name, :email_address, :phone_number)
+  end
+
+  def load_schools_by_order_status
+    @schools = @responsible_body.schools_by_order_status
   end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -176,6 +176,20 @@ class ResponsibleBody < ApplicationRecord
     schools.gias_status_open.that_can_order_now.any?
   end
 
+  def schools_by_order_status
+    schools_by_name = schools
+      .includes(:preorder_information)
+      .includes(:std_device_allocation)
+      .gias_status_open
+      .order(name: :asc)
+
+    {
+      ordering_schools: schools_by_name.can_order,
+      specific_circumstances_schools: schools_by_name.can_order_for_specific_circumstances,
+      fully_open_schools: schools_by_name.where(order_state: %w[cannot_order cannot_order_as_reopened]),
+    }
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/views/responsible_body/devices/chromebook_information/edit.html.erb
+++ b/app/views/responsible_body/devices/chromebook_information/edit.html.erb
@@ -16,7 +16,5 @@
 
 <p class="govuk-body">
   <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-  <% end %>
+  <%= render ResponsibleBody::NextSchoolLinkComponent.new(current_school: @school, recordsets: @schools.values) %>
 </p>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -37,21 +37,21 @@
 </div>
 <%- end %>
 
-<% if @specific_circumstances_schools.count.positive? %>
-  <%= render partial: 'school_states_table', locals: { schools: @specific_circumstances_schools,
+<% if @schools[:specific_circumstances_schools].count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @schools[:specific_circumstances_schools],
                                                        table_id: 'specific-circumstances-schools',
                                                        heading: t('.specific_circumstances_heading') } %>
 <%- end %>
 
-<% if @ordering_schools.count.positive? %>
-  <%= render partial: 'school_states_table', locals: { schools: @ordering_schools,
+<% if @schools[:ordering_schools].count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @schools[:ordering_schools],
                                                        table_id: 'ordering-schools',
                                                        heading: t('.ordering_schools_heading'),
                                                        heading_text: t('.ordering_schools_heading_text') } %>
 <%- end %>
 
-<% if @fully_open_schools.count.positive? %>
-  <%= render partial: 'school_states_table', locals: { schools: @fully_open_schools,
+<% if @schools[:fully_open_schools].count.positive? %>
+  <%= render partial: 'school_states_table', locals: { schools: @schools[:fully_open_schools],
                                                        table_id: 'fully-open-schools',
                                                        heading: t('.fully_open_schools_heading') } %>
 <%- end %>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -41,4 +41,5 @@
 
 <p class="govuk-body">
   <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
+  <%= render ResponsibleBody::NextSchoolLinkComponent.new(current_school: @school, recordsets: @schools.values) %>
 </p>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -41,7 +41,4 @@
 
 <p class="govuk-body">
   <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-  <% end %>
 </p>

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -25,7 +25,5 @@
 
 <p class="govuk-body">
   <%= govuk_link_to 'Return to list of schools', responsible_body_devices_schools_path %>
-  <% if @school.next_school_in_responsible_body_when_sorted_by_name_ascending.present? %>
-    or <%= govuk_link_to 'go to the next school', responsible_body_devices_school_path(@school.next_school_in_responsible_body_when_sorted_by_name_ascending.urn) %>
-  <% end %>
+  <%= render ResponsibleBody::NextSchoolLinkComponent.new(current_school: @school, recordsets: @schools.values) %>
 </p>

--- a/spec/controllers/responsible_body/devices/schools_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/schools_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe ResponsibleBody::Devices::SchoolsController do
   describe '#index' do
     it 'excludes closed schools' do
       get :index
-      expect(assigns(:ordering_schools)).not_to include(closed_school)
-      expect(assigns(:specific_circumstances_schools)).not_to include(closed_school)
-      expect(assigns(:fully_open_schools)).not_to include(closed_school)
+      expect(assigns(:schools)[:ordering_schools]).not_to include(closed_school)
+      expect(assigns(:schools)[:specific_circumstances_schools]).not_to include(closed_school)
+      expect(assigns(:schools)[:fully_open_schools]).not_to include(closed_school)
     end
   end
 end

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature 'Setting up the devices ordering' do
 
       when_i_follow_the_link_to_the_next_school
       then_i_see_the_details_of_the_second_school
+      and_i_do_not_see_a_next_school_link
 
       when_i_select_to_contact_someone_else_and_save_their_details
       then_i_see_a_confirmation_and_the_someone_else_as_the_contact
@@ -385,6 +386,10 @@ RSpec.feature 'Setting up the devices ordering' do
 
   def when_i_follow_the_link_to_the_next_school
     click_on 'go to the next school'
+  end
+
+  def and_i_do_not_see_a_next_school_link
+    expect(page).not_to have_link('go to the next school')
   end
 
   def when_i_select_to_contact_someone_else_and_save_their_details


### PR DESCRIPTION
### Context

A proposed alternative to #906 - please see that PR for @ralph-hawkins ' v. thorough explanation of the problem, and [this slack thread](https://ukgovernmentdfe.slack.com/archives/C01A7DVKE9J/p1607441294239600?thread_ts=1607440654.234200&cid=C01A7DVKE9J) for the team discussion in which this alternative version is proposed.
 
### Changes proposed in this pull request

Make the 'go to next school' links consistent with the schools being grouped by order state.
These links are present in several places -
```
   app/views/responsible_body/devices/chromebook_information/edit.html.erb
   app/views/responsible_body/devices/schools/index.html.erb
   app/views/responsible_body/devices/schools/show.html.erb
   app/views/responsible_body/devices/who_to_contact/new.html.erb
```
- so I abstracted the logic into a new ViewComponent called `ResponsibleBody::NextSchoolLinkComponent`, and the query into the `ResponsibleBody` model class

### Guidance to review

Find or create a ResponsibleBody with several schools in the various order_states (cannot_order, cannot_order_as_reopened, can_order_for_specific_circumstances and can_order)
Log in as a user for that ResponsibleBody
Visit `Home > Get laptops and tablets > Your schools`
Click on the first school in a list - see that the chain of 'go to next school' links follows the schools in that list, and does not include schools from the other lists
Check that when you get to the last school in the list, there is no 'go to next school link'
Check that when specifying who to contact at a school, or when editing chromebook information, the link behaves as above  

