### PR TITLE
Prevent changes that don't affect cap or devices_ordered from generating cap updates

### DIFF
--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -17,11 +17,15 @@ class VirtualCapPool < ApplicationRecord
   end
 
   def recalculate_caps!
+    Rails.logger.info("***=== recalculating caps ===*** pool-id: #{id}")
+
     self.cap = school_device_allocations.sum(:cap)
     self.devices_ordered = school_device_allocations.sum(:devices_ordered)
     self.allocation = school_device_allocations.sum(:allocation)
+
+    notify_cc = cap_changed? || devices_ordered_changed?
     save!
-    notify_computacenter!
+    notify_computacenter! if notify_cc
   end
 
   def add_school!(school)


### PR DESCRIPTION
### Context
Prevent the VirtualCapPool from generating Cap update API requests unless the total `:cap` or `:devices_ordered` has changed.

### Changes proposed in this pull request
Check whether the `cap` or `devices_ordered` will be modified in `#recalculate_caps!` and only send notification if one or both have changed.

### Guidance to review
You may need to set the `GHWT__COMPUTACENTER__OUTGOING_API__ENDPOINT` env var to point to a dummy service to see the cap updates being generated.  Copy the following into a file and run it from the command line and set the env var to point to `http://localhost:8000`:

```ruby
require 'webrick'
​
server = WEBrick::HTTPServer.new Port: 8000
​
trap 'INT' do server.shutdown end
​
server.mount_proc '/' do |req, res|
  res.body = '<CapAdjustmentResponse dateTime="2020-09-14T21:55:37Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult piMessageID="11111111111111111111111111111111" status="Success"/><FailedRecords/></CapAdjustmentResponse>'
end
​
server.start
```

Given a responsible body that is enabled for virtual caps and has schools in a virtual cap pool, from the console update the `:allocation` of one of the `SchoolDeviceAllocation` records in the pool and it should not generate cap update messages.
Update either/both the `:cap` or `:devices_ordered` attributes and you should see cap update messages generated.
