### PR TITLE
[1168] spike an easier way of batch processing

### DIFF
--- a/app/models/batch_job.rb
+++ b/app/models/batch_job.rb
@@ -3,10 +3,10 @@ class BatchJob
   attr_accessor :records
   attr_accessor :run_id, :job_name, :logger
 
-  def initialize(records:, job_name:, logger: nil)
+  def initialize(records:, job_name:, logger: Rails.logger)
     @records = records
     @job_name = job_name
-    @logger = logger || Rails.logger
+    @logger = logger
     new_run!
   end
 

--- a/app/models/batch_job.rb
+++ b/app/models/batch_job.rb
@@ -1,0 +1,55 @@
+class BatchJob
+  attr_accessor :successes, :failures
+  attr_accessor :records
+  attr_accessor :run_id, :job_name, :logger
+
+  def initialize(records:, job_name:, logger: nil)
+    @records = records
+    @job_name = job_name
+    @logger = logger || Rails.logger
+  end
+
+  def process!(&block)
+    @run_id = SecureRandom.uuid
+    @successes = []
+    @failures = []
+    @records.each_with_index do |record, index|
+      log index: index, message: "processing #{record.class.name}: #{record.id}"
+      yield record
+      success!(record)
+    rescue Exception => e
+      failure!(record: record, error: e)
+    end
+    report_stats
+  end
+
+private
+
+  def success!(record)
+    entry = BatchJobLogEntry.create!(
+      job_name:     @job_name,
+      run_id:       @run_id,
+      record_id:    record.id,
+      record_class: record.class.name,
+      status:       'success',
+    )
+    @successes << entry
+  end
+
+  def failure!(record:, error:)
+    BatchJobLogEntry.create!(
+      job_name:     @job_name,
+      run_id:       @run_id,
+      record_id:    record.id,
+      record_class: record.class.name,
+      status:       'error',
+      error:        error.message,
+    )
+    @failures << entry
+  end
+
+  def log(index:, message:)
+    prefix = "(#{index}/#{@records.count - 1})"
+    @logger.info [@job_name, @run_id, prefix, message].join(' - ')
+  end
+end

--- a/app/models/batch_job.rb
+++ b/app/models/batch_job.rb
@@ -14,7 +14,7 @@ class BatchJob
     @successes = []
     @failures = []
     @records.each_with_index do |record, index|
-      log index: index, message: "processing #{record.class.name}: #{record.id}"
+      log index: index, message: "processing #{record.class.name}: #{record_id(record)}"
       yield record
       success!(record)
     rescue Exception => e
@@ -23,13 +23,21 @@ class BatchJob
     report_stats
   end
 
+  def report_stats
+    puts BatchJobLogEntry.status(run_id: @run_id)
+    puts BatchJobLogEntry.speed_stats(run_id: @run_id)
+  end
+
 private
+  def record_id(record)
+    record.respond_to?(:id) ? record.id : record.to_s.first(100)
+  end
 
   def success!(record)
     entry = BatchJobLogEntry.create!(
       job_name:     @job_name,
       run_id:       @run_id,
-      record_id:    record.id,
+      record_id:    record_id(record),
       record_class: record.class.name,
       status:       'success',
     )
@@ -37,12 +45,12 @@ private
   end
 
   def failure!(record:, error:)
-    BatchJobLogEntry.create!(
+    entry = BatchJobLogEntry.create!(
       job_name:     @job_name,
       run_id:       @run_id,
-      record_id:    record.id,
+      record_id:    record_id(record),
       record_class: record.class.name,
-      status:       'error',
+      status:       'failure',
       error:        error.message,
     )
     @failures << entry

--- a/app/models/batch_job_log_entry.rb
+++ b/app/models/batch_job_log_entry.rb
@@ -1,0 +1,25 @@
+class BatchJobLogEntry < ApplicationRecord
+  def self.status(run_id:)
+    where(run_id: run_id).group(:status).count
+  end
+
+  def self.latest_for_job(job_name:)
+    where(job_name: job_name).order(:created_at).last
+  end
+
+  def self.speed_stats(run_id:)
+    sql = <<~SQL
+      SELECT  MAX(created_at) AS max_created_at,
+              MIN(created_at) AS min_created_at,
+              COUNT(*) AS number_of_records
+      FROM    #{table_name}
+      WHERE   run_id = :run_id
+    SQL
+    stats = connection.select_all(sanitize_sql_for_assignment([sql, run_id: run_id])).first.symbolize_keys
+    stats.merge({
+      duration: stats[:max_created_at] - stats[:min_created_at],
+      records_per_second: (stats[:number_of_records] / (stats[:max_created_at] - stats[:min_created_at])),
+      time_per_record: (stats[:max_created_at] - stats[:min_created_at]) / stats[:number_of_records],
+    })
+  end
+end

--- a/app/models/batch_job_log_entry.rb
+++ b/app/models/batch_job_log_entry.rb
@@ -1,6 +1,8 @@
 class BatchJobLogEntry < ApplicationRecord
   def self.status(run_id:)
-    where(run_id: run_id).group(:status).count.symbolize_keys
+    { success: 0, failure: 0 }.merge(
+      where(run_id: run_id).group(:status).count.symbolize_keys,
+    )
   end
 
   def self.latest_for_job(job_name:)

--- a/app/models/batch_job_log_entry.rb
+++ b/app/models/batch_job_log_entry.rb
@@ -1,6 +1,6 @@
 class BatchJobLogEntry < ApplicationRecord
   def self.status(run_id:)
-    where(run_id: run_id).group(:status).count
+    where(run_id: run_id).group(:status).count.symbolize_keys
   end
 
   def self.latest_for_job(job_name:)

--- a/db/migrate/20201215120852_add_batch_job_log_entries.rb
+++ b/db/migrate/20201215120852_add_batch_job_log_entries.rb
@@ -1,0 +1,14 @@
+class AddBatchJobLogEntries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :batch_job_log_entries do |t|
+      t.string    :record_id
+      t.string    :record_class
+      t.string    :job_name
+      t.string    :run_id
+      t.string    :status
+      t.string    :message
+      t.string    :error
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201216144840_add_indexes_to_batch_job_log_entries.rb
+++ b/db/migrate/20201216144840_add_indexes_to_batch_job_log_entries.rb
@@ -1,0 +1,7 @@
+class AddIndexesToBatchJobLogEntries < ActiveRecord::Migration[6.0]
+  def change
+    add_index :batch_job_log_entries, [:job_name, :created_at]
+    add_index :batch_job_log_entries, [:run_id, :created_at]
+    add_index :batch_job_log_entries, [:run_id, :record_class, :record_id], name: 'ix_btle_run_record'
+  end
+end

--- a/db/migrate/20201216144840_add_indexes_to_batch_job_log_entries.rb
+++ b/db/migrate/20201216144840_add_indexes_to_batch_job_log_entries.rb
@@ -1,7 +1,7 @@
 class AddIndexesToBatchJobLogEntries < ActiveRecord::Migration[6.0]
   def change
-    add_index :batch_job_log_entries, [:job_name, :created_at]
-    add_index :batch_job_log_entries, [:run_id, :created_at]
-    add_index :batch_job_log_entries, [:run_id, :record_class, :record_id], name: 'ix_btle_run_record'
+    add_index :batch_job_log_entries, %i[job_name created_at]
+    add_index :batch_job_log_entries, %i[run_id created_at]
+    add_index :batch_job_log_entries, %i[run_id record_class record_id], name: 'ix_btle_run_record'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_15_120852) do
+ActiveRecord::Schema.define(version: 2020_12_16_144840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,9 @@ ActiveRecord::Schema.define(version: 2020_12_15_120852) do
     t.string "error"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["job_name", "created_at"], name: "index_batch_job_log_entries_on_job_name_and_created_at"
+    t.index ["run_id", "created_at"], name: "index_batch_job_log_entries_on_run_id_and_created_at"
+    t.index ["run_id", "record_class", "record_id"], name: "ix_btle_run_record"
   end
 
   create_table "bt_wifi_voucher_allocations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_114914) do
+ActiveRecord::Schema.define(version: 2020_12_15_120852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,18 @@ ActiveRecord::Schema.define(version: 2020_12_14_114914) do
     t.index ["user_id", "name"], name: "index_api_tokens_on_user_id_and_name", unique: true
     t.index ["user_id", "token"], name: "index_api_tokens_on_user_id_and_token", unique: true
     t.index ["user_id"], name: "index_api_tokens_on_user_id"
+  end
+
+  create_table "batch_job_log_entries", force: :cascade do |t|
+    t.string "record_id"
+    t.string "record_class"
+    t.string "job_name"
+    t.string "run_id"
+    t.string "status"
+    t.string "message"
+    t.string "error"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "bt_wifi_voucher_allocations", force: :cascade do |t|
@@ -187,8 +199,8 @@ ActiveRecord::Schema.define(version: 2020_12_14_114914) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true

--- a/spec/models/batch_job_log_entry_spec.rb
+++ b/spec/models/batch_job_log_entry_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe BatchJobLogEntry do
+  describe '.status' do
+    before do
+      BatchJobLogEntry.create!(run_id: '123', status: 'ok')
+      BatchJobLogEntry.create!(run_id: '890', status: 'not_ok')
+      BatchJobLogEntry.create!(run_id: '123', status: 'not_ok')
+    end
+
+    it 'returns a count of status values for all entries with the given run_id' do
+      result = BatchJobLogEntry.status(run_id: '123')
+      expect(result[:ok]).to eq(1)
+      expect(result[:not_ok]).to eq(1)
+    end
+
+    it 'includes :success and :failure counts even when there are not records with that status' do
+      result = BatchJobLogEntry.status(run_id: '123')
+      expect(result[:success]).to eq(0)
+      expect(result[:failure]).to eq(0)
+    end
+  end
+
+  describe '.latest_for_job' do
+    before do
+      BatchJobLogEntry.create!(job_name: 'my job', run_id: '123', status: 'ok')
+      BatchJobLogEntry.create!(job_name: 'my job', run_id: '890', status: 'not_ok')
+      BatchJobLogEntry.create!(job_name: 'not my job', run_id: '456', status: 'not_ok')
+    end
+
+    context 'when multiple entries are present for the given job_name' do
+      it 'returns the latest entry' do
+        expect(BatchJobLogEntry.latest_for_job(job_name: 'my job')).to have_attributes(job_name: 'my job', run_id: '890', status: 'not_ok')
+      end
+    end
+  end
+
+  describe '.speed_stats' do
+    before do
+      BatchJobLogEntry.create!(run_id: '123', status: 'ok')
+      BatchJobLogEntry.create!(run_id: '123', status: 'not_ok')
+      BatchJobLogEntry.create!(run_id: '123', status: 'not_ok')
+      BatchJobLogEntry.create!(run_id: '890', status: 'not_ok')
+    end
+
+    let(:result) { BatchJobLogEntry.speed_stats(run_id: '123') }
+
+    it 'is a Hash' do
+      expect(result).to be_a(Hash)
+    end
+
+    it 'has the number_of_records' do
+      expect(result[:number_of_records]).to eq(3)
+    end
+
+    it 'has a max_created_at and min_created_at' do
+      expect(result.keys).to include(:max_created_at, :min_created_at)
+    end
+
+    it 'has correct duration' do
+      expect(result[:duration]).to eq(result[:max_created_at] - result[:min_created_at])
+    end
+
+    it 'has correct time_per_record' do
+      expect(result[:time_per_record]).to eq(result[:duration] / result[:number_of_records])
+    end
+
+    it 'has correct records_per_second' do
+      expect(result[:records_per_second]).to eq(result[:number_of_records] / result[:duration])
+    end
+  end
+end

--- a/spec/models/batch_job_spec.rb
+++ b/spec/models/batch_job_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe BatchJob do
+  let(:records) { create_list(:local_authority, 3) }
+  let(:job) { BatchJob.new(records: records, job_name: 'my job') }
+
+  describe '#process!' do
+    context 'given a block' do
+      it 'yields each record to the block' do
+        yielded_records = []
+        job.process! { |record| yielded_records << record }
+        expect(yielded_records).to eq(records)
+      end
+
+      context 'when the block does not raise an error for a record' do
+        before do
+          job.process! { |_| 'do nothing' }
+        end
+
+        it 'adds a BatchJobLogEntry for the record to successes' do
+          expect(job.successes.size).to eq(records.size)
+          expect(job.successes).to all(be_a(BatchJobLogEntry))
+        end
+
+        describe 'each BatchJobLogEntry' do
+          it 'identifies the job' do
+            expect(job.successes).to all(have_attributes(job_name: 'my job', run_id: job.run_id))
+          end
+
+          it 'identifies the record' do
+            expect(job.successes).to all(have_attributes(record_class: 'LocalAuthority'))
+            expect(job.successes.map { |s| s.record_id.to_i }.sort).to eq(records.map(&:id).sort)
+          end
+
+          it 'has status of success' do
+            expect(job.successes.map(&:status)).to all(eq('success'))
+          end
+        end
+      end
+
+      context 'when the block raises an error for a record' do
+        let(:result) do
+          job.process! { |_| raise 'fail!' }
+        end
+
+        it 'does not let the error bubble out' do
+          expect { result }.not_to raise_error
+        end
+
+        it 'adds a BatchJobLogEntry for the record to failures' do
+          result
+          expect(job.failures.size).to eq(records.size)
+          expect(job.failures).to all(be_a(BatchJobLogEntry))
+        end
+
+        describe 'each BatchJobLogEntry' do
+          before { result }
+
+          it 'identifies the job' do
+            expect(job.failures).to all(have_attributes(job_name: 'my job', run_id: job.run_id))
+          end
+
+          it 'identifies the record' do
+            expect(job.failures).to all(have_attributes(record_class: 'LocalAuthority'))
+            expect(job.failures.map { |s| s.record_id.to_i }.sort).to eq(records.map(&:id).sort)
+          end
+
+          it 'records the error' do
+            expect(job.failures.map(&:error)).to all(eq('fail!'))
+          end
+
+          it 'has status of success' do
+            expect(job.failures.map(&:status)).to all(eq('failure'))
+          end
+        end
+      end
+
+      it 'returns statistics on completion' do
+        result = job.process! { |_| puts 'processing record' }
+        expect(result.keys).to include(:success, :failure, :number_of_records, :duration, :max_created_at, :min_created_at, :records_per_second, :time_per_record)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

See [Trello card](https://trello.com/c/QuI2b5kR/1168-spike-an-easier-way-of-batch-processing) for full context.

When running arbitrary ad-hoc code from the console (for instance, to raise allocations for a selection of schools) we often end up re-writing basic code to handle errors, report success & failures, etc. This is wasteful and error-prone, and means that our actual processing code is more difficult to debug.

### Changes proposed in this pull request

* Add `BatchJob` and `BatchJobLogEntry` classes.

This is a first iteration to handle the basic error handling and status reporting for running an arbitrary block against a series of records.  

### Guidance to review

Use it as follows:

```
# records must be iterable, but can be anything - ActiveRecord resultsets, Arrays of Hashes, etc.
job = BatchJob.new(job_name: 'some helpful name to identify this job', records: [ ... ]
job.process! do |record|
  # The BatchJob will yield records one at a time
  # Do whatever you like with this record
  # Let errors bubble out to be caught & recorded by the BatchJob
end
```

Each new instance of `BatchJob` gets a unique `run_id` on creation (or if you call '#new_run!' manually).
This is used to tie together the generated `BatchJobLogEntry` records for each run, which are then used to report progress / completion stats.

It will log as it goes, both to STDOUT and by writing `BatchJobLogEntry` record for each processed record. On completion, it will finish up by returning a Hash of job stats, like this -

```
{:failure=>2044,
 :success=>31,
 :max_created_at=>"2020-12-15T16:54:56.031Z",
 :min_created_at=>"2020-12-15T16:54:21.028Z",
 :number_of_records=>2075,
 :duration=>35.002967,
 :records_per_second=>59.28068897702301,
 :time_per_record=>0.016868899759036143}
```
You can generate this Hash at any time after _or during_ processing by calling:
```
BatchJob.stats(run_id: '...')
```
You can also get the latest run_id for a given job_name by calling:
```
BatchJobLogEntry.latest_for_job(job_name: 'job name').run_id
```

All generated `BatchJobLogEntry` records are both written to the database, AND collected in the jobs successes / failures arrays:

```
> job.failures.size
2044
> job.failures.first
#<BatchJobLogEntry:0x0000559707ec38f0
 id: 74295,
 record_id: "{:urn=>136577, :allocation=>53}",
 record_class: "Hash",
 job_name: "raise to 100%",
 run_id: "567af869-7f9f-4080-85ed-38299a8e251b",
 status: "failure",
 message: nil,
 error: "undefined method `update!' for nil:NilClass",
 created_at: Tue, 15 Dec 2020 16:54:56 GMT +00:00,
 updated_at: Tue, 15 Dec 2020 16:54:56 GMT +00:00>

```

There are no explicit transactions (yet) - so that `BatchJobLogEntry` records are visible to other processes as they are written.
This will be useful for situations where several people are waiting on the outcome of a job, or a developer has multiple sessions open, with the job running in one terminal while working on other things and occasionally seeing progress in another, etc.

Future iterations could include:
* a simple UI in the admin interface for reporting progress of jobs, clearing old log entries and so on.
* a batch_size parameter for chunking up records into convenient groups / transactions
* the ability to write pending `BatchJobLogEntry` records in advance for the records you intend to process - so that progress  & status of records processed so far doesn't get lost if the ssh session is dropped
* probably much more elegant code :)


