### PR TITLE
Create CapUpdateCall records even when the cap update requests fails

### DIFF
--- a/app/models/computacenter/cap_change_notifier.rb
+++ b/app/models/computacenter/cap_change_notifier.rb
@@ -27,6 +27,17 @@ module Computacenter
         allocation.cap_update_calls << CapUpdateCall.new(request_body: api_request.body, response_body: response.body)
       end
       response
+    rescue Computacenter::OutgoingAPI::Error => e
+      ids.each do |allocation_id|
+        CapUpdateCall.create!(
+          school_device_allocation_id: allocation_id,
+          request_body: e.cap_update_request.body,
+          response_body: e.cap_update_request&.response&.body,
+          failure: true,
+        )
+      end
+
+      raise
     end
   end
 end

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -17,7 +17,6 @@ class SchoolOrderStateAndCapUpdateService
 
     caps.each do |cap|
       allocation = update_cap!(cap[:device_type], cap[:cap])
-
       if notify_computacenter_of_cap_changes?
         if FeatureFlag.active? :virtual_caps
           # don't send updates as they will happen when the pool is updated and the caps adjusted

--- a/db/migrate/20201214114914_add_failure_to_cap_update_calls.rb
+++ b/db/migrate/20201214114914_add_failure_to_cap_update_calls.rb
@@ -1,0 +1,5 @@
+class AddFailureToCapUpdateCalls < ActiveRecord::Migration[6.0]
+  def change
+    add_column :cap_update_calls, :failure, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_140102) do
+ActiveRecord::Schema.define(version: 2020_12_14_114914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_12_10_140102) do
     t.text "response_body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "failure", default: false
     t.index ["school_device_allocation_id"], name: "index_cap_update_calls_on_school_device_allocation_id"
   end
 

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       allocation.update!(allocation: 400, cap: 300, devices_ordered: 200)
       allocation.reload
       expect(allocation.cap_update_calls).to be_present
+      expect(allocation.cap_update_calls.last.failure).to be false
       expect(allocation.cap_update_calls.last.request_body).to include('test-request')
       expect(allocation.cap_update_calls.last.response_body).to include('test-response')
     end

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe VirtualCapPool, type: :model do
         pool.add_school!(schools.first)
         allocation = schools.first.std_device_allocation
         expect(allocation.cap_update_calls).to be_present
+        expect(allocation.cap_update_calls.last.failure).to be false
         expect(allocation.cap_update_calls.last.request_body).to include('test-request')
         expect(allocation.cap_update_calls.last.response_body).to include('test-response')
       end


### PR DESCRIPTION
### Context

Previously we were only creating a `CapUpdateCall` record once a cap update was successfully received. This PR adds a new `failure` column that will toggle on when we receive an error from CC.

