### PR TITLE
Attempt to prevent intermittent spec failures by making RB names unique

### DIFF
--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
 
   factory :local_authority, parent: :responsible_body, class: 'LocalAuthority' do
     organisation_type             { LocalAuthority.organisation_types.values.sample }
-    name                          { [Faker::Address.county, organisation_type].join(' ') }
+    name                          { [Faker::Address.unique.county, organisation_type, Faker::Number.unique.number(digits: 3)].join(' ') }
     local_authority_official_name { [organisation_type, name].join(' of ') }
     local_authority_eng           { name.first(3).upcase }
     gias_id                       { Faker::Number.unique.number(digits: 3) }
@@ -41,7 +41,7 @@ FactoryBot.define do
 
   factory :trust, parent: :responsible_body, class: 'Trust' do
     organisation_type             { Trust.organisation_types.values.sample }
-    name                          { [Faker::App.name, organisation_type == 'Single academy trust' ? 'Academy' : 'Academies'].join(' ') }
+    name                          { [Faker::App.unique.name, organisation_type == 'Single academy trust' ? 'Academy' : 'Academies'].join(' ') }
     local_authority_official_name { nil }
     local_authority_eng           { nil }
     companies_house_number        { Faker::Number.leading_zero_number(digits: 8) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,6 +86,8 @@ RSpec.configure do |config|
   config.before do
     Faker::Number.unique.clear
     Faker::Educator.unique.clear
+    Faker::Address.unique.clear
+    Faker::App.unique.clear
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
### Context

`spec/features/computacenter/responsible_body_changes_spec.rb` has been failing intermittently on CI because it relies on the RB name being unique.

### Changes proposed in this pull request

Change the Faker settings (used by the spec factories) to generate unique RB names within the context of a given spec.

