### PR TITLE
Hide 'Increased allocations' banner at RB level when it has no schools that were increased

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -83,6 +83,10 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
+  def has_increased_allocation_feature_flags?
+    FeatureFlag.active?(:increased_allocations_banner) && schools.any?(&:increased_allocations_feature_flag)
+  end
+
   def has_virtual_cap_feature_flags?
     FeatureFlag.active?(:virtual_caps) && vcap_feature_flag?
   end

--- a/app/views/shared/banners/_responsible_body.html.erb
+++ b/app/views/shared/banners/_responsible_body.html.erb
@@ -1,15 +1,15 @@
-<% if FeatureFlag.active?(:christmas_banner) || FeatureFlag.active?(:increased_allocations_banner) %>
+<% if FeatureFlag.active?(:christmas_banner) || @responsible_body.has_increased_allocation_feature_flags? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render NotificationBanner.new(title: 'Important') do |banner| %>
-        <% if FeatureFlag.active?(:increased_allocations_banner) %>
+        <% if @responsible_body.has_increased_allocation_feature_flags? %>
           <p class="govuk-notification-banner__heading"><%= t('banners.increased_allocations.responsible_body.heading') %></p>
           <p class="govuk-body">
             <%= t('banners.increased_allocations.responsible_body.content') %>
           </p>
         <% end %>
 
-        <% if FeatureFlag.active?(:christmas_banner) && FeatureFlag.active?(:increased_allocations_banner) %>
+        <% if FeatureFlag.active?(:christmas_banner) && @responsible_body.has_increased_allocation_feature_flags? %>
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         <% end %>
 

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -529,6 +529,62 @@ RSpec.describe ResponsibleBody, type: :model do
       end
     end
 
+    describe '#has_increased_allocation_feature_flags?' do
+      subject(:responsible_body) { create(:trust) }
+
+      let(:school) { create(:school, responsible_body: responsible_body) }
+
+      context 'when some schools had their allocations increased' do
+        before do
+          school.update! increased_allocations_feature_flag: true
+        end
+
+        context 'without any feature flags', with_feature_flags: { increased_allocations_banner: 'inactive' } do
+          before do
+            school.update! increased_allocations_feature_flag: false
+          end
+
+          it 'returns false' do
+            expect(responsible_body.has_increased_allocation_feature_flags?).to be false
+          end
+        end
+
+        context 'when global feature flag is enabled', with_feature_flags: { increased_allocations_banner: 'active' } do
+          before do
+            school.update! increased_allocations_feature_flag: false
+          end
+
+          it 'returns false' do
+            expect(responsible_body.has_increased_allocation_feature_flags?).to be false
+          end
+        end
+
+        context 'when school feature flag is enabled', with_feature_flags: { increased_allocations_banner: 'inactive' } do
+          before do
+            school.update! increased_allocations_feature_flag: true
+          end
+
+          it 'returns false' do
+            expect(responsible_body.has_increased_allocation_feature_flags?).to be false
+          end
+        end
+
+        context 'when responsible body flag and global feature flag are enabled', with_feature_flags: { increased_allocations_banner: 'active' } do
+          before do
+            school.update! increased_allocations_feature_flag: true
+          end
+
+          it 'returns true' do
+            expect(responsible_body.has_increased_allocation_feature_flags?).to be true
+          end
+        end
+
+        it 'returns false' do
+          expect(responsible_body.has_increased_allocation_feature_flags?).to be false
+        end
+      end
+    end
+
     context 'when no schools are centrally managed' do
       before do
         schools[0].preorder_information.school_will_order_devices!

--- a/spec/views/responsible_body/home/show.html.erb_spec.rb
+++ b/spec/views/responsible_body/home/show.html.erb_spec.rb
@@ -22,8 +22,12 @@ RSpec.describe 'responsible_body/home/show.html.erb' do
   end
 
   describe 'increased_allocations_banner' do
+    let(:trust) { create(:trust) }
+    let(:school) { create(:school, responsible_body: trust) }
+
     before do
-      assign(:responsible_body, build(:trust))
+      school.update! increased_allocations_feature_flag: false
+      assign(:responsible_body, trust)
     end
 
     context 'when increased_allocations_banner feature flag disabled' do
@@ -34,6 +38,10 @@ RSpec.describe 'responsible_body/home/show.html.erb' do
     end
 
     context 'when increased_allocations_banner feature flag enabled', with_feature_flags: { increased_allocations_banner: 'active' } do
+      before do
+        school.update increased_allocations_feature_flag: true
+      end
+
       it 'renders increased_allocations_banner' do
         render
         expect(rendered).to include('We’ve restored original device allocations')

--- a/spec/views/support/responsible_bodies/show.html.erb_spec.rb
+++ b/spec/views/support/responsible_bodies/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'support/responsible_bodies/show.html.erb' do
   let(:responsible_body) { create(:trust) }
-  let(:schools) { [] }
+  let(:schools) { [create(:school, responsible_body: responsible_body)] }
 
   before do
     controller.singleton_class.class_eval do
@@ -20,6 +20,10 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
 
   describe 'banners' do
     context 'when feature flags disabled' do
+      before do
+        schools.each { |school| school.update!(increased_allocations_feature_flag: false) }
+      end
+
       it 'shows banners' do
         render
         expect(rendered).not_to include('No orders over Christmas')
@@ -28,6 +32,10 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
     end
 
     context 'when feature flags enabled', with_feature_flags: { christmas_banner: 'active', increased_allocations_banner: 'active' } do
+      before do
+        schools.each { |school| school.update!(increased_allocations_feature_flag: true) }
+      end
+
       it 'shows banners' do
         render
         expect(rendered).to include('No orders over Christmas')


### PR DESCRIPTION
### Context

An extension of https://trello.com/c/EGYSK7OO/1141-add-notification-banner-for-schools-and-rbs-telling-them-that-allocations-have-increased-also-show-no-xmas-ordering-banner-%F0%9F%8E%84-%F0%9F%8E%85

### Changes proposed in this pull request

We previously decided to show this generic messaging to RBs regardless of whether they had their allocations increased. This ensures that they have at least one school where allocations were increased.

### Guidance to review

RB level messaging should only show when 1) the global feature flag is enabled, and 2) It has at least one school where we've increased allocations and toggled its flag.
