### PR TITLE
Adds a parent/carer notice banner to public pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -127,4 +127,12 @@ private
       schools_path
     end
   end
+
+  def show_parent_carer_pupil_banner?
+    @show_parent_carer_pupil_banner = if current_user.id.present?
+                                        false
+                                      else
+                                        true
+                                      end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,10 +129,6 @@ private
   end
 
   def show_parent_carer_pupil_banner?
-    @show_parent_carer_pupil_banner = if current_user.id.present?
-                                        false
-                                      else
-                                        true
-                                      end
+    @show_parent_carer_pupil_banner = current_user&.new_record?
   end
 end

--- a/app/controllers/devices_guidance_controller.rb
+++ b/app/controllers/devices_guidance_controller.rb
@@ -1,4 +1,6 @@
 class DevicesGuidanceController < ApplicationController
+  before_action :show_parent_carer_pupil_banner?
+
   def index
     @responsible_body_pages = devices_guidance.pages_for(audience: :responsible_body_users)
     @device_user_pages = devices_guidance.pages_for(audience: :device_users)

--- a/app/controllers/guide_to_collecting_mobile_information_controller.rb
+++ b/app/controllers/guide_to_collecting_mobile_information_controller.rb
@@ -1,6 +1,7 @@
 class GuideToCollectingMobileInformationController < ApplicationController
   include Rails.application.routes.url_helpers
   before_action :set_guide_navigation
+  before_action :show_parent_carer_pupil_banner?
 
   def index; end
 

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,4 +1,6 @@
 class LandingPagesController < ApplicationController
+  before_action :show_parent_carer_pupil_banner?
+
   layout 'page_with_toc'
 
   def digital_platforms

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  before_action :show_parent_carer_pupil_banner?, except: %i[accessibility privacy start]
+
   layout 'single_page', only: %i[accessibility privacy]
 
   def guidance; end
@@ -28,4 +30,6 @@ class PagesController < ApplicationController
   def general_privacy_notice; end
 
   def request_a_change; end
+
+  def internet_access; end
 end

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -21,8 +21,6 @@
       Find out <a href="https://www.gov.uk/guidance/get-laptops-and-tablets-for-children-who-cannot-attend-school-due-to-coronavirus-covid-19#who-can-get-laptops-and-tablets" class="govuk-link">who can get laptops and tablets</a>. We’re also providing <a href="/internet-access" class="govuk-link">internet connections</a> where they’re needed.
     </p>
 
-    <%= render GovukComponent::InsetText.new(text: 'Parents, carers and pupils cannot apply for digital devices or internet access through this scheme themselves. They should contact their school to discuss requirements for accessing remote education.') %>
-
     <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active">
       <ol class="app-step-nav__steps">
         <li class="app-step-nav__step" id="decide-who-will-place-orders" >

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
       </div>
       <%= content_for(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
-        <%= render partial: "shared/banners/global_notice_banner" if @show_parent_carer_pupil_banner%>
+        <%= render partial: "shared/banners/global_notice_banner" if @show_parent_carer_pupil_banner %>
         <%= render partial: 'shared/flash_message' %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,6 +72,7 @@
       </div>
       <%= content_for(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
+        <%= render partial: "shared/banners/global_notice_banner" if @show_parent_carer_pupil_banner%>
         <%= render partial: 'shared/flash_message' %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>

--- a/app/views/shared/banners/_global_notice_banner.html.erb
+++ b/app/views/shared/banners/_global_notice_banner.html.erb
@@ -1,20 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Important
-        </h2>
-      </div>
-
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">
-          Parents, carers and pupils
-        </p>
-        <p class="govuk-notification-banner__body">
-          Parents, carers and pupils cannot apply for laptops, tablets or internet access. You should contact your school for help accessing remote education.
-        </p>
-      </div>
-    </div>
+    <%= render GovukComponent::NotificationBanner.new({ title: 'Important'}) do |component| %>
+      <%= component.slot(:heading, text: "Parents, carers and pupils") %>
+      <p class="govuk-notification-banner__body">
+        Parents, carers and pupils cannot apply for laptops, tablets or internet access. You should contact your school for help accessing remote education.
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/banners/_global_notice_banner.html.erb
+++ b/app/views/shared/banners/_global_notice_banner.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+          Parents, carers and pupils
+        </p>
+        <p class="govuk-notification-banner__body">
+          Parents, carers and pupils cannot apply for laptops, tablets or internet access. You should contact your school for help accessing remote education.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### Context
The banner should only be shown on specific public pages.

Eg.
- Home page
- all second level content pages
- all guidance pages

Should not display at all if the user is signed in (ie they are not a
parent/carer/pupil) or the user is on the following pages

- Cookie policy page
- Privacy policy page
- Accessibility statement page
- Sign in page
### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/3441519/103802211-b5070100-5046-11eb-86fb-284e59d3d79a.png)


### Guidance to review


- Visit https://dfe-ghwt-pr-1048.herokuapp.com/ and visit a few pages within the service
- https://dfe-ghwt-pr-1048.herokuapp.com/start (no notification banner)
- https://dfe-ghwt-pr-1048.herokuapp.com/sign-in (no notification banner)
- https://dfe-ghwt-pr-1048.herokuapp.com/token/email-not-recognised (no notification banner)
-
