### PR TITLE
Support console: add responsible body autocomplete to school search

### DIFF
--- a/app/webpacker/scripts/responsible-bodies-autocomplete.js
+++ b/app/webpacker/scripts/responsible-bodies-autocomplete.js
@@ -2,14 +2,20 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initResponsibleBodiesAutocomplete = () => {
   try {
-    const id = "#support-user-responsible-body-form-responsible-body-id-field";
-    const responsibleBodiesSelect = document.querySelector(id);
-    if (!responsibleBodiesSelect) return;
+    const inputIds = [
+      "#support-user-responsible-body-form-responsible-body-id-field",
+      '#school-search-form-responsible-body-id-field'
+    ];
 
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: responsibleBodiesSelect,
-      showAllValues: true,
-      confirmOnBlur: false
+    inputIds.forEach(inputId => {
+      const responsibleBodiesSelect = document.querySelector(inputId);
+      if (!responsibleBodiesSelect) return;
+
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: responsibleBodiesSelect,
+        showAllValues: true,
+        confirmOnBlur: false
+      });
     });
   } catch (err) {
     console.error("Could not enhance responsible bodies select:", err);


### PR DESCRIPTION
### Context

Support agents can search for schools in the support console by providing the responsible body. Currently this page element is a select box with > 1000 entries, which isn't very easy to use.

### Changes proposed in this pull request

Progressively enhance the select box with an autocomplete.

### Guidance to review

![Kapture 2021-01-08 at 16 52 08](https://user-images.githubusercontent.com/23801/104042341-49519f00-51d2-11eb-971f-4a64eb877c7b.gif)
