### PR TITLE
Support console: redesign the 'add school to a user' flow

### DIFF
--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -14,7 +14,11 @@ class Support::Users::SchoolsController < Support::BaseController
 
   def new
     @form = Support::SchoolSuggestionForm.new(user_school_params.merge(except: @user.schools))
-    @school_options = @form.matching_schools_options
+    if @form.valid?
+      @school_options = @form.matching_schools_options
+    else
+      render :search_again, status: :unprocessable_entity
+    end
   end
 
   def create

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -14,7 +14,7 @@ class Support::Users::SchoolsController < Support::BaseController
 
   def new
     @form = Support::SchoolSuggestionForm.new(user_school_params)
-    @schools = @form.matching_schools
+    @school_options = @form.matching_schools_options
   end
 
   def create
@@ -41,11 +41,11 @@ private
   end
 
   def set_school
-    @school = @user.schools.find_by(urn: params[:urn]) || School.gias_status_open.find_by(urn: params[:urn])
+    @school = @user.schools.find_by(urn: params[:urn]) || School.gias_status_open.find_by(urn: params[:urn] || user_school_params[:school_urn])
   end
 
   def user_school_params(opts = params)
-    opts.fetch('support_school_suggestion_form').permit(:name_or_urn, :school_urn)
+    opts.fetch('support_school_suggestion_form', {}).permit(:name_or_urn, :school_urn)
   end
 
   def update_schools_params

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -13,7 +13,7 @@ class Support::Users::SchoolsController < Support::BaseController
   end
 
   def new
-    @form = Support::SchoolSuggestionForm.new(user_school_params)
+    @form = Support::SchoolSuggestionForm.new(user_school_params.merge(except: @user.schools))
     @school_options = @form.matching_schools_options
   end
 

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -1,7 +1,7 @@
 class Support::SchoolSuggestionForm
   include ActiveModel::Model
 
-  MAX_NUMBER_OF_SUGGESTED_SCHOOLS = 50
+  MAX_NUMBER_OF_SUGGESTED_SCHOOLS = 20
 
   attr_accessor :name_or_urn, :school_urn, :except
 

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -5,7 +5,7 @@ class Support::SchoolSuggestionForm
 
   attr_accessor :name_or_urn, :school_urn, :except
 
-  validates :name_or_urn, length: { minimum: 3 }, allow_blank: true
+  validates :name_or_urn, length: { minimum: 3 }, unless: ->(form) { form.school_urn.present? }
 
   def matching_schools
     schools = school_by_urn.presence || schools_by_name_or_urn

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -16,6 +16,14 @@ class Support::SchoolSuggestionForm
     matching_schools.map { |school| option_for(school) }
   end
 
+  def matching_schools_capped?
+    matching_schools.size == MAX_NUMBER_OF_SUGGESTED_SCHOOLS
+  end
+
+  def maximum_matching_schools
+    MAX_NUMBER_OF_SUGGESTED_SCHOOLS
+  end
+
 private
 
   def option_for(school)

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -5,7 +5,7 @@ class Support::SchoolSuggestionForm
 
   attr_accessor :name_or_urn, :school_urn, :except
 
-  validates :name_or_urn, length: { minimum: 3 }
+  validates :name_or_urn, length: { minimum: 3 }, allow_blank: true
 
   def matching_schools
     schools = school_by_urn.presence || schools_by_name_or_urn

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -11,7 +11,23 @@ class Support::SchoolSuggestionForm
     school_by_urn.present? ? [school_by_urn] : schools_by_name_or_urn
   end
 
+  def matching_schools_options
+    matching_schools.map { |school| option_for(school) }
+  end
+
 private
+
+  def option_for(school)
+    meta_info = [school.urn, school.town, school.postcode]
+      .reject(&:blank?)
+      .compact
+      .join(', ')
+    OpenStruct.new(
+      id: school.id,
+      name: "#{school.name} (#{meta_info})",
+      urn: school.urn,
+    )
+  end
 
   def school_by_urn
     if @school_urn

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -16,7 +16,7 @@
       <%- end %>
     <%- end %>
 
-    <%= form_for @user_school_form, url: new_support_user_school_path(@user), method: :get do |f| %>
+    <%= form_for @user_school_form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
         <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
         <%= f.hidden_field :school_urn %>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -18,7 +18,7 @@
 
     <%= form_for @user_school_form, url: new_support_user_school_path(@user), method: :get do |f| %>
       <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds' %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit %>
       <%- end %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -8,49 +8,48 @@
       <span class="govuk-caption-xl"><%= @user.full_name %></span>
       <%= title %>
     </h1>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">
-      Schools matching <q><%= @form.name_or_urn %></q>
-    </h2>
+    <p class="govuk-body">
+      You searched for “<%= @form.name_or_urn %>”.
+    </p>
 
-    <%- if @schools.present? %>
-      <table class="govuk-table schools">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Name and URN</th>
-            <th scope="col" class="govuk-table__header">Responsible body</th>
-            <th scope="col" class="govuk-table__header"></th>
-          </tr>
-        </thead>
+    <%- if @school_options.present? %>
+      <p class="govuk-body">
+        We found these schools which matched your search:
+      </p>
 
-        <tbody class="govuk-table__body">
-          <% @schools.each do |school| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %>
-                <br>
-                <%= school.type_label %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
-              </td>
-              <td class="govuk-table__cell">
-                <%- if @user.school_ids.include?(school.id) %>
-                  (already associated)
-                <%- else %>
-                  <%= govuk_button_to('Associate', support_user_schools_path(urn: school.urn, id: @user.id), method: :post) %>
-                <%- end %>
-              </td>
-            </tr>
+      <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:school_id, legend: nil) do %>
+          <% @school_options.each do |school| %>
+            <%= f.govuk_radio_button :school_urn, school.urn, label: { text: school.name } %>
           <% end %>
-        </tbody>
-      </table>
+        <% end %>
+        <%= f.govuk_submit 'Grant access' %>
+      <% end %>
     <%- else %>
-      <p class="govuk-body">(none matching)</p>
+      <p class="govuk-body">
+        There were no matches that <%= @user.full_name %> doesn’t already have access to.
+      </p>
     <%- end %>
+
+    <%- if @user.schools.any? %>
+      <p class="govuk-body">
+        <%= @user.full_name %> can already access:
+      </p>
+
+      <ul id="existing-schools" class="govuk-list govuk-list--bullet">
+        <% @user.schools.order(name: :asc).each do |school| %>
+          <li><%= school.name %></li>
+        <% end %>
+      </ul>
+    <%- end %>
+
+    <%= govuk_details(summary: 'Try another school') do %>
+      <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
+        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+        <%= f.hidden_field :school_urn %>
+        <%= f.govuk_submit 'Search again' %>
+      <%- end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -46,7 +46,7 @@
     <%- end %>
 
     <%= govuk_details(summary: 'Try another school') do %>
-      <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
+      <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
         <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit 'Search again' %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -15,7 +15,8 @@
 
     <%- if @school_options.present? %>
       <p class="govuk-body">
-        We found these schools which matched your search:
+        We found these schools which matched your search
+        <%- if @form.matching_schools_capped? %> (showing the first <%= @form.maximum_matching_schools %> results)<%- end %>:
       </p>
 
       <%= form_for @form, url: support_user_schools_path(@user) do |f| %>

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -9,8 +9,8 @@
       <%= title %>
     </h1>
 
-    <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
-    <%= f.govuk_error_summary %>
+    <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
       <%= f.hidden_field :school_urn %>
       <%= f.govuk_submit 'Search again' %>

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -1,0 +1,19 @@
+<%- title = t('page_titles.support.users.schools.new') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', support_user_schools_path(@user), class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @user.full_name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: new_support_user_school_path(@user), method: :get do |f| %>
+    <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+      <%= f.hidden_field :school_urn %>
+      <%= f.govuk_submit 'Search again' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -21,3 +21,11 @@ initSchoolAutocomplete(
     hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
   }
 );
+
+initSchoolAutocomplete(
+  {
+    input: "support-school-suggestion-form-name-or-urn-field-error",
+    path: "/support/schools/results",
+    hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
+  }
+);

--- a/spec/controllers/support/users/schools_controller_spec.rb
+++ b/spec/controllers/support/users/schools_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Support::Users::SchoolsController, type: :controller do
+  let(:user) { create(:support_user) }
+  let(:trust_user) { create(:trust_user) }
+
+  before do
+    sign_in_as user
+  end
+
+  describe '#new' do
+    it 'validates that the name or URN param is 3 characters or longer' do
+      get :new, params: { user_id: trust_user.id, support_new_user_school_form: { name_or_urn: 'ab' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(:search_again)
+    end
+  end
+end

--- a/spec/controllers/support/users/schools_controller_spec.rb
+++ b/spec/controllers/support/users/schools_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Support::Users::SchoolsController, type: :controller do
   let(:user) { create(:support_user) }
-  let(:trust_user) { create(:trust_user) }
+  let(:trust_user) { create(:trust_user, full_name: 'Jane Smith') }
 
   before do
     sign_in_as user
@@ -10,7 +10,70 @@ RSpec.describe Support::Users::SchoolsController, type: :controller do
 
   describe '#new' do
     it 'validates that the name or URN param is 3 characters or longer' do
-      get :new, params: { user_id: trust_user.id, support_new_user_school_form: { name_or_urn: 'ab' } }
+      get :new, params: { user_id: trust_user.id, support_school_suggestion_form: { name_or_urn: 'ab' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(:search_again)
+    end
+  end
+
+  describe '#create' do
+    let(:school_to_add) { create(:school, name: 'ABC school') }
+    let(:another_school) { create(:school, name: 'DEF school') }
+
+    it 'grants user access to the school when the support agent provides a URN via the text box (no JS)' do
+      get :create, params: {
+        user_id: trust_user.id,
+        support_school_suggestion_form: { name_or_urn: school_to_add.urn.to_s },
+      }
+
+      expect(trust_user.schools.reload).to include(school_to_add)
+      expect(response).to redirect_to(support_user_path(trust_user))
+      expect(flash[:success]).to eq('Jane Smith is now associated with ABC school')
+    end
+
+    it 'grants user access to the school when the support agent picks a school via the JS-powered autocomplete' do
+      get :create, params: {
+        user_id: trust_user.id,
+        support_school_suggestion_form: { school_urn: school_to_add.urn },
+      }
+
+      expect(trust_user.schools.reload).to include(school_to_add)
+      expect(response).to redirect_to(support_user_path(trust_user))
+      expect(flash[:success]).to eq('Jane Smith is now associated with ABC school')
+    end
+
+    it 'grants user access to the school when the support agent types in the partial name and there is an exact match' do
+      school_to_add
+      another_school
+
+      get :create, params: {
+        user_id: trust_user.id,
+        support_school_suggestion_form: { name_or_urn: 'ABC' },
+      }
+
+      expect(trust_user.schools.reload).to include(school_to_add)
+      expect(response).to redirect_to(support_user_path(trust_user))
+      expect(flash[:success]).to eq('Jane Smith is now associated with ABC school')
+    end
+
+    it 'redirects to :new when the support agent types in the partial name and there are multiple matches' do
+      school_to_add
+      another_school
+
+      get :create, params: {
+        user_id: trust_user.id,
+        support_school_suggestion_form: { name_or_urn: 'school' },
+      }
+
+      expect(response).to redirect_to(new_support_user_school_path(trust_user, 'support_school_suggestion_form[name_or_urn]' => 'school'))
+    end
+
+    it 'prompts to search again if the support agent enters a school name that is too short' do
+      get :create, params: {
+        user_id: trust_user.id,
+        support_school_suggestion_form: { name_or_urn: 'ab' },
+      }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(:search_again)

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Changing users’ associated organisations' do
     and_i_see_a_message_telling_me_the_school_has_been_associated
   end
 
-  xscenario 'a support user cannot add a user to a school twice' do
+  scenario 'a support user cannot add a user to a school twice' do
     given_i_am_logged_in_as_a_support_user
     when_i_visit_a_users_schools_page
     and_i_enter_a_school_urn_that_the_user_already_has

--- a/spec/form_objects/support/school_suggestion_form_spec.rb
+++ b/spec/form_objects/support/school_suggestion_form_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Support::SchoolSuggestionForm, type: :model do
   subject(:form) { described_class.new }
 
+  it { is_expected.to validate_length_of(:name_or_urn).is_at_least(3).allow_blank }
+
   it 'returns a set of matching schools from a search string' do
     school1 = create(:school, name: 'Southmead School')
     school2 = create(:school, name: 'Southdean School')

--- a/spec/form_objects/support/school_suggestion_form_spec.rb
+++ b/spec/form_objects/support/school_suggestion_form_spec.rb
@@ -31,4 +31,13 @@ RSpec.describe Support::SchoolSuggestionForm, type: :model do
 
     expect(form.matching_schools).to contain_exactly(matching_school)
   end
+
+  it 'excludes specified schools from the results when that parameter is present' do
+    matching_school = create(:school, name: 'Southmead School', urn: 123_456)
+    excluded_school = create(:school, name: 'Southdean School', urn: 654_321)
+
+    form = Support::SchoolSuggestionForm.new(name_or_urn: 'South', except: [excluded_school])
+
+    expect(form.matching_schools).to contain_exactly(matching_school)
+  end
 end

--- a/spec/form_objects/support/school_suggestion_form_spec.rb
+++ b/spec/form_objects/support/school_suggestion_form_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Support::SchoolSuggestionForm, type: :model do
 
     form = Support::SchoolSuggestionForm.new(name_or_urn: 'AA')
 
+    expect(form.maximum_matching_schools).to eq(2)
     expect(form.matching_schools.size).to eq(2)
+    expect(form.matching_schools_capped?).to be_truthy
   end
 
   it 'returns an exact match on the school URN when one is provided' do

--- a/spec/form_objects/support/school_suggestion_form_spec.rb
+++ b/spec/form_objects/support/school_suggestion_form_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe Support::SchoolSuggestionForm, type: :model do
   subject(:form) { described_class.new }
 
-  it { is_expected.to validate_length_of(:name_or_urn).is_at_least(3).allow_blank }
+  it { is_expected.to validate_length_of(:name_or_urn).is_at_least(3) }
+
+  it 'allows name_or_urn to be nil if school_urn is set' do
+    expect(described_class.new(school_urn: '123456')).to be_valid
+  end
 
   it 'returns a set of matching schools from a search string' do
     school1 = create(:school, name: 'Southmead School')

--- a/spec/page_objects/support/users/matching_schools_page.rb
+++ b/spec/page_objects/support/users/matching_schools_page.rb
@@ -4,9 +4,8 @@ module PageObjects
       class MatchingSchoolsPage < PageObjects::BasePage
         set_url '/support/users/{id}/schools/new'
 
-        element :associate_school_link, 'table.schools tbody tr input[type=submit][value=Associate]'
-        elements :schools, 'table.schools tbody tr'
-        elements :school_names, 'table.schools tbody tr td:first-child a'
+        element :form_with_suggested_schools, '#new_support_school_suggestion_form'
+        element :existing_schools, '#existing-schools'
       end
     end
   end


### PR DESCRIPTION
### Context

Support agents can grant access to schools to existing users via the support console.

### Changes proposed in this pull request

- Avoid showing the interstitial 'choose a school' page if the support agent picks a single school from the auto-complete or enters an exact name or URN match
- Strip down the 'choose a school' interstitial page and make searching again easier
- Add validation if the support agent inadvertently enters a school name that's too short (to avoid returning thousands of results)

### Screenshots and videos

#### Picking a school in the auto-complete

https://user-images.githubusercontent.com/23801/103926416-cddbe900-5110-11eb-9b2c-5ce7e219d334.mp4

#### Choosing from multiple suggestions

https://user-images.githubusercontent.com/23801/103926397-c61c4480-5110-11eb-8af3-1c91f8d80654.mp4

#### Entering a school name that's too short

![image](https://user-images.githubusercontent.com/23801/103926654-1bf0ec80-5111-11eb-8e5a-1a1ad05d4d8a.png)

#### Not finding any matches

![image](https://user-images.githubusercontent.com/23801/103926692-2c08cc00-5111-11eb-9d1d-4a15d51c49d7.png)

#### Finding too many results

![image](https://user-images.githubusercontent.com/23801/103927068-b5200300-5111-11eb-8139-bebc36ce877f.png)
