### PR TITLE
Load JavaScript after the DOM has loaded

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,6 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application', defer: true %>
     <%= yield(:head) %>
   </head>
 
@@ -117,5 +116,6 @@
         </div>
       </div>
     </footer>
+    <%= javascript_pack_tag 'application', defer: true %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template">
   <head>
     <%= csp_meta_tag %>
     <%- if Settings.google.analytics.tracking_id.present? && cookies['consented-to-cookies'].to_s == 'yes' %>
@@ -22,7 +22,7 @@
     <%= yield(:head) %>
   </head>
 
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body">
     <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     <% end -%>

--- a/app/webpacker/packs/mno/extra-mobile-data-requests.js
+++ b/app/webpacker/packs/mno/extra-mobile-data-requests.js
@@ -11,7 +11,7 @@ setupSelectAllNone = function() {
   })
 }
 
-$(document).ready(function() {
-  hideOnLoad();
-  setupSelectAllNone();
-});
+
+hideOnLoad();
+setupSelectAllNone();
+


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
This has many benefits and follows good practices

- No need to use jquery `.ready()` method because the dom would be loaded
  before the browser starts downloading the js and executing it.
- It will also help improve perceived performance by loading up and displaying
  the content so the users gets to see the content first while the js is
  being downloaded and executed.
### Guidance to review

