### PR TITLE
connectivity policy clarification

### DIFF
--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -26,7 +26,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>in years 3 to 11 who do not have internet access and whose face-to-face education is disrupted</li>
+      <li>in years 3 to 13 who do not have internet access and whose face-to-face education is disrupted</li>
       <li>in any year group who have been <%= govuk_link_to 'advised to shield', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> because they (or someone they live with) are clinically extremely vulnerable</li>
       <li>in any year group attending a hospital school</li>
     </ul>

--- a/app/views/shared/internet/_mno_information.html.erb
+++ b/app/views/shared/internet/_mno_information.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children can continue their remote education without incurring extra data charges.</p>
+<p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children in years 3 to 11 can continue their remote education without incurring extra data charges.</p>
 
 <p class="govuk-body">If they do not have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
 


### PR DESCRIPTION
### Context

We're adding support for FE and need to add clarity on how this affects connectivity policy
- children in years 3 to 13 can have access to 4g routers, the guidance currently says 3 to 11
- children in years 3 to 11 can have access to MNO, but the guidance isn't explicit which years have access

### Changes proposed in this pull request

Changes 'years 3 to 11' to 'years 3 to 13' in 4g router guidance.
Adds 'in years 3 to 11' to a description of what the MNO is for.
