### PR TITLE
School search: backend improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'paper_trail'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 
+# Fuzzy school search
+gem 'pg_search'
+
 # Pry console is more resilient to readline issues that can stop
 # the arrow keys etc working
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,9 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -519,6 +522,7 @@ DEPENDENCIES
   paper_trail
   parallel_tests
   pg (>= 0.18, < 2.0)
+  pg_search
   pry-byebug
   pry-rails
   puma (~> 5.1)

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -9,8 +9,9 @@ class Support::NewUserSchoolForm
   end
 
   def matching_schools
-    School.includes(:responsible_body)
-          .where('urn = ? OR name ILIKE(?)', @name_or_urn.to_i, "%#{@name_or_urn}%")
-          .order(:name)
+    School
+      .matching_name_or_urn(@name_or_urn)
+      .includes(:responsible_body)
+      .order(:name)
   end
 end

--- a/app/form_objects/support/new_user_school_form.rb
+++ b/app/form_objects/support/new_user_school_form.rb
@@ -1,17 +1,15 @@
 class Support::NewUserSchoolForm
   include ActiveModel::Model
 
-  attr_accessor :user, :name_or_urn
+  MAX_NUMBER_OF_SUGGESTED_SCHOOLS = 50
 
-  def initialize(user:, name_or_urn: nil)
-    @user = user
-    @name_or_urn = name_or_urn
-  end
+  attr_accessor :user, :name_or_urn
 
   def matching_schools
     School
       .matching_name_or_urn(@name_or_urn)
       .includes(:responsible_body)
       .order(:name)
+      .limit(MAX_NUMBER_OF_SUGGESTED_SCHOOLS)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,6 @@
 class School < ApplicationRecord
   has_paper_trail
+  include PgSearch::Model
 
   belongs_to :responsible_body
   has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
@@ -19,7 +20,7 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
-  scope :matching_name_or_urn, ->(name_or_urn) { where(urn: name_or_urn).or(where('name ILIKE(?)', "%#{name_or_urn}%")) }
+  pg_search_scope :matching_name_or_urn, against: %i[name urn], using: { tsearch: { prefix: true } }
 
   before_create :set_computacenter_change
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,6 +19,8 @@ class School < ApplicationRecord
   validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
   validates :name, presence: true
 
+  scope :matching_name_or_urn, ->(name_or_urn) { where(urn: name_or_urn).or(where('name ILIKE(?)', "%#{name_or_urn}%")) }
+
   before_create :set_computacenter_change
 
   enum status: {

--- a/spec/form_objects/support/new_user_school_form_spec.rb
+++ b/spec/form_objects/support/new_user_school_form_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Support::NewUserSchoolForm, type: :model do
+  subject(:form) { described_class.new }
+
+  it 'returns a set of matching schools from a search string' do
+    school1 = create(:school, name: 'Southmead School')
+    school2 = create(:school, name: 'Southdean School')
+    create(:school, name: 'Northfields School')
+
+    form = Support::NewUserSchoolForm.new(name_or_urn: 'South')
+
+    expect(form.matching_schools).to contain_exactly(school1, school2)
+  end
+
+  it 'limits the number of matched results to a hardcoded maximum' do
+    stub_const 'Support::NewUserSchoolForm::MAX_NUMBER_OF_SUGGESTED_SCHOOLS', 2
+
+    create_list(:school, 4, name: 'AA School')
+
+    form = Support::NewUserSchoolForm.new(name_or_urn: 'AA')
+
+    expect(form.matching_schools.size).to eq(2)
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -433,4 +433,21 @@ RSpec.describe School, type: :model do
       expect(schools.last.in_virtual_cap_pool?).to be false
     end
   end
+
+  describe '.matching_name_or_urn' do
+    it 'returns schools with the provided URN' do
+      matched_school = create(:school, urn: 123_456)
+      create(:school, urn: 123_458) # non-matching school
+
+      expect(School.matching_name_or_urn(123_456)).to eq([matched_school])
+    end
+
+    it 'returns schools which match the name partially or exactly' do
+      matched_school1 = create(:school, name: 'Southside')
+      matched_school2 = create(:school, name: 'Southside Primary')
+      create(:school, name: 'Northside') # non-matching school
+
+      expect(School.matching_name_or_urn('Southside')).to contain_exactly(matched_school1, matched_school2)
+    end
+  end
 end


### PR DESCRIPTION
### Context

The support console allows support agents to grant school access to users. When the agent types in part of a school name (or a school URN), the system returns schools that match the provided search term.

There's an ambition to extend this functionality to a more generalised schools auto-complete, to use in other places in the support console and in the user support form. This technical change is a step towards realising this ambition.

### Changes proposed in this pull request

1. Introduce an upper limit to how many results the school suggest returns. A user can hit this limit if they enter a very short or common search term (e.g. `St`). Returning more than 50 suggestions isn't a useful user interaction – in that case, the user should refine their search.

2. Improve the quality of matched results by switching to the [`pg_search` gem and PostgreSQL's full text search](https://github.com/Casecommons/pg_search#tsearch-full-text-search). For instance, after this change, searching for `st joseph's` now matches schools called `St. Joseph's` (with a full stop) as well as `St Joseph's` (without a full stop).

### Guidance to review

-