### PR TITLE
Change the breadcrumb to a back link on the 'Associated orgs' page

### DIFF
--- a/app/views/support/users/associated_organisations.html.erb
+++ b/app/views/support/users/associated_organisations.html.erb
@@ -1,13 +1,6 @@
 <%- title = t('page_titles.support.users.associated_organisations') %>
 <% content_for :title, title %>
-<%- content_for :before_content do %>
-  <%= breadcrumbs([
-    { 'Support home' => support_home_path },
-    { t('page_titles.support.users.search') => search_support_users_path },
-    @user.full_name,
-    title,
-  ]) %>
-<%- end %>
+<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This makes the navigation more consistent with the user editing page.

![image](https://user-images.githubusercontent.com/23801/102340812-de27fa80-3f8e-11eb-9ae2-3942e1b1d6b4.png)
