### PR TITLE
Append content about deliveries to xmas banner

### DIFF
--- a/app/views/shared/banners/_responsible_body.html.erb
+++ b/app/views/shared/banners/_responsible_body.html.erb
@@ -18,6 +18,9 @@
           <p class="govuk-body">
             <%= t('banners.christmas.content') %>
           </p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content_2') %>
+          </p>
         <% end %>
       <% end %>
     </div>

--- a/app/views/shared/banners/_school.html.erb
+++ b/app/views/shared/banners/_school.html.erb
@@ -20,6 +20,9 @@
           <p class="govuk-body">
             <%= t('banners.christmas.content') %>
           </p>
+          <p class="govuk-body">
+            <%= t('banners.christmas.content_2') %>
+          </p>
         <% end %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -639,6 +639,7 @@ en:
     christmas:
       heading: No orders over Christmas
       content: You will not be able to place orders over the Christmas break. We’ll accept orders up until 4pm on Thursday 17 December and we’ll then close ordering until Monday 4 January.
+      content_2: Deliveries will continue until 6pm on 18 December. Any outstanding deliveries will be dispatched from 4 January.
     increased_allocations:
       school:
         heading:


### PR DESCRIPTION
Let schools know when deliveries will run to.

![Screen Shot 2020-12-16 at 15 57 44](https://user-images.githubusercontent.com/319055/102373185-d7fa4400-3fb7-11eb-8093-6020b0faa026.png)
