### PR TITLE
Fix cap update issue

### DIFF
--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -19,7 +19,7 @@ class SchoolOrderStateAndCapUpdateService
       allocation = update_cap!(cap[:device_type], cap[:cap])
 
       if notify_computacenter_of_cap_changes?
-        if FeatureFlag.active? :virtual_caps
+        if responsible_body_has_virtual_caps_enabled?
           # don't send updates as they will happen when the pool is updated and the caps adjusted
           unless allocation.is_in_virtual_cap_pool?
             update_cap_on_computacenter!(allocation.id)
@@ -47,6 +47,10 @@ class SchoolOrderStateAndCapUpdateService
   end
 
 private
+
+  def responsible_body_has_virtual_caps_enabled?
+    @school.responsible_body.has_virtual_cap_feature_flags?
+  end
 
   def update_order_state!(order_state)
     @school.update!(order_state: order_state)


### PR DESCRIPTION
### Context
The code that guards against updates being handled only in the virtual cap pool is not considering the `:vcap_feature_flag` only the FeatureFlag :virtual_caps. This resulted in cap updates not being sent when a school that was in the virtual pool but was in a non ordering state, being enabled for ordering again.

### Changes proposed in this pull request
Use both guard flags on code block.

### Guidance to review
Assume a means to observe cap update requests e.g. dummy api service
Given a school in a virtual pool with the `order_state: :cannot_order`
Change allocation and enable ordering via the `SchoolOrderStateAndCapUpdateService`.
Caps update requests should be seen when enabling a school to order.
