### PR TITLE
[286] Add zendesk integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ gem 'notifications-ruby-client'
 # parsing XLSX spreadsheets for bulk extra data requests
 gem 'rubyXL'
 
+# Integrate with zendesk to create support tickets
+gem 'zendesk_api'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    hashie (4.1.0)
     http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -198,6 +199,7 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
+    inflection (1.0.0)
     jwt (2.2.2)
     listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -220,6 +222,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -454,6 +459,12 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
+    zendesk_api (1.28.0)
+      faraday (>= 0.9.0, < 2.0.0)
+      hashie (>= 3.5.2, < 5.0.0)
+      inflection
+      mime-types
+      multipart-post (~> 2.0)
 
 PLATFORMS
   ruby
@@ -518,6 +529,7 @@ DEPENDENCIES
   webdrivers (~> 4.4)
   webmock
   webpacker
+  zendesk_api
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ GHWT__SLACK__EVENT_NOTIFICATIONS__WEBHOOK_URL    | URL for the incoming webhook 
 GHWT__COMPUTACENTER__OUTGOING_API__ENDPOINT      | URL of the CapUpdateRequest API at TechSource | (nil)
 GHWT__COMPUTACENTER__OUTGOING_API__USERNAME      | Basic auth username to use for the TechSource CapUpdateRequest API | (nil)
 GHWT__COMPUTACENTER__OUTGOING_API__PASSWORD      | Basic auth password to use for the TechSource CapUpdateRequest API | (nil)
-
+GHWT__ZENDESK__USERNAME                          | Username for Zendesk account to be able to use the Zendesk API. Both Zendesk options need to set before Zendesk API can be used. | (nil)
+GHWT__ZENDESK__TOKEN                             | Token for Zendesk account to be able to use the Zendesk API.Both Zendesk options need to set before Zendesk API can be used. | (nil)
 
 
 See the [settings.yaml file](config/settings.yml) for full details on configurable options.

--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -8,6 +8,8 @@ class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
 
   def save
     if form.valid?
+      form.create_ticket
+      session[:support_ticket] = nil
       redirect_to next_step
     else
       render 'support_tickets/check_your_request'
@@ -20,7 +22,7 @@ private
     @form ||= SupportTicket::CheckYourRequestForm.new(ticket: session[:support_ticket])
   end
 
-  def check__params(opts = params)
+  def check_params(opts = params)
     opts.fetch(:support_ticket_support_details_form, {})
   end
 

--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -6,7 +6,7 @@ class SupportTicket::CheckYourRequestForm
   validates :ticket, presence: true
 
   def create_ticket
-    if Settings.zendesk.present? && Settings.zendesk.username.present? && Settings.zendesk.token.present?
+    if Settings.zendesk&.username.present? && Settings.zendesk&.token.present?
       ticket['subject'] = build_subject
       ZendeskService.send!(ticket)
     end

--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -6,7 +6,17 @@ class SupportTicket::CheckYourRequestForm
   validates :ticket, presence: true
 
   def create_ticket
-    ticket['subject'] = "TESTING - (#{ticket['school_unique_id']}) #{ticket['school_name']} "
-    ZendeskService.send!(ticket)
+    if Settings.zendesk.present? && Settings.zendesk.username.present? && Settings.zendesk.token.present?
+      ticket['subject'] = build_subject
+      ZendeskService.send!(ticket)
+    end
+  end
+
+private
+
+  def build_subject
+    urn_or_ukprn = "(#{ticket['school_unique_id']}) " if ticket['school_unique_id'].present?
+
+    "ONLINE FORM - #{urn_or_ukprn}#{ticket['school_name']}"
   end
 end

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -1,9 +1,16 @@
 class ZendeskService
   attr_accessor :ticket
 
+  CUSTOM_FIELD_IDS = {
+    contact_form: '360011490478',
+    user_type: '360011798678',
+    support_topics: '360011519218',
+    telephone_number: '360011762698',
+  }.freeze
+
   class << self
     def send!(ticket)
-      ZendeskService.new(ticket).send!
+      new(ticket).send!
     end
   end
 
@@ -20,10 +27,10 @@ class ZendeskService
         body: ticket['message'],
       },
       custom_fields: [
-        { id: '360011490478', value: 'contact_form' },
-        { id: '360011798678', value: ticket['user_type'] },
-        { id: '360011519218', value: ticket['support_topics'] },
-        { id: '360011762698', value: ticket['telephone_number'] },
+        { id: CUSTOM_FIELD_IDS[:contact_form], value: 'contact_form' },
+        { id: CUSTOM_FIELD_IDS[:user_type], value: ticket['user_type'] },
+        { id: CUSTOM_FIELD_IDS[:support_topics], value: ticket['support_topics'] },
+        { id: CUSTOM_FIELD_IDS[:telephone_number], value: ticket['telephone_number'] },
       ],
     )
   end

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -1,0 +1,45 @@
+class ZendeskService
+  attr_accessor :ticket
+
+  class << self
+    def send!(ticket)
+      ZendeskService.new(ticket).send!
+    end
+  end
+
+  def initialize(ticket)
+    @ticket = ticket
+  end
+
+  def send!
+    ZendeskAPI::Request.create!(
+      client,
+      requester: { email: ticket['email_address'], name: ticket['full_name'] },
+      subject: ticket['subject'],
+      comment: {
+        body: ticket['message'],
+      },
+      custom_fields: [
+        { id: '360011490478', value: 'contact_form' },
+        { id: '360011798678', value: ticket['user_type'] },
+        { id: '360011519218', value: ticket['support_topics'] },
+        { id: '360011762698', value: ticket['telephone_number'] },
+      ],
+    )
+  end
+
+private
+
+  def client
+    @client ||= ZendeskAPI::Client.new do |config|
+      config.url = 'https://get-help-with-tech-education.zendesk.com/api/v2'
+      config.username = Settings.zendesk.username
+      config.token = Settings.zendesk.token
+      config.retry = true
+
+      require 'logger'
+      config.logger = Logger.new('log/zendesk.log')
+      config.logger.level = Logger::DEBUG
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -103,3 +103,7 @@ logstash:
 
 support:
   performance_data_access_token: # bearer token for support performance data
+
+zendesk:
+  username:  # Zendesk user account details
+  token: # API Token generated from zendesk

--- a/spec/controllers/support_ticket/check_your_request_controller_spec.rb
+++ b/spec/controllers/support_ticket/check_your_request_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
+  describe '#new' do
+    before do
+      get :new, session: { support_ticket: { hello: 'world' } }
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_successful
+    end
+
+    it 'creates a form object' do
+      expect(assigns(:form)).to be_instance_of(SupportTicket::CheckYourRequestForm)
+    end
+
+    it 'assigns the session data to a variable to play back all the details to the user' do
+      expect(assigns(:support_ticket)).to eq({ hello: 'world' })
+    end
+  end
+
+  describe '#save' do
+    it 'clears the data in session state' do
+      session[:support_ticket] = { hello: 'world' }
+      post :save
+      expect(session[:support_ticket]).to be_nil
+    end
+
+    it 'redirects to thank you page' do
+      session[:support_ticket] = { hello: 'world' }
+      post :save
+      expect(response).to redirect_to(support_ticket_thank_you_path)
+    end
+  end
+end

--- a/spec/form_objects/support_ticket/check_your_request_form_spec.rb
+++ b/spec/form_objects/support_ticket/check_your_request_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
     }
   end
 
-  describe 'when in production and znedesk creditials are provided' do
+  describe 'when zendesk credentials are provided' do
     before do
       allow(Settings.zendesk).to receive(:username).and_return('Test User')
       allow(Settings.zendesk).to receive(:token).and_return('123456')
@@ -47,7 +47,7 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
     end
   end
 
-  describe 'when not in production and znedesk creditials are not provided' do
+  describe 'when zendesk credentials are not provided' do
     it 'does not call zendesk service' do
       allow(ZendeskService).to receive(:send!)
       described_class.new(ticket: mock_ticket).create_ticket

--- a/spec/form_objects/support_ticket/check_your_request_form_spec.rb
+++ b/spec/form_objects/support_ticket/check_your_request_form_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket::CheckYourRequestForm do
+  let(:mock_ticket) do
+    {
+      'full_name' => 'Joe Blogg',
+      'email_address' => 'joe@bloggs.com',
+      'user_type' => 'parent',
+      'telephone_number' => '0207 333 4444',
+      'subject' => 'My query',
+      'message' => 'This is my query',
+      'support_topics' => %w[hello world],
+    }
+  end
+
+  describe 'when in production and znedesk creditials are provided' do
+    before do
+      allow(Settings.zendesk).to receive(:username).and_return('Test User')
+      allow(Settings.zendesk).to receive(:token).and_return('123456')
+    end
+
+    it 'calls the zendesk service to create a ticket in zendesk' do
+      allow(ZendeskService).to receive(:send!)
+      described_class.new(ticket: mock_ticket).create_ticket
+      expect(ZendeskService).to have_received(:send!)
+    end
+
+    context 'Subject' do
+      it 'sets the email subject line to include just school name' do
+        allow(ZendeskService).to receive(:send!)
+        described_class.new(ticket: { 'school_name' => 'School 1' }).create_ticket
+        expect(ZendeskService).to have_received(:send!)
+                                    .with({ 'school_name' => 'School 1',
+                                            'subject' => 'ONLINE FORM - School 1' })
+      end
+
+      it 'sets the email subject line include name and URN/UKPRN' do
+        allow(ZendeskService).to receive(:send!)
+        described_class.new(ticket: { 'school_name' => 'School 1', 'school_unique_id' => '123456' }).create_ticket
+        expect(ZendeskService).to have_received(:send!)
+                                    .with({
+                                      'school_name' => 'School 1',
+                                      'school_unique_id' => '123456',
+                                      'subject' => 'ONLINE FORM - (123456) School 1',
+                                    })
+      end
+    end
+  end
+
+  describe 'when not in production and znedesk creditials are not provided' do
+    it 'does not call zendesk service' do
+      allow(ZendeskService).to receive(:send!)
+      described_class.new(ticket: mock_ticket).create_ticket
+      expect(ZendeskService).not_to have_received(:send!)
+    end
+  end
+end

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ZendeskService, type: :model do
+  subject(:service) { ZendeskService.new(ticket) }
+
+  let(:ticket) do
+    {
+      'full_name' => 'Joe Blogg',
+      'email_address' => 'joe@bloggs.com',
+      'user_type' => 'parent',
+      'telephone_number' => '0207 333 4444',
+      'subject' => 'My query',
+      'message' => 'This is my query',
+      'support_topics' => %w[hello world],
+    }
+  end
+
+  describe '#send!' do
+    it 'calls ZendeskAPI::Request.create!' do
+      allow(ZendeskAPI::Request).to receive(:create!)
+      service.send!
+      expect(ZendeskAPI::Request).to have_received(:create!)
+    end
+
+    it 'makes the expected request, with common and custom fields' do
+      call_to_zendesk = stub_request(:post, 'https://get-help-with-tech-education.zendesk.com/api/v2/requests')
+        .with(
+          body: '{"request":{"requester":{"email":"joe@bloggs.com","name":"Joe Blogg"},"subject":"My query","comment":{"body":"This is my query"},"custom_fields":[{"id":"360011490478","value":"contact_form"},{"id":"360011798678","value":"parent"},{"id":"360011519218","value":["hello","world"]},{"id":"360011762698","value":"0207 333 4444"}]}}',
+          headers: {
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic Og==',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'ZendeskAPI Ruby 1.28.0',
+          },
+        )
+        .to_return(status: 200, body: '', headers: {})
+
+      service.send!
+      expect(call_to_zendesk).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
### Context
Integrate Zendesk into the service so that we are able to log zendesk tickets through our service instead of users having to send us emails.

Before merging this PR, two new environment vars for zendesk username & token will be added to the production instance for API calls to work. We plan on testing get support forms and this integration before soft-launching it across the service.

### Changes proposed in this pull request

### Guidance to review

