### PR TITLE
Use raw allocation numbers when implying cap from order state

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -103,9 +103,9 @@ class SchoolDeviceAllocation < ApplicationRecord
   def cap_implied_by_order_state(order_state:, given_cap: nil)
     case order_state.to_sym
     when :cannot_order, :cannot_order_as_reopened
-      devices_ordered.to_i
+      raw_devices_ordered.to_i
     when :can_order
-      allocation.to_i
+      raw_allocation.to_i
     else # specific circumstances
       given_cap
     end

--- a/app/views/support/schools/devices/allocation/edit.html.erb
+++ b/app/views/support/schools/devices/allocation/edit.html.erb
@@ -21,7 +21,8 @@
       <%= f.govuk_number_field :allocation,
                               only_integer: true,
                               label: {text: 'New allocation'},
-                              width: 3 %>
+                              width: 3,
+                              value: @form.current_allocation.raw_allocation %>
 
       <%= f.govuk_submit 'Save' %>
     <%- end %>


### PR DESCRIPTION
### Context

1. When a school within a virtual pool has its state changed, we shouldn't imply the cap on the school allocation using the v-cap devices_ordered or allocation number.
2. Show raw allocation number on allocation edit screen

---

The tests are a duplicate of the previous cap_implied_by_order_state ones except the school is within a virtual cap with 2x the allocation.