### PR TITLE
adds banner for when schools closed for mass testing  can order

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -267,6 +267,13 @@
                 </p>
               </div>
             <% end %>
+            <% if FeatureFlag.active?(:secondary_mass_testing_banner) %>
+              <div class="app-card govuk-!-margin-bottom-4">
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                  All secondary schools closed for mass testing, and all primary schools closed under the contingency framework can order laptops and tablets now
+                </p>
+              </div>
+            <% end %>
             <p class="app-step-nav__paragraph">
               If face-to-face education at a school is disrupted due to coronavirus (such as a ‘bubble’ or year group being advised not to attend), schools can make us aware via the <%= link_to_ed_settings_form %> which is monitored daily.
             </p>

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -270,7 +270,7 @@
             <% if FeatureFlag.active?(:secondary_mass_testing_banner) %>
               <div class="app-card govuk-!-margin-bottom-4">
                 <p class="govuk-body govuk-!-margin-bottom-0">
-                  All secondary schools closed for mass testing, and all primary schools closed under the contingency framework can order laptops and tablets now
+                  All secondary schools closed for mass testing, and all primary schools closed under the contingency framework can order laptops and tablets now.
                 </p>
               </div>
             <% end %>

--- a/spec/views/devices_guidance/how_to_order.html.erb_spec.rb
+++ b/spec/views/devices_guidance/how_to_order.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'devices_guidance/how_to_order.html.erb' do
+  it 'does not show mass testing banner by default' do
+    render
+    expect(rendered).not_to include('mass testing')
+  end
+
+  it 'show mass testing banner with feature flag', with_feature_flags: { secondary_mass_testing_banner: 'active' } do
+    render
+    expect(rendered).to include('mass testing')
+  end
+end


### PR DESCRIPTION
### Context

Schools closed for mass testing can order their device allocation.

### Changes proposed in this pull request

Adds a banner (as used to notify schools about Christmas ordering closure) to say schools closed for testing can order their device allocation on the how to order page.

![Screenshot 2021-01-04 at 14 04 21](https://user-images.githubusercontent.com/8417288/103544400-f907d380-4e97-11eb-8aad-26b358befd5e.png)

### Guidance to review

Set 'secondary_mass_testing_banner' feature flag to active and visit devices/how-to-order.