### PR TITLE
Increased allocation and Christmas messaging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'faker'
 # Manage multiple processes i.e. web server and webpack
 gem 'foreman'
 gem 'govuk_design_system_formbuilder'
-gem 'govuk-components', '>=0.5.0'
+gem 'govuk-components', '>=0.8.0'
 
 gem 'http'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,9 +188,9 @@ GEM
       net-http-pipeline
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-components (0.6.0)
+    govuk-components (0.8.0)
       rails (~> 6.0.3, >= 6.0.3)
-      view_component (~> 2.18.1)
+      view_component (~> 2.22.1)
     govuk_design_system_formbuilder (2.1.5)
       actionview (>= 5.2)
       activemodel (>= 5.2)
@@ -453,7 +453,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    view_component (2.18.2)
+    view_component (2.22.1)
       activesupport (>= 5.0.0, < 7.0)
     web-console (4.1.0)
       actionview (>= 6.0.0)
@@ -502,7 +502,7 @@ DEPENDENCIES
   faker
   fakeredis
   foreman
-  govuk-components (>= 0.5.0)
+  govuk-components (>= 0.8.0)
   govuk_design_system_formbuilder
   http
   i18n-debug

--- a/app/components/notification_banner.rb
+++ b/app/components/notification_banner.rb
@@ -1,0 +1,5 @@
+class NotificationBanner < GovukComponent::NotificationBanner
+  def render?
+    true
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,6 +9,7 @@ class FeatureFlag
     reduced_allocations
     virtual_caps
     christmas_banner
+    increased_allocations_banner
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,6 +8,7 @@ class FeatureFlag
     mno_offer
     reduced_allocations
     virtual_caps
+    christmas_banner
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,14 +1,29 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if FeatureFlag.active?(:christmas_banner) %>
+  <div class="govuk-grid-column-full">
+      <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
       <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-        <p class="govuk-body">
-          <%= t('banners.christmas.content') %>
-        </p>
+        <% if FeatureFlag.active?(:increased_allocations_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.increased_allocations.responsible_body.content') %>
+          </p>
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content') %>
+          </p>
+        <% end %>
       <% end %>
     <% end %>
+  </div>
 
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @responsible_body.name %></span>
       <%= t('page_titles.responsible_body_home') %>

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,5 +1,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if FeatureFlag.active?(:christmas_banner) %>
+      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+        <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+        <p class="govuk-body">
+          <%= t('banners.christmas.content') %>
+        </p>
+      <% end %>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @responsible_body.name %></span>
       <%= t('page_titles.responsible_body_home') %>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -5,15 +5,29 @@
 <%- content_for :title, title %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if FeatureFlag.active?(:christmas_banner) %>
+  <div class="govuk-grid-column-full">
+    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
       <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-        <p class="govuk-body">
-          <%= t('banners.christmas.content') %>
-        </p>
+        <% if FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
+          <p class="govuk-notification-banner__heading">
+            <%= t('banners.increased_allocations.school.heading', count: @school&.std_device_allocation&.allocation) %>
+          </p>
+          <p class="govuk-body">
+            <%= t('banners.increased_allocations.school.content') %>
+          </p>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content') %>
+          </p>
+        <% end %>
       <% end %>
     <% end %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
       <%= title %>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -6,6 +6,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if FeatureFlag.active?(:christmas_banner) %>
+      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+        <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+        <p class="govuk-body">
+          <%= t('banners.christmas.content') %>
+        </p>
+      <% end %>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -629,3 +629,13 @@ en:
     christmas:
       heading: No orders over Christmas
       content: You will not be able to place orders over the Christmas break. We’ll accept orders up until 4pm on Thursday 17 December and we’ll then close ordering until Monday 4 January.
+    increased_allocations:
+      school:
+        heading:
+          zero: Your allocation has increased to 0 devices
+          one: Your allocation has increased to 1 device
+          other: Your allocation has increased to %{count} devices
+        content: As international stocks of laptops and tablets have increased, we’ve restored your allocation to what it was before October half term.
+      responsible_body:
+        heading: We’ve restored original device allocations
+        content: As international stocks of laptops and tablets have increased, we’ve restored allocations to what they were before October half term.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -625,3 +625,7 @@ en:
         name_or_urn: School name or URN
       support_user_responsible_body_form:
         name: Responsible body name
+  banners:
+    christmas:
+      heading: No orders over Christmas
+      content: You will not be able to place orders over the Christmas break. We’ll accept orders up until 4pm on Thursday 17 December and we’ll then close ordering until Monday 4 January.

--- a/db/migrate/20201210140102_add_increased_allocations_feature_flag.rb
+++ b/db/migrate/20201210140102_add_increased_allocations_feature_flag.rb
@@ -1,0 +1,5 @@
+class AddIncreasedAllocationsFeatureFlag < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :increased_allocations_feature_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_111700) do
+ActiveRecord::Schema.define(version: 2020_12_10_140102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,9 +186,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_111700) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
-    t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
     t.index ["gias_id"], name: "index_responsible_bodies_on_gias_id", unique: true
@@ -272,8 +270,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_111700) do
     t.string "order_state", default: "cannot_order", null: false
     t.string "status", default: "open", null: false
     t.boolean "mno_feature_flag", default: false
-    t.string "computacenter_change", default: "none", null: false
-    t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
+    t.boolean "increased_allocations_feature_flag", default: false
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/views/responsible_body/home/show.html.erb_spec.rb
+++ b/spec/views/responsible_body/home/show.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'responsible_body/home/show.html.erb' do
+  describe 'Christmas banner' do
+    before do
+      assign(:responsible_body, build(:trust))
+    end
+
+    context 'when christmas_banner feature flag disabled' do
+      it 'does not render christmas banner' do
+        render
+        expect(rendered).not_to include('No orders over Christmas')
+      end
+    end
+
+    context 'when christmas_banner feature flag enabled', with_feature_flags: { christmas_banner: 'active' } do
+      it 'does renders christmas banner' do
+        render
+        expect(rendered).to include('No orders over Christmas')
+      end
+    end
+  end
+end

--- a/spec/views/responsible_body/home/show.html.erb_spec.rb
+++ b/spec/views/responsible_body/home/show.html.erb_spec.rb
@@ -14,9 +14,29 @@ RSpec.describe 'responsible_body/home/show.html.erb' do
     end
 
     context 'when christmas_banner feature flag enabled', with_feature_flags: { christmas_banner: 'active' } do
-      it 'does renders christmas banner' do
+      it 'renders christmas banner' do
         render
         expect(rendered).to include('No orders over Christmas')
+      end
+    end
+  end
+
+  describe 'increased_allocations_banner' do
+    before do
+      assign(:responsible_body, build(:trust))
+    end
+
+    context 'when increased_allocations_banner feature flag disabled' do
+      it 'does not render increased_allocations_banner' do
+        render
+        expect(rendered).not_to include('We’ve restored original device allocations')
+      end
+    end
+
+    context 'when increased_allocations_banner feature flag enabled', with_feature_flags: { increased_allocations_banner: 'active' } do
+      it 'renders increased_allocations_banner' do
+        render
+        expect(rendered).to include('We’ve restored original device allocations')
       end
     end
   end

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -42,4 +42,31 @@ RSpec.describe 'school/home/show.html.erb' do
       end
     end
   end
+
+  describe 'increased_allocations_banner' do
+    before do
+      assign(:school, build(:school, increased_allocations_feature_flag: true))
+    end
+
+    context 'when increased_allocations_banner feature flag disabled' do
+      it 'does not render increased_allocations_banner' do
+        render
+        expect(rendered).not_to include('Your allocation has increased to')
+      end
+    end
+
+    context 'when increased_allocations_banner feature flag enabled', with_feature_flags: { increased_allocations_banner: 'active' } do
+      let(:school) { build(:school, :with_std_device_allocation, increased_allocations_feature_flag: true) }
+
+      before do
+        school.std_device_allocation.update!(allocation: 10)
+        assign(:school, school)
+      end
+
+      it 'renders increased_allocations_banner' do
+        render
+        expect(rendered).to include('Your allocation has increased to 10 devices')
+      end
+    end
+  end
 end

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe 'school/home/show.html.erb' do
   let(:school) { user.school }
   let(:user) { build(:school_user) }
 
+  before do
+    assign(:school, school)
+    assign(:current_user, user)
+  end
+
   context 'when school mno_feature_flag is not enabled' do
     it 'does not show Get internet access section' do
-      assign(:school, school)
-      assign(:current_user, user)
-
       render
       expect(rendered).not_to include('Get internet access')
     end
@@ -20,11 +22,24 @@ RSpec.describe 'school/home/show.html.erb' do
     end
 
     it 'does not show Get internet access section' do
-      assign(:school, school)
-      assign(:current_user, user)
-
       render
       expect(rendered).to include('Get internet access')
+    end
+  end
+
+  describe 'Christmas banner' do
+    context 'when christmas_banner feature flag disabled' do
+      it 'does not render christmas banner' do
+        render
+        expect(rendered).not_to include('No orders over Christmas')
+      end
+    end
+
+    context 'when christmas_banner feature flag enabled', with_feature_flags: { christmas_banner: 'active' } do
+      it 'does renders christmas banner' do
+        render
+        expect(rendered).to include('No orders over Christmas')
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Card: https://trello.com/c/EGYSK7OO/1141-add-notification-banner-for-schools-and-rbs-telling-them-that-allocations-have-increased-also-show-no-xmas-ordering-banner-%F0%9F%8E%84-%F0%9F%8E%85

### Changes proposed in this pull request

Add two global feature flags:

- christmas_banner
- increased_allocations_banner

The Christmas banner feature places a message on both RB and school pages.

The 'Increased allocations' banner places a message on the RB side, and adds a similar message to the school side _if_ the school itself _also_ has `increased_allocations_feature_flag` enabled.

### Guidance to review

RB (both features enabled):
![screencapture-localhost-3000-responsible-body-2020-12-10-14_24_07](https://user-images.githubusercontent.com/31316/101784564-95d28d80-3af3-11eb-9593-fefcaab1442e.png)

School (Christmas only)
![screencapture-localhost-3000-schools-100000-2020-12-10-14_23_43 (1)](https://user-images.githubusercontent.com/31316/101784575-99feab00-3af3-11eb-9b1d-71bf5e0e8c6c.png)

School (plus Increased allocations)
![screencapture-localhost-3000-schools-100000-2020-12-10-14_46_24](https://user-images.githubusercontent.com/31316/101787004-8143c480-3af6-11eb-8c7e-12c67d83aec3.png)
