### PR TITLE
add 2 more web instances to prod

### DIFF
--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -7,7 +7,7 @@ applications:
     health-check-http-endpoint: /healthcheck.json
     health-check-type: http
     health-check-invocation-timeout: 10
-    instances: 2
+    instances: 4
   - type: sidekiq
     disk_quota: 2G
     health-check-type: process


### PR DESCRIPTION
### Context

Our traffic is up by well over 500% this week. Our response times are suffering, and our web instances are sometimes timing out when the PaaS healthcheck tries to hit the `healthcheck.json` endpoint. As a result, PaaS restarts the instances - which leads to more congestion on the remaining instance, etc etc 

### Changes proposed in this pull request

Scale out by adding 2 more instances to the web process

### Guidance to review

