### PR TITLE
Don't try getting 'Sold To' numbers for RBs without schools

### DIFF
--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -1,7 +1,10 @@
 module Computacenter::ResponsibleBodyUrns
   module ClassMethods
     def requiring_a_new_computacenter_reference
-      gias_status_open.where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
+      gias_status_open
+        .where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
+        .joins(:schools)
+        .distinct
     end
 
     def find_by_computacenter_urn!(cc_urn)

--- a/spec/features/computacenter/responsible_body_changes_spec.rb
+++ b/spec/features/computacenter/responsible_body_changes_spec.rb
@@ -4,9 +4,10 @@ require 'shared/expect_download'
 RSpec.feature 'Administering responsible body changes' do
   describe 'signed in as a Computacenter user' do
     let(:user) { create(:computacenter_user) }
-    let!(:new_trusts) { create_list(:trust, 2) }
-    let!(:amended_trusts) { create_list(:trust, 2) }
-    let!(:trusts) { create_list(:trust, 2) }
+    let!(:new_trusts) { create_list(:trust, 2, :with_schools) }
+    let!(:amended_trusts) { create_list(:trust, 2, :with_schools) }
+    let!(:trusts) { create_list(:trust, 2, :with_schools) }
+    let!(:trusts_without_schools) { create_list(:trust, 2) }
 
     before do
       given_the_responsible_bodies_have_the_correct_computacenter_change_states
@@ -63,7 +64,7 @@ RSpec.feature 'Administering responsible body changes' do
 
     def given_the_responsible_bodies_have_the_correct_computacenter_change_states
       new_trusts.each { |s| s.update!(computacenter_change: 'new', computacenter_reference: nil) }
-      amended_trusts.each(&:computacenter_change_amended!)
+      (trusts_without_schools + amended_trusts).each(&:computacenter_change_amended!)
       trusts.each(&:computacenter_change_none!)
     end
 
@@ -90,7 +91,7 @@ RSpec.feature 'Administering responsible body changes' do
         expect(page).to have_text(t.computacenter_identifier)
       end
 
-      trusts.each do |t|
+      (trusts_without_schools + trusts).each do |t|
         expect(page).not_to have_text(t.computacenter_identifier)
       end
     end


### PR DESCRIPTION
### Context

#876 introduced the functionality to allow CC users to assign sold_to numbers to responsible bodies. We don't want this to be done for RBs which don't manage any schools, and there's quite of few of these in production.

### Changes proposed in this pull request

Filter out RBs without schools when identifying 'changed RBs' for CC's benefit.
Also refactor the responsible body FactoryBot factory, to make the local authority and trust factories work much more consistently.

### Guidance to review

