### PR TITLE
Set up RB home page and internet pages for MNO offer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,6 +63,12 @@ private
     end
   end
 
+  def render_404_unless_responsible_body_in_mno_feature(responsible_body)
+    unless responsible_body.has_mno_feature_flags_and_centrally_managed_schools?
+      render 'errors/not_found', status: :not_found and return
+    end
+  end
+
   def not_found
     render 'errors/not_found', status: :not_found and return
   end

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -1,7 +1,5 @@
 class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
-  before_action only: :new do
-    render_404_if_feature_flag_inactive(:mno_offer)
-  end
+  before_action { render_404_unless_responsible_body_in_mno_feature(@responsible_body) }
 
   def index
     @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -104,6 +104,10 @@ class ResponsibleBody < ApplicationRecord
     has_virtual_cap_feature_flags? && has_centrally_managed_schools?
   end
 
+  def has_mno_feature_flags_and_centrally_managed_schools?
+    FeatureFlag.active?(:mno_offer) && in_connectivity_pilot? && has_centrally_managed_schools?
+  end
+
   def self.in_connectivity_pilot
     where(in_connectivity_pilot: true)
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -166,7 +166,7 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def is_ordering_for_schools?
-    schools.gias_status_open.that_are_centrally_managed.any?
+    has_centrally_managed_schools?
   end
 
   def is_ordering_for_all_schools?

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -18,18 +18,15 @@
       <li>give schools access to the services they need</li>
     </ul>
 
-    <%- if @responsible_body.in_connectivity_pilot? %>
+    <%- if @responsible_body.has_mno_feature_flags_and_centrally_managed_schools? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Get the internet pilots', responsible_body_internet_path %>
+        <%= govuk_link_to t('page_titles.responsible_body_internet_home'), responsible_body_internet_path %>
       </h2>
 
-      <p class="govuk-body">
-        These pilot schemes have come to an end. We are now:
-      </p>
-
+      <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>working with mobile companies to prepare for the next phase of the increasing mobile data scheme</li>
-        <li>closing the BT wifi hotspot pilot</li>
+        <li>request extra data for mobile devices</li>
+        <li>request 4G wireless routers</li>
       </ul>
     <%- end %>
 

--- a/app/views/responsible_body/internet/home/_bt_wifi_offer.html.erb
+++ b/app/views/responsible_body/internet/home/_bt_wifi_offer.html.erb
@@ -1,9 +1,0 @@
-<h2 class="govuk-heading-l">Give free access to wifi hotspots</h2>
-
-<p class="govuk-body">
-  We’ve allocated <%= number_with_delimiter(@responsible_body.bt_wifi_vouchers.count) %> BT hotspot log-ins for you to pass on to schools and families. A log-in is a username and password. BT calls these ‘vouchers’.
-</p>
-
-<h2 class="govuk-heading-m govuk-!-margin-bottom-4">
-  <%= govuk_link_to 'Download log-ins for BT wifi hotspots', download_responsible_body_internet_bt_wifi_vouchers_path %>
-</h2>

--- a/app/views/responsible_body/internet/home/_extra_mobile_data_offer.html.erb
+++ b/app/views/responsible_body/internet/home/_extra_mobile_data_offer.html.erb
@@ -1,7 +1,0 @@
-<h2 class="govuk-heading-l">Increase data allowances</h2>
-
-<p class="govuk-body">Give us mobile numbers and network details and we’ll request extra data for these devices. How much data someone gets will depend on their network.</p>
-
-<h2 class="govuk-heading-m govuk-!-margin-bottom-8">
-  <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_internet_mobile_extra_data_requests_path %>
-</h2>

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -1,54 +1,33 @@
+<%- title = t('page_titles.responsible_body_internet_home') %>
+<%- content_for :title, title %>
 <%- content_for :before_content do %>
   <% breadcrumbs([
                    { "Home" => responsible_body_home_path },
-                   t('page_titles.responsible_body_internet_home') ,
+                   title ,
                  ]) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.responsible_body_internet_home') %>
+      <%= title %>
     </h1>
 
-    <% if FeatureFlag.active?(:mno_offer) %>
-      <%= render partial: 'extra_mobile_data_offer' %>
-    <% else %>
-      <h2 class="govuk-heading-l">
-        Increasing mobile data pilot
-      </h2>
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      When to make requests for schools
+    </h2>
+    <p class="govuk-body">If you are ordering devices for a school, you must also make their requests for extra mobile data and routers.</p>
 
-      <p class="govuk-body">
-        This pilot has ended. We’re now working with the mobile companies to prepare for the next phase of the scheme. We’ll let you know when it’s up and running again.
-      </p>
-    <% end %>
-
-    <h2 class="govuk-heading-l">
-      BT wifi hotspot pilot
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_internet_mobile_extra_data_requests_path %>
     </h2>
 
-    <p class="govuk-body">
-      This pilot has now come to an end. This offer will not be extended to schools, local authorities or trusts outside of the pilot because we have learned that it did not suitably meet children and young people’s needs.
-    </p>
+    <%= render partial: 'shared/internet/mno_information' %>
 
-    <p class="govuk-body">
-      Any vouchers that have already been downloaded and distributed will still work until the end of December 2020.
-    </p>
-
-    <p class="govuk-body">
-      If you were invited to take part in the pilot and have not downloaded your vouchers yet, please contact <%= ghwt_contact_mailto %> for support.
-    </p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to 'Find out more about the pilots', connectivity_home_path %>
-    </p>
-
-    <h2 class="govuk-heading-l">
-      You can request 4G wireless routers
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
     </h2>
 
-    <p class="govuk-body">
-      If a school is facing disruption to face-to-face education and they’ve been invited to order devices, <%= govuk_link_to 'you can request 4G wireless routers', how_to_request_4g_wireless_routers_path %>.
-    </p>
+    <p class="govuk-body">If a school is facing disruption to education and you’ve been invited to order devices, you can request 4G wireless routers.</p>
   </div>
 </div>

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -16,15 +16,11 @@
       <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
     </h2>
 
-    <p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children can continue their remote education without incurring extra data charges.</p>
-
-    <p class="govuk-body">If they do not have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
-
-    <p class="govuk-body">If they do not have access to a mobile device, or are not on a participating network a 4G wireless router might be more suitable.</p>
+    <%= render partial: 'shared/internet/mno_information' %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
-   </h2>
+    </h2>
 
     <p class="govuk-body">If your school is facing disruption to education and you’ve been invited to order devices, you can request 4G wireless routers.</p>
   </div>

--- a/app/views/shared/internet/_mno_information.html.erb
+++ b/app/views/shared/internet/_mno_information.html.erb
@@ -1,0 +1,5 @@
+<p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children can continue their remote education without incurring extra data charges.</p>
+
+<p class="govuk-body">If they do not have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
+
+<p class="govuk-body">If they do not have access to a mobile device, or are not on a participating network, a 4G wireless router might be more suitable.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
     responsible_body_devices_home: Get laptops and tablets
     responsible_body_devices_tell_us: Tell us who will order a school’s laptops and tablets
     responsible_body_devices_request_devices: Request devices for specific circumstances
-    responsible_body_internet_home: Get the internet pilots
+    responsible_body_internet_home: Get internet access
     responsible_body_users_index: Manage %{rb_type} users
     responsible_body_trust_users_index: Manage trust administrators
     responsible_body_devices_chromebooks: Will the school need Chromebooks?

--- a/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
@@ -1,10 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ResponsibleBody::Internet::Mobile::ExtraDataRequestsController, type: :controller do
-  let(:local_authority_user) { create(:local_authority_user) }
-
   context 'when authenticated', with_feature_flags: { mno_offer: 'active' } do
+    let(:responsible_body) { create(:local_authority) }
+    let(:local_authority_user) { create(:local_authority_user, responsible_body: responsible_body) }
+    let(:mobile_network) { create(:mobile_network) }
+    let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
     before do
+      school.preorder_information.responsible_body_will_order_devices!
+      responsible_body.update!(in_connectivity_pilot: true)
       sign_in_as local_authority_user
     end
 

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature ResponsibleBody do
   let(:sign_in_page) { PageObjects::SignInPage.new }
   let(:responsible_body_home_page) { PageObjects::ResponsibleBody::HomePage.new }
 
-  let(:rb_user) { create(:local_authority_user) }
+  let(:responsible_body) { create(:local_authority) }
+  let(:rb_user) { create(:local_authority_user, responsible_body: responsible_body) }
   let(:mno_user) { create(:mno_user) }
-  let(:responsible_body) { rb_user.responsible_body }
 
   context 'not signed-in' do
     scenario 'visiting the page redirects to sign-in' do
@@ -43,31 +43,60 @@ RSpec.feature ResponsibleBody do
       expect(page).to have_link('Get laptops and tablets')
     end
 
-    context 'with the in_connectivity_pilot flag set' do
-      before do
-        rb_user.responsible_body.update(in_connectivity_pilot: true)
+    context 'with the MNO offer feature flag active', with_feature_flags: { mno_offer: 'active' } do
+      context 'with a responsible body managing at least 1 school centrally' do
+        let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
+        before do
+          schools[0].preorder_information.responsible_body_will_order_devices!
+        end
+
+        context 'with the in_connectivity_pilot flag set' do
+          before do
+            responsible_body.update!(in_connectivity_pilot: true)
+          end
+
+          it 'shows link to get extra data' do
+            visit responsible_body_home_path
+            expect(page).to have_link('Get internet access')
+          end
+        end
+
+        context 'with the in_connectivity_pilot flag not set' do
+          before do
+            responsible_body.update!(in_connectivity_pilot: false)
+          end
+
+          it 'does not show link to get extra data' do
+            visit responsible_body_home_path
+            expect(page).not_to have_link('Get internet access')
+          end
+        end
       end
 
-      it 'shows link to get extra data' do
-        visit responsible_body_home_path
+      context 'with a responsible body devolved to all schools' do
+        before do
+          responsible_body.update!(in_connectivity_pilot: true)
+        end
 
-        expect(responsible_body_home_page).to be_displayed
-        expect(page.status_code).to eq 200
-        expect(page).to have_link('Get the internet')
+        it 'does not show link to get extra data' do
+          visit responsible_body_home_path
+          expect(page).not_to have_link('Get internet access')
+        end
       end
     end
 
-    context 'with the in_connectivity_pilot flag not set' do
+    context 'with the MNO offer feature flag disabled' do
+      let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
       before do
-        rb_user.responsible_body.update(in_connectivity_pilot: false)
+        responsible_body.update!(in_connectivity_pilot: true)
+        schools[0].preorder_information.responsible_body_will_order_devices!
       end
 
       it 'does not show link to get extra data' do
         visit responsible_body_home_path
-
-        expect(responsible_body_home_page).to be_displayed
-        expect(page.status_code).to eq 200
-        expect(page).not_to have_link('Get the internet')
+        expect(page).not_to have_link('Get internet access')
       end
     end
 

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -15,10 +15,15 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
   end
 
   context 'signed in and the MNO offer is activated', with_feature_flags: { mno_offer: 'active' } do
-    let(:user) { create(:local_authority_user) }
+    let(:responsible_body) { create(:local_authority) }
+    let(:user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }
+    let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     before do
+      school.preorder_information.responsible_body_will_order_devices!
+      responsible_body.update!(in_connectivity_pilot: true)
+
       mobile_network
       sign_in_as user
       # prevent api call to Notify
@@ -46,25 +51,6 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
       click_on 'Upload requests'
       expect(page.status_code).not_to eq(200)
       expect(page).to have_text('There is a problem')
-    end
-  end
-
-  context 'signed in and the MNO offer is deactivated', with_feature_flags: { mno_offer: 'inactive' } do
-    let(:user) { create(:local_authority_user) }
-    let(:mobile_network) { create(:mobile_network) }
-
-    before do
-      mobile_network
-      sign_in_as user
-      # prevent api call to Notify
-      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms')
-        .to_return(status: 201, body: '{}')
-    end
-
-    scenario 'user is informed about the initial pilot having ended' do
-      visit responsible_body_internet_mobile_extra_data_requests_path
-      expect(page).to have_text('Our initial pilot ended on 30 September 2020')
-      expect(page).not_to have_link('New request')
     end
   end
 end

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -18,11 +18,10 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
     let(:responsible_body) { create(:local_authority) }
     let(:user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }
-
-    let(:schools) { create_list(:school, 1, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
     before do
-      schools[0].preorder_information.responsible_body_will_order_devices!
+      school.preorder_information.responsible_body_will_order_devices!
       responsible_body.update!(in_connectivity_pilot: true)
 
       mobile_network

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -15,10 +15,16 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
   end
 
   context 'signed in', with_feature_flags: { mno_offer: 'active' } do
-    let(:user) { create(:local_authority_user) }
+    let(:responsible_body) { create(:local_authority) }
+    let(:user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }
 
+    let(:schools) { create_list(:school, 1, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+
     before do
+      schools[0].preorder_information.responsible_body_will_order_devices!
+      responsible_body.update!(in_connectivity_pilot: true)
+
       mobile_network
       sign_in_as user
       # prevent api call to Notify
@@ -28,7 +34,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
 
     scenario 'Navigating to the form' do
       visit responsible_body_home_path
-      click_on('Get the internet pilots')
+      click_on('Get internet access')
       click_on('Request extra data for mobile devices')
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')


### PR DESCRIPTION
### Context

First part of enabling MNO for RBs:

- Remove guidance on closed pilots for all users
- Show MNO feature for RBs when:
  - feature flag enabled
  - managing at least one school centrally
  - are in connectivity pilot
- Rename internet page to "Get internet access"

https://trello.com/c/2WdDchuS/1138-mno-rb-journey-build-the-responsible-body-home-page
https://ghwt-design-history.herokuapp.com/mno-for-rbs/

![localhost_3000_responsible-body](https://user-images.githubusercontent.com/319055/102097088-5ff81680-3e1d-11eb-847f-0e29e5639488.png)
![localhost_3000_responsible-body_internet](https://user-images.githubusercontent.com/319055/102097096-625a7080-3e1d-11eb-847a-9984b4405fc8.png)


