### PR TITLE
[286] Add form objects needed for get support flow

### DIFF
--- a/app/form_objects/support_ticket/academy_details_form.rb
+++ b/app/form_objects/support_ticket/academy_details_form.rb
@@ -1,0 +1,7 @@
+class SupportTicket::AcademyDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :academy_name
+
+  validates :academy_name, presence: { message: 'Enter your academy trust name' }
+end

--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -1,0 +1,12 @@
+class SupportTicket::CheckYourRequestForm
+  include ActiveModel::Model
+
+  attr_accessor :ticket
+
+  validates :ticket, presence: true
+
+  def create_ticket
+    ticket['subject'] = "TESTING - (#{ticket['school_unique_id']}) #{ticket['school_name']} "
+    ZendeskService.send!(ticket)
+  end
+end

--- a/app/form_objects/support_ticket/college_details_form.rb
+++ b/app/form_objects/support_ticket/college_details_form.rb
@@ -1,0 +1,8 @@
+class SupportTicket::CollegeDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :college_name, :college_ukprn
+
+  validates :college_name, presence: { message: 'Enter your college name' }
+  validates :college_ukprn, presence: { message: 'Enter your college UKPRN' }
+end

--- a/app/form_objects/support_ticket/contact_details_form.rb
+++ b/app/form_objects/support_ticket/contact_details_form.rb
@@ -1,0 +1,8 @@
+class SupportTicket::ContactDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :full_name, :email_address, :telephone_number
+
+  validates :full_name, presence: { message: 'Enter your full name' }
+  validates :email_address, presence: { message: 'Enter your email address' }
+end

--- a/app/form_objects/support_ticket/describe_yourself_form.rb
+++ b/app/form_objects/support_ticket/describe_yourself_form.rb
@@ -1,0 +1,29 @@
+class SupportTicket::DescribeYourselfForm
+  include ActiveModel::Model
+
+  attr_accessor :user_type
+
+  validates :user_type, presence: { message: 'Tell us which of these best describes you' }
+
+  OPTIONS = {
+    school_or_single_academy_trust: 'I work for a school or single-academy trust',
+    multi_academy_trust: 'I work for a multi-academy trust',
+    local_authority: 'I work for a local authority',
+    college: 'I work for a college',
+    parent_or_guardian_or_carer_or_pupil_or_care_leaver: "I'm a parent, guardian, pupil or care leaver",
+    other_type_of_user: "I'm none of the above",
+  }.freeze
+
+  def describe_yourself_options
+    OPTIONS.map do |option_value, option_label|
+      OpenStruct.new(
+        value: option_value,
+        label: option_label,
+      )
+    end
+  end
+
+  def selected_option_label(selected_value)
+    OPTIONS[selected_value.to_sym]
+  end
+end

--- a/app/form_objects/support_ticket/local_authority_details_form.rb
+++ b/app/form_objects/support_ticket/local_authority_details_form.rb
@@ -1,0 +1,7 @@
+class SupportTicket::LocalAuthorityDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :local_authority_name
+
+  validates :local_authority_name, presence: { message: 'Enter your local authority name' }
+end

--- a/app/form_objects/support_ticket/school_details_form.rb
+++ b/app/form_objects/support_ticket/school_details_form.rb
@@ -1,0 +1,8 @@
+class SupportTicket::SchoolDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :school_name, :school_urn
+
+  validates :school_name, presence: { message: 'Enter your school name' }
+  validates :school_urn, presence: { message: 'Enter your school URN' }
+end

--- a/app/form_objects/support_ticket/support_details_form.rb
+++ b/app/form_objects/support_ticket/support_details_form.rb
@@ -1,0 +1,7 @@
+class SupportTicket::SupportDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :message
+
+  validates :message, presence: { message: 'Tell us how can we help you' }
+end

--- a/app/form_objects/support_ticket/support_needs_form.rb
+++ b/app/form_objects/support_ticket/support_needs_form.rb
@@ -1,0 +1,36 @@
+class SupportTicket::SupportNeedsForm
+  include ActiveModel::Model
+
+  attr_accessor :support_topics
+
+  validate :must_have_a_support_topic
+
+  OPTIONS = {
+    'laptops_and_tablets' => 'Laptops and tablets',
+    '4g_wireless_routers_and_internet_access' => '4G wireless routers and internet access',
+    'digital_education_platforms' => 'Digital education platforms (G Suite for Education or Office 365 Education)',
+    'technology_training_and_support' => 'Technology training and support for schools and colleges',
+    'something_else' => 'Something else',
+  }.freeze
+
+  def support_needs_options
+    OPTIONS.map do |option_value, option_label|
+      OpenStruct.new(
+        value: option_value,
+        label: option_label,
+      )
+    end
+  end
+
+  def selected_option_label(selected_value)
+    OPTIONS[selected_value]
+  end
+
+private
+
+  def must_have_a_support_topic
+    if support_topics.blank? || support_topics.reject(&:blank?).blank?
+      errors.add(:support_topics, :blank, message: 'Tell us what you need help with')
+    end
+  end
+end

--- a/spec/form_objects/support_ticket/academy_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/academy_details_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::AcademyDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:academy_name).with_message('Enter your academy trust name') }
+  end
+end

--- a/spec/form_objects/support_ticket/college_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/college_details_form_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::CollegeDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:college_name).with_message('Enter your college name') }
+    it { is_expected.to validate_presence_of(:college_ukprn).with_message('Enter your college UKPRN') }
+  end
+end

--- a/spec/form_objects/support_ticket/contact_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/contact_details_form_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::ContactDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:full_name).with_message('Enter your full name') }
+    it { is_expected.to validate_presence_of(:email_address).with_message('Enter your email address') }
+  end
+end

--- a/spec/form_objects/support_ticket/describe_yourself_form_spec.rb
+++ b/spec/form_objects/support_ticket/describe_yourself_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::DescribeYourselfForm, type: :model do
+  subject(:form) { described_class.new }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:user_type).with_message('Tell us which of these best describes you') }
+  end
+
+  describe '#descibe_yourself_options' do
+    it 'returns an array of label & value pairs' do
+      stub_const('SupportTicket::DescribeYourselfForm::OPTIONS', { type_of_user_value: 'Type of user label' })
+      expect(form.describe_yourself_options).to match_array([OpenStruct.new(value: :type_of_user_value, label: 'Type of user label')])
+    end
+  end
+
+  describe '#selected_option_label' do
+    it 'returns label for the selected option' do
+      stub_const('SupportTicket::DescribeYourselfForm::OPTIONS', { option_1: 'Hello world' })
+      expect(form.selected_option_label('option_1')).to eq('Hello world')
+    end
+  end
+end

--- a/spec/form_objects/support_ticket/local_authority_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/local_authority_details_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::LocalAuthorityDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:local_authority_name).with_message('Enter your local authority name') }
+  end
+end

--- a/spec/form_objects/support_ticket/school_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/school_details_form_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SchoolDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:school_name).with_message('Enter your school name') }
+    it { is_expected.to validate_presence_of(:school_urn).with_message('Enter your school URN') }
+  end
+end

--- a/spec/form_objects/support_ticket/support_details_form_spec.rb
+++ b/spec/form_objects/support_ticket/support_details_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SupportDetailsForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:message).with_message('Tell us how can we help you') }
+  end
+end

--- a/spec/form_objects/support_ticket/support_needs_form_spec.rb
+++ b/spec/form_objects/support_ticket/support_needs_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SupportNeedsForm, type: :model do
+  subject(:form) { described_class.new }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:support_topics).with_message('Tell us what you need help with') }
+  end
+
+  describe '#support_needs_options' do
+    it 'returns an array of label & value pairs' do
+      stub_const('SupportTicket::SupportNeedsForm::OPTIONS', { support_1: 'Support option 1' })
+      expect(form.support_needs_options).to match_array([OpenStruct.new(value: :support_1, label: 'Support option 1')])
+    end
+  end
+
+  describe '#selected_option_label' do
+    it 'returns label for the selected option' do
+      stub_const('SupportTicket::SupportNeedsForm::OPTIONS', { option_1: 'Hello world' })
+      expect(form.selected_option_label(:option_1)).to eq('Hello world')
+    end
+  end
+end


### PR DESCRIPTION
### Context

The breakup of #889 into smaller PR, these new form objects are not being used in the service at the moment as the views/controllers, etc will be part of another PR. If you want to view the user journey you can see it by visiting https://dfe-ghwt-pr-889.herokuapp.com/get-support

The form objects will be used by the form builder. We do not want to
store the user's query in the service which is why it's not using 
traditional ActiveModel implementation to store it in a database table.
### Changes proposed in this pull request

### Guidance to review

