### PR TITLE
fix erronous generation of Add-type UserChanges for soft-deleted users

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -46,7 +46,7 @@ private
   end
 
   def is_addition?
-    user.relevant_to_computacenter? && (last_change_for_user.nil? || last_change_for_user.type_of_update == 'Remove')
+    user.relevant_to_computacenter? && !user.soft_deleted? && (last_change_for_user.nil? || last_change_for_user.type_of_update == 'Remove')
   end
 
   def is_change?


### PR DESCRIPTION
### Context

Please see [Trello card 1190](https://trello.com/c/h1JfNld4/1190-investigate-issue-with-user-being-repeatedly-added-to-removed-from-techsource) for the full explanation - it's complex, so here I will just summarize as: we're incorrectly generating Add-type `UserChange` records for users who have been soft-deleted 

### Changes proposed in this pull request

* fix the loophole in the logic, by adding a check on `user.soft_deleted?` to the `is_addition?`method in `Computacenter::UserChangeGenerator`

### Guidance to review

