### PR TITLE
Fix email subject

### DIFF
--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -17,7 +17,7 @@ private
   def build_subject
     urn_or_ukprn = "(#{ticket['school_unique_id']}) " if ticket['school_unique_id'].present?
 
-    if ticket['user_type'] == SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user]
+    if ticket['user_type'] == 'other_type_of_user'
       'ONLINE FORM - Other'
     else
       "ONLINE FORM - #{urn_or_ukprn}#{ticket['school_name']}"

--- a/spec/form_objects/support_ticket/check_your_request_form_spec.rb
+++ b/spec/form_objects/support_ticket/check_your_request_form_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
 
       it 'set the email subject line to say "Other" if its not from school,LA,college, academy' do
         allow(ZendeskService).to receive(:send!)
-        described_class.new(ticket: { 'user_type' => SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user] }).create_ticket
+        described_class.new(ticket: { 'user_type' => 'other_type_of_user' }).create_ticket
         expect(ZendeskService).to have_received(:send!)
                                     .with({ 'subject' => 'ONLINE FORM - Other',
-                                            'user_type' => SupportTicket::DescribeYourselfForm::OPTIONS[:other_type_of_user] })
+                                            'user_type' => 'other_type_of_user' })
       end
 
       it 'sets the email subject line include name and URN/UKPRN' do


### PR DESCRIPTION
### Context
I attempted to fix the initial issue with the email subject being set as
"ONLINE FORM -" but what I hadn't realised was that we were setting the
user_type to the option key and not the label value which the user sees.
### Changes proposed in this pull request

### Guidance to review

