### PR TITLE
Allow schools in any order state to be added to virtual pools

### DIFF
--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -45,7 +45,6 @@ private
   def school_can_be_added_to_pool?(school)
     school.responsible_body_id == responsible_body_id &&
       school&.preorder_information&.responsible_body_will_order_devices? &&
-      (school.can_order? || school.can_order_for_specific_circumstances?) &&
       school.device_allocations.exists?(device_type: device_type) &&
       !school_virtual_caps.exists?(school_device_allocation: school.device_allocations.find_by(device_type: device_type))
   end

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -65,8 +65,7 @@ private
   end
 
   def add_school_to_virtual_cap_pool_if_eligible
-    if @school.can_order? || @school.can_order_for_specific_circumstances? &&
-        @school.preorder_information.responsible_body_will_order_devices?
+    if @school.preorder_information.responsible_body_will_order_devices?
       unless @school.device_allocations.first.is_in_virtual_cap_pool?
         begin
           @school.responsible_body.add_school_to_virtual_cap_pools!(@school)

--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -65,7 +65,7 @@ private
   end
 
   def add_school_to_virtual_cap_pool_if_eligible
-    if @school.preorder_information.responsible_body_will_order_devices?
+    if @school&.preorder_information&.responsible_body_will_order_devices?
       unless @school.device_allocations.first.is_in_virtual_cap_pool?
         begin
           @school.responsible_body.add_school_to_virtual_cap_pools!(@school)

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -161,8 +161,8 @@ RSpec.feature 'Viewing your schools' do
     school = schools.third
     expect(your_schools_page.fully_open_school_rows[0].title).to have_content(school.name)
     expect(your_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('School')
-    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} devices")
-    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} routers")
+    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} #{'device'.pluralize(school.std_device_allocation.raw_allocation)}")
+    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} #{'router'.pluralize(school.coms_device_allocation&.raw_allocation || 0)}")
   end
 
   def then_i_see_the_summary_pooled_device_count_card


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/CX6BQRF4/1153-allow-schools-that-cannot-order-in-virtual-cap)
Currently, one of the requirements for a school to be added to a virtual cap pool is that they are in an ordering state (`can_order` or `can_order_for_specific_circumstances`). This PR removes this requirement so taht schools in any order state can be added to their responsible body's virtual cap pool.

### Changes proposed in this pull request
Remove order state from eligibility criteria

### Guidance to review
Given a responsible body that centrally manages and a centrally managed school that is not in an ordering state, you should be able to add the school to the responsible body's virtual cap pool with `responsible_body.add_school_to_virtual_cap_pool!(school)`
