### PR TITLE
Use raw_allocation instead of allocation

### DIFF
--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -22,7 +22,7 @@ private
   def device_allocation_row
     {
       key: 'Device allocation',
-      value: pluralize(@school.std_device_allocation&.allocation.to_i, 'device'),
+      value: pluralize(@school.std_device_allocation&.raw_allocation.to_i, 'device'),
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query allocation',
     }
@@ -31,14 +31,14 @@ private
   def router_allocation_row
     {
       key: 'Router allocation',
-      value: pluralize(@school.coms_device_allocation&.allocation.to_i, 'router'),
+      value: pluralize(@school.coms_device_allocation&.raw_allocation.to_i, 'router'),
       action_path: devices_guidance_subpage_path(subpage_slug: 'device-allocations', anchor: 'how-to-query-an-allocation'),
       action: 'Query allocation',
     }
   end
 
   def display_router_allocation_row?
-    @school.coms_device_allocation&.allocation.to_i.positive?
+    @school.coms_device_allocation&.raw_allocation.to_i.positive?
   end
 
   def type_of_school_row

--- a/app/controllers/support/schools/devices/allocation_controller.rb
+++ b/app/controllers/support/schools/devices/allocation_controller.rb
@@ -2,7 +2,7 @@ class Support::Schools::Devices::AllocationController < Support::BaseController
   before_action :set_school_and_allocation
 
   def edit
-    @form = Support::AllocationForm.new(allocation: @allocation.allocation, school_allocation: @allocation)
+    @form = Support::AllocationForm.new(allocation: @allocation.raw_allocation, school_allocation: @allocation)
   end
 
   def update

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -79,7 +79,7 @@
             <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
             <%- device_allocations_data = school.std_device_allocation %>
             <td class="govuk-table__cell">
-              <%= device_allocations_data&.allocation || 0 %> allocated<br>
+              <%= device_allocations_data&.raw_allocation.to_i %> allocated<br>
               <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
                 <%= device_allocations_data&.cap || 0 %> caps<br>
                 <%= device_allocations_data&.devices_ordered || 0 %> ordered
@@ -87,7 +87,7 @@
             </td>
             <%- dongles_allocations_data = school.coms_device_allocation %>
             <td class="govuk-table__cell">
-              <%= dongles_allocations_data&.allocation || 0 %> allocated<br>
+              <%= dongles_allocations_data&.raw_allocation.to_i %> allocated<br>
               <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
                 <%= dongles_allocations_data&.cap || 0 %> caps<br>
                 <%= dongles_allocations_data&.devices_ordered || 0 %> ordered

--- a/spec/components/school/school_details_summary_list_component_spec.rb
+++ b/spec/components/school/school_details_summary_list_component_spec.rb
@@ -39,7 +39,7 @@ describe School::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school allocation' do
-      expect(value_for_row(result, 'Device allocation').text).to include('3 devices')
+      expect(value_for_row(result, 'Device allocation').text).to include("#{school.std_device_allocation.raw_allocation} devices")
     end
 
     it 'renders the school type' do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -43,7 +43,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school allocation' do
-      expect(value_for_row(result, 'Device allocation').text).to include('3 devices')
+      expect(value_for_row(result, 'Device allocation').text).to include("#{school.std_device_allocation.raw_allocation}")
     end
 
     it 'renders the school type' do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -43,7 +43,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'renders the school allocation' do
-      expect(value_for_row(result, 'Device allocation').text).to include("#{school.std_device_allocation.raw_allocation}")
+      expect(value_for_row(result, 'Device allocation').text).to include("#{school.std_device_allocation.raw_allocation} devices")
     end
 
     it 'renders the school type' do

--- a/spec/features/support/adjusting_a_schools_allocation_spec.rb
+++ b/spec/features/support/adjusting_a_schools_allocation_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Adjusting a schools allocation' do
       end
 
       it 'shows me a form to change the allocation' do
-        expect(page).to have_field('New allocation')
+        expect(page).to have_field('New allocation', with: school.std_device_allocation.raw_allocation)
       end
 
       context 'filling in an invalid value and clicking Save' do

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -361,11 +361,11 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     first_row = responsible_body_page.school_rows[0]
     expect(first_row).to have_text('Alpha Primary School (567891)')
     # devices
-    expect(first_row).to have_text('10 allocated')
+    expect(first_row).to have_text('5 allocated')
     expect(first_row).not_to have_text('3 caps')
     expect(first_row).not_to have_text('1 ordered')
     # dongles
-    expect(first_row).to have_text('8 allocated')
+    expect(first_row).to have_text('4 allocated')
     expect(first_row).not_to have_text('2 caps')
     expect(first_row).not_to have_text('0 ordered')
     expect(first_row).to have_text('Trust')
@@ -374,11 +374,11 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     expect(second_row).to have_text('Beta Secondary School (123457)')
 
     # devices
-    expect(second_row).to have_text('10 allocated')
+    expect(second_row).to have_text('5 allocated')
     expect(second_row).not_to have_text('3 caps')
     expect(second_row).not_to have_text('1 ordered')
     # dongles
-    expect(second_row).to have_text('8 allocated')
+    expect(second_row).to have_text('4 allocated')
     expect(second_row).not_to have_text('2 caps')
     expect(second_row).not_to have_text('0 ordered')
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/azJIAHqC/1150-amend-allocation-on-support-console-for-schools-in-virtual-cap)
Schools are shown with virtual pool allocation amounts not individual allocation amounts in support interface

### Changes proposed in this pull request
Use `raw_allocation` instead of `allocation` when displaying the allocation value for a school.

### Guidance to review
As a support user, whether a school is in a virtual pool or not, the allocation displayed in the support interface should be local school value not the aggregated pool value.
