### PR TITLE
Refactor select all/none js functionality & remove jQuery

### DIFF
--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -1,14 +1,10 @@
 <tr class="govuk-table__row" id="request-<%= extra_mobile_data_request.id %>">
   <td class="govuk-table__cell">
-    <div class="govuk-form-group govuk-!-margin-bottom-0">
-      <%= form.govuk_collection_check_boxes :extra_mobile_data_request_ids,
-      [OpenStruct.new(id: extra_mobile_data_request.id, label: '')],
-      :id,
-      :label,
-      small: false,
-      classes: 'all-none-item',
-      legend: { hidden: true } %>
-    </div>
+    <%= form.govuk_check_box :extra_mobile_data_request_ids,
+                             extra_mobile_data_request.id,
+                             multiple: true,
+                             label: { text: "Select #{extra_mobile_data_request.account_holder_name} request",
+                                      hidden: true } %>
   </td>
   <td class="govuk-table__cell">
     <%= extra_mobile_data_request.account_holder_name %>

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -23,18 +23,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= form_for @extra_mobile_data_requests_form, url: bulk_update_mno_extra_mobile_data_requests_path, method: :put do |f| %>
-        <table class="govuk-table">
+        <table class="govuk-table" data-module="app-select-all-none">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-table__header">
-                <div id="all-none-links" class="non-js-only">
+                <div class="non-js-only">
                   Select
                   <br />
                   <%= govuk_link_to 'all', mno_extra_mobile_data_requests_path(select: 'all') %>
                   |
                   <%= govuk_link_to 'none', mno_extra_mobile_data_requests_path(select: 'none') %>
                 </div>
-                <div id="all-none-checkbox" class="js-only govuk-checkboxes__item" data-controls="all-none-item">
+                <div class="js-only govuk-checkboxes__item">
                   <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
                   <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows"></label>
                 </div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,6 +11,5 @@ initAll();
 initWarnOnUnsavedChanges();
 import {initSelectAllNone} from './mno/extra-mobile-data-requests'
 
-require('jquery')
 initSelectAllNone();
 initResponsibleBodiesAutocomplete();

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -9,8 +9,8 @@ import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
 
 initAll();
 initWarnOnUnsavedChanges();
+import {initSelectAllNone} from './mno/extra-mobile-data-requests'
 
 require('jquery')
-require('./mno/extra-mobile-data-requests.js');
-
+initSelectAllNone();
 initResponsibleBodiesAutocomplete();

--- a/app/webpacker/packs/mno/extra-mobile-data-requests.js
+++ b/app/webpacker/packs/mno/extra-mobile-data-requests.js
@@ -1,17 +1,42 @@
-hideOnLoad = function() {
-  $('.non-js-only').hide();
-  $('.js-only').show();
-}
+const hideFallbackOnLoad = (component) => {
+  component.querySelectorAll('.non-js-only').forEach((el) => {
+    el.style.display = 'none'
+  })
 
-setupSelectAllNone = function() {
-  $('#all-rows').change(function() {
-    className = $(this).parent().data('controls')
-    controlled_items = $(this).closest('table').find('.' + className).find('input[type=checkbox]')
-    controlled_items.prop('checked', $(this).prop('checked'))
+  component.querySelectorAll('.js-only').forEach((el) => {
+    el.style.display = 'block'
   })
 }
 
+const changeCheckboxStateForEachRow = (event) => {
+  const $allNoneCheckbox = event.target
+  const controlledItems = $allNoneCheckbox.closest('table').querySelectorAll('tbody input[type=checkbox]')
 
-hideOnLoad();
-setupSelectAllNone();
+  controlledItems.forEach((checkbox) => {
+    checkbox.checked = $allNoneCheckbox.checked
+  })
+}
+
+let setupIndividualComponent = ($component) => {
+  const $selectAllNoneCheckbox = $component.querySelector('thead input[type=checkbox]')
+
+  hideFallbackOnLoad($component)
+
+  $selectAllNoneCheckbox.addEventListener('change', changeCheckboxStateForEachRow)
+}
+
+const initSelectAllNone = () => {
+  const $components = document.querySelectorAll('[data-module="app-select-all-none"]')
+
+  if( $components.length === 0 ){ return false }
+
+  $components.forEach((component) =>{
+    setupIndividualComponent(component)
+  })
+}
+
+export {
+  initSelectAllNone,
+  setupIndividualComponent
+}
 

--- a/app/webpacker/packs/mno/extra-mobile-data-requests.test.js
+++ b/app/webpacker/packs/mno/extra-mobile-data-requests.test.js
@@ -1,0 +1,98 @@
+import * as SelectAllNone from './extra-mobile-data-requests'
+
+describe('initSelectAllNone', () => {
+
+  const mockHTML = '<table data-module="app-select-all-none">' +
+    '  <thead>' +
+    '    <tr>' +
+    '      <th>' +
+    '        <div class="non-js-only">' +
+    '          Select' +
+    '          <br>' +
+    '          <a href="#">all</a>' +
+    '          | ' +
+    '          <a href="#">none</a>' +
+    '        </div>' +
+    '        <div class="js-only">' +
+    '          <input type="checkbox">' +
+    '        </div>' +
+    '      </th>' +
+    '    </tr>' +
+    '  </thead>' +
+    '  <tbody>' +
+    '    <tr>' +
+    '      <td>' +
+    '        <input type="checkbox" value="1">' +
+    '      </td>' +
+    '    </tr>' +
+    '    <tr>' +
+    '      <td>' +
+    '        <input type="checkbox" value="2">' +
+    '      </td>' +
+    '    </tr>' +
+    '    <tr>' +
+    '      <td>' +
+    '        <input type="checkbox" value="3">' +
+    '      </td>' +
+    '    </tr>' +
+    '  </tbody>' +
+    '</table>'
+
+
+  describe('when method is called and there is no SelectAllNone component on the page', () => {
+
+    it('should return false with no further action', () => {
+      document.body.innerHTML = '<div></div>'
+      expect(SelectAllNone.initSelectAllNone()).toBeFalsy()
+      document.body.innerHTML = ''
+    })
+
+  })
+
+  describe('when method is called and there is a SelectAllNone component on the page', () => {
+    beforeAll(() => {
+      document.body.innerHTML = mockHTML
+
+      SelectAllNone.initSelectAllNone()
+    })
+
+    it('should hide non-js-only if js is enabled', () => {
+      expect(document.querySelectorAll('.non-js-only')[0].style.display).toBe('none')
+    })
+
+    it('should show js-only if js is enabled', () => {
+      expect(document.querySelectorAll('.js-only')[0].style.display).toBeNull
+    })
+
+    it('should check every checkbox if all-items checkbox is checked', () => {
+      document.querySelector('thead input[type="checkbox"]').click()
+      const options = document.querySelectorAll('input[type="checkbox"]')
+      expect(Array.from(options).filter(checkbox => checkbox.checked).length).toBe(4)
+    })
+
+    it('should uncheck every checkbox if all-items checkbox is checked', () => {
+      document.querySelectorAll('input[type="checkbox"]').forEach((el) => {
+        el.checked = true
+      })
+      document.querySelector('thead input[type="checkbox"]').click()
+      const options = document.querySelectorAll('input[type="checkbox"]')
+
+      document.querySelectorAll('input[type="checkbox"]')
+      expect(Array.from(options).filter(checkbox => checkbox.checked).length).toBe(0)
+    })
+  })
+
+  describe('when method is called and there are multiple SelectAllNone components on the page', () => {
+    beforeAll(() => {
+      document.body.innerHTML = mockHTML + mockHTML
+    })
+
+    it.skip('should setup an instance for each component on the page', () => {
+      // jest.spyOn( SelectAllNone, 'setupIndividualComponent')
+      SelectAllNone.setupIndividualComponent = jest.fn((component)=> component)
+      SelectAllNone.initSelectAllNone()
+      expect(SelectAllNone.setupIndividualComponent).toBeCalledTimes(2)
+    })
+
+  })
+})

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,12 +1,3 @@
 const { environment } = require('@rails/webpacker')
 
-// importing jquery, as per https://blog.makersacademy.com/how-to-install-bootstrap-and-jquery-on-rails-6-da6e810c1b87
-const webpack = require('webpack')
-environment.plugins.prepend('Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery/src/jquery',
-    jQuery: 'jquery/src/jquery'
-  })
-)
-
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "accessible-autocomplete": "^2.0.3",
     "core-js": ">=3",
     "govuk-frontend": ">=3.10.2",
-    "jquery": "3.5.1",
     "serialize-javascript": ">=5.0.1",
     "set-value": ">=3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,12 +1640,19 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
     color-convert "^2.0.1"
 
 anymatch@^2.0.0:
@@ -5197,11 +5204,6 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-base64@^2.1.8:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
@@ -8540,10 +8542,17 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

This was in desperate need of being a refactor for the following reasons:

- jQuery: This relied on jQuery and seemed a bit of overkill to import and include it on every page. It also seemed to be included twice.
  jQuery is no longer a dependency for this code to work.

- would only work for a single instance of this component. It now supports
  multiple components

- The js was not scoped to just the component in question. For example,
  when the page has loaded, any element that had a class of `js-only` or `non-js-only` would be
  hidden/shown regardless of what our intentions were for those elements
  when the page loaded.

- There was a lot of additional markup added just to add the feature.
  The markup has now been cleaned up.

- No unit tests

### Guidance to review

I analyzed the bundles locally before & after the changes:


<table>
<tr>
    <th> 
    <th>Before
    <th>After
    <th>% Reduction
<tr>
	<td>gzipped
	<td>130KB
	<td>35KB
	<td>73%
<tr>
	<td>parsed
	<td>408KB
	<td>117KB
	<td>71%
</table>

#### Before:
![image](https://user-images.githubusercontent.com/3441519/103357879-29243080-4aac-11eb-84c8-e582489a75b8.png)


#### After:
![image](https://user-images.githubusercontent.com/3441519/103357897-33dec580-4aac-11eb-8471-7f20a9a16b68.png)


