### PR TITLE
[286] Soft launch the get support form 

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,14 +82,13 @@
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <h2 class="govuk-heading-m">Need help?</h2>
-            <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-              <li>Email: <%= ghwt_contact_mailto %></li>
-              <li>We aim to respond within 4 working days.</li>
-            </ul>
-
             <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="<%= support_ticket_path %>">
+                  Contact us
+                </a>
+              </li>
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="<%= accessibility_path %>">
                   Accessibility

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -74,7 +74,7 @@
     </h2>
     <p class="govuk-body-s">
       If you work for a local authority, academy trust or school and you need help with any of the devices or services
-      offered by this programme, please email <%= ghwt_contact_mailto %>. We aim to respond within 4 working days.
+      offered by this programme, <%= govuk_link_to "please contact us", support_ticket_path %>.
     </p>
     <p class="govuk-body-s">
       If you’ve been given a laptop, tablet or 4G wireless router by your local authority or school and need some help,


### PR DESCRIPTION
### Context
**DO NOT MERGE** - This PR needs to be reviewed and only merged in once the get support form has been tested by the team and we are confident in releasing the feature to our users.

### Changes proposed in this pull request
- Adds a link to the get support form on the home page
- Adds a link to the get support form in the services footer

### Guidance to review

visit https://dfe-ghwt-pr-1035.herokuapp.com/ and you should see the links and the pages (You can go through the journey but it will not actually create zendesk ticket)