### PR TITLE
Support console: streamline the editing a user's responsible body

### DIFF
--- a/app/controllers/support/users/responsible_body_controller.rb
+++ b/app/controllers/support/users/responsible_body_controller.rb
@@ -10,7 +10,8 @@ class Support::Users::ResponsibleBodyController < Support::BaseController
   end
 
   def update
-    @user.update!(responsible_body_id: responsible_body_params[:responsible_body])
+    form = Support::UserResponsibleBodyForm.new(responsible_body_params)
+    @user.update!(responsible_body_id: form.new_responsible_body_id)
     flash[:success] = success_message
     redirect_to support_user_path(@user)
   end
@@ -18,7 +19,7 @@ class Support::Users::ResponsibleBodyController < Support::BaseController
 private
 
   def responsible_body_params
-    params.require(:support_user_responsible_body_form).permit(:responsible_body)
+    params.require(:support_user_responsible_body_form).permit(:responsible_body_id, :change)
   end
 
   def success_message

--- a/app/form_objects/support/user_responsible_body_form.rb
+++ b/app/form_objects/support/user_responsible_body_form.rb
@@ -1,15 +1,20 @@
 class Support::UserResponsibleBodyForm
   include ActiveModel::Model
 
-  attr_accessor :user
+  attr_accessor :user, :change, :possible_responsible_bodies
+  attr_writer :responsible_body_id
 
-  def initialize(user:, possible_responsible_bodies: nil)
-    @user = user
-    @possible_responsible_bodies = possible_responsible_bodies
+  def new_responsible_body_id
+    case change
+    when 'add', 'move' then responsible_body_id
+    when 'remove' then nil
+    else
+      raise "Unexpected change #{change}"
+    end
   end
 
-  def responsible_body
-    @user.responsible_body&.id
+  def responsible_body_id
+    @responsible_body_id || @user.responsible_body&.id
   end
 
   def select_responsible_body_options

--- a/app/views/support/users/responsible_body/edit.html.erb
+++ b/app/views/support/users/responsible_body/edit.html.erb
@@ -31,7 +31,8 @@
           @user_responsible_body_form.select_responsible_body_options,
           :id,
           :name,
-          label: { text: 'Add user to a responsible body' }
+          label: { text: 'Add user to a responsible body' },
+          options: { include_blank: true }
           ) %>
       <%- end %>
       <%= f.govuk_submit 'Update' %>

--- a/app/views/support/users/responsible_body/edit.html.erb
+++ b/app/views/support/users/responsible_body/edit.html.erb
@@ -8,54 +8,33 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <%- if @responsible_body.present? %>
-      <table class="govuk-table responsible-body">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-            <th scope="col" class="govuk-table__header">Type</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
-
-        <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <%= govuk_link_to @responsible_body.name, support_responsible_body_path(id: @responsible_body.id) %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= @responsible_body.humanized_type %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= form_for @user_responsible_body_form, url: support_user_responsible_body_path(@user), method: :patch do |f| %>
-
-                <%= f.hidden_field :responsible_body, value: nil %>
-                <%= f.govuk_submit 'Remove' %>
-              <%- end %>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-    <%- else %>
-      <p class="govuk-body">(none)</p>
-    <%- end %>
 
     <%= form_for @user_responsible_body_form, url: support_user_responsible_body_path(@user), method: :patch do |f| %>
 
-      <%= f.govuk_collection_select(
-        :responsible_body,
-        @user_responsible_body_form.select_responsible_body_options,
-        :id,
-        :name,
-        label: { text: 'Move to a different responsible body' }
-        ) %>
-      <%= f.govuk_submit 'Move' %>
-    <%- end %>
+      <%- if @responsible_body.present? %>
+        <%= f.govuk_radio_buttons_fieldset(:change, legend: nil) do %>
+          <%= f.govuk_radio_button :change, 'move', label: { text: 'Move user to a different responsible body' } do %>
+            <%= f.govuk_collection_select(
+              :responsible_body_id,
+              @user_responsible_body_form.select_responsible_body_options,
+              :id,
+              :name,
+              label: { text: 'New responsible body' }
+              ) %>
+          <% end %>
+          <%= f.govuk_radio_button :change, 'remove', label: { text: 'Remove user from responsible body' }, link_errors: true %>
+        <% end %>
+      <% else %>
+        <%= f.hidden_field 'change', value: 'add' %>
+        <%= f.govuk_collection_select(
+          :responsible_body_id,
+          @user_responsible_body_form.select_responsible_body_options,
+          :id,
+          :name,
+          label: { text: 'Add user to a responsible body' }
+          ) %>
+      <%- end %>
+      <%= f.govuk_submit 'Update' %>
+    <% end %>
   </div>
 </div>

--- a/app/webpacker/scripts/responsible-bodies-autocomplete.js
+++ b/app/webpacker/scripts/responsible-bodies-autocomplete.js
@@ -2,7 +2,7 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initResponsibleBodiesAutocomplete = () => {
   try {
-    const id = "#support-user-responsible-body-form-responsible-body-field";
+    const id = "#support-user-responsible-body-form-responsible-body-id-field";
     const responsibleBodiesSelect = document.querySelector(id);
     if (!responsibleBodiesSelect) return;
 

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -138,7 +138,8 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_remove_the_responsible_body
-    click_on 'Remove'
+    choose 'Remove user from responsible body'
+    click_on 'Update'
   end
 
   def and_i_see_a_message_telling_me_the_responsible_body_has_been_removed
@@ -199,8 +200,9 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_select_a_new_responsible_body_name
-    select other_local_authority.name, from: 'support-user-responsible-body-form-responsible-body-field'
-    click_on 'Move'
+    choose 'Move user to a different responsible body'
+    select other_local_authority.name, from: 'New responsible body'
+    click_on 'Update'
   end
 
   def then_i_see_the_new_responsible_body_replaces_their_existing_responsible_body


### PR DESCRIPTION
### Context

The support console allows removing and adding new schools for users of the system.

### Changes proposed in this pull request

Apply the same interaction patterns for:

- adding
- updating
- removing a user's responsible body

as are present in the school-user-facing parts of the app.

### Guidance to review

#### Setting a responsible body when there wasn't one before

**Before:**

![image](https://user-images.githubusercontent.com/23801/102914551-653a0e80-4478-11eb-8f65-66ab6ac08321.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102914608-771bb180-4478-11eb-821c-b1393a6cf972.png)

#### Removing a responsible body and moving to a new responsible body

**Before:**

![image](https://user-images.githubusercontent.com/23801/102914773-b64a0280-4478-11eb-88e9-5f6b7cf50fae.png)

**After:**

![image](https://user-images.githubusercontent.com/23801/102914806-c235c480-4478-11eb-87a6-4f2fed83ceee.png)

![image](https://user-images.githubusercontent.com/23801/102914908-d8438500-4478-11eb-82a8-55763fe69626.png)