### PR TITLE
Don't allow support operations on deleted users

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -101,7 +101,7 @@ private
   end
 
   def set_user
-    @user = User.find(params[:id])
+    @user = User.not_deleted.find(params[:id])
     authorize @user
   end
 end

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe Support::UsersController do
         get :edit, params: { id: existing_user.id }
       }.to be_forbidden_for(create(:computacenter_user))
     end
+
+    it 'does not edit deleted users' do
+      sign_in_as support_user
+
+      deleted_user = create(:school_user, :deleted)
+
+      get :edit, params: { id: deleted_user }
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
### Context

Deleted users are filtered out in support search and various user lists, but it's still possible to get to the edit pages if you know the user's id.

### Changes proposed in this pull request

Change the user management functionality to return 404 when they're applied to deleted users.

### Guidance to review

