### PR TITLE
Explain why schools that can order for specific circumstances can't order their full allocation yet (during lockdown)

### DIFF
--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -11,7 +11,7 @@
 
     <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order.</p>
     <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">You cannot order full allocations yet. We’re opening orders for primary schools gradually, and will invite all to order by 22 January.</p>
+      <p class="govuk-body">You cannot order full allocations yet. We’re opening orders for primary schools gradually, and will invite all to order by 15 January.</p>
       <p class="govuk-body">We’ll email you as soon as you can order full allocations.</p>
     <% else %>
       <p class="govuk-body">You cannot order a school’s full allocation yet because no school closures or groups of self-isolating children have been reported.</p>

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -9,7 +9,13 @@
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
 
-    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order. You cannot order a school’s full allocation yet because no school closures or groups of self-isolating children have been reported.</p>
+    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', responsible_body_devices_request_devices_path %>, you can go ahead with your order.</p>
+    <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
+      <p class="govuk-body">You cannot order full allocations yet. We’re opening orders for primary schools gradually, and will invite all to order by 22 January.</p>
+      <p class="govuk-body">We’ll email you as soon as you can order full allocations.</p>
+    <% else %>
+      <p class="govuk-body">You cannot order a school’s full allocation yet because no school closures or groups of self-isolating children have been reported.</p>
+    <% end %>
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
   </div>

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -14,7 +14,7 @@
 
     <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', request_devices_school_path(@school) %>, you can go ahead with your order.</p>
     <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">You cannot order your full allocation yet. We’re opening orders for primary schools gradually, and will invite all to order by 22 January.</p>
+      <p class="govuk-body">You cannot order your full allocation yet. We’re opening orders for primary schools gradually, and will invite all to order by 15 January.</p>
       <p class="govuk-body">We’ll email you as soon as you can order your full allocation.</p>
     <% else %>
       <p class="govuk-body">You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -12,7 +12,13 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
-    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', request_devices_school_path(@school) %>, you can go ahead with your order. You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>
+    <p class="govuk-body">Now you’ve contacted us to <%= govuk_link_to 'request devices for specific circumstances', request_devices_school_path(@school) %>, you can go ahead with your order.</p>
+    <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
+      <p class="govuk-body">You cannot order your full allocation yet. We’re opening orders for primary schools gradually, and will invite all to order by 22 January.</p>
+      <p class="govuk-body">We’ll email you as soon as you can order your full allocation.</p>
+    <% else %>
+      <p class="govuk-body">You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>
+    <% end %>
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
 


### PR DESCRIPTION
It's because we haven't opened up ordering, rather than a closure not being reported.

![Screen Shot 2021-01-07 at 11 36 59](https://user-images.githubusercontent.com/319055/103888498-c3076100-50dc-11eb-97b1-18e5a94ca6f2.png)
