### PR TITLE
[286] Routes/controllers/views for support wizard

### DIFF
--- a/app/controllers/support_ticket/academy_details_controller.rb
+++ b/app/controllers/support_ticket/academy_details_controller.rb
@@ -1,0 +1,41 @@
+class SupportTicket::AcademyDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::AcademyDetailsForm.new(set_params)
+    render 'support_tickets/academy_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({
+        academy_name: form.academy_name,
+        school_name: form.academy_name,
+        school_unique_id: '',
+      })
+      redirect_to next_step
+    else
+      render 'support_tickets/academy_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::AcademyDetailsForm.new(academy_details_params)
+  end
+
+  def academy_details_params(opts = params)
+    opts.fetch(:support_ticket_academy_details_form, {}).permit(:academy_name)
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        academy_name: session[:support_ticket]['academy_name'],
+      }
+    end
+  end
+
+  def next_step
+    support_ticket_contact_details_path
+  end
+end

--- a/app/controllers/support_ticket/base_controller.rb
+++ b/app/controllers/support_ticket/base_controller.rb
@@ -1,0 +1,13 @@
+class SupportTicket::BaseController < ApplicationController
+  def start
+    render 'support_tickets/start'
+  end
+
+  def parent_support
+    render 'support_tickets/parent_support'
+  end
+
+  def thank_you
+    render 'support_tickets/thank_you'
+  end
+end

--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -1,0 +1,43 @@
+class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
+  def new
+    @support_ticket = session[:support_ticket]
+    @form = form
+    @school_details_path = school_details_path
+    render 'support_tickets/check_your_request'
+  end
+
+  def save
+    if form.valid?
+      redirect_to next_step
+    else
+      render 'support_tickets/check_your_request'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::CheckYourRequestForm.new(ticket: session[:support_ticket])
+  end
+
+  def check__params(opts = params)
+    opts.fetch(:support_ticket_support_details_form, {})
+  end
+
+  def next_step
+    support_ticket_thank_you_path
+  end
+
+  def school_details_path
+    case @support_ticket['user_type']
+    when 'school_or_single_academy_trust'
+      support_ticket_school_details_path
+    when 'multi_academy_trust'
+      support_ticket_academy_details_path
+    when 'local_authority'
+      support_ticket_local_authority_details_path
+    when 'college'
+      support_ticket_college_details_path
+    end
+  end
+end

--- a/app/controllers/support_ticket/college_details_controller.rb
+++ b/app/controllers/support_ticket/college_details_controller.rb
@@ -1,0 +1,45 @@
+class SupportTicket::CollegeDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::CollegeDetailsForm.new(set_params)
+    render 'support_tickets/college_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({
+        college_name: form.college_name,
+        college_ukprn: form.college_ukprn,
+        school_name: form.college_name,
+        school_unique_id: form.college_ukprn,
+      })
+      redirect_to next_step
+    else
+      render 'support_tickets/college_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::CollegeDetailsForm.new(college_details_params)
+  end
+
+  def college_details_params(opts = params)
+    opts.fetch(:support_ticket_college_details_form, {}).permit(:college_name, :college_ukprn)
+  end
+
+  def set_params
+    if session[:support_ticket].present? && session[:support_ticket]['college_name'].present?
+      {
+        college_name: session[:support_ticket]['college_name'],
+        college_ukprn: session[:support_ticket]['college_ukprn'],
+      }
+    else
+      { college_name: nil, college_ukprn: nil }
+    end
+  end
+
+  def next_step
+    support_ticket_contact_details_path
+  end
+end

--- a/app/controllers/support_ticket/contact_details_controller.rb
+++ b/app/controllers/support_ticket/contact_details_controller.rb
@@ -1,0 +1,43 @@
+class SupportTicket::ContactDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::ContactDetailsForm.new(set_params)
+    render 'support_tickets/contact_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({ full_name: helpers.sanitize(form.full_name),
+                                        email_address: helpers.sanitize(form.email_address),
+                                        telephone_number: helpers.sanitize(form.telephone_number) })
+      redirect_to next_step
+    else
+      render 'support_tickets/contact_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::ContactDetailsForm.new(contact_details_params)
+  end
+
+  def contact_details_params(opts = params)
+    opts.fetch(:support_ticket_contact_details_form, {}).permit(:full_name, :email_address, :telephone_number)
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        full_name: session[:support_ticket]['full_name'],
+        email_address: session[:support_ticket]['email_address'],
+        telephone_number: session[:support_ticket]['telephone_number'],
+      }
+    else
+      { full_name: nil, email_address: nil, telephone_number: nil }
+    end
+  end
+
+  def next_step
+    support_ticket_support_needs_path
+  end
+end

--- a/app/controllers/support_ticket/describe_yourself_controller.rb
+++ b/app/controllers/support_ticket/describe_yourself_controller.rb
@@ -1,0 +1,50 @@
+class SupportTicket::DescribeYourselfController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::DescribeYourselfForm.new(set_params)
+    render 'support_tickets/describe_yourself'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket] = { user_type: form.user_type }
+      redirect_to next_step
+    else
+      render 'support_tickets/describe_yourself'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::DescribeYourselfForm.new(describe_yourself_params)
+  end
+
+  def describe_yourself_params(opts = params)
+    opts.fetch(:support_ticket_describe_yourself_form, {}).permit(:user_type)
+  end
+
+  def set_params
+    if session[:support_ticket].present? && session[:support_ticket]['user_type'].present?
+      { user_type: session[:support_ticket]['user_type'] }
+    else
+      { user_type: nil }
+    end
+  end
+
+  def next_step
+    case form.user_type
+    when 'school_or_single_academy_trust'
+      support_ticket_school_details_path
+    when 'multi_academy_trust'
+      support_ticket_academy_details_path
+    when 'local_authority'
+      support_ticket_local_authority_details_path
+    when 'college'
+      support_ticket_college_details_path
+    when 'parent_or_guardian_or_carer_or_pupil_or_care_leaver'
+      support_ticket_parent_support_path
+    when 'other_type_of_user'
+      support_ticket_contact_details_path
+    end
+  end
+end

--- a/app/controllers/support_ticket/local_authority_details_controller.rb
+++ b/app/controllers/support_ticket/local_authority_details_controller.rb
@@ -1,0 +1,41 @@
+class SupportTicket::LocalAuthorityDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::LocalAuthorityDetailsForm.new(set_params)
+    render 'support_tickets/local_authority_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({
+        local_authority_name: form.local_authority_name,
+        school_name: form.local_authority_name,
+        school_unique_id: '',
+      })
+      redirect_to next_step
+    else
+      render 'support_tickets/local_authority_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::LocalAuthorityDetailsForm.new(local_authority_details_params)
+  end
+
+  def local_authority_details_params(opts = params)
+    opts.fetch(:support_ticket_local_authority_details_form, {}).permit(:local_authority_name)
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        local_authority_name: session[:support_ticket]['local_authority_name'],
+      }
+    end
+  end
+
+  def next_step
+    support_ticket_contact_details_path
+  end
+end

--- a/app/controllers/support_ticket/school_details_controller.rb
+++ b/app/controllers/support_ticket/school_details_controller.rb
@@ -1,0 +1,42 @@
+class SupportTicket::SchoolDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::SchoolDetailsForm.new(set_params)
+    render 'support_tickets/school_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({
+        school_name: form.school_name,
+        school_urn: form.school_urn,
+        school_unique_id: form.school_urn,
+      })
+      redirect_to next_step
+    else
+      render 'support_tickets/school_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::SchoolDetailsForm.new(school_details_params)
+  end
+
+  def school_details_params(opts = params)
+    opts.fetch(:support_ticket_school_details_form, {}).permit(:school_name, :school_urn)
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        school_name: session[:support_ticket]['school_name'],
+        school_urn: session[:support_ticket]['school_urn'],
+      }
+    end
+  end
+
+  def next_step
+    support_ticket_contact_details_path
+  end
+end

--- a/app/controllers/support_ticket/support_details_controller.rb
+++ b/app/controllers/support_ticket/support_details_controller.rb
@@ -1,0 +1,37 @@
+class SupportTicket::SupportDetailsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::SupportDetailsForm.new(set_params)
+    render 'support_tickets/support_details'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({ message: form.message })
+      redirect_to next_step
+    else
+      render 'support_tickets/support_details'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::SupportDetailsForm.new(support_details_params)
+  end
+
+  def support_details_params(opts = params)
+    opts.fetch(:support_ticket_support_details_form, {}).permit(:message)
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        message: session[:support_ticket]['message'],
+      }
+    end
+  end
+
+  def next_step
+    support_ticket_check_your_request_path
+  end
+end

--- a/app/controllers/support_ticket/support_needs_controller.rb
+++ b/app/controllers/support_ticket/support_needs_controller.rb
@@ -1,0 +1,41 @@
+class SupportTicket::SupportNeedsController < SupportTicket::BaseController
+  def new
+    @form ||= SupportTicket::SupportNeedsForm.new(set_params)
+    render 'support_tickets/support_needs'
+  end
+
+  def save
+    if form.valid?
+      session[:support_ticket].merge!({ support_topics: remove_empty_topics })
+      redirect_to next_step
+    else
+      render 'support_tickets/support_needs'
+    end
+  end
+
+private
+
+  def form
+    @form ||= SupportTicket::SupportNeedsForm.new(support_needs_params)
+  end
+
+  def support_needs_params(opts = params)
+    opts.fetch(:support_ticket_support_needs_form, {}).permit(support_topics: [])
+  end
+
+  def set_params
+    if session[:support_ticket].present?
+      {
+        support_topics: session[:support_ticket]['support_topics'],
+      }
+    end
+  end
+
+  def next_step
+    support_ticket_support_details_path
+  end
+
+  def remove_empty_topics
+    form.support_topics.reject(&:blank?)
+  end
+end

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, 'Which academy trust do you work for?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Which academy trust do you work for?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: support_ticket_academy_details_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Get support</span>
+        Which academy trust do you work for?
+      </h1>
+
+      <%= f.govuk_text_field :academy_name, label: {text: 'Academy trust name', size: 's'} %>
+
+      <%= f.govuk_submit 'Next' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -1,0 +1,82 @@
+<% content_for :title, 'Check your answers, then submit your request' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Check your answers, then submit your request',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Get support</span>
+      Check your answers, then submit your request
+    </h1>
+
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render GovukComponent::SummaryList.new do |component| %>
+      <% component.slot(
+         :row,
+         key: "Which of these best describes you?",
+         value: SupportTicket::DescribeYourselfForm.new.selected_option_label(@support_ticket["user_type"]),
+         action: govuk_link_to("Change", support_ticket_describe_yourself_path),
+         classes: "Which of these best describes you".to_s.downcase.gsub(/ /, "-"),
+         )
+      %>
+
+      <% unless [ 'parent_or_guardian_or_carer_or_pupil_or_care_leaver', 'other_type_of_user'].include?  @support_ticket["user_type"] %>
+
+        <% component.slot(
+           :row,
+           key: "Which school do you work for?",
+           value: "#{@support_ticket["school_name"]} (URN: #{ @support_ticket["school_unique_id"]})",
+           action: govuk_link_to("Change", @school_details_path),
+           classes: "Which of these best describes you".to_s.downcase.gsub(/ /, "-"),
+           )
+        %>
+      <% end %>
+
+      <% component.slot(
+         :row,
+         key: "How can we contact you?",
+         value: "#{ @support_ticket["full_name"]}<br>#{ @support_ticket["email_address"]}<br>#{ @support_ticket["telephone_number"]}".html_safe ,
+         action: govuk_link_to("Change", support_ticket_contact_details_path),
+         classes: "Name".to_s.downcase.gsub(/ /, "-"),
+       ) %>
+
+      <% support_topics = @support_ticket["support_topics"].each{} %>
+      <% component.slot(
+         :row,
+         key: "What do you need help with?",
+         value: content_tag(:ul, :class => 'govuk-list govuk-list--bullet') do
+           @support_ticket["support_topics"].collect do |topic|
+             content_tag(:li, SupportTicket::SupportNeedsForm.new.selected_option_label(topic))
+           end.join.html_safe
+         end ,
+         action: govuk_link_to("Change", support_ticket_support_needs_path),
+         classes: "Name".to_s.downcase.gsub(/ /, "-"),
+         ) %>
+
+      <% component.slot(
+         :row,
+         key: "How can we help you?",
+         value: @support_ticket["message"] ,
+         action: govuk_link_to("Change", support_ticket_support_details_path),
+         classes: "Name".to_s.downcase.gsub(/ /, "-"),
+         ) %>
+
+    <% end %>
+
+    <div class="govuk-form-group">
+      <%= form_for @form, url: support_ticket_check_your_request_path do |f| %>
+        <%= f.govuk_submit 'Submit' %>
+      <% end %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, 'Which college do you work for?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Which college do you work for?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: support_ticket_college_details_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Get support</span>
+        Which college do you work for?
+      </h1>
+
+      <%= f.govuk_text_field :college_name, label: {text: 'College name', size: 's'} %>
+      <%= f.govuk_text_field :college_ukprn,
+                             label: {text: 'College UKPRN', size: 's'},
+                             hint: { text: 'This 8-digit number helps us to locate your college. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">UKPRN</a>.'.html_safe },
+                             width: 5 %>
+      <%= f.govuk_submit 'Next' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/contact_details.html.erb
+++ b/app/views/support_tickets/contact_details.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, 'How can we contact you?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'How can we contact you?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: support_ticket_contact_details_path do |f| %>
+      <%= f.govuk_error_summary "There's a problem" %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Get support</span>
+        How can we contact you?
+      </h1>
+
+      <%= f.govuk_text_field :full_name, label: {size: 's',text: 'Your full name'} %>
+      <%= f.govuk_text_field :email_address,
+                             label: {size: 's', text: 'Your email address'},
+                             hint: { text: "We’ll use this to reply to your query. Give us the email address linked to your school, college, trust, local authority or organisation."} %>
+      <%= f.govuk_text_field :telephone_number, width: "one-half",
+                             label: {size: 's', text: 'Telephone number (Optional)'},
+                             hint: {text: "It will help our support team if they need to call you to resolve your query."} %>
+
+      <%= f.govuk_submit "Next" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/describe_yourself.html.erb
+++ b/app/views/support_tickets/describe_yourself.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, t('landing_pages.get_support.describe_yourself')%>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  t('landing_pages.get_support.describe_yourself'),
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_for @form, url: support_ticket_describe_yourself_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <%= f.govuk_collection_radio_buttons  :user_type,
+          @form.describe_yourself_options,
+                                            :value,
+                                            :label,
+                                            legend: {size: 'l', text: t('landing_pages.get_support.describe_yourself')},
+                                            caption: { text: 'Get support', size: 'l'}
+      %>
+
+
+
+      <%= f.govuk_submit "Next"%>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, 'Which local authority do you work for?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Which local authority do you work for?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: support_ticket_local_authority_details_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Get support</span>
+        Which local authority do you work for?
+      </h1>
+
+      <%= f.govuk_text_field :local_authority_name, label: {text: 'Local authority name', size: 's'} %>
+
+      <%= f.govuk_submit 'Next' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/parent_support.html.erb
+++ b/app/views/support_tickets/parent_support.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, 'Contact your school, college or local authority for support' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Contact your school, college or local authority for support',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      Contact your school, college or local authority for support
+    </h1>
+
+    <p class="govuk-body">The Get help with technology scheme is open to schools, colleges and local authorities only.</p>
+
+    <p class="govuk-body">
+      Parents, carers and pupils cannot apply for devices through this scheme themselves.
+    </p>
+
+    <p class="govuk-body">
+      If you have received a device from your school, college or local authority and need help with it,
+      please contact the person who gave it to you. These guides may also be helpful to you:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <a class="govuk-link" href="/devices/getting-started-with-your-microsoft-windows-device">Getting started with your Microsoft Windows device</a>
+      </li>
+      <li>
+        <a class="govuk-link" href="/devices/getting-started-with-your-google-chromebook">Getting started with your Google Chromebook</a>
+      </li>
+      <li>
+        <a class="govuk-link" href="/devices/4g-user-guidance">How to get started with your 4G wireless router</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, 'Which school do you work for?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Which school do you work for?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @form, url: support_ticket_school_details_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Get support</span>
+        Which school do you work for?
+      </h1>
+
+      <%= f.govuk_text_field :school_name, label: {text: 'School name', size: 's'} %>
+      <%= f.govuk_text_field :school_urn,
+                             label: {text: 'School URN', size: 's'},
+                             hint: { text: 'This 6-digit number helps us to locate your school. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">URN</a>.'.html_safe },
+                             width: 5 %>
+      <%= f.govuk_submit 'Next' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/start.html.erb
+++ b/app/views/support_tickets/start.html.erb
@@ -1,0 +1,62 @@
+<% content_for :title, t('landing_pages.get_support.start') %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  t('landing_pages.get_support.start'),
+                 ]) %>
+<% end %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      <%= t('landing_pages.get_support.start') %>
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      We're here to answer any queries you have about the Get help with technology programme.
+      To help us respond to you more quickly (within 3 working days), please answer a few questions.
+      These should take no longer than 5 minutes.
+    </p>
+
+    <%= render GovukComponent::StartNowButton.new(
+      text: 'Start now',
+      href: support_ticket_describe_yourself_path) %>
+
+    <p class="govuk-body govuk-!-margin-top-3">
+      If you'd rather not answer these questions, you can email <a href="COVID.TECHNOLOGY@education.gov.uk" class="govuk-link">COVID.TECHNOLOGY@education.gov.uk</a>
+      instead. We'll still aim to respond to you within 3 working days.
+
+    <p class="govuk-body">You can also find out more about the Department for Education&rsquo;s Get help with technology programme on <a href="https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19" class="govuk-link">GOV.UK.</a></p>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+
+    <aside class="app-related-items" role="complementary">
+      <h2 class="govuk-heading-m" id="help-guides">
+        Most viewed help guides
+      </h2>
+      <!-- @TODO NEED TRACKING FOR THESE LINKS ? -->
+      <nav role="navigation" aria-labelledby="help-guides">
+        <ul class="govuk-list govuk-!-font-size-16">
+          <li>
+            <%= govuk_link_to "How and when to order laptops and tablets" , devices_how_to_order_path %>
+          </li>
+          <li>
+            <a class="govuk-link" href="/devices/device-allocations">
+              About device allocations
+            </a>
+          </li>
+          <li>
+            <a class="govuk-link" href="/devices/device-specification">
+              Device options and specifications
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+  </div>
+</div>

--- a/app/views/support_tickets/support_details.html.erb
+++ b/app/views/support_tickets/support_details.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, 'How can we help you?' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'How can we help you?',
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_for @form, url: support_ticket_support_details_path  do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <%= f.govuk_text_area :message, rows: 10,
+                            caption: { text: 'Get support', size: 'l'},
+                            label: { text: 'How can we help you?', size: 'l',  tag:'h1'},
+                            hint: { text: "Please provide us with as much detail as possible", size: 'l'} %>
+
+      <%= f.govuk_submit 'Next' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/support_needs.html.erb
+++ b/app/views/support_tickets/support_needs.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, "What do you need help with?" %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  "What do you need help with?",
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_for @form, url: support_ticket_support_needs_path do |f| %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <%= f.govuk_collection_check_boxes :support_topics,
+          @form.support_needs_options,
+                                            :value,
+                                            :label,
+                                            caption: { text: "Get support", size: "l"},
+                                            legend: { text: "What do you need help with?", size: "l"},
+                                            hint:{text: "Please select all of the options that apply", size: 'l'}
+      %>
+
+
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title,  'Thank you for completing this form' %>
+
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => guidance_page_path },
+                  {t('landing_pages.get_support.start') => support_ticket_path},
+                  'Thank you for completing this form',
+                 ]) %>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      Thank you for completing this form
+    </h1>
+    <p class="govuk-body">Our support team has received your request. If you do not receive an email from us within that time, please check your spam or junk folder.</p>
+
+    <p class="govuk-body">We aim to respond within 3 working days.</p>
+
+    <!-- @TODO TRACK LINK ? -->
+    <p class="govuk-body">Access further resources on
+      <a href="https://get-help-with-tech.education.gov.uk/" rel="noreferrer noopener" target="_blank">Get help with technology</a>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,9 @@ en:
     your_schools: Your schools
     your_organisations: Your organisations
   landing_pages:
+    get_support:
+      start: Get support
+      describe_yourself: Which of these best describes you?
     get_support_guides:
       title: Get support guides for laptops, tablets and 4G wireless routers
     digital_platforms:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,31 @@ Rails.application.routes.draw do
 
   resources :sessions, only: %i[create destroy]
 
+  namespace :support_ticket, path: '/get-support' do
+    get '/', to: 'base#start'
+    get '/describe-yourself', to: 'describe_yourself#new'
+    post '/describe-yourself', to: 'describe_yourself#save'
+    get '/school-details', to: 'school_details#new'
+    post '/school-details', to: 'school_details#save'
+    get '/academy-details', to: 'academy_details#new'
+    post '/academy-details', to: 'academy_details#save'
+    get '/local-authority-details', to: 'local_authority_details#new'
+    post '/local-authority-details', to: 'local_authority_details#save'
+    get '/college-details', to: 'college_details#new'
+    post '/college-details', to: 'college_details#save'
+    get '/contact-details', to: 'contact_details#new'
+    post '/contact-details', to: 'contact_details#save'
+    get '/support-needs', to: 'support_needs#new'
+    post '/support-needs', to: 'support_needs#save'
+    get '/support-details', to: 'support_details#new'
+    post '/support-details', to: 'support_details#save'
+    get '/check-your-request', to: 'check_your_request#new'
+    post '/check-your-request', to: 'check_your_request#save'
+
+    get '/parent-support', to: 'base#parent_support'
+    get '/thank-you', to: 'base#thank_you'
+  end
+
   get '/token/validate', to: 'sign_in_tokens#validate', as: :validate_sign_in_token
   delete '/token/validate', to: 'sign_in_tokens#destroy', as: :destroy_sign_in_token
   get '/token/validate-manual', to: 'sign_in_tokens#validate_manual', as: :validate_manually_entered_sign_in_token

--- a/spec/controllers/support_ticket/academy_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/academy_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::AcademyDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::AcademyDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_academy_details_form: { academy_name: 'Academy 1' } }
+      expect(session[:support_ticket]).to eq({ academy_name: 'Academy 1', school_name: 'Academy 1', school_unique_id: '' })
+    end
+
+    it 'redirects to contact details page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_academy_details_form: { academy_name: 'Academy 1' } }
+      expect(response).to redirect_to(support_ticket_contact_details_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/base_controller_spec.rb
+++ b/spec/controllers/support_ticket/base_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::BaseController, type: :controller do
+  describe '#start' do
+    it 'responds successfully' do
+      get :start
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#parent_support' do
+    it 'responds successfully' do
+      get :parent_support
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#thank_you' do
+    it 'responds successfully' do
+      get :thank_you
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/controllers/support_ticket/college_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/college_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::CollegeDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::CollegeDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_college_details_form: { college_name: 'College 1', college_ukprn: '123456' } }
+      expect(session[:support_ticket]).to eq({ college_name: 'College 1', college_ukprn: '123456', school_name: 'College 1', school_unique_id: '123456' })
+    end
+
+    it 'redirects to contact details page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_college_details_form: { college_name: 'College 1', college_ukprn: '123456' } }
+      expect(response).to redirect_to(support_ticket_contact_details_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/contact_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/contact_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::ContactDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::ContactDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_contact_details_form: { full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333' } }
+      expect(session[:support_ticket]).to eq({ full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333' })
+    end
+
+    it 'redirects to support needs page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_contact_details_form: { full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333' } }
+      expect(response).to redirect_to(support_ticket_support_needs_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
+++ b/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::DescribeYourselfController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::DescribeYourselfForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the selected usser type in session state' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'local_authority' } }
+      expect(session[:support_ticket]).to eq({ user_type: 'local_authority' })
+    end
+
+    it 'redirects to academy details page' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'multi_academy_trust' } }
+      expect(response).to redirect_to(support_ticket_academy_details_path)
+    end
+
+    it 'redirects to LA details page' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'local_authority' } }
+      expect(response).to redirect_to(support_ticket_local_authority_details_path)
+    end
+
+    it 'redirects to college details page' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'college' } }
+      expect(response).to redirect_to(support_ticket_college_details_path)
+    end
+
+    it 'redirects to parents info page' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'parent_or_guardian_or_carer_or_pupil_or_care_leaver' } }
+      expect(response).to redirect_to(support_ticket_parent_support_path)
+    end
+
+    it 'redirects to contact details page for other types of users' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'other_type_of_user' } }
+      expect(response).to redirect_to(support_ticket_contact_details_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::LocalAuthorityDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::LocalAuthorityDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_local_authority_details_form: { local_authority_name: 'LA 1' } }
+      expect(session[:support_ticket]).to eq({ local_authority_name: 'LA 1', school_name: 'LA 1', school_unique_id: '' })
+    end
+
+    it 'redirects to contact details page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_local_authority_details_form: { local_authority_name: 'LA 1' } }
+      expect(response).to redirect_to(support_ticket_contact_details_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/school_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/school_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SchoolDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::SchoolDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_school_details_form: { school_name: 'School 1', school_urn: '123456' } }
+      expect(session[:support_ticket]).to eq({ school_name: 'School 1', school_urn: '123456', school_unique_id: '123456' })
+    end
+
+    it 'redirects to contact details page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_school_details_form: { school_name: 'School 1', school_urn: '123456' } }
+      expect(response).to redirect_to(support_ticket_contact_details_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/support_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_details_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SupportDetailsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::SupportDetailsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_support_details_form: { message: 'please help me with this issue' } }
+      expect(session[:support_ticket]).to eq({ message: 'please help me with this issue' })
+    end
+
+    it 'redirects to check your answers page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_support_details_form: { message: 'please help me with this issue' } }
+      expect(response).to redirect_to(support_ticket_check_your_request_path)
+    end
+  end
+end

--- a/spec/controllers/support_ticket/support_needs_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_needs_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::SupportNeedsController, type: :controller do
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::SupportNeedsForm)
+    end
+  end
+
+  describe '#save' do
+    it 'stores the data in session state' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_support_needs_form: { support_topics: ['i_need_help', 'with the following'] } }
+      expect(session[:support_ticket]).to eq({ support_topics: ['i_need_help', 'with the following'] })
+    end
+
+    it 'removes any empty options from the support topics' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_support_needs_form: { support_topics: ['', 'i_need_help', 'with the following'] } }
+      expect(session[:support_ticket]).to eq({ support_topics: ['i_need_help', 'with the following'] })
+    end
+
+    it 'redirects to support details page' do
+      session[:support_ticket] = {}
+      post :save, params: { support_ticket_support_needs_form: { support_topics: ['i_need_help', 'with the following'] } }
+      expect(response).to redirect_to(support_ticket_support_details_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context
The breakup of #889 into smaller PR, this can be merged as-is, and the user should not be able to find it because we have not published any URL in the service or comms. If you want to view the user journey you can see it by visiting https://dfe-ghwt-pr-889.herokuapp.com/get-support


### Changes proposed in this pull request
- Adds routes/controllers to the get support form pages
- Adds views for the get support form pages
- Only has basic validation for required fields
- Does not create any zendesk tickets
### Guidance to review

Visit https://dfe-ghwt-pr-1022.herokuapp.com/get-support
