### PR TITLE
Add "Cannot order over Christmas" page

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,6 +8,7 @@ class FeatureFlag
     mno_offer
     virtual_caps
     christmas_banner
+    ordering_closed_for_christmas
     increased_allocations_banner
   ].freeze
 

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -4,26 +4,41 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= t('page_titles.order_devices.title') %></span>
-      <%= t('page_titles.order_devices.you_cannot_order_yet') %>
+      <% if FeatureFlag.active?(:ordering_closed_for_christmas) %>
+        <%= t('page_titles.cannot_order_devices_over_christmas') %>
+      <% else %>
+        <%= t('page_titles.order_devices.you_cannot_order_yet') %>
+      <% end %>
     </h1>
 
-    <p class="govuk-body">You can order a school’s full allocation when:</p>
+    <% if FeatureFlag.active?(:ordering_closed_for_christmas) %>
+      <p class="govuk-body">Ordering is now closed until Monday 4 January.</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <% t('pages.order_devices.can_order_full_allocation_when_list').each do |li| %>
-        <li><%= li %></li>
-      <% end %>
-    </ul>
+      <p class="govuk-body">When ordering reopens, you can order a school’s full allocation if:</p>
 
-    <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= link_to_ed_settings_form %>.</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>a school closure is reported</li>
+        <li>15 or more children (in years 3 to 11) are self-isolating</li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">You can order a school’s full allocation when:</p>
 
-    <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
-    <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> reported disruption.</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <% t('pages.order_devices.can_order_full_allocation_when_list').each do |li| %>
+          <li><%= li %></li>
+        <% end %>
+      </ul>
 
-    <% if @responsible_body.has_schools_that_can_order_devices_now? %>
-      <%= render partial: 'some_schools_can_order' %>
-    <%- end %>
+      <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= link_to_ed_settings_form %>.</p>
 
-    <%= render partial: 'get_devices_early' %>
+      <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
+      <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> reported disruption.</p>
+
+      <% if @responsible_body.has_schools_that_can_order_devices_now? %>
+        <%= render partial: 'some_schools_can_order' %>
+      <%- end %>
+
+      <%= render partial: 'get_devices_early' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -1,5 +1,9 @@
-<%- who_cannot_order = @current_user.orders_devices? ? 'school_user' : 'school' %>
-<%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices.title") %>
+<% if FeatureFlag.active?(:ordering_closed_for_christmas) %>
+  <%- title = t('page_titles.cannot_order_devices_over_christmas') %>
+<% else %>
+  <%- who_cannot_order = @current_user.orders_devices? ? 'school_user' : 'school' %>
+  <%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices.title") %>
+<% end %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <%- school_breadcrumbs items: 'Order devices', school: @school, user: @current_user %>
@@ -12,29 +16,40 @@
       <%= title %>
     </h1>
 
-    <p class="govuk-body"><%= t("page_titles.#{who_cannot_order}_cannot_order_devices.can_order_when") %></p>
+    <% if FeatureFlag.active?(:ordering_closed_for_christmas) %>
+      <p class="govuk-body">Ordering is now closed until Monday 4 January.</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <% t('pages.order_devices.can_order_full_allocation_when_list').each do |list_item| %>
-        <li><%= list_item %></li>
+      <p class="govuk-body">When ordering reopens, you can order your full allocation if:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>a school closure is reported</li>
+        <li>15 or more children (in years 3 to 11) are self-isolating</li>
+      </ul>
+    <% else %>
+      <p class="govuk-body"><%= t("page_titles.#{who_cannot_order}_cannot_order_devices.can_order_when") %></p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <% t('pages.order_devices.can_order_full_allocation_when_list').each do |list_item| %>
+          <li><%= list_item %></li>
+        <% end %>
+      </ul>
+
+      <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to_ed_settings_form %>.</p>
+
+      <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
+      <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', request_devices_school_path(@school) %> from any year group who:</p>
+
+      <%= render partial: 'shared/devices/who_to_request_for_list' %>
+
+      <% unless @current_user.orders_devices? %>
+        <h2 class="govuk-heading-m">
+          You won’t be able to place orders yourself
+        </h2>
+
+        <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
+
+        <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
       <% end %>
-    </ul>
-
-    <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to_ed_settings_form %>.</p>
-
-    <h2 class="govuk-heading-m">Get devices early for specific circumstances</h2>
-    <p class="govuk-body">You can still <%= govuk_link_to 'request devices for disadvantaged children', request_devices_school_path(@school) %> from any year group who:</p>
-
-    <%= render partial: 'shared/devices/who_to_request_for_list' %>
-
-    <% unless @current_user.orders_devices? %>
-      <h2 class="govuk-heading-m">
-        You won’t be able to place orders yourself
-      </h2>
-
-      <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
-
-      <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,7 @@ en:
       schools: The school will place their own orders
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
+    cannot_order_devices_over_christmas: You cannot place orders over Christmas
     school_home: Get devices for your school
     school_can_order_devices: Your school can order devices
     school_cannot_order_devices:

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -19,6 +19,17 @@ RSpec.feature 'Ordering devices' do
     then_i_see_the_cannot_order_devices_yet_page
   end
 
+  context 'when it’s Christmas', with_feature_flags: { ordering_closed_for_christmas: 'active' } do
+    scenario 'navigate to order devices page' do
+      when_i_visit_the_responsible_body_home_page
+      and_i_follow_the_get_laptops_and_tablets_link
+      then_i_see_the_get_laptops_and_tablets_page
+
+      when_i_follow_the_order_devices_link
+      then_i_see_that_i_cannot_order_devices_over_christmas
+    end
+  end
+
   scenario 'a centrally managed school can order for specific circumstances' do
     given_a_centrally_managed_school_can_order_for_specific_circumstances
     when_i_visit_the_order_devices_page
@@ -174,5 +185,9 @@ RSpec.feature 'Ordering devices' do
 
   def what_to_order_state(school)
     "You’ve ordered #{school.std_device_allocation.devices_ordered} devices"
+  end
+
+  def then_i_see_that_i_cannot_order_devices_over_christmas
+    expect(page).to have_content('You cannot place orders over Christmas')
   end
 end

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -42,6 +42,17 @@ RSpec.feature 'Order devices' do
     then_i_see_that_i_cannot_order_devices_yet
   end
 
+  context 'when it’s Christmas', with_feature_flags: { ordering_closed_for_christmas: 'active' } do
+    scenario 'when my school cannot order devices but I can' do
+      given_the_school_cannot_order_devices
+      given_i_can_order_devices
+      given_i_am_signed_in_as_a_school_user
+
+      when_i_visit_the_order_devices_page
+      then_i_see_that_i_cannot_order_devices_over_christmas
+    end
+  end
+
   scenario 'when my school cannot order devices and I cannot order devices' do
     given_the_school_cannot_order_devices
     given_i_cannot_order_devices
@@ -125,6 +136,10 @@ RSpec.feature 'Order devices' do
   def then_i_see_that_the_school_cannot_order_devices_yet
     expect(page).to have_content('Your school cannot your full allocation yet')
     expect(page).to have_link('request devices for disadvantaged children')
+  end
+
+  def then_i_see_that_i_cannot_order_devices_over_christmas
+    expect(page).to have_content('You cannot place orders over Christmas')
   end
 
   def then_i_see_techsource_ready_soon


### PR DESCRIPTION
Ordering will be closed over Christmas. During this period a different order page is shown.

This PR assumes that all schools and RBs will be placed into the cannot order state during the festive period.

(Best reviewed by ignoring whitespace)

### Context

![localhost_3000_schools_124500_order-devices](https://user-images.githubusercontent.com/319055/102363576-73d28280-3fad-11eb-8dd2-21afd020bb4b.png)
![localhost_3000_responsible-body_devices_order-devices](https://user-images.githubusercontent.com/319055/102363593-76cd7300-3fad-11eb-9aba-cb5f49d8b69b.png)
