### PR TITLE
Allow soldTo number to be added to DfE by adding Pundit policy

### DIFF
--- a/app/policies/dfe_policy.rb
+++ b/app/policies/dfe_policy.rb
@@ -1,0 +1,2 @@
+class DfEPolicy < ResponsibleBodyPolicy
+end

--- a/spec/controllers/computacenter/responsible_body_changes_controller_spec.rb
+++ b/spec/controllers/computacenter/responsible_body_changes_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ResponsibleBodyChangesController do
+  let(:user) { create(:computacenter_user) }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#edit' do
+    let(:dfe) { ImportResponsibleBodiesService.new.import_dfe }
+
+    it 'loads the page when the responsible body is the Department for Education' do
+      get :edit, params: { id: dfe.id }
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
### Context

#876 introduced an interface for adding sold_to and ship_to numbers to responsible bodies and schools that don't have them. That PR had a bug whereby trying to add a sold_to number to `DfE`, a special responsible body (used for test devices) failed.

### Changes proposed in this pull request

Authorise Computacenter users to add a ship_to number to `DfE`.
