### PR TITLE
Don't return deleted users in the support console user search

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -13,6 +13,7 @@ class Support::UsersController < Support::BaseController
     @search_term = @search_form.email_address_or_full_name
     @results = policy_scope(User)
       .search_by_email_address_or_full_name(@search_term)
+      .not_deleted
       .distinct
       .includes(:responsible_body, :schools)
       .order(full_name: :asc)

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Support::UsersController do
   let(:support_user) { create(:support_user) }
   let(:user_who_has_seen_privacy_notice) { create(:school_user, :has_seen_privacy_notice, full_name: 'Jane Smith') }
   let(:user_who_has_not_seen_privacy_notice) { create(:school_user, :has_not_seen_privacy_notice, full_name: 'John Smith') }
+  let(:user_who_is_deleted) { create(:school_user, :has_seen_privacy_notice, :deleted, full_name: 'July Smith') }
 
   describe '#search' do
     it 'is successful for support users' do
@@ -23,6 +24,7 @@ RSpec.describe Support::UsersController do
     before do
       user_who_has_seen_privacy_notice
       user_who_has_not_seen_privacy_notice
+      user_who_is_deleted
     end
 
     it 'returns all matching school and RB users for support users' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       sign_in_token_expires_at { 30.minutes.from_now }
     end
 
+    trait :deleted do
+      deleted_at { 30.minutes.ago }
+    end
+
     factory :local_authority_user do
       association :responsible_body, factory: %i[local_authority in_connectivity_pilot]
     end


### PR DESCRIPTION
### Context

The user search in the support console returns deleted users.

### Changes proposed in this pull request

Hide deleted users from support console search results.
