### PR TITLE
[1131] - add webmock initializer that allows localhost only

### DIFF
--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -1,0 +1,4 @@
+if Rails.env.test?
+  require 'webmock'
+  WebMock.disable_net_connect!(allow_localhost: true)
+end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/zTfOX6I9/1131-fix-intermittent-build-error-on-assetpackpath) - we've had a long-standing intermittent build failure, of this form:

```
Failure/Error: <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>

     ActionView::Template::Error:
       784: unexpected token at ''
     # ./app/views/layouts/application.html.erb:13:in `_app_views_layouts_application_html_erb___776826877070931037_107660'
```
I haven't yet found the root cause, but I _have_ found someone else reporting the [same problem on Stack Overflow](https://stackoverflow.com/questions/58621271/actionviewtemplateerror-785-unexpected-token-at), and that it was [fixed with an initializer for Webmock](https://stackoverflow.com/a/59049650). I'm not totally sure that's the source of our error, but there's no harm in giving it a try

### Changes proposed in this pull request

* add a test-only initializer that allows Webmock to connect to localhost-only, as suggested in the Stack Overflow issue.

### Guidance to review

See if the build fails or not :)
