### PR TITLE
[1141] Banners for support agents

### DIFF
--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,28 +1,6 @@
+<%= render partial: 'shared/banners/responsible_body' %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
-      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <% if FeatureFlag.active?(:increased_allocations_banner) %>
-          <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
-          <p class="govuk-body">
-            <%= t('banners.increased_allocations.responsible_body.content') %>
-          </p>
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
-          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) %>
-          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-          <p class="govuk-body">
-            <%= t('banners.christmas.content') %>
-          </p>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @responsible_body.name %></span>

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-      <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
+    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
       <%= render NotificationBanner.new(title: 'Important') do |banner| %>
         <% if FeatureFlag.active?(:increased_allocations_banner) %>
           <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -4,34 +4,10 @@
 <%- end %>
 <%- content_for :title, title %>
 
+<%= render partial: 'shared/banners/school' %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
-      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <% if FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
-          <p class="govuk-notification-banner__heading">
-            <%= t('banners.increased_allocations.school.heading', count: @school&.std_device_allocation&.allocation) %>
-          </p>
-          <p class="govuk-body">
-            <%= t('banners.increased_allocations.school.content') %>
-          </p>
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
-          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) %>
-          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-          <p class="govuk-body">
-            <%= t('banners.christmas.content') %>
-          </p>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
   <div class="govuk-grid-column-two-thirds">
-
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -15,6 +15,9 @@
           <p class="govuk-body">
             <%= t('banners.increased_allocations.school.content') %>
           </p>
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         <% end %>
 

--- a/app/views/shared/banners/_responsible_body.html.erb
+++ b/app/views/shared/banners/_responsible_body.html.erb
@@ -1,0 +1,25 @@
+<% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+        <% if FeatureFlag.active?(:increased_allocations_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.increased_allocations.responsible_body.content') %>
+          </p>
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content') %>
+          </p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/banners/_school.html.erb
+++ b/app/views/shared/banners/_school.html.erb
@@ -1,0 +1,27 @@
+<% if FeatureFlag.active?(:christmas_banner) || (FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag?) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+        <% if FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
+          <p class="govuk-notification-banner__heading">
+            <%= t('banners.increased_allocations.school.heading', count: @school&.std_device_allocation&.allocation) %>
+          </p>
+          <p class="govuk-body">
+            <%= t('banners.increased_allocations.school.content') %>
+          </p>
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content') %>
+          </p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -7,119 +7,103 @@
   ]) %>
 <% end %>
 
-<% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
-  <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-    <% if FeatureFlag.active?(:increased_allocations_banner) %>
-      <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
-      <p class="govuk-body">
-        <%= t('banners.increased_allocations.responsible_body.content') %>
-      </p>
+<%= render partial: 'shared/banners/responsible_body' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= @responsible_body.name %>
+    </h1>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
+
+    <% if policy(User).new? %>
+      <%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
     <% end %>
 
-    <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <% end %>
-
-    <% if FeatureFlag.active?(:christmas_banner) %>
-      <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-      <p class="govuk-body">
-        <%= t('banners.christmas.content') %>
-      </p>
-    <% end %>
-  <% end %>
-<% end %>
-
-<h1 class="govuk-heading-xl">
-  <%= @responsible_body.name %>
-</h1>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
-
-<% if policy(User).new? %>
-  <%= govuk_button_link_to t('page_titles.new_responsible_body_user'), new_support_responsible_body_user_path(@responsible_body) %>
-<% end %>
-
-<% if @users.present? %>
-  <% @users.each do |user| %>
-    <div class="user">
-      <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-1"><%= user.full_name %></h3>
-      <% if policy(user).edit? %>
-        <p class="govuk-body">
-          <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user) %>
-        </p>
+    <% if @users.present? %>
+      <% @users.each do |user| %>
+        <div class="user">
+          <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-1"><%= user.full_name %></h3>
+          <% if policy(user).edit? %>
+            <p class="govuk-body">
+              <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_responsible_body_user_path(@responsible_body, user) %>
+            </p>
+          <% end %>
+          <%= render Support::UserSummaryListComponent.new(user: user) %>
+        </div>
       <% end %>
-      <%= render Support::UserSummaryListComponent.new(user: user) %>
-    </div>
-  <% end %>
-<% else %>
-  <p class="govuk-body">None</p>
-<% end %>
-
-<% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
-  <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools</h2>
-  <p class="govuk-body"><%= @responsible_body.name %>:</p>
-  <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
-    <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools</li>
-    <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available to order right now</li>
-    <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %></li>
-  </ul>
-<% end %>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Schools</h2>
-
-<% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        For centrally managed schools, device allocations are combined. We only know how many devices <%= @responsible_body.name %> has ordered, not how many devices went to which school.
-      </p>
-    </div>
-  </div>
-<% end %>
-
-<table id="responsible-body-schools" class="govuk-table">
-  <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
-
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
-      <th scope="col" class="govuk-table__header">Status</th>
-      <th scope="col" class="govuk-table__header">Devices</th>
-      <th scope="col" class="govuk-table__header">Routers</th>
-      <th scope="col" class="govuk-table__header">Who is ordering</th>          
-      <th scope="col" class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @schools.each do |school| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
-        <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
-        <%- device_allocations_data = school.std_device_allocation %>
-        <td class="govuk-table__cell">
-          <%= device_allocations_data&.allocation || 0 %> allocated<br>
-          <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
-            <%= device_allocations_data&.cap || 0 %> caps<br>
-            <%= device_allocations_data&.devices_ordered || 0 %> ordered
-          <% end %>
-        </td>
-        <%- dongles_allocations_data = school.coms_device_allocation %>
-        <td class="govuk-table__cell">
-          <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
-          <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
-            <%= dongles_allocations_data&.cap || 0 %> caps<br>
-            <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
-          <% end %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
-        </td>
-        <td class="govuk-table__cell">
-          <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>
-            <%= govuk_link_to 'Invite', support_school_confirm_invitation_path(school_urn: school.urn) %>
-          <% end %>
-        </td>
-      </tr>
+    <% else %>
+      <p class="govuk-body">None</p>
     <% end %>
-  </tbody>
-</table>
+
+    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools</h2>
+      <p class="govuk-body"><%= @responsible_body.name %>:</p>
+      <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
+        <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools</li>
+        <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available to order right now</li>
+        <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %></li>
+      </ul>
+    <% end %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-9">Schools</h2>
+
+    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body">
+            For centrally managed schools, device allocations are combined. We only know how many devices <%= @responsible_body.name %> has ordered, not how many devices went to which school.
+          </p>
+        </div>
+      </div>
+    <% end %>
+
+    <table id="responsible-body-schools" class="govuk-table">
+      <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
+
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Devices</th>
+          <th scope="col" class="govuk-table__header">Routers</th>
+          <th scope="col" class="govuk-table__header">Who is ordering</th>
+          <th scope="col" class="govuk-table__header">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @schools.each do |school| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.type_label %></td>
+            <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
+            <%- device_allocations_data = school.std_device_allocation %>
+            <td class="govuk-table__cell">
+              <%= device_allocations_data&.allocation || 0 %> allocated<br>
+              <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                <%= device_allocations_data&.cap || 0 %> caps<br>
+                <%= device_allocations_data&.devices_ordered || 0 %> ordered
+              <% end %>
+            </td>
+            <%- dongles_allocations_data = school.coms_device_allocation %>
+            <td class="govuk-table__cell">
+              <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
+              <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                <%= dongles_allocations_data&.cap || 0 %> caps<br>
+                <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+              <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
+            </td>
+            <td class="govuk-table__cell">
+              <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>
+                <%= govuk_link_to 'Invite', support_school_confirm_invitation_path(school_urn: school.urn) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -7,6 +7,28 @@
   ]) %>
 <% end %>
 
+<% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
+  <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+    <% if FeatureFlag.active?(:increased_allocations_banner) %>
+      <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
+      <p class="govuk-body">
+        <%= t('banners.increased_allocations.responsible_body.content') %>
+      </p>
+    <% end %>
+
+    <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <% end %>
+
+    <% if FeatureFlag.active?(:christmas_banner) %>
+      <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+      <p class="govuk-body">
+        <%= t('banners.christmas.content') %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <%= @responsible_body.name %>
 </h1>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -9,6 +9,34 @@
 <% end %>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
+      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
+        <% if FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
+          <p class="govuk-notification-banner__heading">
+            <%= t('banners.increased_allocations.school.heading', count: @school&.std_device_allocation&.allocation) %>
+          </p>
+          <p class="govuk-body">
+            <%= t('banners.increased_allocations.school.content') %>
+          </p>
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+
+        <% if FeatureFlag.active?(:christmas_banner) %>
+          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content') %>
+          </p>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @school.responsible_body.name %></span>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -8,33 +8,7 @@
   ]) %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
-      <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <% if FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
-          <p class="govuk-notification-banner__heading">
-            <%= t('banners.increased_allocations.school.heading', count: @school&.std_device_allocation&.allocation) %>
-          </p>
-          <p class="govuk-body">
-            <%= t('banners.increased_allocations.school.content') %>
-          </p>
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) && @school.increased_allocations_feature_flag? %>
-          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        <% end %>
-
-        <% if FeatureFlag.active?(:christmas_banner) %>
-          <p class="govuk-notification-banner__heading"><%= t('banners.christmas.heading') %></p>
-          <p class="govuk-body">
-            <%= t('banners.christmas.content') %>
-          </p>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<%= render partial: 'shared/banners/school' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/views/support/responsible_bodies/show.html.erb_spec.rb
+++ b/spec/views/support/responsible_bodies/show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'support/responsible_bodies/show.html.erb' do
+  let(:responsible_body) { create(:trust) }
+  let(:schools) { [] }
+
+  before do
+    controller.singleton_class.class_eval do
+      protected
+        def policy(klass)
+          OpenStruct.new(:new? => true, :edit? => true)
+        end
+        helper_method :policy
+    end
+
+    assign(:responsible_body, responsible_body)
+    assign(:schools, schools)
+  end
+
+  describe 'banners' do
+    context 'when feature flags disabled' do
+      it 'shows banners' do
+        render
+        expect(rendered).not_to include('No orders over Christmas')
+        expect(rendered).not_to include('We’ve restored original device allocations')
+      end
+    end
+
+    context 'when feature flags enabled', with_feature_flags: { christmas_banner: 'active', increased_allocations_banner: 'active' } do
+      it 'shows banners' do
+        render
+        expect(rendered).to include('No orders over Christmas')
+        expect(rendered).to include('We’ve restored original device allocations')
+      end
+    end
+  end
+end

--- a/spec/views/support/schools/show.html.erb_spec.rb
+++ b/spec/views/support/schools/show.html.erb_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'support/responsible_bodies/show.html.erb' do
-  let(:responsible_body) { create(:trust) }
-  let(:schools) { [] }
+RSpec.describe 'support/schools/show.html.erb' do
+  let(:school) { create(:school, :with_std_device_allocation, increased_allocations_feature_flag: true) }
 
   before do
+    create(:support_user)
+
     controller.singleton_class.class_eval do
     protected
 
@@ -12,10 +13,14 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
         OpenStruct.new(new?: true, edit?: true)
       end
       helper_method :policy
+
+      def current_user
+        User.where(is_support: true).first!
+      end
+      helper_method :current_user
     end
 
-    assign(:responsible_body, responsible_body)
-    assign(:schools, schools)
+    assign(:school, school)
   end
 
   describe 'banners' do
@@ -23,7 +28,7 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
       it 'shows banners' do
         render
         expect(rendered).not_to include('No orders over Christmas')
-        expect(rendered).not_to include('We’ve restored original device allocations')
+        expect(rendered).not_to include('Your allocation has increased to')
       end
     end
 
@@ -31,7 +36,7 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
       it 'shows banners' do
         render
         expect(rendered).to include('No orders over Christmas')
-        expect(rendered).to include('We’ve restored original device allocations')
+        expect(rendered).to include("Your allocation has increased to #{school.std_device_allocation.allocation} devices")
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/EGYSK7OO/1141-add-notification-banner-for-schools-and-rbs-telling-them-that-allocations-have-increased-also-show-no-xmas-ordering-banner-%F0%9F%8E%84-%F0%9F%8E%85

### Changes proposed in this pull request

- Support agents see banners that school or responsible body users would see

### Guidance to review

- Log in as support staff
- Enable/disable feature toggles
- See banners accordingly