### PR TITLE
tell Cloudfront to cache all static assets for 1hr

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,8 +9,8 @@ Rails.application.configure do
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance..
-  .
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
 
   # Full error reports are disabled and caching is turned on.
@@ -28,7 +28,7 @@ Rails.application.configure do
   # tell CDNs (and browsers) to cache static assets for 1hr by default
   if Settings.static_file_cache_ttl.present?
     config.public_file_server.headers = {
-      '+' => 'public, max-age=' + Settings.static_file_cache_ttl
+      'Cache-Control' => 'public, max-age=' + Settings.static_file_cache_ttl
     }
   end
   # Compress CSS using a preprocessor.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,8 +9,9 @@ Rails.application.configure do
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  # Rake tasks automatically ignore this option for performance..
+  .
+
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
@@ -25,9 +26,9 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # tell CDNs (and browsers) to cache static assets for 1hr by default
-  if ENV['STATIC_FILE_CACHE_TTL'].present?
+  if Settings.static_file_cache_ttl.present?
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=' + Settings.static_file_cache_ttl
+      '+' => 'public, max-age=' + Settings.static_file_cache_ttl
     }
   end
   # Compress CSS using a preprocessor.

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,3 +2,5 @@ hostname_for_urls: get-help-with-tech.education.gov.uk
 slack:
   event_notifications:
     channel: get-help-with-tech-notifications
+# Tell Cloudfront to cache all static assets for 1hr
+static_file_cache_ttl: 3600

--- a/spec/features/static_asset_cache_headers_spec.rb
+++ b/spec/features/static_asset_cache_headers_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Cache header on static assets', type: :feature do
+  context 'when requesting a static asset' do
+    before do
+      visit('/')
+      first_image = page.html.match(/.+"(\/packs\/[^\"]+)".+/).captures.first
+      visit(first_image)
+    end
+
+    it 'has a Cache-Control header with a max-age value' do
+      expect(response_headers['Cache-Control']).to include('max-age=')
+    end
+  end
+end


### PR DESCRIPTION
### Context

see [Trello card #1242](https://trello.com/c/Q0lJyeVV/1242-improve-our-use-of-caching-and-cloudfront) - Cloudfront is not actually caching our static assets, due to 

a) what looks like a mis-matched ENV var reference that should have been replaced with a `Settings` var
b) the corresponding `Settings` var not being set anyway

### Changes proposed in this pull request

Replace the ENV var STATIC_FILE_CACHE_TTL with `Settings.static_file_cache_ttl`
Set the value on prod to 1 hour

### Guidance to review

This can only really be tested on prod, as that's the only Cloudfront-ed environment - but we should do so carefully. 

