### PR TITLE
Support console: streamline the design of the user's 'update schools' page

### DIFF
--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -24,13 +24,13 @@ class Support::Users::SchoolsController < Support::BaseController
     else
       flash[:warning] = @user_school.errors.full_messages.join("\n")
     end
-    redirect_to support_user_schools_path(@user)
+    redirect_to support_user_path(@user)
   end
 
-  def destroy
-    @user.schools.destroy(@school)
-    flash[:success] = "#{@user.full_name} is no longer associated with #{@school.name}"
-    redirect_to support_user_schools_path(@user)
+  def update_schools
+    @user.schools = @user.schools.where(id: update_schools_params)
+    flash[:success] = 'Schools updated'
+    redirect_to support_user_path(@user)
   end
 
 private
@@ -46,5 +46,9 @@ private
 
   def user_school_params(opts = params)
     opts.fetch('support_school_suggestion_form').permit(:name_or_urn, :school_urn)
+  end
+
+  def update_schools_params
+    params.require(:user).require(:school_ids).reject(&:blank?)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,4 +14,5 @@ class UserPolicy < SupportPolicy
   alias_method :search?, :readable?
   alias_method :results?, :readable?
   alias_method :confirm_destroy?, :editable?
+  alias_method :update_schools?, :editable?
 end

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -8,48 +8,17 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 id="schools" class="govuk-heading-l">Schools</h2>
     <%- if @schools.present? %>
-      <table class="govuk-table schools">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name and URN</th>
-            <th scope="col" class="govuk-table__header">Responsible body</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
-
-        <tbody class="govuk-table__body">
-          <% @schools.each do |school| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
-                <br>
-                <%= school.type_label %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_button_to('Remove', support_user_school_path(@user, urn: school.urn), method: :delete, form_class: 'form-inline')  %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-
-    <%- else %>
-      <p class="govuk-body">(none)</p>
+      <%= form_for @user, url: support_user_update_schools_path(@user) do |f| %>
+        <%= f.govuk_collection_check_boxes :school_ids, @schools, :id, :name, legend: nil %>
+        <%= f.govuk_submit 'Update' %>
+      <%- end %>
     <%- end %>
 
     <%= form_for @user_school_form, url: new_support_user_school_path(@user), method: :get do |f| %>
-      <%= f.govuk_fieldset legend: { text: 'Associate with a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn, width: 'one-third' %>
+      <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds' %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit %>
       <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,8 +73,8 @@ en:
         results: Users
         new: Invite a new user
         schools:
-          index: Update schools
-          new: Associate with a school
+          index: Update school access
+          new: Grant access to a school
         responsible_bodies:
           index: Associate with a responsible body
           edit: Update responsible body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,7 +209,8 @@ Rails.application.routes.draw do
       member do
         get 'confirm-deletion', to: 'users#confirm_destroy'
       end
-      resources :schools, only: %i[index new create destroy], controller: 'users/schools', param: :urn
+      resources :schools, only: %i[index new create], controller: 'users/schools', param: :urn
+      patch 'schools', to: 'users/schools#update_schools', as: :update_schools
       resource :responsible_body, only: %i[edit update], controller: 'users/responsible_body', path: 'responsible-body'
     end
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -26,9 +26,9 @@ RSpec.feature 'Changing users’ associated organisations' do
   scenario 'a support agent removes a user from a school' do
     given_i_am_logged_in_as_a_support_user
     when_i_visit_a_users_schools_page
-    and_i_click_the_remove_link_next_to_a_school
+    and_i_remove_the_first_school
     then_i_no_longer_see_the_removed_school_in_their_schools
-    and_i_see_a_message_telling_me_the_school_has_been_removed
+    and_i_see_a_message_telling_me_the_schools_have_been_updated
   end
 
   scenario 'a support agent removes a user from a responsible body' do
@@ -115,19 +115,18 @@ RSpec.feature 'Changing users’ associated organisations' do
     visit support_user_schools_path(responsible_body_user_with_multiple_schools)
   end
 
-  def and_i_click_the_remove_link_next_to_a_school
-    within(user_schools_page.schools[0]) do
-      click_on('Remove')
-    end
+  def and_i_remove_the_first_school
+    uncheck trust_school_1.name
+    click_on 'Update'
   end
 
   def then_i_no_longer_see_the_removed_school_in_their_schools
-    expect(user_schools_page.schools.size).to eq(1)
-    expect(user_schools_page.schools[0]).to have_text(trust_school_2.name)
+    expect(user_page.summary_list['Schools']).not_to have_text(trust_school_1.name)
+    expect(user_page.summary_list['Schools']).to have_text(trust_school_2.name)
   end
 
-  def and_i_see_a_message_telling_me_the_school_has_been_removed
-    expect(user_schools_page).to have_text("#{responsible_body_user_with_multiple_schools.full_name} is no longer associated with #{trust_school_1.name}")
+  def and_i_see_a_message_telling_me_the_schools_have_been_updated
+    expect(user_schools_page).to have_text('Schools updated')
   end
 
   def then_i_see_the_user_has_no_responsible_body
@@ -177,8 +176,7 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def then_i_see_the_school_added_to_their_schools
-    expect(user_schools_page.schools.size).to eq(3)
-    expect(user_schools_page.schools[2]).to have_text(other_school.name)
+    expect(user_page.summary_list['Schools']).to have_text(other_school.name)
   end
 
   def and_i_see_a_message_telling_me_the_school_has_been_associated

--- a/spec/page_objects/support/users/schools_page.rb
+++ b/spec/page_objects/support/users/schools_page.rb
@@ -7,7 +7,6 @@ module PageObjects
         element :school_name_or_urn, 'input#support-school-suggestion-form-name-or-urn-field'
         element :school_urn, 'input#support_school_suggestion_form_school_urn'
         element :submit_school_name_or_urn, '#new_support_school_suggestion_form input[value=Continue]'
-        elements :schools, 'table.schools tbody tr'
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe UserPolicy do
   subject(:policy) { described_class }
 
-  permissions :new?, :create?, :edit?, :update?, :destroy?, :confirm_destroy? do
+  permissions :new?, :create?, :edit?, :update?, :destroy?, :confirm_destroy?, :update_schools? do
     it 'grants access to support users' do
       expect(policy).to permit(build(:support_user), :support)
     end


### PR DESCRIPTION
### Context

The support console allows removing and adding new schools for users of the system.

### Changes proposed in this pull request

Streamline the design of the user's 'update schools' page by:

- not surfacing information that's unnecessary to removing a school, like the responsible body and the type of school (since support requests almost always mention the name of the school from which the user needs to be removed)
- allowing bulk removal (by unticking multiple schools), instead of having to do it one button at a time

### Guidance to review

**Before:**

![image](https://user-images.githubusercontent.com/23801/102915061-13de4f00-4479-11eb-8e7d-1336e52370e0.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102915034-0a54e700-4479-11eb-9463-bee50b49b6fb.png)