### PR TITLE
Fix zendesk ticket subject output

### DIFF
--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -17,6 +17,10 @@ private
   def build_subject
     urn_or_ukprn = "(#{ticket['school_unique_id']}) " if ticket['school_unique_id'].present?
 
-    "ONLINE FORM - #{urn_or_ukprn}#{ticket['school_name']}"
+    if ticket['user_type'] == SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user]
+      'ONLINE FORM - Other'
+    else
+      "ONLINE FORM - #{urn_or_ukprn}#{ticket['school_name']}"
+    end
   end
 end

--- a/spec/form_objects/support_ticket/check_your_request_form_spec.rb
+++ b/spec/form_objects/support_ticket/check_your_request_form_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
                                             'subject' => 'ONLINE FORM - School 1' })
       end
 
+      it 'set the email subject line to say "Other" if its not from school,LA,college, academy' do
+        allow(ZendeskService).to receive(:send!)
+        described_class.new(ticket: { 'user_type' => SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user] }).create_ticket
+        expect(ZendeskService).to have_received(:send!)
+                                    .with({ 'subject' => 'ONLINE FORM - Other',
+                                            'user_type' => SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user] })
+      end
+
       it 'sets the email subject line include name and URN/UKPRN' do
         allow(ZendeskService).to receive(:send!)
         described_class.new(ticket: { 'school_name' => 'School 1', 'school_unique_id' => '123456' }).create_ticket


### PR DESCRIPTION
### Context
When a ticket is created we build up the subject based on the options
a user selects from the get support contact form.

The subject seems to be formatted correctly for all users where they have
selected school, LA, a multi-academy trust, college but not when
"I'm none of the above" has been chosen. The subject was being created
as "ONLINE FORM -". This commit now makes sure that the subject is set to
"ONLINE FORM - Other"

### Changes proposed in this pull request

### Guidance to review

