### PR TITLE
Schools can order because of lockdown, update designs

### DIFF
--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -29,10 +29,8 @@
       </h2>
 
       <p class="govuk-body">Use this section to:</p>
-
       <ul class="govuk-list govuk-list--bullet">
-        <li>place orders in the event of disruption</li>
-        <li>place orders for specific circumstances</li>
+        <li>place orders</li>
         <li>access the Computacenter TechSource website</li>
       </ul>
     <%- end %>

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -3,22 +3,24 @@
 
     <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
 
-    <% if @schools_can_order.any? && @schools_can_order_for_specific_circumstances.any? %>
-      <p class="govuk-body govuk-!-margin-bottom-1">
-        The number of devices you can order is the remaining allocation of devices for:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>approved requests <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %></li>
-        <li><%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time</li>
-      </ul>
-    <% elsif @schools_can_order.any? %>
-      <p class="govuk-body">
-        The number of devices you can order is the remaining allocation of devices for <%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time.
-      </p>
-    <% elsif @schools_can_order_for_specific_circumstances.any? %>
-      <p class="govuk-body">
-        The number of devices you can order is the remaining allocation of devices where a request <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %> has been approved.
-      </p>
+    <% unless FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
+      <% if @schools_can_order.any? && @schools_can_order_for_specific_circumstances.any? %>
+        <p class="govuk-body govuk-!-margin-bottom-1">
+          The number of devices you can order is the remaining allocation of devices for:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>approved requests <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %></li>
+          <li><%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time</li>
+        </ul>
+      <% elsif @schools_can_order.any? %>
+        <p class="govuk-body">
+          The number of devices you can order is the remaining allocation of devices for <%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time.
+        </p>
+      <% elsif @schools_can_order_for_specific_circumstances.any? %>
+        <p class="govuk-body">
+          The number of devices you can order is the remaining allocation of devices where a request <%= govuk_link_to 'for specific circumstances', responsible_body_devices_request_devices_path %> has been approved.
+        </p>
+      <% end %>
     <% end %>
 
     <h2 class="govuk-heading-m">

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -46,12 +46,12 @@
 <% if @schools[:ordering_schools].count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @schools[:ordering_schools],
                                                        table_id: 'ordering-schools',
-                                                       heading: t('.ordering_schools_heading'),
-                                                       heading_text: t('.ordering_schools_heading_text') } %>
+                                                       heading: t('.ordering_schools_heading') } %>
 <%- end %>
 
 <% if @schools[:fully_open_schools].count.positive? %>
   <%= render partial: 'school_states_table', locals: { schools: @schools[:fully_open_schools],
-                                                       table_id: 'fully-open-schools',
-                                                       heading: t('.fully_open_schools_heading') } %>
+                                                       table_id: 'cannot-order-yet-schools',
+                                                       heading: t('.cannot_order_yet_schools_heading'),
+                                                       heading_text: t('.cannot_order_yet_schools_text') } %>
 <%- end %>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -17,7 +17,6 @@
     <% if @school&.std_device_allocation&.available_devices_count > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
-    <p class="govuk-body">Ordering will close when your school reopens.</p>
 
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -17,9 +17,8 @@
     </h2>
 
     <p class="govuk-body">Use this section to:</p>
-
     <ul class="govuk-list govuk-list--bullet">
-      <li>check if you can place orders</li>
+      <li>place orders</li>
       <li>access the Computacenter TechSource website to order devices</li>
     </ul>
 

--- a/app/views/school/welcome_wizard/techsource_account.html.erb
+++ b/app/views/school/welcome_wizard/techsource_account.html.erb
@@ -11,8 +11,11 @@
 
       <p class="govuk-body">You will need to place orders on a website called TechSource, which is run by Computacenter.</p>
 
-      <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when your school can place orders.</p>
-
+      <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
+        <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when it is ready.</p>
+      <% else %>
+        <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when your school can place orders.</p>
+      <% end %>
       <%= f.govuk_submit 'Continue' %>
     <%- end %>
   </div>

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -9,16 +9,14 @@
         <%= title %>
       </h1>
 
+      <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
       <p class="govuk-body">You can continue to use this service to:</p>
-
-      <ul class="govuk-list govuk-list--bullet">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>check how many devices you can order</li>
         <li>add more users</li>
         <li>change your Chromebook settings</li>
-        <li>review your allocation</li>
         <li>request devices for clinically vulnerable children who are shielding</li>
       </ul>
-
-      <p class="govuk-body govuk-!-margin-bottom-6">If your school reports a closure or a group of self-isolating children, we’ll contact you as soon as you’re able to place orders.</p>
 
       <%= f.govuk_submit (@current_user.has_multiple_schools? ? 'Finish and go to school page' : 'Finish and go to homepage' ) %>
     <%- end %>

--- a/app/views/shared/_school_user_welcome_text.html.erb
+++ b/app/views/shared/_school_user_welcome_text.html.erb
@@ -1,9 +1,7 @@
 <p class="govuk-body">You can use the ‘Get help with technology’ service to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-  <li>manage who will order devices for your school</li>
-
-  <li>access the Computacenter TechSource website to place orders when devices are made available</li>
-
+  <li>check how many devices you can order</li>
+  <li>access the Computacenter TechSource website to place orders</li>
   <li>give us technical details for Chromebooks if you’ll be ordering them</li>
-  <li>view your device allocation</li>
+  <li>manage who can order devices</li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -592,10 +592,10 @@ en:
           success: We’ve saved your choice
       schools:
         index:
-          ordering_schools_heading: Schools reporting a closure or self-isolation group
-          ordering_schools_heading_text: When a school has reported either a closure or a group of 15 or more pupils self-isolating at the same time, you can order its allocation of devices or routers
+          ordering_schools_heading: Schools that can order
           specific_circumstances_heading: Schools with approved requests for specific circumstances
-          fully_open_schools_heading: Schools without a reported closure or self-isolating group
+          cannot_order_yet_schools_heading: Schools that cannot order yet
+          cannot_order_yet_schools_text: We’re opening orders for primary schools gradually, and will invite all to order by 15 January
         who_to_contact:
           create:
             failure: "Saved. We will email %{email_address} shortly"

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -249,33 +249,33 @@ RSpec.feature 'Setting up the devices ordering' do
 
   def then_i_see_a_list_of_the_schools_i_am_responsible_for
     expect(page).to have_content('Your schools')
-    expect(responsible_body_schools_page.fully_open_school_rows[0].title)
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].title)
       .to have_content('Aardvark Primary School (456654) Primary school')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].title)
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].title)
       .to have_content('Zebra Secondary School (123321) Secondary school')
   end
 
   def then_i_see_a_list_of_the_academies_i_am_responsible_for
     expect(page).to have_content('Your schools')
-    expect(responsible_body_schools_page.fully_open_school_rows[0].title)
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].title)
       .to have_content('Koala Academy')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].title)
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].title)
       .to have_content('Pangolin Primary Academy')
   end
 
   def and_each_school_needs_a_contact
-    expect(responsible_body_schools_page.fully_open_school_rows[0].status).to have_content('Needs a contact')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].status).to have_content('Needs a contact')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].status).to have_content('Needs a contact')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].status).to have_content('Needs a contact')
   end
 
   def and_each_school_needs_information
-    expect(responsible_body_schools_page.fully_open_school_rows[0].status).to have_content('Needs information')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].status).to have_content('Needs information')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].status).to have_content('Needs information')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].status).to have_content('Needs information')
   end
 
   def and_each_school_shows_the_devices_allocated_or_zero_if_no_allocation
-    expect(responsible_body_schools_page.fully_open_school_rows[0].allocation).to have_content('42')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].allocation).to have_content('0')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].allocation).to have_content('42')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].allocation).to have_content('0')
   end
 
   def given_the_responsible_body_has_decided_to_order_centrally
@@ -290,13 +290,13 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_the_list_shows_that_schools_will_place_all_orders
-    expect(responsible_body_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('School')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].who_will_order_devices).to have_content('School')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].who_will_order_devices).to have_content('School')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].who_will_order_devices).to have_content('School')
   end
 
   def and_the_list_shows_that_the_responsible_body_will_place_all_orders
-    expect(responsible_body_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('Local authority')
-    expect(responsible_body_schools_page.fully_open_school_rows[1].who_will_order_devices).to have_content('Local authority')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[0].who_will_order_devices).to have_content('Local authority')
+    expect(responsible_body_schools_page.cannot_order_yet_school_rows[1].who_will_order_devices).to have_content('Local authority')
   end
 
   def when_i_click_on_the_first_school_name

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -159,10 +159,10 @@ RSpec.feature 'Viewing your schools' do
 
   def then_i_see_the_school_in_the_fully_open_schools_list
     school = schools.third
-    expect(your_schools_page.fully_open_school_rows[0].title).to have_content(school.name)
-    expect(your_schools_page.fully_open_school_rows[0].who_will_order_devices).to have_content('School')
-    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} #{'device'.pluralize(school.std_device_allocation.raw_allocation)}")
-    expect(your_schools_page.fully_open_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} #{'router'.pluralize(school.coms_device_allocation&.raw_allocation || 0)}")
+    expect(your_schools_page.cannot_order_yet_school_rows[0].title).to have_content(school.name)
+    expect(your_schools_page.cannot_order_yet_school_rows[0].who_will_order_devices).to have_content('School')
+    expect(your_schools_page.cannot_order_yet_school_rows[0].allocation).to have_content("#{school.std_device_allocation.raw_allocation} #{'device'.pluralize(school.std_device_allocation.raw_allocation)}")
+    expect(your_schools_page.cannot_order_yet_school_rows[0].allocation).to have_content("#{school.coms_device_allocation&.raw_allocation} #{'router'.pluralize(school.coms_device_allocation&.raw_allocation || 0)}")
   end
 
   def then_i_see_the_summary_pooled_device_count_card

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -232,7 +232,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def then_i_see_information_about_what_happens_next
     expect(page).to have_current_path(welcome_wizard_what_happens_next_school_path(urn: school.urn))
-    expect(page).to have_text('we’ll contact you as soon as you’re able to place orders')
+    expect(page).to have_text('We’ll contact you as soon as you’re able to place orders')
   end
 
   def when_i_choose_yes_and_click_continue

--- a/spec/page_objects/responsible_body/schools_page.rb
+++ b/spec/page_objects/responsible_body/schools_page.rb
@@ -10,7 +10,7 @@ module PageObjects
     class SchoolsPage < PageObjects::BasePage
       sections :specific_circumstances_school_rows, SchoolRow, '#specific-circumstances-schools tbody tr'
       sections :ordering_school_rows, SchoolRow, '#ordering-schools tbody tr'
-      sections :fully_open_school_rows, SchoolRow, '#fully-open-schools tbody tr'
+      sections :cannot_order_yet_school_rows, SchoolRow, '#cannot-order-yet-schools tbody tr'
     end
   end
 end


### PR DESCRIPTION
### Context

This essentially applies designs for push/proactive ordering:
https://ghwt-design-history.herokuapp.com/push/
https://github.com/DFE-Digital/get-help-with-tech-prototype/pull/28

Schools list:

![Screen Shot 2021-01-07 at 16 46 51](https://user-images.githubusercontent.com/319055/103922497-bea66c80-510b-11eb-9758-d0476c41fb88.png)
