### PR TITLE
Support console: user management redesign (part 2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'paper_trail'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 
+# Fuzzy school search
+gem 'pg_search'
+
 # Pry console is more resilient to readline issues that can stop
 # the arrow keys etc working
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,9 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -519,6 +522,7 @@ DEPENDENCIES
   paper_trail
   parallel_tests
   pg (>= 0.18, < 2.0)
+  pg_search
   pry-byebug
   pry-rails
   puma (~> 5.1)

--- a/app/controllers/support/users/responsible_body_controller.rb
+++ b/app/controllers/support/users/responsible_body_controller.rb
@@ -10,7 +10,8 @@ class Support::Users::ResponsibleBodyController < Support::BaseController
   end
 
   def update
-    @user.update!(responsible_body_id: responsible_body_params[:responsible_body])
+    form = Support::UserResponsibleBodyForm.new(responsible_body_params)
+    @user.update!(responsible_body_id: form.new_responsible_body_id)
     flash[:success] = success_message
     redirect_to support_user_path(@user)
   end
@@ -18,7 +19,7 @@ class Support::Users::ResponsibleBodyController < Support::BaseController
 private
 
   def responsible_body_params
-    params.require(:support_user_responsible_body_form).permit(:responsible_body)
+    params.require(:support_user_responsible_body_form).permit(:responsible_body_id, :change)
   end
 
   def success_message

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -24,13 +24,13 @@ class Support::Users::SchoolsController < Support::BaseController
     else
       flash[:warning] = @user_school.errors.full_messages.join("\n")
     end
-    redirect_to support_user_schools_path(@user)
+    redirect_to support_user_path(@user)
   end
 
-  def destroy
-    @user.schools.destroy(@school)
-    flash[:success] = "#{@user.full_name} is no longer associated with #{@school.name}"
-    redirect_to support_user_schools_path(@user)
+  def update_schools
+    @user.schools = @user.schools.where(id: update_schools_params)
+    flash[:success] = 'Schools updated'
+    redirect_to support_user_path(@user)
   end
 
 private
@@ -46,5 +46,9 @@ private
 
   def user_school_params(opts = params)
     opts.fetch('support_new_user_school_form').permit(:name_or_urn)
+  end
+
+  def update_schools_params
+    params.require(:user).require(:school_ids).reject(&:blank?)
   end
 end

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -41,11 +41,11 @@ private
   end
 
   def set_school
-    @school = @user.schools.find_by(urn: params[:urn]) || School.gias_status_open.find_by(urn: params[:urn])
+    @school = @user.schools.find_by(urn: params[:urn]) || School.gias_status_open.find_by(urn: params[:urn] || user_school_params[:urn])
   end
 
   def user_school_params(opts = params)
-    opts.fetch('support_new_user_school_form').permit(:name_or_urn)
+    opts.fetch('support_new_user_school_form', {}).permit(:name_or_urn, :urn)
   end
 
   def update_schools_params

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -14,7 +14,11 @@ class Support::Users::SchoolsController < Support::BaseController
 
   def new
     @form = Support::NewUserSchoolForm.new(user: @user, name_or_urn: user_school_params[:name_or_urn])
-    @schools = @form.matching_schools
+    if @form.valid?
+      @schools = @form.matching_schools
+    else
+      render :search_again, status: :unprocessable_entity
+    end
   end
 
   def create

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -1,6 +1,8 @@
 class Support::NewUserSchoolForm
   include ActiveModel::Model
 
+  MAX_NUMBER_OF_SUGGESTED_SCHOOLS = 50
+
   attr_accessor :user, :name_or_urn
 
   def initialize(user:, name_or_urn: nil)
@@ -13,5 +15,6 @@ class Support::NewUserSchoolForm
       .matching_name_or_urn(@name_or_urn)
       .includes(:responsible_body)
       .order(:name)
+      .limit(MAX_NUMBER_OF_SUGGESTED_SCHOOLS)
   end
 end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -9,8 +9,9 @@ class Support::NewUserSchoolForm
   end
 
   def matching_schools
-    School.includes(:responsible_body)
-          .where('urn = ? OR name ILIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn}%")
-          .order(:name)
+    School
+      .matching_name_or_urn(@name_or_urn)
+      .includes(:responsible_body)
+      .order(:name)
   end
 end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -11,13 +11,21 @@ class Support::NewUserSchoolForm
   end
 
   def matching_schools
-    School
+    @matching_schools ||= School
       .matching_name_or_urn(@name_or_urn)
       .includes(:responsible_body)
       .where.not(id: @user.school_ids)
       .order(:name)
       .limit(MAX_NUMBER_OF_SUGGESTED_SCHOOLS)
       .map { |school| option_for(school) }
+  end
+
+  def matching_schools_capped?
+    matching_schools.size == MAX_NUMBER_OF_SUGGESTED_SCHOOLS
+  end
+
+  def maximum_matching_schools
+    MAX_NUMBER_OF_SUGGESTED_SCHOOLS
   end
 
 private

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -5,10 +5,7 @@ class Support::NewUserSchoolForm
 
   attr_accessor :user, :name_or_urn, :urn
 
-  def initialize(user:, name_or_urn: nil)
-    @user = user
-    @name_or_urn = name_or_urn
-  end
+  validates :name_or_urn, length: { minimum: 3 }
 
   def matching_schools
     @matching_schools ||= School

--- a/app/form_objects/support/user_responsible_body_form.rb
+++ b/app/form_objects/support/user_responsible_body_form.rb
@@ -1,15 +1,20 @@
 class Support::UserResponsibleBodyForm
   include ActiveModel::Model
 
-  attr_accessor :user
+  attr_accessor :user, :change, :possible_responsible_bodies
+  attr_writer :responsible_body_id
 
-  def initialize(user:, possible_responsible_bodies: nil)
-    @user = user
-    @possible_responsible_bodies = possible_responsible_bodies
+  def new_responsible_body_id
+    case change
+    when 'add', 'move' then responsible_body_id
+    when 'remove' then nil
+    else
+      raise "Unexpected change #{change}"
+    end
   end
 
-  def responsible_body
-    @user.responsible_body&.id
+  def responsible_body_id
+    @responsible_body_id || @user.responsible_body&.id
   end
 
   def select_responsible_body_options

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,6 @@
 class School < ApplicationRecord
   has_paper_trail
+  include PgSearch::Model
 
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
@@ -19,7 +20,7 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
-  scope :matching_name_or_urn, ->(name_or_urn) { where(urn: name_or_urn).or(where('name ILIKE(?)', "%#{name_or_urn}%")) }
+  pg_search_scope :matching_name_or_urn, against: %i[name urn], using: { tsearch: { prefix: true } }
 
   before_create :set_computacenter_change
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,6 +19,8 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
+  scope :matching_name_or_urn, ->(name_or_urn) { where(urn: name_or_urn).or(where('name ILIKE(?)', "%#{name_or_urn}%")) }
+
   before_create :set_computacenter_change
 
   enum status: {

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,4 +14,5 @@ class UserPolicy < SupportPolicy
   alias_method :search?, :readable?
   alias_method :results?, :readable?
   alias_method :confirm_destroy?, :editable?
+  alias_method :update_schools?, :editable?
 end

--- a/app/views/support/users/responsible_body/edit.html.erb
+++ b/app/views/support/users/responsible_body/edit.html.erb
@@ -8,54 +8,33 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <%- if @responsible_body.present? %>
-      <table class="govuk-table responsible-body">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-            <th scope="col" class="govuk-table__header">Type</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
-
-        <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <%= govuk_link_to @responsible_body.name, support_responsible_body_path(id: @responsible_body.id) %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= @responsible_body.humanized_type %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= form_for @user_responsible_body_form, url: support_user_responsible_body_path(@user), method: :patch do |f| %>
-
-                <%= f.hidden_field :responsible_body, value: nil %>
-                <%= f.govuk_submit 'Remove' %>
-              <%- end %>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-    <%- else %>
-      <p class="govuk-body">(none)</p>
-    <%- end %>
 
     <%= form_for @user_responsible_body_form, url: support_user_responsible_body_path(@user), method: :patch do |f| %>
 
-      <%= f.govuk_collection_select(
-        :responsible_body,
-        @user_responsible_body_form.select_responsible_body_options,
-        :id,
-        :name,
-        label: { text: 'Move to a different responsible body' }
-        ) %>
-      <%= f.govuk_submit 'Move' %>
-    <%- end %>
+      <%- if @responsible_body.present? %>
+        <%= f.govuk_radio_buttons_fieldset(:change, legend: nil) do %>
+          <%= f.govuk_radio_button :change, 'move', label: { text: 'Move user to a different responsible body' } do %>
+            <%= f.govuk_collection_select(
+              :responsible_body_id,
+              @user_responsible_body_form.select_responsible_body_options,
+              :id,
+              :name,
+              label: { text: 'New responsible body' }
+              ) %>
+          <% end %>
+          <%= f.govuk_radio_button :change, 'remove', label: { text: 'Remove user from responsible body' }, link_errors: true %>
+        <% end %>
+      <% else %>
+        <%= f.hidden_field 'change', value: 'add' %>
+        <%= f.govuk_collection_select(
+          :responsible_body_id,
+          @user_responsible_body_form.select_responsible_body_options,
+          :id,
+          :name,
+          label: { text: 'Add user to a responsible body' }
+          ) %>
+      <%- end %>
+      <%= f.govuk_submit 'Update' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -18,7 +18,7 @@
 
     <%= form_for @user_school_form, url: new_support_user_school_path(@user), method: :get do |f| %>
       <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds' %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
         <%= f.govuk_submit %>
       <%- end %>
     <%- end %>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -8,48 +8,17 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 id="schools" class="govuk-heading-l">Schools</h2>
     <%- if @schools.present? %>
-      <table class="govuk-table schools">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name and URN</th>
-            <th scope="col" class="govuk-table__header">Responsible body</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
-
-        <tbody class="govuk-table__body">
-          <% @schools.each do |school| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
-                <br>
-                <%= school.type_label %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_button_to('Remove', support_user_school_path(@user, urn: school.urn), method: :delete, form_class: 'form-inline')  %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-
-    <%- else %>
-      <p class="govuk-body">(none)</p>
+      <%= form_for @user, url: support_user_update_schools_path(@user) do |f| %>
+        <%= f.govuk_collection_check_boxes :school_ids, @schools, :id, :name, legend: nil %>
+        <%= f.govuk_submit 'Update' %>
+      <%- end %>
     <%- end %>
 
     <%= form_for @user_school_form, url: new_support_user_school_path(@user), method: :get do |f| %>
-      <%= f.govuk_fieldset legend: { text: 'Associate with a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn, width: 'one-third' %>
+      <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds' %>
         <%= f.govuk_submit %>
       <%- end %>
     <%- end %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -19,7 +19,8 @@
 
     <%- if @schools.present? %>
       <p class="govuk-body">
-        We found these schools which matched your search:
+        We found these schools which matched your search
+        <%- if @form.matching_schools_capped? %> (showing the first <%= @form.maximum_matching_schools %> results)<%- end %>:
       </p>
 
       <%= form_for @form, url: support_user_schools_path(@user) do |f| %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -12,45 +12,47 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">
-      Schools matching <q><%= @form.name_or_urn %></q>
-    </h2>
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      You searched for “<%= @form.name_or_urn %>”.
+    </p>
 
     <%- if @schools.present? %>
-      <table class="govuk-table schools">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Name and URN</th>
-            <th scope="col" class="govuk-table__header">Responsible body</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
+      <p class="govuk-body">
+        We found these schools which matched your search:
+      </p>
 
-        <tbody class="govuk-table__body">
+      <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:school_id, legend: nil) do %>
           <% @schools.each do |school| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
-                <br>
-                <%= school.type_label %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
-              </td>
-              <td class="govuk-table__cell">
-                <%- if @user.school_ids.include?(school.id) %>
-                  (already associated)
-                <%- else %>
-                  <%= govuk_button_to('Associate', support_user_schools_path(urn: school.urn, id: @user.id), method: :post) %>
-                <%- end %>
-              </td>
-            </tr>
+            <%= f.govuk_radio_button :urn, school.urn, label: { text: school.name } %>
           <% end %>
-        </tbody>
-      </table>
+        <% end %>
+        <%= f.govuk_submit 'Grant access' %>
+      <% end %>
     <%- else %>
-      <p class="govuk-body">(none matching)</p>
+      <p class="govuk-body">
+        There were no matches that <%= @user.full_name %> doesn’t already have access to.
+      </p>
     <%- end %>
+
+    <%- if @user.schools.any? %>
+      <p class="govuk-body">
+        <%= @user.full_name %> can already access:
+      </p>
+
+      <ul id="existing-schools" class="govuk-list govuk-list--bullet">
+        <% @user.schools.order(name: :asc).each do |school| %>
+          <li><%= school.name %></li>
+        <% end %>
+      </ul>
+    <%- end %>
+
+    <%= govuk_details(summary: 'Try another school') do %>
+      <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+        <%= f.govuk_submit 'Search again' %>
+      <%- end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -8,11 +8,7 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
       You searched for “<%= @form.name_or_urn %>”.
     </p>

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -1,0 +1,18 @@
+<%- title = t('page_titles.support.users.schools.new') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', support_user_schools_path(@user), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
+    <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+      <%= f.govuk_submit 'Search again' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/webpacker/packs/responsible-bodies-autocomplete.js
+++ b/app/webpacker/packs/responsible-bodies-autocomplete.js
@@ -2,7 +2,7 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initResponsibleBodiesAutocomplete = () => {
   try {
-    const id = "#support-user-responsible-body-form-responsible-body-field";
+    const id = "#support-user-responsible-body-form-responsible-body-id-field";
     const responsibleBodiesSelect = document.querySelector(id);
     if (!responsibleBodiesSelect) return;
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,13 @@ en:
               lte_allocation: Enter an allocation that’s greater than, or the same as, the current cap
             allocation:
               greater_than: Enter an allocation that’s non-negative
+  activemodel:
+    errors:
+      models:
+        support/new_user_school_form:
+          attributes:
+            name_or_urn:
+              too_short: Enter a school name that is at least %{count} characters
   activerecord:
     attributes:
       api_token:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,8 +73,8 @@ en:
         results: Users
         new: Invite a new user
         schools:
-          index: Update schools
-          new: Associate with a school
+          index: Update school access
+          new: Grant access to a school
         responsible_bodies:
           index: Associate with a responsible body
           edit: Update responsible body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,8 @@ Rails.application.routes.draw do
       member do
         get 'confirm-deletion', to: 'users#confirm_destroy'
       end
-      resources :schools, only: %i[index new create destroy], controller: 'users/schools', param: :urn
+      resources :schools, only: %i[index new create], controller: 'users/schools', param: :urn
+      patch 'schools', to: 'users/schools#update_schools', as: :update_schools
       resource :responsible_body, only: %i[edit update], controller: 'users/responsible_body', path: 'responsible-body'
     end
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin

--- a/spec/controllers/support/users/schools_controller_spec.rb
+++ b/spec/controllers/support/users/schools_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Support::Users::SchoolsController, type: :controller do
+  let(:user) { create(:support_user) }
+  let(:trust_user) { create(:trust_user) }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#new' do
+    it 'validates that the name or URN param is 3 characters or longer' do
+      get :new, params: { user_id: trust_user.id, support_new_user_school_form: { name_or_urn: 'ab' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(:search_again)
+    end
+  end
+end

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -26,9 +26,9 @@ RSpec.feature 'Changing users’ associated organisations' do
   scenario 'a support agent removes a user from a school' do
     given_i_am_logged_in_as_a_support_user
     when_i_visit_a_users_schools_page
-    and_i_click_the_remove_link_next_to_a_school
+    and_i_remove_the_first_school
     then_i_no_longer_see_the_removed_school_in_their_schools
-    and_i_see_a_message_telling_me_the_school_has_been_removed
+    and_i_see_a_message_telling_me_the_schools_have_been_updated
   end
 
   scenario 'a support agent removes a user from a responsible body' do
@@ -108,19 +108,18 @@ RSpec.feature 'Changing users’ associated organisations' do
     visit support_user_schools_path(responsible_body_user_with_multiple_schools)
   end
 
-  def and_i_click_the_remove_link_next_to_a_school
-    within(user_schools_page.schools[0]) do
-      click_on('Remove')
-    end
+  def and_i_remove_the_first_school
+    uncheck trust_school_1.name
+    click_on 'Update'
   end
 
   def then_i_no_longer_see_the_removed_school_in_their_schools
-    expect(user_schools_page.schools.size).to eq(1)
-    expect(user_schools_page.schools[0]).to have_text(trust_school_2.name)
+    expect(user_page.summary_list['Schools']).not_to have_text(trust_school_1.name)
+    expect(user_page.summary_list['Schools']).to have_text(trust_school_2.name)
   end
 
-  def and_i_see_a_message_telling_me_the_school_has_been_removed
-    expect(user_schools_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is no longer associated with #{trust_school_1.name}")
+  def and_i_see_a_message_telling_me_the_schools_have_been_updated
+    expect(user_schools_page).to have_text('Schools updated')
   end
 
   def then_i_see_the_user_has_no_responsible_body
@@ -158,8 +157,7 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def then_i_see_the_school_added_to_their_schools
-    expect(user_schools_page.schools.size).to eq(3)
-    expect(user_schools_page.schools[2]).to have_text(other_school.name)
+    expect(user_page.summary_list['Schools']).to have_text(other_school.name)
   end
 
   def and_i_see_a_message_telling_me_the_school_has_been_associated

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Changing users’ associated organisations' do
   let(:trust) { create(:trust) }
   let(:trust_school_1) { create(:school, responsible_body: trust, name: 'AAA school') }
   let(:trust_school_2) { create(:school, responsible_body: trust, name: 'BBB school') }
-  let(:other_school) { create(:school, name: 'CCC school') }
+  let(:other_school) { create(:school, name: 'CCC school', urn: 123_456, town: 'Westminster', postcode: 'AB12 3AA') }
   let(:responsible_body_user_with_multiple_schools) { create(:trust_user, responsible_body: trust, schools: [trust_school_1, trust_school_2]) }
   let!(:other_local_authority) { create(:local_authority, name: 'AN ALL-UPPERCASE LA') }
   let(:results_page) { PageObjects::Support::Users::ResultsPage.new }
@@ -45,8 +45,7 @@ RSpec.feature 'Changing users’ associated organisations' do
     when_i_visit_a_users_schools_page
     and_i_enter_a_partial_school_name_in_any_case
     then_i_see_schools_matching_that_name
-    and_i_see_an_associate_button_next_to_each_school
-    when_i_click_the_associate_button
+    when_i_select_the_appropriate_school
     then_i_see_the_school_added_to_their_schools
     and_i_see_a_message_telling_me_the_school_has_been_associated
   end
@@ -56,7 +55,7 @@ RSpec.feature 'Changing users’ associated organisations' do
     when_i_visit_a_users_schools_page
     and_i_enter_a_school_urn_that_the_user_already_has
     then_i_see_the_school_is_already_associated
-    and_i_dont_see_a_button_to_associate_the_school
+    and_i_am_not_able_to_associate_the_school
   end
 
   scenario 'a support agent moves the user to a different responsible body' do
@@ -146,15 +145,12 @@ RSpec.feature 'Changing users’ associated organisations' do
 
   def then_i_see_schools_matching_that_name
     expect(matching_schools_page).to be_displayed
-    expect(matching_schools_page.school_names).to all(have_text(other_school.name.first(3)))
+    expect(matching_schools_page.form_with_suggested_schools).to have_text(other_school.name)
   end
 
-  def and_i_see_an_associate_button_next_to_each_school
-    expect(matching_schools_page.schools).to all(have_button('Associate'))
-  end
-
-  def when_i_click_the_associate_button
-    matching_schools_page.associate_school_link.click
+  def when_i_select_the_appropriate_school
+    choose 'CCC school (123456, Westminster, AB12 3AA)'
+    click_on 'Grant access'
   end
 
   def then_i_see_the_school_added_to_their_schools
@@ -172,12 +168,11 @@ RSpec.feature 'Changing users’ associated organisations' do
 
   def then_i_see_the_school_is_already_associated
     expect(matching_schools_page).to be_displayed
-    expect(matching_schools_page.school_names).to all(have_text(trust_school_1.name))
-    expect(matching_schools_page.schools[0]).to have_text('already associated')
+    expect(matching_schools_page.existing_schools.text).to include(trust_school_1.name, trust_school_2.name)
   end
 
-  def and_i_dont_see_a_button_to_associate_the_school
-    expect(matching_schools_page.schools[0]).not_to have_button('Associate')
+  def and_i_am_not_able_to_associate_the_school
+    expect(matching_schools_page).not_to have_form_with_suggested_schools
   end
 
   def and_i_select_a_new_responsible_body_name

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -131,7 +131,8 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_remove_the_responsible_body
-    click_on 'Remove'
+    choose 'Remove user from responsible body'
+    click_on 'Update'
   end
 
   def and_i_see_a_message_telling_me_the_responsible_body_has_been_removed
@@ -180,8 +181,9 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_select_a_new_responsible_body_name
-    select other_local_authority.name, from: 'support-user-responsible-body-form-responsible-body-field'
-    click_on 'Move'
+    choose 'Move user to a different responsible body'
+    select other_local_authority.name, from: 'New responsible body'
+    click_on 'Update'
   end
 
   def then_i_see_the_new_responsible_body_replaces_their_existing_responsible_body

--- a/spec/form_objects/support/new_user_school_form_spec.rb
+++ b/spec/form_objects/support/new_user_school_form_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Support::NewUserSchoolForm, type: :model do
+  it { is_expected.to validate_length_of(:name_or_urn).is_at_least(3) }
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -433,4 +433,21 @@ RSpec.describe School, type: :model do
       expect(schools.last.in_virtual_cap_pool?).to be false
     end
   end
+
+  describe '.matching_name_or_urn' do
+    it 'returns schools with the provided URN' do
+      matched_school = create(:school, urn: 123_456)
+      create(:school, urn: 123_458) # non-matching school
+
+      expect(School.matching_name_or_urn(123_456)).to eq([matched_school])
+    end
+
+    it 'returns schools which match the name partially or exactly' do
+      matched_school1 = create(:school, name: 'Southside')
+      matched_school2 = create(:school, name: 'Southside Primary')
+      create(:school, name: 'Northside') # non-matching school
+
+      expect(School.matching_name_or_urn('Southside')).to contain_exactly(matched_school1, matched_school2)
+    end
+  end
 end

--- a/spec/page_objects/support/users/matching_schools_page.rb
+++ b/spec/page_objects/support/users/matching_schools_page.rb
@@ -4,9 +4,8 @@ module PageObjects
       class MatchingSchoolsPage < PageObjects::BasePage
         set_url '/support/users/{id}/schools/new'
 
-        element :associate_school_link, 'table.schools tbody tr input[type=submit][value=Associate]'
-        elements :schools, 'table.schools tbody tr'
-        elements :school_names, 'table.schools tbody tr td:first-child a'
+        element :form_with_suggested_schools, '#new_support_new_user_school_form'
+        element :existing_schools, '#existing-schools'
       end
     end
   end

--- a/spec/page_objects/support/users/schools_page.rb
+++ b/spec/page_objects/support/users/schools_page.rb
@@ -6,7 +6,6 @@ module PageObjects
 
         element :school_name_or_urn, 'input#support-new-user-school-form-name-or-urn-field'
         element :submit_school_name_or_urn, '#new_support_new_user_school_form input[value=Continue]'
-        elements :schools, 'table.schools tbody tr'
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe UserPolicy do
   subject(:policy) { described_class }
 
-  permissions :new?, :create?, :edit?, :update?, :destroy?, :confirm_destroy? do
+  permissions :new?, :create?, :edit?, :update?, :destroy?, :confirm_destroy?, :update_schools? do
     it 'grants access to support users' do
       expect(policy).to permit(build(:support_user), :support)
     end


### PR DESCRIPTION
~Depends on #998 - merge that first.~ ✅ 
~Depends on #1002 - merge that first.~ ✅ 

### Context

User management is very commonly used by support agents, and as such, should follow similar best practice design and code patterns.

### Changes proposed in this pull request

Tidy up the design of various user management functions in the support console:

- editing a user's responsible body
- granting access to, and removing access to schools

### Guidance to review

#### Setting a responsible body when there wasn't one before

**Before:**

![image](https://user-images.githubusercontent.com/23801/102914551-653a0e80-4478-11eb-8f65-66ab6ac08321.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102914608-771bb180-4478-11eb-821c-b1393a6cf972.png)

#### Removing a responsible body and moving to a new responsible body

**Before:**

![image](https://user-images.githubusercontent.com/23801/102914773-b64a0280-4478-11eb-88e9-5f6b7cf50fae.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102914806-c235c480-4478-11eb-87a6-4f2fed83ceee.png)

![image](https://user-images.githubusercontent.com/23801/102914908-d8438500-4478-11eb-82a8-55763fe69626.png)

#### Removing school access

**Before:**

![image](https://user-images.githubusercontent.com/23801/102915061-13de4f00-4479-11eb-8e7d-1336e52370e0.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102915034-0a54e700-4479-11eb-9463-bee50b49b6fb.png)

#### Suggesting a new school for access

**Before:**

![image](https://user-images.githubusercontent.com/23801/102915165-3c664900-4479-11eb-80b1-8cff1d45c23d.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102915210-52740980-4479-11eb-8252-7f39018c5fa2.png)
