### PR TITLE
[1224] fix error when downloading a CSV of allocations for specified URNs

### DIFF
--- a/app/form_objects/school_search_form.rb
+++ b/app/form_objects/school_search_form.rb
@@ -44,7 +44,7 @@ class SchoolSearchForm
 
   def csv_filename
     tokens = %w[allocations]
-    tokens << "#{urns.count}-URNs" if urns.present?
+    tokens << "#{array_of_urns.count}-URNs" if urns.present?
     tokens << "RB-#{responsible_body_id}" if responsible_body_id.present?
     tokens << order_state if order_state.present?
     tokens << Time.zone.now.utc.iso8601

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe SchoolSearchForm do
       let(:responsible_body_id) { 1234 }
 
       it 'includes RB-(responsible_body_id)' do
-        expect(form.csv_filename).to include("RB-1234")
+        expect(form.csv_filename).to include('RB-1234')
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe SchoolSearchForm do
       let(:order_state) { 'my_order_state' }
 
       it 'includes the order_state' do
-        expect(form.csv_filename).to include("my_order_state")
+        expect(form.csv_filename).to include('my_order_state')
       end
     end
 

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -66,4 +66,46 @@ RSpec.describe SchoolSearchForm do
       end
     end
   end
+
+  describe '#csv_filename' do
+    let(:urns) { nil }
+    let(:responsible_body_id) { nil }
+    let(:order_state) { nil }
+    let(:form) { SchoolSearchForm.new(urns: urns, responsible_body_id: responsible_body_id, order_state: order_state) }
+    let(:expected_timestamp) { Time.zone.now.utc.iso8601 }
+
+    before do
+      Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
+    end
+
+    context 'when no search params were given' do
+      it 'returns allocations-(timestamp).csv' do
+        expect(form.csv_filename).to eq("allocations-#{expected_timestamp}.csv")
+      end
+    end
+
+    context 'when a responsible_body_id was given' do
+      let(:responsible_body_id) { 1234 }
+
+      it 'includes RB-(responsible_body_id)' do
+        expect(form.csv_filename).to include("RB-1234")
+      end
+    end
+
+    context 'when an order_state was given' do
+      let(:order_state) { 'my_order_state' }
+
+      it 'includes the order_state' do
+        expect(form.csv_filename).to include("my_order_state")
+      end
+    end
+
+    context 'when URNs are given' do
+      let(:urns) { "101111\r\n101222\r\n101333\r\n" }
+
+      it 'includes (number of urns)-URNs' do
+        expect(form.csv_filename).to include('3-URNs')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

[Trello card #1224](https://trello.com/c/vJ14NTGR/1224-exception-on-support-schools-search) - When in the support school search, if you searched by particular URNs and then clicked 'Download allocations as CSV' (new behaviour in #970), [an error was being thrown](https://sentry.io/organizations/dfe-get-help-with-tech/issues/2132906815/?environment=production&project=5320558&referrer=alert_email)

### Changes proposed in this pull request

Fix the error, and add a test for this case

### Guidance to review

