### PR TITLE
1097 virtual cap force handle multiple chromebook domains

### DIFF
--- a/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
+++ b/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
@@ -1,7 +1,6 @@
 require 'csv'
 
 class Computacenter::MultiDomainChromebooksController < Computacenter::BaseController
-
   def index
     @responsible_bodies = ResponsibleBody.managing_multiple_chromebook_domains.order(type: :asc, name: :asc)
     respond_to do |format|
@@ -21,10 +20,10 @@ private
       csv << ['RB Type', 'RB Name', 'RB URN', 'Sold To']
       @responsible_bodies.each do |responsible_body|
         csv << [
-            responsible_body.humanized_type,
-            responsible_body.computacenter_name,
-            responsible_body.computacenter_identifier,
-            responsible_body.computacenter_reference,
+          responsible_body.humanized_type,
+          responsible_body.computacenter_name,
+          responsible_body.computacenter_identifier,
+          responsible_body.computacenter_reference,
         ]
       end
     end

--- a/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
+++ b/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
@@ -1,0 +1,5 @@
+class Computacenter::MultiDomainChromebooksController < Computacenter::BaseController
+  def index
+    @responsible_bodies = ResponsibleBody.managing_multiple_chromebook_domains
+  end
+end

--- a/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
+++ b/app/controllers/computacenter/multi_domain_chromebooks_controller.rb
@@ -1,5 +1,32 @@
+require 'csv'
+
 class Computacenter::MultiDomainChromebooksController < Computacenter::BaseController
+
   def index
-    @responsible_bodies = ResponsibleBody.managing_multiple_chromebook_domains
+    @responsible_bodies = ResponsibleBody.managing_multiple_chromebook_domains.order(type: :asc, name: :asc)
+    respond_to do |format|
+      format.html { @show_download_link = @responsible_bodies.any? }
+      format.csv { send_data csv_generator, filename: make_filename }
+    end
+  end
+
+private
+
+  def make_filename
+    "multi-chromebook-domain-responsible-bodies-#{Time.zone.now.strftime('%Y%m%d')}.csv"
+  end
+
+  def csv_generator
+    CSV.generate(headers: true) do |csv|
+      csv << ['RB Type', 'RB Name', 'RB URN', 'Sold To']
+      @responsible_bodies.each do |responsible_body|
+        csv << [
+            responsible_body.humanized_type,
+            responsible_body.computacenter_name,
+            responsible_body.computacenter_identifier,
+            responsible_body.computacenter_reference,
+        ]
+      end
+    end
   end
 end

--- a/app/models/computacenter/outgoing_api/cap_update_request.rb
+++ b/app/models/computacenter/outgoing_api/cap_update_request.rb
@@ -65,7 +65,7 @@ private
       records = records.map do |allocation|
         OpenStruct.new(cap_type: allocation.computacenter_cap_type,
                        ship_to: allocation.school.computacenter_reference,
-                       cap: zero_caps ? 0 : allocation.computacenter_cap)
+                       cap: zero_caps ? allocation.raw_devices_ordered : allocation.computacenter_cap)
       end
     end
 

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -109,7 +109,7 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def has_multiple_chromebook_domains_in_managed_schools?
-    schools.gias_status_open.joins(:preorder_information).merge(PreorderInformation.responsible_body_will_order_devices).filter_map { |s| s.chromebook_domain }.uniq.count > 1
+    schools.gias_status_open.joins(:preorder_information).merge(PreorderInformation.responsible_body_will_order_devices).filter_map(&:chromebook_domain).uniq.count > 1
   end
 
   def self.in_connectivity_pilot
@@ -175,17 +175,17 @@ class ResponsibleBody < ApplicationRecord
 
   def self.managing_multiple_chromebook_domains
     where(
-      <<~SQL
-      id IN
-        (SELECT rb_id FROM
-          (SELECT DISTINCT s.responsible_body_id AS rb_id, p.school_or_rb_domain
-            FROM schools s JOIN preorder_information p ON (p.school_id = s.id)
-            WHERE s.status='open'
-            AND p.who_will_order_devices='responsible_body'
-            AND NOT (p.school_or_rb_domain = '' OR p.school_or_rb_domain IS NULL)
-          ) AS t1
-          GROUP BY t1.rb_id HAVING COUNT(*) > 1
-        )
+      <<~SQL,
+        id IN
+          (SELECT rb_id FROM
+            (SELECT DISTINCT s.responsible_body_id AS rb_id, p.school_or_rb_domain
+              FROM schools s JOIN preorder_information p ON (p.school_id = s.id)
+              WHERE s.status='open'
+              AND p.who_will_order_devices='responsible_body'
+              AND NOT (p.school_or_rb_domain = '' OR p.school_or_rb_domain IS NULL)
+            ) AS t1
+            GROUP BY t1.rb_id HAVING COUNT(*) > 1
+          )
       SQL
     )
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -108,6 +108,10 @@ class ResponsibleBody < ApplicationRecord
     FeatureFlag.active?(:mno_offer) && in_connectivity_pilot? && has_centrally_managed_schools?
   end
 
+  def has_multiple_chromebook_domains_in_managed_schools?
+    schools.gias_status_open.joins(:preorder_information).merge(PreorderInformation.responsible_body_will_order_devices).filter_map { |s| s.chromebook_domain }.uniq.count > 1
+  end
+
   def self.in_connectivity_pilot
     where(in_connectivity_pilot: true)
   end
@@ -166,6 +170,23 @@ class ResponsibleBody < ApplicationRecord
             AND preorder_information.status NOT IN ('needs_info', 'needs_contact')
         ) AS completed_preorder_info_count
       ",
+    )
+  end
+
+  def self.managing_multiple_chromebook_domains
+    where(
+      <<~SQL
+      id IN
+        (SELECT rb_id FROM
+          (SELECT DISTINCT s.responsible_body_id AS rb_id, p.school_or_rb_domain
+            FROM schools s JOIN preorder_information p ON (p.school_id = s.id)
+            WHERE s.status='open'
+            AND p.who_will_order_devices='responsible_body'
+            AND NOT (p.school_or_rb_domain = '' OR p.school_or_rb_domain IS NULL)
+          ) AS t1
+          GROUP BY t1.rb_id HAVING COUNT(*) > 1
+        )
+      SQL
     )
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -178,6 +178,10 @@ class School < ApplicationRecord
     update!(computacenter_reference: new_value, computacenter_change: 'none')
   end
 
+  def chromebook_domain
+    preorder_information&.school_or_rb_domain if preorder_information&.will_need_chromebooks? 
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -179,7 +179,7 @@ class School < ApplicationRecord
   end
 
   def chromebook_domain
-    preorder_information&.school_or_rb_domain if preorder_information&.will_need_chromebooks? 
+    preorder_information&.school_or_rb_domain if preorder_information&.will_need_chromebooks?
   end
 
 private

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -39,6 +39,13 @@
     </h2>
 
     <p class="govuk-body">Review and update Sold To references for responsible bodies that have changed.</p>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Responsible bodies managing multiple Chromebook domains', computacenter_multi_domain_chromebooks_path %>
+    </h2>
+
+    <p class="govuk-body">View details of responsible bodies that manage schools with mutliple Chromebook domains.</p>
+
     <% if policy(:support).readable? %>
       <h2 class="govuk-heading-m">
         <%= govuk_link_to 'Support home', support_home_path %>

--- a/app/views/computacenter/multi_domain_chromebooks/index.html.erb
+++ b/app/views/computacenter/multi_domain_chromebooks/index.html.erb
@@ -1,0 +1,50 @@
+<% title = t('page_titles.computacenter.multi_domain_chromebooks') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<% if @show_download_link %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-body">
+      <%= govuk_link_to 'Download as a CSV file', computacenter_multi_domain_chromebooks_path(format: :csv) %>
+    </div>
+  </div>
+</div>
+<%- end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table" id="closed-schools">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">RB Type</th>
+          <th scope="col" class="govuk-table__header">RB Name</th>
+          <th scope="col" class="govuk-table__header">RB URN</th>
+          <th scope="col" class="govuk-table__header">Sold To</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @responsible_bodies.each do |responsible_body| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= responsible_body.humanized_type %></td>
+            <td class="govuk-table__cell"><%= responsible_body.computacenter_name %></td>
+            <td class="govuk-table__cell"><%= responsible_body.computacenter_identifier %></td>
+            <td class="govuk-table__cell"><%= responsible_body.computacenter_reference %></td>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+    <div class="govuk-body">
+      <%- item_count = @responsible_bodies.count %>
+      <%= "#{item_count} #{'record'.pluralize(item_count)} found" -%>
+    </div>
+  </div>
+</div>

--- a/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
+++ b/app/views/computacenter/outgoing_api/base/cap_update_request.xml.builder
@@ -1,8 +1,8 @@
 xml.instruct!
 xml.CapAdjustmentRequest(payloadID: assigns[:payload_id], dateTime: assigns[:timestamp].iso8601) do
   assigns[:allocations].each do |allocation|
-    xml.Record(capType: allocation.computacenter_cap_type,
-               shipTo: allocation.school.computacenter_reference,
-               capAmount: allocation.computacenter_cap)
+    xml.Record(capType: allocation.cap_type,
+               shipTo: allocation.ship_to,
+               capAmount: allocation.cap)
   end
 end

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -46,6 +46,13 @@
       When using TechSource, you will be asked for a URN. Use any URN for one of the schools you manage.
     </p>
 
+    <%- if @responsible_body.has_multiple_chromebook_domains_in_managed_schools? %>
+      <h3 class="govuk-heading-s">Chromebooks</h3>
+      <p class="govuk-body">
+        If you place an order for Chromebooks, TechSource will contact you about which ‘G Suite for Education’ domains you want to use.
+      </p>
+    <%- end %>
+
     <h3 class="govuk-heading-s">Using TechSource for the first time</h3>
     <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address } %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       school_changes_edit: Verify the school details
       responsible_body_changes: Changes to responsible bodies
       responsible_body_changes_edit: Verify the responsible body details
+      multi_domain_chromebooks: Responsible bodies managing multiple Chromebook domains
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
       schools: Each school will place their own orders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,6 +197,7 @@ Rails.application.routes.draw do
     resources :responsible_bodies, only: %i[index edit update], path: '/responsible-body-changes', as: :responsible_body_changes, controller: 'responsible_body_changes'
     get '/techsource', to: 'techsource#new'
     post '/techsource', to: 'techsource#create'
+    get '/multi-domain-chromebooks', to: 'multi_domain_chromebooks#index', as: :multi_domain_chromebooks
     resources :api_tokens, path: '/api-tokens'
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
     and_i_see_1_school_in_local_restrictions_that_i_need_to_place_orders_for
     and_is_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
     and_i_see_where_my_allocation_has_come_from_for_the_1_school_in_local_restrictions
+    and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
   scenario 'a centrally managed school that can order for specific circumstances' do
@@ -36,6 +37,7 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
     and_i_see_1_school_with_specific_circumstances_that_i_need_to_place_orders_for
     and_is_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
     and_i_see_where_my_allocation_has_come_from_for_the_1_school_with_specific_circumstances
+    and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
   scenario 'centrally managed schools that can order for local restrictions and specific circumstances' do
@@ -46,6 +48,15 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
     and_i_see_2_schools_that_i_need_to_place_orders_for
     and_i_see_2_schools_that_i_have_already_placed_orders_for
     and_i_see_where_my_allocation_has_come_from_for_the_2_schools
+    and_i_do_not_see_a_section_on_ordering_chromebooks
+  end
+
+  scenario 'centrally managed schools with multiple Chromebook domains that can order' do
+    given_there_are_multiple_chromebook_domains_being_managed
+    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+    when_i_visit_the_order_devices_page
+    then_i_see_the_order_now_page
+    and_i_see_a_section_regarding_ordering_chromebooks
   end
 
   def given_i_am_signed_in_as_a_responsible_body_user
@@ -73,6 +84,15 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
     schools[1].coms_device_allocation.update!(cap: 0, allocation: 0, devices_ordered: 0) # 0 left
 
     add_school_to_virtual_cap(school: schools[1])
+  end
+
+  def given_there_are_multiple_chromebook_domains_being_managed
+    schools[0].preorder_information.update!(will_need_chromebooks: 'yes',
+                                            school_or_rb_domain: 'school_1.com',
+                                            recovery_email_address: 'school_1@gmail.com')
+    schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
+                                            school_or_rb_domain: 'school_2.com',
+                                            recovery_email_address: 'school_2@gmail.com')
   end
 
   def when_i_visit_the_responsible_body_home_page
@@ -144,6 +164,15 @@ RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { vi
     expect(page).to have_text('remaining allocation of devices for:')
     expect(page).to have_text('approved requests for specific circumstances')
     expect(page).to have_text('schools that have reported a closure or 15')
+  end
+
+  def and_i_do_not_see_a_section_on_ordering_chromebooks
+    expect(page).not_to have_css('h3', text: 'Chromebooks')
+  end
+
+  def and_i_see_a_section_regarding_ordering_chromebooks
+    expect(page).to have_css('h3', text: 'Chromebooks')
+    expect(page).to have_text('If you place an order for Chromebooks, TechSource will contact you about which ‘G Suite for Education’ domains you want to use')
   end
 
   def add_school_to_virtual_cap(school:)

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
   let(:response_body) { 'response body' }
-  let(:school_1) { create(:school, computacenter_reference: '01234567') }
-  let(:school_2) { create(:school, computacenter_reference: '98765432') }
+  let(:trust) { create(:trust, :manages_centrally) }
+  let(:school_1) { create(:school, responsible_body: trust, computacenter_reference: '01234567') }
+  let(:school_2) { create(:school, responsible_body: trust, computacenter_reference: '98765432') }
   let(:allocation_1) { create(:school_device_allocation, school: school_1, device_type: 'std_device', allocation: 11, cap: 1) }
   let(:allocation_2) { create(:school_device_allocation, school: school_2, device_type: 'coms_device', allocation: 22, cap: 0) }
 
@@ -37,6 +38,45 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
         </CapAdjustmentRequest>
       XML
       expect(@network_call.with(body: expected_xml)).to have_been_requested
+    end
+
+    context 'when the responsible_body is managing multiple chromebook domains', with_feature_flags: { virtual_caps: 'active' } do
+      subject(:request) { described_class.new(allocation_ids: [allocation_1.id, allocation_2.id]) }
+
+      before do
+        allocation_1.update!(cap: allocation_1.allocation)
+        allocation_2.update!(cap: allocation_2.allocation)
+
+        trust.update!(vcap_feature_flag: true)
+        school_1.create_preorder_information!(who_will_order_devices: 'responsible_body',
+                                              will_need_chromebooks: 'yes',
+                                              school_or_rb_domain: 'school_1.com',
+                                              recovery_email_address: 'school_1@gmail.com')
+        school_2.create_preorder_information!(who_will_order_devices: 'responsible_body',
+                                              will_need_chromebooks: 'yes',
+                                              school_or_rb_domain: 'school_2.com',
+                                              recovery_email_address: 'school_2@gmail.com')
+        school_1.can_order!
+        school_2.can_order!
+        trust.add_school_to_virtual_cap_pools!(school_1)
+        trust.add_school_to_virtual_cap_pools!(school_2)
+        trust.reload
+      end
+
+      it 'generates a correct body with zero cap amounts' do
+        request.payload_id = '123456789'
+        request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
+        request.post!
+
+        expected_xml = <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
+          <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="0"/>
+          <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="0"/>
+        </CapAdjustmentRequest>
+        XML
+        expect(@network_call.with(body: expected_xml)).to have_been_requested
+      end
     end
 
     context 'when the response status is success' do

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       subject(:request) { described_class.new(allocation_ids: [allocation_1.id, allocation_2.id]) }
 
       before do
-        allocation_1.update!(cap: allocation_1.allocation)
-        allocation_2.update!(cap: allocation_2.allocation)
+        allocation_1.update!(cap: allocation_1.allocation, devices_ordered: 2)
+        allocation_2.update!(cap: allocation_2.allocation, devices_ordered: 3)
 
         trust.update!(vcap_feature_flag: true)
         school_1.create_preorder_information!(who_will_order_devices: 'responsible_body',
@@ -63,17 +63,17 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
         trust.reload
       end
 
-      it 'generates a correct body with zero cap amounts' do
+      it 'generates a correct body using devices_ordered for the cap amounts to force manual handling at TechSource' do
         request.payload_id = '123456789'
         request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
         request.post!
 
         expected_xml = <<~XML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
-          <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="0"/>
-          <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="0"/>
-        </CapAdjustmentRequest>
+          <?xml version="1.0" encoding="UTF-8"?>
+          <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
+            <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="2"/>
+            <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="3"/>
+          </CapAdjustmentRequest>
         XML
         expect(@network_call.with(body: expected_xml)).to have_been_requested
       end

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -641,6 +641,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
   describe '.managing_multiple_chromebook_domains' do
     subject(:responsible_body) { create(:trust, :manages_centrally) }
+
     let(:second_rb) { create(:trust, :manages_centrally) }
     let(:third_rb) { create(:trust, :devolves_management) }
 
@@ -664,9 +665,9 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
                                                 school_or_rb_domain: 'school1.google.com')
         second_schools[0].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school0.google2.com')
+                                                       school_or_rb_domain: 'school0.google2.com')
         second_schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school1.google2.com')
+                                                       school_or_rb_domain: 'school1.google2.com')
       end
 
       it 'returns the responsible bodies that manage those schools' do
@@ -683,9 +684,9 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
                                                 school_or_rb_domain: 'school4.google.com')
         second_schools[0].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school0.google2.com')
+                                                       school_or_rb_domain: 'school0.google2.com')
         second_schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school1.google2.com')
+                                                       school_or_rb_domain: 'school1.google2.com')
       end
 
       it 'does not count closed schools when determining the domains' do
@@ -703,9 +704,9 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
                                                 school_or_rb_domain: 'school1.google.com')
         third_schools[0].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school0.google3.com')
+                                                      school_or_rb_domain: 'school0.google3.com')
         third_schools[1].preorder_information.update!(will_need_chromebooks: 'yes',
-                                                school_or_rb_domain: 'school1.google3.com')
+                                                      school_or_rb_domain: 'school1.google3.com')
       end
 
       it 'does not count closed schools when determining the domains' do


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/JFczhXmY/1097-virtual-cap-force-the-orders-of-trusts-that-qualify-for-virtual-cap-and-have-multiple-chromebook-domains-into-the-techsource-man)
Handling of ordering of Chromebooks where multiple G Suite domains exist for responsible bodies managing centrally in virtual pools.  In these circumstances. when a responsible body places an order at TechSource, the order needs to be forced into a manual process in order to resolve which domain should be used for Chromebooks.

### Changes proposed in this pull request
Provide an interface for CC to view (and download as CSV) which responsible bodies that manage centrally and have multiple chromebook domains.
Add additional copy to the "Order devices" page to inform the users that TechSource will be in touch.
During sending cap updates to CC, if the responsible body manages centrally and multiple Chromebook domains exist then the cap amounts are adjusted to the `devices_ordered` amount (i.e. nothing can be ordered) in the API call payload as a means to force any orders into the TechSource manual queue.

### Guidance to review
__Set up__:
* Run the app or console with virtual cap feature flag
```
FEATURES_virtual_caps=active bundle exec rails s
```

* Make one or more responsible bodies manage centrally and be enable for virtual caps.

```ruby
responsible_body.update!(who_will_order_devices: 'responsible_body', vcap_feature_flag: true)
```

* Configure some of the RBs schools to want chromebooks and have different chromebook domains. Do this from the console so as to avoid validation of the domain. Also set the recovery address email.

```ruby
school.preorder_information.update!(who_will_order_devices: 'responsible_body', will_need_chromebooks: 'yes', school_or_rb_domain: 'mydomain.com', recovery_email_address: 'user@email.com')
```

* Ensure the schools have `SchoolDeviceAllocation`s with some allocation and cap values etc.

* Add the schools to the RB's virtual pool.

```ruby
responsible_body.add_school_to_virtual_cap_pools!(school)
```

__Method__
Log into the service as a user for the responsible body. Navigate to Home -> Get laptops and tables -> Order devices and the extra __Chromebook__ section should be visible.
![image](https://user-images.githubusercontent.com/333931/101779648-72a4df80-3aed-11eb-9a5a-5b5ad84dc96c.png)

----

Log in as a Computacenter user
The Home page should have an extra option __Responsible bodies managing multiple Chromebook domains__
![image](https://user-images.githubusercontent.com/333931/101782213-a46b7580-3af0-11eb-889e-142c580ef17f.png)

----

Follow the __Responsible bodies managing multiple Chromebook domains__ link and you should see a table of responsible bodies with multiple Chromebook domains and be able to see the one setup earlier in the list.

![image](https://user-images.githubusercontent.com/333931/101782455-eeecf200-3af0-11eb-8187-1026d7653782.png)

----

__Checking API Payload__
You may need to set the `GHWT__COMPUTACENTER__OUTGOING_API__ENDPOINT` env var to point to a dummy service to see the cap updates being generated.  Copy the following into a file and run it from the command line and set the env var to point to `http://localhost:8000`:

```ruby
require 'webrick'
​
server = WEBrick::HTTPServer.new Port: 8000
​
trap 'INT' do server.shutdown end
​
server.mount_proc '/' do |req, res|
  res.body = '<CapAdjustmentResponse dateTime="2020-09-14T21:55:37Z" payloadID="11111111-1111-1111-1111-111111111111"><HeaderResult piMessageID="11111111111111111111111111111111" status="Success"/><FailedRecords/></CapAdjustmentResponse>'
end
​
server.start
```

Make changes to the `:cap` or `:devices_ordered` in the `SchoolDeviceAllocation` for one of the schools set up earlier. You should see output either in the rails console or from the WEBrick server showign the payload taht would be sent to Computacenter. Verify that the `capAmount` in the XML matches the `raw_devices_ordered` value for the `SchoolDeviceAllocation`.