### PR TITLE
Remove workaround for rails_semantic_logger bug

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,11 +47,6 @@ Rails.application.configure do
     end
   })
 
-  # restore default STDOUT logging format in rails s process as well as log/ file
-  STDOUT.sync = true
-  config.rails_semantic_logger.add_file_appender = true
-  config.semantic_logger.add_appender(io: STDOUT, level: config.log_level)
-
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION

### Context

This workaround was causing duplicate STDOUT entries on local
development.

### Changes proposed in this pull request

Remove the workaround.

### Guidance to review

Timeline how this happened:

- rails_semantic_logger 4.4.5 introduced a regression with broke
logging to STDOUT in dev
- we put in a workaround to the problem in 1351601c8c73ded115b886d01740c2bbcc0715e1
- rails_semantic_logger 4.4.6 fixed the issue (https://github.com/rocketjob/rails_semantic_logger/commit/c3b906661c132e5a72db2deacde36f6d0cf815b2)
and when we upgraded in 18e2f0bcb805c3e1b4a09933b0d98d9f099d4f67 we
started seeming duplicate log entries