### PR TITLE
Confirm when deleting a user in the support console

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -53,10 +53,12 @@ class Support::UsersController < Support::BaseController
     redirect_to associated_organisations_support_user_path(@user.id)
   end
 
+  def confirm_destroy; end
+
   def destroy
     @user.update!(deleted_at: Time.zone.now)
 
-    flash[:success] = 'User has been deleted'
+    flash[:success] = 'You have deleted this user'
 
     return_params = params.fetch(:user, {}).permit(:school_urn, :responsible_body_id)
     if return_params[:responsible_body_id]

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,4 +15,5 @@ class UserPolicy < SupportPolicy
   alias_method :results?, :readable?
   alias_method :associated_organisations?, :editable?
   alias_method :update_responsible_body?, :editable?
+  alias_method :confirm_destroy?, :editable?
 end

--- a/app/views/support/users/confirm_destroy.html.erb
+++ b/app/views/support/users/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<%- title = t('page_titles.confirm_destroy_user') %>
+<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+
+    <p class="govuk-body">
+      Deleting this user will revoke their access to the service. If you need to reinstate them after deletion, contact the GHWT technical support team.
+    </p>
+
+    <%= form_for @user, url: support_user_path(@user), method: :delete do |f| %>
+      <%= f.govuk_submit 'Yes, delete user', warning: true %>
+    <%- end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Cancel', support_user_path(@user) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -14,10 +14,10 @@
 
     <%= render Support::UserSummaryListComponent.new(user: @user, viewer: @current_user) %>
 
-    <% if policy(@user).destroy? %>
-      <%= form_for @user, url: support_user_path(@user), method: :delete do |f| %>
-        <%= f.govuk_submit 'Delete user', warning: true %>
-      <%- end %>
-    <% end %>
+    <p class="govuk-body">
+      <% if policy(@user).destroy? %>
+        <%= govuk_link_to 'Delete this user', confirm_deletion_support_user_path(@user) %>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
       cannot_order_devices: 'No'
     new_school_user: Invite a new user
     edit_user: Change user details
+    confirm_destroy_user: Are you sure you want to delete this user?
     school_user_welcome_wizard:
       welcome:
         title: "You’re signed in as %{school}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,6 +182,7 @@ Rails.application.routes.draw do
       end
       member do
         get 'associated-organisations', as: :associated_organisations
+        get 'confirm-deletion', to: 'users#confirm_destroy'
         patch 'responsible-body', to: 'users#update_responsible_body', as: :update_responsible_body
         resources :schools, only: %i[index create destroy], as: :user_schools, controller: 'users/schools', param: :urn
       end

--- a/spec/features/support/deleting_a_user_spec.rb
+++ b/spec/features/support/deleting_a_user_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Deleting users' do
+  let(:support_user) { create(:support_user) }
+  let(:existing_user) { create(:school_user) }
+
+  scenario 'support deletes an existing user' do
+    given_i_am_signed_in_as_a_support_user
+    when_i_visit_an_existing_users_page
+    and_i_delete_the_user
+    then_user_deletion_is_confirmed
+    and_the_user_cannot_sign_into_the_service
+  end
+
+  def given_i_am_signed_in_as_a_support_user
+    sign_in_as support_user
+  end
+
+  def when_i_visit_an_existing_users_page
+    visit support_user_path(existing_user)
+  end
+
+  def and_i_delete_the_user
+    click_on 'Delete this user' # link to the confirmation page
+    click_on 'Yes, delete user' # button on the confirmation page
+  end
+
+  def then_user_deletion_is_confirmed
+    expect(page).to have_text('You have deleted this user')
+  end
+
+  def and_the_user_cannot_sign_into_the_service
+    click_on 'Sign out'
+
+    click_on 'Sign in'
+    fill_in 'Email address', with: existing_user.email_address
+    click_on 'Continue'
+
+    expect(page).to have_text('We didn’t recognise that email address')
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe UserPolicy do
   subject(:policy) { described_class }
 
-  permissions :new?, :create?, :edit?, :update?, :destroy?, :associated_organisations?, :update_responsible_body? do
+  permissions :new?, :create?, :edit?, :update?, :destroy?, :associated_organisations?, :update_responsible_body?, :confirm_destroy? do
     it 'grants access to support users' do
       expect(policy).to permit(build(:support_user), :support)
     end


### PR DESCRIPTION
### Context

Currently, deletion of a user in the support console happens immediately, as soon as a support agent clicks the button. Since this interaction is fairly rare and can only be undone by a developer, it's desirable to add a bit of friction to make sure it's really intended.

### Changes proposed in this pull request

- Introduce an interstitial confirmation page prior to deletion.
- Add a feature spec covering the deletion scenario

### Guidance to review

The designs are analogous to [course deletion in Publish Teacher Training Courses](https://bat-design-history.netlify.app/publish-teacher-training-courses/deleting-and-withdrawing/).

![image](https://user-images.githubusercontent.com/23801/102554446-ca7ab200-40bc-11eb-8a50-28241e18a830.png)

![image](https://user-images.githubusercontent.com/23801/102554460-d36b8380-40bc-11eb-9f3c-4c291f72e739.png)
