### PR TITLE
1188 remove mno pilot feature flags and virtual caps global feature flag

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -2,7 +2,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
   def rows
     array = super
     array << headteacher_row if headteacher.present?
-    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row) if @school.mno_feature_flag?
+    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row)
     array.map { |row| remove_change_links_if_read_only(row) }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,14 +57,8 @@ private
     end
   end
 
-  def render_404_unless_school_in_mno_feature(school)
-    unless school.mno_feature_flag
-      render 'errors/not_found', status: :not_found and return
-    end
-  end
-
-  def render_404_unless_responsible_body_in_mno_feature(responsible_body)
-    unless responsible_body.has_mno_feature_flags_and_centrally_managed_schools?
+  def render_404_unless_responsible_body_has_centrally_managed_schools(responsible_body)
+    unless responsible_body.in_connectivity_pilot_and_has_centrally_managed_schools?
       render 'errors/not_found', status: :not_found and return
     end
   end

--- a/app/controllers/responsible_body/internet/home_controller.rb
+++ b/app/controllers/responsible_body/internet/home_controller.rb
@@ -1,5 +1,5 @@
 class ResponsibleBody::Internet::HomeController < ResponsibleBody::Internet::BaseController
-  before_action { render_404_unless_responsible_body_in_mno_feature(@responsible_body) }
+  before_action { render_404_unless_responsible_body_has_centrally_managed_schools(@responsible_body) }
 
   def show; end
 end

--- a/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
@@ -1,6 +1,4 @@
 class ResponsibleBody::Internet::Mobile::BulkRequestsController < ResponsibleBody::BaseController
-  before_action { render_404_if_feature_flag_inactive(:mno_offer) }
-
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -1,5 +1,5 @@
 class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
-  before_action { render_404_unless_responsible_body_in_mno_feature(@responsible_body) }
+  before_action { render_404_unless_responsible_body_has_centrally_managed_schools(@responsible_body) }
 
   def index
     @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests

--- a/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
@@ -1,6 +1,4 @@
 class ResponsibleBody::Internet::Mobile::ManualRequestsController < ResponsibleBody::BaseController
-  before_action { render_404_if_feature_flag_inactive(:mno_offer) }
-
   def index
     @extra_mobile_data_requests = @current_user.extra_mobile_data_requests
   end

--- a/app/controllers/school/internet/home_controller.rb
+++ b/app/controllers/school/internet/home_controller.rb
@@ -1,5 +1,3 @@
 class School::Internet::HomeController < School::BaseController
-  before_action { render_404_unless_school_in_mno_feature(@school) }
-
   def show; end
 end

--- a/app/controllers/school/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/bulk_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::BulkRequestsController < School::BaseController
-  before_action { render_404_unless_school_in_mno_feature(@school) }
-
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::ExtraDataRequestsController < School::BaseController
-  before_action { render_404_unless_school_in_mno_feature(@school) }
-
   def index
     @extra_mobile_data_requests = @school.extra_mobile_data_requests
   end

--- a/app/controllers/school/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/manual_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::ManualRequestsController < School::BaseController
-  before_action { render_404_unless_school_in_mno_feature(@school) }
-
   def index
     @extra_mobile_data_requests = @current_user.extra_mobile_data_requests
   end

--- a/app/models/computacenter/outgoing_api/cap_update_request.rb
+++ b/app/models/computacenter/outgoing_api/cap_update_request.rb
@@ -55,7 +55,7 @@ class Computacenter::OutgoingAPI::CapUpdateRequest
 private
 
   def get_allocation_data
-    records = SchoolDeviceAllocation.includes(school: :preorder_information).where(id: @allocation_ids)
+    records = SchoolDeviceAllocation.includes(school: :preorder_information).where(id: @allocation_ids).order(:device_type, :id)
 
     if records.present?
       records = records.map do |allocation|

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -104,8 +104,8 @@ class ResponsibleBody < ApplicationRecord
     has_virtual_cap_feature_flags? && has_centrally_managed_schools?
   end
 
-  def has_mno_feature_flags_and_centrally_managed_schools?
-    FeatureFlag.active?(:mno_offer) && in_connectivity_pilot? && has_centrally_managed_schools?
+  def in_connectivity_pilot_and_has_centrally_managed_schools?
+    in_connectivity_pilot? && has_centrally_managed_schools?
   end
 
   def has_multiple_chromebook_domains_in_managed_schools?

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -97,7 +97,7 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def has_virtual_cap_feature_flags?
-    FeatureFlag.active?(:virtual_caps) && vcap_feature_flag?
+    vcap_feature_flag?
   end
 
   def has_virtual_cap_feature_flags_and_centrally_managed_schools?

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -74,12 +74,4 @@ class Support::ServicePerformance
       .sort_by { |_k, v| v }
       .reverse
   end
-
-  # def mno_schools_count
-  #   @mno_schools_count ||= School.where(mno_feature_flag: true).count
-  # end
-  #
-  # def mno_schools
-  #   @mno_schools ||= School.where(mno_feature_flag: true).includes(:responsible_body)
-  # end
 end

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -75,11 +75,11 @@ class Support::ServicePerformance
       .reverse
   end
 
-  def mno_schools_count
-    @mno_schools_count ||= School.where(mno_feature_flag: true).count
-  end
-
-  def mno_schools
-    @mno_schools ||= School.where(mno_feature_flag: true).includes(:responsible_body)
-  end
+  # def mno_schools_count
+  #   @mno_schools_count ||= School.where(mno_feature_flag: true).count
+  # end
+  #
+  # def mno_schools
+  #   @mno_schools ||= School.where(mno_feature_flag: true).includes(:responsible_body)
+  # end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[
-    virtual_caps
     christmas_banner
     increased_allocations_banner
     secondary_mass_testing_banner

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[
-    mno_offer
     virtual_caps
     christmas_banner
     increased_allocations_banner

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -18,7 +18,7 @@
       <li>give schools access to the services they need</li>
     </ul>
 
-    <%- if @responsible_body.has_mno_feature_flags_and_centrally_managed_schools? %>
+    <%- if @responsible_body.in_connectivity_pilot_and_has_centrally_managed_schools? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to t('page_titles.responsible_body_internet_home'), responsible_body_internet_path %>
       </h2>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -22,38 +22,25 @@
       <li>access the Computacenter TechSource website to order devices</li>
     </ul>
 
-    <% if !@school.mno_feature_flag %>
-      <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to t('page_titles.school_request_devices'), request_devices_school_path(@school) %>
-      </h2>
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Get internet access', internet_school_path(@school) %>
+    </h2>
 
-      <p class="govuk-body">Use this section to request devices for children who:</p>
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>request extra data for mobile devices</li>
+      <li>request 4G wireless routers</li>
+    </ul>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>are shielding on official advice</li>
-        <li>cannot attend school because restrictions prevent them from going</li>
-      </ul>
-    <% else %>
-      <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Get internet access', internet_school_path(@school) %>
-      </h2>
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.school_specific_circumstances'), specific_circumstances_school_path(@school) %>
+    </h2>
 
-      <p class="govuk-body">Use this section to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>request extra data for mobile devices</li>
-        <li>request 4G wireless routers</li>
-      </ul>
-
-      <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to t('page_titles.school_specific_circumstances'), specific_circumstances_school_path(@school) %>
-      </h2>
-
-      <p class="govuk-body">Use this section to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>understand when children can get support</li>
-        <li>see what help they can get</li>
-      </ul>
-    <% end %>
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>understand when children can get support</li>
+      <li>see what help they can get</li>
+    </ul>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.school_details'), details_school_path(@school) %>

--- a/app/views/shared/devices/request_devices.html.erb
+++ b/app/views/shared/devices/request_devices.html.erb
@@ -1,14 +1,10 @@
 <% if @school %>
   <%- title = t('page_titles.school_request_devices') %>
   <%- content_for :before_content do %>
-    <% if @school&.mno_feature_flag %>
-      <% breadcrumbs([{ "Home" => home_school_path },
+    <% breadcrumbs([{ "Home" => home_school_path },
                     { t('page_titles.school_specific_circumstances') => specific_circumstances_school_path(@school) },
                     title
-      ]) %>
-    <% else %>
-      <% breadcrumbs([{ "Home" => home_school_path }, title ]) %>
-    <% end %>
+    ]) %>
   <% end %>
 
 <% elsif @responsible_body %>

--- a/db/migrate/20210105161018_remove_school_mno_pilot_feature_flag.rb
+++ b/db/migrate/20210105161018_remove_school_mno_pilot_feature_flag.rb
@@ -1,0 +1,5 @@
+class RemoveSchoolMnoPilotFeatureFlag < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :schools, :mno_feature_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_144840) do
+ActiveRecord::Schema.define(version: 2021_01_05_161018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,8 +202,8 @@ ActiveRecord::Schema.define(version: 2020_12_16_144840) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
@@ -287,7 +287,6 @@ ActiveRecord::Schema.define(version: 2020_12_16_144840) do
     t.string "phone_number"
     t.string "order_state", default: "cannot_order", null: false
     t.string "status", default: "open", null: false
-    t.boolean "mno_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
     t.boolean "increased_allocations_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"

--- a/spec/components/display_allocations_component_spec.rb
+++ b/spec/components/display_allocations_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DisplayAllocationsComponent, type: :component do
     put_school_in_pool(trust, another_school)
   end
 
-  context 'when in a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
+  context 'when in a virtual pool' do
     before do
       put_school_in_pool(trust, school)
       school.reload
@@ -31,7 +31,7 @@ RSpec.describe DisplayAllocationsComponent, type: :component do
     end
   end
 
-  context 'when not in a virtual pool', with_feature_flags: { virtual_caps: 'inactive' } do
+  context 'when not in a virtual pool' do
     before do
       trust.update!(vcap_feature_flag: false)
     end

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -143,7 +143,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       expect(result.css('dl').text).not_to include('School contact')
     end
 
-    context 'when the responsible body has virtual caps enabled', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when the responsible body has virtual caps enabled' do
       let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
       let(:school) { create(:school, :primary, :academy, responsible_body: responsible_body) }
 

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -168,16 +168,8 @@ describe Support::SchoolDetailsSummaryListComponent do
   end
 
   describe 'extra mobile data' do
-    context 'when school is not using mno_feature' do
-      let(:school) { build(:school, mno_feature_flag: false) }
-
-      it 'does not display row' do
-        expect(result.text).not_to include('Extra mobile data requests')
-      end
-    end
-
     context 'when there are no requests' do
-      let(:school) { build(:school, mno_feature_flag: true) }
+      let(:school) { build(:school) }
 
       it 'shows Extra mobile data row with 0 requests' do
         expect(value_for_row(result, 'Extra mobile data requests').text).to include('0 requests')
@@ -191,7 +183,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     context 'when there are requests' do
-      let(:school) { create(:school, mno_feature_flag: true) }
+      let(:school) { create(:school) }
 
       before do
         school.extra_mobile_data_requests << create(:extra_mobile_data_request)

--- a/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
-  context 'when authenticated', with_feature_flags: { mno_offer: 'active' } do
+  context 'when authenticated' do
     before do
       sign_in_as local_authority_user
     end

--- a/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ResponsibleBody::Internet::Mobile::ExtraDataRequestsController, type: :controller do
-  context 'when authenticated', with_feature_flags: { mno_offer: 'active' } do
+  context 'when authenticated' do
     let(:responsible_body) { create(:local_authority) }
     let(:local_authority_user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }

--- a/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ResponsibleBody::Internet::Mobile::ManualRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
-  context 'when authenticated', with_feature_flags: { mno_offer: 'active' } do
+  context 'when authenticated' do
     before do
       sign_in_as local_authority_user
     end

--- a/spec/controllers/school/internet/home_controller_spec.rb
+++ b/spec/controllers/school/internet/home_controller_spec.rb
@@ -8,21 +8,8 @@ RSpec.describe School::Internet::HomeController do
     sign_in_as user
   end
 
-  context 'when school mno_feature_flag not active' do
-    it 'renders 404' do
-      get :show, params: { urn: school.urn }
-      expect(response).to be_not_found
-    end
-  end
-
-  context 'when school mno_feature_flag active' do
-    before do
-      school.update(mno_feature_flag: true)
-    end
-
-    it 'renders 200' do
-      get :show, params: { urn: school.urn }
-      expect(response).to be_successful
-    end
+  it 'renders 200' do
+    get :show, params: { urn: school.urn }
+    expect(response).to be_successful
   end
 end

--- a/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe School::Internet::Mobile::BulkRequestsController, type: :controll
 
   context 'when authenticated' do
     before do
-      school.update!(mno_feature_flag: true)
       sign_in_as user
     end
 

--- a/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe School::Internet::Mobile::ExtraDataRequestsController, type: :con
 
   context 'when authenticated' do
     before do
-      school.update!(mno_feature_flag: true)
       sign_in_as user
     end
 

--- a/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe School::Internet::Mobile::ManualRequestsController, type: :contro
 
   context 'when authenticated' do
     before do
-      school.update!(mno_feature_flag: true)
       sign_in_as user
     end
 

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -12,35 +12,33 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     sign_in_as rb_user
   end
 
-  context 'when the MNO offer is activated', with_feature_flags: { mno_offer: 'active' } do
-    scenario 'the user can navigate to the manual request form from the responsible body home page' do
-      click_on 'Get internet access'
-      click_on 'Request extra data for mobile devices'
+  scenario 'the user can navigate to the manual request form from the responsible body home page' do
+    click_on 'Get internet access'
+    click_on 'Request extra data for mobile devices'
 
-      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
-      expect(page).to have_http_status(:ok)
-      click_on 'New request'
-      expect(page).to have_css('h1', text: 'How would you like to submit information?')
-      choose 'Manually (entering details one at a time)'
-      click_on 'Continue'
-      expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
-    end
-
-    scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
-      click_on 'Get internet access'
-      click_on 'Request extra data for mobile devices'
-
-      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
-      expect(page).to have_http_status(:ok)
-      click_on 'New request'
-      expect(page).to have_css('h1', text: 'How would you like to submit information?')
-      choose 'Using a spreadsheet'
-      click_on 'Continue'
-      expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
-    end
+    expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
+    expect(page).to have_http_status(:ok)
+    click_on 'New request'
+    expect(page).to have_css('h1', text: 'How would you like to submit information?')
+    choose 'Manually (entering details one at a time)'
+    click_on 'Continue'
+    expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
   end
 
-  context 'when the user has already submitted requests', with_feature_flags: { mno_offer: 'active' } do
+  scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
+    click_on 'Get internet access'
+    click_on 'Request extra data for mobile devices'
+
+    expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
+    expect(page).to have_http_status(:ok)
+    click_on 'New request'
+    expect(page).to have_css('h1', text: 'How would you like to submit information?')
+    choose 'Using a spreadsheet'
+    click_on 'Continue'
+    expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
+  end
+
+  context 'when the user has already submitted requests' do
     let(:another_user_from_the_same_rb) { create(:user, responsible_body: responsible_body) }
 
     before do

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -43,46 +43,44 @@ RSpec.feature ResponsibleBody do
       expect(page).to have_link('Get laptops and tablets')
     end
 
-    context 'with the MNO offer feature flag active', with_feature_flags: { mno_offer: 'active' } do
-      context 'with a responsible body managing at least 1 school centrally' do
-        let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+    context 'with a responsible body managing at least 1 school centrally' do
+      let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
 
+      before do
+        schools[0].preorder_information.responsible_body_will_order_devices!
+      end
+
+      context 'with the in_connectivity_pilot flag set' do
         before do
-          schools[0].preorder_information.responsible_body_will_order_devices!
+          responsible_body.update!(in_connectivity_pilot: true)
         end
 
-        context 'with the in_connectivity_pilot flag set' do
-          before do
-            responsible_body.update!(in_connectivity_pilot: true)
-          end
-
-          it 'shows link to get extra data' do
-            visit responsible_body_home_path
-            expect(page).to have_link('Get internet access')
-          end
-        end
-
-        context 'with the in_connectivity_pilot flag not set' do
-          before do
-            responsible_body.update!(in_connectivity_pilot: false)
-          end
-
-          it 'does not show link to get extra data' do
-            visit responsible_body_home_path
-            expect(page).not_to have_link('Get internet access')
-          end
+        it 'shows link to get extra data' do
+          visit responsible_body_home_path
+          expect(page).to have_link('Get internet access')
         end
       end
 
-      context 'with a responsible body devolved to all schools' do
+      context 'with the in_connectivity_pilot flag not set' do
         before do
-          responsible_body.update!(in_connectivity_pilot: true)
+          responsible_body.update!(in_connectivity_pilot: false)
         end
 
         it 'does not show link to get extra data' do
           visit responsible_body_home_path
           expect(page).not_to have_link('Get internet access')
         end
+      end
+    end
+
+    context 'with a responsible body devolved to all schools' do
+      before do
+        responsible_body.update!(in_connectivity_pilot: true)
+      end
+
+      it 'does not show link to get extra data' do
+        visit responsible_body_home_path
+        expect(page).not_to have_link('Get internet access')
       end
     end
 

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -86,20 +86,6 @@ RSpec.feature ResponsibleBody do
       end
     end
 
-    context 'with the MNO offer feature flag disabled' do
-      let(:schools) { create_list(:school, 4, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
-
-      before do
-        responsible_body.update!(in_connectivity_pilot: true)
-        schools[0].preorder_information.responsible_body_will_order_devices!
-      end
-
-      it 'does not show link to get extra data' do
-        visit responsible_body_home_path
-        expect(page).not_to have_link('Get internet access')
-      end
-    end
-
     context 'when the RB is a local authority' do
       it 'shows link to Manage local authority users' do
         visit responsible_body_home_path

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Ordering devices within a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
+RSpec.feature 'Ordering devices within a virtual pool' do
   let(:responsible_body) { create(:trust, :manages_centrally) }
   let(:schools) { create_list(:school, 3, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body) }
   let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Ordering via a school' do
     end
   end
 
-  context 'when the virtual_caps feature flag is active and responsible body does have the vcap_feature_flag enabled', with_feature_flags: { virtual_caps: 'active' } do
+  context 'when the responsible body does have the vcap_feature_flag enabled' do
     let(:rb) { create(:trust, :vcap_feature_flag, schools: [school, school_that_cannot_order_as_reopened]) }
 
     context 'when school has no devices to order' do

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
     end
   end
 
-  context 'signed in and the MNO offer is activated', with_feature_flags: { mno_offer: 'active' } do
+  context 'signed in' do
     let(:responsible_body) { create(:local_authority) }
     let(:user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
     end
   end
 
-  context 'signed in', with_feature_flags: { mno_offer: 'active' } do
+  context 'signed in' do
     let(:responsible_body) { create(:local_authority) }
     let(:user) { create(:local_authority_user, responsible_body: responsible_body) }
     let(:mobile_network) { create(:mobile_network) }

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -46,14 +46,14 @@ RSpec.feature 'Viewing your schools' do
     then_i_see_the_school_in_the_fully_open_schools_list
   end
 
-  scenario 'when virtual caps are enabled and the trust manages centrally', with_feature_flags: { virtual_caps: 'active' } do
+  scenario 'when the trust manages centrally' do
     given_there_are_schools_in_the_pool
     when_i_visit_the_your_schools_page
     then_i_see_the_order_devices_link
     then_i_see_the_summary_pooled_device_count_card
   end
 
-  scenario 'when virtual caps are enabled and the trust manages centrally but there is nothing to order', with_feature_flags: { virtual_caps: 'active' } do
+  scenario 'when the trust manages centrally but there is nothing to order' do
     given_there_are_schools_in_the_pool_that_cant_order
     when_i_visit_the_your_schools_page
     then_i_dont_see_the_order_devices_link

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -5,36 +5,33 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
   let(:school) { user.school }
 
   before do
-    school.update!(mno_feature_flag: true)
     sign_in_as user
   end
 
-  context 'when the MNO offer is activated' do
-    scenario 'the user can navigate to the manual request form from the home page' do
-      click_on 'Get internet access'
-      click_on 'Request extra data for mobile devices'
+  scenario 'the user can navigate to the manual request form from the home page' do
+    click_on 'Get internet access'
+    click_on 'Request extra data for mobile devices'
 
-      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
-      expect(page).to have_http_status(:ok)
-      click_on 'New request'
-      expect(page).to have_css('h1', text: 'How would you like to submit information?')
-      choose 'Manually (entering details one at a time)'
-      click_on 'Continue'
-      expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
-    end
+    expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
+    expect(page).to have_http_status(:ok)
+    click_on 'New request'
+    expect(page).to have_css('h1', text: 'How would you like to submit information?')
+    choose 'Manually (entering details one at a time)'
+    click_on 'Continue'
+    expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
+  end
 
-    scenario 'the user can navigate to the bulk upload form from the home page' do
-      click_on 'Get internet access'
-      click_on 'Request extra data for mobile devices'
+  scenario 'the user can navigate to the bulk upload form from the home page' do
+    click_on 'Get internet access'
+    click_on 'Request extra data for mobile devices'
 
-      expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
-      expect(page).to have_http_status(:ok)
-      click_on 'New request'
-      expect(page).to have_css('h1', text: 'How would you like to submit information?')
-      choose 'Using a spreadsheet'
-      click_on 'Continue'
-      expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
-    end
+    expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
+    expect(page).to have_http_status(:ok)
+    click_on 'New request'
+    expect(page).to have_css('h1', text: 'How would you like to submit information?')
+    choose 'Using a spreadsheet'
+    click_on 'Continue'
+    expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
   end
 
   context 'when the user has already submitted requests' do

--- a/spec/features/school/request_devices_spec.rb
+++ b/spec/features/school/request_devices_spec.rb
@@ -10,31 +10,15 @@ RSpec.feature 'Request devices in special circumstances' do
     end
 
     scenario 'Finding out about requesting devices' do
+      visit specific_circumstances_school_path(school)
       click_on 'Request devices for specific circumstances'
 
       expect(page).to have_content('You can request devices at any time for disadvantaged children')
     end
 
-    context 'when the MNO offer is activated' do
-      before do
-        school.update!(mno_feature_flag: true)
-      end
-
-      scenario 'includes the intermediary specific circumstances page in breadcrumbs' do
-        visit request_devices_school_path(school)
-        expect(page).to have_link('Get help for specific circumstances')
-      end
-    end
-
-    context 'when the MNO offer is not activated' do
-      before do
-        school.update!(mno_feature_flag: false)
-      end
-
-      scenario 'does not include the intermediary specific circumstances page in breadcrumbs' do
-        visit request_devices_school_path(school)
-        expect(page).not_to have_link('Get help for specific circumstances')
-      end
+    scenario 'includes the intermediary specific circumstances page in breadcrumbs' do
+      visit request_devices_school_path(school)
+      expect(page).to have_link('Get help for specific circumstances')
     end
   end
 end

--- a/spec/features/school/specific_circumstances_spec.rb
+++ b/spec/features/school/specific_circumstances_spec.rb
@@ -4,42 +4,28 @@ RSpec.feature 'Accessing the get help for specific circumstances area as a schoo
   let(:user) { create(:school_user) }
   let(:school) { user.school }
 
-  context 'when the MNO offer is activated' do
-    before do
-      school.update!(mno_feature_flag: true)
-      sign_in_as user
-    end
-
-    scenario 'the user can navigate to the specific circumstances page from the home page' do
-      click_on 'Get help for specific circumstances'
-
-      expect(page).to have_css('h1', text: 'Get help for specific circumstances')
-      expect(page).to have_http_status(:ok)
-    end
-
-    scenario 'the user can navigate to request devices from the specific circumstances page' do
-      visit specific_circumstances_school_path(school)
-
-      click_on 'Request devices for specific circumstances'
-      expect(page).to have_css('h1', text: 'Request devices for specific circumstances')
-    end
-
-    scenario 'the user can navigate to request extra mobile data from the specific circumstances page' do
-      visit specific_circumstances_school_path(school)
-
-      click_on 'Request extra mobile data for specific circumstances'
-      expect(page).to have_css('h1', text: 'Get internet access')
-    end
+  before do
+    sign_in_as user
   end
 
-  context 'when the MNO offer is not activated' do
-    before do
-      school.update!(mno_feature_flag: false)
-      sign_in_as user
-    end
+  scenario 'the user can navigate to the specific circumstances page from the home page' do
+    click_on 'Get help for specific circumstances'
 
-    scenario 'the user cannot navigate to the specific circumstances page from the home page' do
-      expect(page).not_to have_content('Get help for specific circumstances')
-    end
+    expect(page).to have_css('h1', text: 'Get help for specific circumstances')
+    expect(page).to have_http_status(:ok)
+  end
+
+  scenario 'the user can navigate to request devices from the specific circumstances page' do
+    visit specific_circumstances_school_path(school)
+
+    click_on 'Request devices for specific circumstances'
+    expect(page).to have_css('h1', text: 'Request devices for specific circumstances')
+  end
+
+  scenario 'the user can navigate to request extra mobile data from the specific circumstances page' do
+    visit specific_circumstances_school_path(school)
+
+    click_on 'Request extra mobile data for specific circumstances'
+    expect(page).to have_css('h1', text: 'Get internet access')
   end
 end

--- a/spec/features/school/wireless_router_requests_spec.rb
+++ b/spec/features/school/wireless_router_requests_spec.rb
@@ -5,17 +5,14 @@ RSpec.feature 'Accessing the 4G wireless routers requests area as a school user'
   let(:school) { user.school }
 
   before do
-    school.update!(mno_feature_flag: true)
     sign_in_as user
   end
 
-  context 'when the MNO offer is activated' do
-    scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
-      click_on 'Get internet access'
-      click_on 'Request 4G wireless routers'
+  scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
+    click_on 'Get internet access'
+    click_on 'Request 4G wireless routers'
 
-      expect(page).to have_css('h1', text: 'How to request 4G wireless routers')
-      expect(page).to have_http_status(:ok)
-    end
+    expect(page).to have_css('h1', text: 'How to request 4G wireless routers')
+    expect(page).to have_http_status(:ok)
   end
 end

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Session behaviour', type: :feature do
     expect(page).to have_text('Sign in')
   end
 
-  context 'with a participating mobile network', with_feature_flags: { mno_offer: 'active' } do
+  context 'with a participating mobile network' do
     let(:user) { create(:local_authority_user) }
     let(:participating_mobile_network) do
       create(:mobile_network)

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     end
   end
 
-  context 'with virtual caps enabled', with_feature_flags: { virtual_caps: 'active' } do
+  context 'with virtual caps enabled' do
     context 'when some schools are centrally managed' do
       scenario 'DfE users see the centrally managed schools' do
         given_a_centrally_managed_responsible_body_with_users

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -34,7 +34,6 @@ RSpec.feature 'Viewing service performance', type: :feature do
     rb = local_authority
     school_requester = create(:school_user)
     school = school_requester.school
-    school.update!(mno_feature_flag: true)
 
     create_list(:extra_mobile_data_request, 1,
                 status: :requested,

--- a/spec/models/computacenter/api/cap_usage_update_spec.rb
+++ b/spec/models/computacenter/api/cap_usage_update_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
       end
     end
 
-    context 'if the devices_ordered update triggers a cap update', with_feature_flags: { virtual_caps: 'active' } do
+    context 'if the devices_ordered update triggers a cap update' do
       let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
       let!(:school) { create(:school, :in_lockdown, preorder_information: preorder, computacenter_reference: '123456', responsible_body: responsible_body) }
 

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -34,11 +34,48 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       expected_xml = <<~XML
         <?xml version="1.0" encoding="UTF-8"?>
         <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
-          <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="1"/>
           <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="0"/>
+          <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="1"/>
         </CapAdjustmentRequest>
       XML
       expect(@network_call.with(body: expected_xml)).to have_been_requested
+    end
+
+    context 'when the responsible_body is managing multiple chromebook domains' do
+      subject(:request) { described_class.new(allocation_ids: [allocation_1.id, allocation_2.id]) }
+
+      before do
+        allocation_1.update!(cap: allocation_1.allocation, devices_ordered: 2)
+        allocation_2.update!(cap: allocation_2.allocation, devices_ordered: 3)
+
+        trust.update!(vcap_feature_flag: true)
+        school_1.create_preorder_information!(who_will_order_devices: 'responsible_body',
+                                              will_need_chromebooks: 'yes',
+                                              school_or_rb_domain: 'school_1.com',
+                                              recovery_email_address: 'school_1@gmail.com')
+        school_2.create_preorder_information!(who_will_order_devices: 'school',
+                                              will_need_chromebooks: 'no')
+
+        school_1.can_order!
+        school_2.can_order!
+        trust.add_school_to_virtual_cap_pools!(school_1)
+        trust.reload
+      end
+
+      it 'generates a correct body using devices_ordered for the cap amounts to force manual handling at TechSource' do
+        request.payload_id = '123456789'
+        request.timestamp = Time.new(2020, 9, 2, 15, 3, 35, '+02:00')
+        request.post!
+
+        expected_xml = <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <CapAdjustmentRequest payloadID="123456789" dateTime="2020-09-02T15:03:35+02:00">
+            <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="98765432" capAmount="22"/>
+            <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="01234567" capAmount="11"/>
+          </CapAdjustmentRequest>
+        XML
+        expect(@network_call.with(body: expected_xml)).to have_been_requested
+      end
     end
 
     context 'when the response status is success' do

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe ResponsibleBody, type: :model do
   describe '#has_virtual_cap_feature_flags?' do
     subject(:responsible_body) { create(:trust, :manages_centrally) }
 
-    context 'without any feature flags', with_feature_flags: { virtual_caps: 'inactive' } do
+    context 'without any feature flags' do
       before do
         responsible_body.update!(vcap_feature_flag: false)
       end
@@ -440,27 +440,7 @@ RSpec.describe ResponsibleBody, type: :model do
       end
     end
 
-    context 'when global feature flag is enabled', with_feature_flags: { virtual_caps: 'active' } do
-      before do
-        responsible_body.update!(vcap_feature_flag: false)
-      end
-
-      it 'returns false' do
-        expect(responsible_body.has_virtual_cap_feature_flags?).to be false
-      end
-    end
-
-    context 'when responsible body flag is enabled', with_feature_flags: { virtual_caps: 'inactive' } do
-      before do
-        responsible_body.update!(vcap_feature_flag: true)
-      end
-
-      it 'returns false' do
-        expect(responsible_body.has_virtual_cap_feature_flags?).to be false
-      end
-    end
-
-    context 'when responsible body flag and global feature flag are enabled', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when responsible body flag is enabled' do
       before do
         responsible_body.update!(vcap_feature_flag: true)
       end
@@ -484,7 +464,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[3].update!(status: :closed)
       end
 
-      context 'without any feature flags', with_feature_flags: { virtual_caps: 'inactive' } do
+      context 'without any feature flags' do
         before do
           responsible_body.update!(vcap_feature_flag: false)
         end
@@ -494,27 +474,7 @@ RSpec.describe ResponsibleBody, type: :model do
         end
       end
 
-      context 'when global feature flag is enabled', with_feature_flags: { virtual_caps: 'active' } do
-        before do
-          responsible_body.update!(vcap_feature_flag: false)
-        end
-
-        it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
-        end
-      end
-
-      context 'when responsible body flag is enabled', with_feature_flags: { virtual_caps: 'inactive' } do
-        before do
-          responsible_body.update!(vcap_feature_flag: true)
-        end
-
-        it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
-        end
-      end
-
-      context 'when responsible body flag and global feature flag are enabled', with_feature_flags: { virtual_caps: 'active' } do
+      context 'when responsible body flag is enabled' do
         before do
           responsible_body.update!(vcap_feature_flag: true)
         end
@@ -522,10 +482,6 @@ RSpec.describe ResponsibleBody, type: :model do
         it 'returns true' do
           expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be true
         end
-      end
-
-      it 'returns false' do
-        expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
       end
     end
 
@@ -593,7 +549,7 @@ RSpec.describe ResponsibleBody, type: :model do
         schools[3].update!(status: :closed)
       end
 
-      context 'without any feature flags', with_feature_flags: { virtual_caps: 'inactive' } do
+      context 'without any feature flags' do
         before do
           responsible_body.update!(vcap_feature_flag: false)
         end
@@ -603,17 +559,7 @@ RSpec.describe ResponsibleBody, type: :model do
         end
       end
 
-      context 'when global feature flag is enabled', with_feature_flags: { virtual_caps: 'active' } do
-        before do
-          responsible_body.update!(vcap_feature_flag: false)
-        end
-
-        it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
-        end
-      end
-
-      context 'when responsible body flag is enabled', with_feature_flags: { virtual_caps: 'inactive' } do
+      context 'when responsible body flag is enabled' do
         before do
           responsible_body.update!(vcap_feature_flag: true)
         end
@@ -621,20 +567,6 @@ RSpec.describe ResponsibleBody, type: :model do
         it 'returns false' do
           expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
         end
-      end
-
-      context 'when responsible body flag and global feature flag are enabled', with_feature_flags: { virtual_caps: 'active' } do
-        before do
-          responsible_body.update!(vcap_feature_flag: true)
-        end
-
-        it 'returns true' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
-        end
-      end
-
-      it 'returns false' do
-        expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
       end
     end
   end

--- a/spec/models/school_can_order_devices_notifications_spec.rb
+++ b/spec/models/school_can_order_devices_notifications_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe SchoolCanOrderDevicesNotifications, with_feature_flags: { slack_n
       end
     end
 
-    context 'when school ordering centrally in virtual cap which is ready changes from cannot_order to can_order', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when school ordering centrally in virtual cap which is ready changes from cannot_order to can_order' do
       let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
       let(:school) do
         create(:school,

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
       end
     end
 
-    context 'within a virtual cap', with_feature_flags: { virtual_caps: 'active' } do
+    context 'within a virtual cap' do
       let(:responsible_body) { create(:trust, :vcap_feature_flag) }
       let(:schools) { create_list(:school, 2, :with_preorder_information, :with_std_device_allocation, :in_lockdown, responsible_body: responsible_body) }
 
@@ -154,7 +154,7 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
     end
   end
 
-  context 'when in a virtual pool', with_feature_flags: { virtual_caps: 'active' } do
+  context 'when in a virtual pool' do
     let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
     let(:school) { create(:school, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
     let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest, timestamp: Time.zone.now, payload_id: '123456789', body: '<xml>test-request</xml>') }

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe UserCanOrderDevicesNotifications do
     end
   end
 
-  context 'when orders can be placed within a virtual cap', with_feature_flags: { virtual_caps: 'active' } do
+  context 'when orders can be placed within a virtual cap' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:preorder) { create(:preorder_information, :school_will_order, status: :rb_can_order) }
     let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
     let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }
     let(:user) { create(:trust_user, orders_devices: true, responsible_body: responsible_body) }

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VirtualCapPool, type: :model do
 
   subject(:pool) { local_authority.virtual_cap_pools.std_device.create! }
 
-  describe '#add_school!', with_feature_flags: { virtual_caps: 'active' } do
+  describe '#add_school!' do
     before do
       allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
       allow(mock_request).to receive(:post!).and_return(response)
@@ -108,7 +108,7 @@ RSpec.describe VirtualCapPool, type: :model do
     end
   end
 
-  describe '#recalculate_caps!', with_feature_flags: { virtual_caps: 'active' } do
+  describe '#recalculate_caps!' do
     let(:schools) { create_list(:school, 2, :with_preorder_information, :with_std_device_allocation, :in_lockdown, responsible_body: local_authority) }
 
     before do
@@ -174,7 +174,7 @@ RSpec.describe VirtualCapPool, type: :model do
     end
   end
 
-  describe '#has_school?', with_feature_flags: { virtual_caps: 'active' } do
+  describe '#has_school?' do
     before do
       allow(Computacenter::OutgoingAPI::CapUpdateRequest).to receive(:new).and_return(mock_request)
       allow(mock_request).to receive(:post!).and_return(response)

--- a/spec/services/allocations_exporter_spec.rb
+++ b/spec/services/allocations_exporter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AllocationsExporter, type: :model do
     end
   end
 
-  context 'when exporting schools in a virtual_cap_pool', with_feature_flags: { virtual_caps: 'active' } do
+  context 'when exporting schools in a virtual_cap_pool' do
     subject(:exporter) { described_class.new }
 
     let(:trust) { create(:trust, :multi_academy_trust, :vcap_feature_flag) }

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
-    context 'when a school is not in the virtual cap pool', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when a school is not in the virtual cap pool' do
       before do
         responsible_body.update!(vcap_feature_flag: true)
       end
@@ -125,7 +125,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
-    context 'when a school is centrally managed and the school is not in the virtual cap pool', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when a school is centrally managed and the school is not in the virtual cap pool' do
       before do
         school.preorder_information.responsible_body_will_order_devices!
         responsible_body.update!(vcap_feature_flag: true)
@@ -137,7 +137,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
-    context 'when a school that cannot order and is in the virtual cap pool is enabled for ordering', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when a school that cannot order and is in the virtual cap pool is enabled for ordering' do
       let(:allocation) { create(:school_device_allocation, :with_std_allocation, allocation: 7, school: school) }
       let(:router_allocation) { create(:school_device_allocation, :with_coms_allocation, allocation: 17, school: school) }
 
@@ -161,7 +161,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       end
     end
 
-    context 'when a school that cannot order and is in the virtual cap pool is enabled for ordering when the responsible body does not have the feature enabled', with_feature_flags: { virtual_caps: 'active' } do
+    context 'when a school that cannot order and is in the virtual cap pool is enabled for ordering when the responsible body does not have the feature enabled' do
       let(:allocation) { create(:school_device_allocation, :with_std_allocation, allocation: 7, school: school) }
 
       before do

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -9,22 +9,9 @@ RSpec.describe 'school/home/show.html.erb' do
     assign(:current_user, user)
   end
 
-  context 'when school mno_feature_flag is not enabled' do
-    it 'does not show Get internet access section' do
-      render
-      expect(rendered).not_to include('Get internet access')
-    end
-  end
-
-  context 'when school mno_feature_flag is enabled' do
-    before do
-      school.update(mno_feature_flag: true)
-    end
-
-    it 'does not show Get internet access section' do
-      render
-      expect(rendered).to include('Get internet access')
-    end
+  it 'always shows the Get internet access section' do
+    render
+    expect(rendered).to include('Get internet access')
   end
 
   describe 'Christmas banner' do


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/EARtuK29/1188-remove-mno-pilot-feature-flags-and-virtual-caps-global-feature-flag)
Remove the global feature flags `:mno_offer` and `:virtual_caps` and remove the `mno_feature_flag` column from `schools` table as these now apply to all.
 
### Changes proposed in this pull request
Migration to removed boolean column from schools table
Updates to remove conditions for `mno_feature_flag`
Removed `:mno_offer` from `FeatureFlag` and updates to remove conditional handling where flag was used.
Removed `:virtual_caps` from `FeatureFlag` and updates to remove conditional handling where flag was used.

### Guidance to review
Relying pretty heavily on the test suite, but all instances where these flags were considered across the code base should now be treated as though the flags are set.
