### PR TITLE
[1075] Introduce Further Education bodies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,3 +148,7 @@ Rake/Desc:
 
 RSpec/NestedGroups:
   Max: 5
+
+Rails/Output:
+  Exclude:
+    - 'app/services/importers/*'

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -36,7 +36,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
 private
 
   def set_school
-    @school = School.gias_status_open.find_by(urn: params[:id])
+    @school = School.gias_status_open.where_urn_or_ukprn(params[:id]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -25,7 +25,7 @@ class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::
 private
 
   def set_school
-    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
+    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
   end
 
   def who_will_order

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -28,7 +28,7 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
 private
 
   def find_school!
-    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
+    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
   end
 
   def chromebook_params

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -4,7 +4,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
   def index; end
 
   def show
-    @school = @responsible_body.schools.find_by!(urn: params[:urn])
+    @school = @responsible_body.schools.where_urn_or_ukprn(params[:urn]).first!
     if @school.preorder_information.needs_contact?
       redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn)
     elsif @school.preorder_information.orders_managed_centrally?
@@ -13,7 +13,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
   end
 
   def order_devices
-    @school = @responsible_body.schools.find_by!(urn: params[:urn])
+    @school = @responsible_body.schools.where_urn_or_ukprn(params[:urn]).first!
   end
 
 private

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -44,7 +44,7 @@ private
   end
 
   def find_school!
-    @school = @responsible_body.schools.find_by!(urn: params[:school_urn])
+    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
   end
 
   def who_to_contact_form_params

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -12,7 +12,7 @@ private
   end
 
   def set_school
-    @school = @current_user.schools.find_by!(urn: params[:urn])
+    @school = @current_user.schools.where_urn_or_ukprn(params[:urn].to_i).first!
   end
 
   def require_completed_welcome_wizard!

--- a/app/controllers/support/schools/devices/allocation_controller.rb
+++ b/app/controllers/support/schools/devices/allocation_controller.rb
@@ -40,7 +40,7 @@ private
   helper_method :device_type
 
   def set_school_and_allocation
-    @school = School.find_by_urn(params[:school_urn])
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
     authorize @school, :show?
     @allocation = SchoolDeviceAllocation.find_or_initialize_by(school: @school, device_type: device_type)
     authorize @allocation

--- a/app/controllers/support/schools/devices/chromebooks_controller.rb
+++ b/app/controllers/support/schools/devices/chromebooks_controller.rb
@@ -28,7 +28,7 @@ class Support::Schools::Devices::ChromebooksController < Support::BaseController
 private
 
   def set_school
-    @school = School.find_by_urn(params[:school_urn])
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/support/schools/devices/order_status_controller.rb
+++ b/app/controllers/support/schools/devices/order_status_controller.rb
@@ -65,7 +65,7 @@ class Support::Schools::Devices::OrderStatusController < Support::BaseController
 private
 
   def set_school
-    @school = School.find_by_urn(params[:school_urn])
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -27,13 +27,13 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def show
-    @school = School.find_by!(urn: params[:urn])
+    @school = School.where_urn_or_ukprn(params[:urn]).first!
     @users = policy_scope(@school.users).not_deleted
     @email_audits = @school.email_audits.order(created_at: :desc)
   end
 
   def confirm_invitation
-    @school = School.find_by!(urn: params[:school_urn])
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
     @school_contact = @school.preorder_information&.school_contact
     if @school_contact.nil?
       flash[:warning] = I18n.t('support.schools.invite.no_school_contact', name: @school.name)
@@ -42,7 +42,7 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def invite
-    school = School.find_by!(urn: params[:school_urn])
+    school = School.where_urn_or_ukprn(params[:school_urn]).first!
     success = school.invite_school_contact
     if success
       flash[:success] = I18n.t('support.schools.invite.success', name: school.name)
@@ -55,6 +55,6 @@ class Support::SchoolsController < Support::BaseController
 private
 
   def search_params
-    params.require(:school_search_form).permit(:urns, :responsible_body_id, :order_state)
+    params.require(:school_search_form).permit(:identifiers, :responsible_body_id, :order_state)
   end
 end

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -57,6 +57,10 @@ private
     params.fetch('support_school_suggestion_form', {}).permit(:name_or_urn, :school_urn)
   end
 
+  def set_school
+    @school = @user.schools.where_urn_or_ukprn(params[:urn]).first || School.gias_status_open.where_urn_or_ukprn(params[:urn]).first
+  end
+
   def update_schools_params
     params.require(:user).require(:school_ids).reject(&:blank?)
   end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -119,7 +119,7 @@ private
 
   def set_school_if_present
     if params[:school_urn]
-      @school = School.gias_status_open.find_by(urn: params[:school_urn])
+      @school = School.gias_status_open.where_urn_or_ukprn(params[:school_urn]).first!
       authorize @school, :show?
     end
   end

--- a/app/models/compulsory_school.rb
+++ b/app/models/compulsory_school.rb
@@ -1,0 +1,7 @@
+class CompulsorySchool < School
+  validates :urn, presence: true, format: { with: /\A\d{6}\z/ }
+
+  def to_param
+    urn.to_s
+  end
+end

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -48,6 +48,9 @@ module Computacenter::ResponsibleBodyUrns
         else
           "t#{companies_house_number.to_i}"
         end
+      when 'FurtherEducationCollege'
+        # potential n+1
+        schools.first&.ukprn
       when 'DfE'
         'DfE'
       end
@@ -57,7 +60,7 @@ module Computacenter::ResponsibleBodyUrns
       case type
       when 'LocalAuthority'
         local_authority_official_name
-      when 'Trust'
+      when 'Trust', 'FurtherEducationCollege'
         name
       when 'DfE'
         'Department for Education'

--- a/app/models/further_education_college.rb
+++ b/app/models/further_education_college.rb
@@ -1,0 +1,2 @@
+class FurtherEducationCollege < ResponsibleBody
+end

--- a/app/models/further_education_school.rb
+++ b/app/models/further_education_school.rb
@@ -1,0 +1,13 @@
+class FurtherEducationSchool < School
+  def to_param
+    ukprn.to_s
+  end
+
+  def urn
+    ukprn
+  end
+
+  def computacenter_identifier
+    "fe#{ukprn}"
+  end
+end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -44,7 +44,7 @@ class PreorderInformation < ApplicationRecord
     elsif school_will_order_devices? && any_school_users? && chromebook_information_complete?
       if school.can_order_devices_right_now?
         'school_can_order'
-      elsif (school.std_device_allocation&.devices_ordered || 0).positive?
+      elsif (school.std_device_allocation&.devices_ordered || 0).positive? # bug should do all device types
         'ordered'
       else
         'school_ready'
@@ -52,7 +52,7 @@ class PreorderInformation < ApplicationRecord
     elsif chromebook_information_complete?
       if orders_managed_centrally? && school.can_order_devices_right_now?
         'rb_can_order'
-      elsif orders_managed_centrally? && (school.std_device_allocation&.devices_ordered || 0).positive?
+      elsif orders_managed_centrally? && (school.std_device_allocation&.devices_ordered || 0).positive? # bug should do all device types
         'ordered'
       else
         'ready'
@@ -145,7 +145,7 @@ private
   end
 
   def any_school_users?
-    school&.users&.any?
+    school&.user_schools&.any?
   end
 
   def set_defaults

--- a/app/policies/compulsory_school_policy.rb
+++ b/app/policies/compulsory_school_policy.rb
@@ -1,0 +1,2 @@
+class CompulsorySchoolPolicy < SchoolPolicy
+end

--- a/app/policies/further_education_college_policy.rb
+++ b/app/policies/further_education_college_policy.rb
@@ -1,0 +1,2 @@
+class FurtherEducationCollegePolicy < ResponsibleBodyPolicy
+end

--- a/app/policies/further_education_school_policy.rb
+++ b/app/policies/further_education_school_policy.rb
@@ -1,0 +1,2 @@
+class FurtherEducationSchoolPolicy < SchoolPolicy
+end

--- a/app/services/importers/fe_csv.rb
+++ b/app/services/importers/fe_csv.rb
@@ -1,0 +1,79 @@
+require 'csv'
+
+module Importers
+  class FeCsv
+    attr_reader :path
+
+    def initialize(path_to_csv:)
+      @path = path_to_csv
+    end
+
+    # UKPRN
+    # URN (if applicable)
+    # Provider name
+    # Provider type
+    # Contact name
+    # Contact email
+    # Contact phone
+    # Contact address (full)
+    # Main address line 1
+    # Main address line 2
+    # Main address line 3
+    # Main town / city
+    # Main county
+    # Main postcode
+
+    def call
+      rows.each do |row|
+        school = School.find_by(ukprn: row['UKPRN'])
+
+        if school.nil?
+          rb = FurtherEducationCollege.create!(
+            name: row['Provider name'],
+            organisation_type: 'FurtherEducationSchool',
+            who_will_order_devices: 'responsible_body',
+            address_1: row['Main address line 1'],
+            address_2: row['Main address line 2'],
+            address_3: row['Main address line 3'],
+            town: row['Main town / city'],
+            county: row['Main county'],
+            postcode: row['Main postcode'],
+          )
+
+          school = FurtherEducationSchool.create!(
+            responsible_body: rb,
+            ukprn: row['UKPRN'],
+            name: row['Provider name'],
+            address_1: row['Main address line 1'],
+            address_2: row['Main address line 2'],
+            address_3: row['Main address line 3'],
+            town: row['Main town / city'],
+            county: row['Main county'],
+            postcode: row['Main postcode'],
+          )
+        end
+
+        contact = school.contacts.first_or_create!(
+          email_address: row['Contact email'],
+          full_name: row['Contact name'],
+          role: 'contact',
+          title: nil,
+          phone_number: row['Contact phone'],
+        )
+
+        next if school.preorder_information.present?
+
+        school.create_preorder_information!(
+          who_will_order_devices: 'responsible_body',
+          school_contact: contact,
+        )
+      end
+    end
+
+  private
+
+    def rows
+      @rows ||= CSV.read(path, headers: true)
+    end
+  end
+end

--- a/app/views/support/home/schools.html.erb
+++ b/app/views/support/home/schools.html.erb
@@ -16,7 +16,7 @@
       <%= govuk_link_to 'Find schools', search_support_schools_path %>
     </h2>
 
-    <p class="govuk-body">Use this section to find one or more schools by URN.</p>
+    <p class="govuk-body">Use this section to find one or more schools by URN or UKPRN.</p>
 
     <% if policy(School).edit? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">

--- a/app/views/support/schools/results.html.erb
+++ b/app/views/support/schools/results.html.erb
@@ -7,15 +7,15 @@
       <%= pluralize(@search_form.result_count, 'school') %> found
     </h1>
 
-    <% if @search_form.missing_urns.any? %>
+    <% if @search_form.missing_identifiers.any? %>
       <div class="govuk-form-group--error">
         <p class="govuk-body">
-          No schools found for <%= pluralize(@search_form.missing_count, 'URN') %>:
+          No schools found for <%= pluralize(@search_form.missing_count, 'identifier') %>:
         </p>
 
         <ul class="govuk-list">
-          <% @search_form.missing_urns.each do |urn| %>
-            <li><%= urn %></li>
+          <% @search_form.missing_identifiers.each do |identifier| %>
+            <li><%= identifier %></li>
           <%- end %>
         </ul>
       </div>
@@ -29,7 +29,7 @@
       <table class="govuk-table schools">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Name and URN</th>
+            <th scope="col" class="govuk-table__header">Name</th>
             <th scope="col" class="govuk-table__header">Status</th>
             <th scope="col" class="govuk-table__header">Responsible body</th>
             <th scope="col" class="govuk-table__header">Who is ordering</th>
@@ -48,7 +48,9 @@
                 <%= render SchoolPreorderStatusTagComponent.new(school: school) %>
               </td>
               <td class="govuk-table__cell">
-                <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
+                <% if school.responsible_body %>
+                  <%= govuk_link_to school.responsible_body.name, support_responsible_body_path(id: school.responsible_body_id) %>
+                <% end %>
               </td>
               <td class="govuk-table__cell">
                 <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>

--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -14,11 +14,11 @@
       <%= title %>
     </h1>
 
-    <p class="govuk-body">Search for schools by entering their URNs. Use one line per URN.</p>
+    <p class="govuk-body">Search for schools by entering their URNs or UKPRNs. Use one line per identifier.</p>
 
     <%= form_with model: @search_form, url: results_support_schools_path do |f| %>
-      <%= f.govuk_text_area :urns,
-                            label: { text: 'URNs', size: 'm' },
+      <%= f.govuk_text_area :identifiers,
+                            label: { text: 'URNs or UKPRNs', size: 'm' },
                             rows: 10 %>
 
       <%= f.govuk_collection_select   :responsible_body_id,

--- a/db/migrate/20201124150456_add_type_to_schools.rb
+++ b/db/migrate/20201124150456_add_type_to_schools.rb
@@ -1,0 +1,8 @@
+class AddTypeToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :type, :string, null: false, default: 'CompulsorySchool'
+
+    add_index :schools, [:type]
+    add_index :schools, %i[type id]
+  end
+end

--- a/db/migrate/20201124153413_schools_handle_ukprn_and_urn.rb
+++ b/db/migrate/20201124153413_schools_handle_ukprn_and_urn.rb
@@ -1,0 +1,8 @@
+class SchoolsHandleUkprnAndUrn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :ukprn, :integer, null: true
+    add_index :schools, :ukprn, unique: true
+
+    change_column_null :schools, :urn, true
+  end
+end

--- a/db/migrate/20210114151534_add_fe_type_to_schools.rb
+++ b/db/migrate/20210114151534_add_fe_type_to_schools.rb
@@ -1,0 +1,5 @@
+class AddFeTypeToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :fe_type, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,7 +270,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_140815) do
   end
 
   create_table "schools", force: :cascade do |t|
-    t.integer "urn", null: false
+    t.integer "urn"
     t.string "name", null: false
     t.string "computacenter_reference"
     t.bigint "responsible_body_id"
@@ -292,9 +292,14 @@ ActiveRecord::Schema.define(version: 2021_01_15_140815) do
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
     t.boolean "hide_mno", default: false
+    t.string "type", default: "CompulsorySchool", null: false
+    t.integer "ukprn"
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
+    t.index ["type", "id"], name: "index_schools_on_type_and_id"
+    t.index ["type"], name: "index_schools_on_type"
+    t.index ["ukprn"], name: "index_schools_on_ukprn", unique: true
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -294,6 +294,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_140815) do
     t.boolean "hide_mno", default: false
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
+    t.text "fe_type"
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Support::SchoolsController, type: :controller do
     end
 
     it 'renders HTML results when POSTing' do
-      post :results, params: { school_search_form: { urns: "#{school.urn}\r\n#{another_school.urn}" } }
+      post :results, params: { school_search_form: { identifiers: "#{school.urn}\r\n#{another_school.urn}" } }
 
       expect(response).to be_successful
       expect(response).to render_template('results')

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -55,4 +55,10 @@ FactoryBot.define do
       organisation_type           { :multi_academy_trust }
     end
   end
+
+  factory :further_education_college, parent: :responsible_body, class: 'FurtherEducationCollege' do
+    type { 'FurtherEducationCollege' }
+    name { [Faker::App.unique.name, 'FE College'].join(' ') }
+    organisation_type { 'FurtherEducationSchool' }
+  end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
-  factory :school do
+  factory :school, class: 'CompulsorySchool' do
+    factory :fe_school, class: 'FurtherEducationSchool' do
+      association :responsible_body, factory: :further_education_college
+      ukprn { Faker::Number.unique.number(digits: 8) }
+      urn { nil }
+    end
+
     association :responsible_body, factory: %i[local_authority trust].sample
     urn { Faker::Number.unique.number(digits: 6) }
     sequence(:name) { |n| "#{Faker::Educator.secondary_school}-#{n}" }

--- a/spec/features/support/searching_schools_spec.rb
+++ b/spec/features/support/searching_schools_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
 
   def when_i_fill_in_some_urns
     data = schools.map(&:urn).append(bad_urn).join("\r\n")
-    search_page.urns.set data
+    search_page.identifiers.set data
   end
 
   def when_i_choose_an_order_state_and_responsible_body
@@ -104,7 +104,7 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
   end
 
   def and_i_see_one_error
-    expect(page).to have_content('No schools found for 1 URN:')
+    expect(page).to have_content('No schools found for 1 identifier:')
   end
 
   def and_i_see_results_with_schools(count)

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -4,33 +4,33 @@ RSpec.describe SchoolSearchForm do
   let(:school) { create(:school) }
   let(:closed_school) { create(:school, status: :closed) }
 
-  describe '#array_of_urns' do
+  describe '#array_of_identifiers' do
     subject(:form) do
-      described_class.new(urns: "   123  \r\ \r\n456\r\n")
+      described_class.new(identifiers: "   123  \r\ \r\n456\r\n")
     end
 
-    it 'returns correct array of urns' do
-      expect(form.array_of_urns).to eql(%w[123 456])
+    it 'returns correct array of identifiers' do
+      expect(form.array_of_identifiers).to eql(%w[123 456])
     end
   end
 
-  describe '#missing_urns' do
+  describe '#missing_identifiers' do
     subject(:form) do
-      described_class.new(urns: "   #{school.urn}  \r\ \r\n456\r\n")
+      described_class.new(identifiers: "   #{school.urn}  \r\ \r\n456\r\n")
     end
 
-    it 'returns array of urns with no matches' do
-      expect(form.missing_urns).to eql(%w[456])
+    it 'returns array of identifiers with no matches' do
+      expect(form.missing_identifiers).to eql(%w[456])
     end
   end
 
   describe '#schools' do
-    context 'given urns' do
+    context 'given identifiers' do
       subject(:form) do
-        described_class.new(urns: "#{school.urn}\r\n#{closed_school.urn}\r\n")
+        described_class.new(identifiers: "#{school.urn}\r\n#{closed_school.urn}\r\n")
       end
 
-      it 'only includes schools matching those urns which are not closed' do
+      it 'only includes schools matching those identifiers which are not closed' do
         expect(form.schools.map(&:urn)).to eq([school.urn])
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe SchoolSearchForm do
     let(:urns) { nil }
     let(:responsible_body_id) { nil }
     let(:order_state) { nil }
-    let(:form) { SchoolSearchForm.new(urns: urns, responsible_body_id: responsible_body_id, order_state: order_state) }
+    let(:form) { SchoolSearchForm.new(identifiers: urns, responsible_body_id: responsible_body_id, order_state: order_state) }
     let(:expected_timestamp) { Time.zone.now.utc.iso8601 }
 
     before do
@@ -103,8 +103,8 @@ RSpec.describe SchoolSearchForm do
     context 'when URNs are given' do
       let(:urns) { "101111\r\n101222\r\n101333\r\n" }
 
-      it 'includes (number of urns)-URNs' do
-        expect(form.csv_filename).to include('3-URNs')
+      it 'includes (number of urns)' do
+        expect(form.csv_filename).to include('3')
       end
     end
   end

--- a/spec/models/computacenter/responsible_body_urns_spec.rb
+++ b/spec/models/computacenter/responsible_body_urns_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ResponsibleBodyUrns do
+  fe_klass = Class.new do
+    include Computacenter::ResponsibleBodyUrns::InstanceMethods
+
+    def type
+      'FurtherEducationCollege'
+    end
+
+    def name
+      'name of FurtherEducationCollege'
+    end
+
+    def schools
+      [OpenStruct.new(ukprn: 12_345_678)]
+    end
+  end
+
+  describe '#computacenter_name' do
+    subject(:model) { fe_klass.new }
+
+    it 'returns name' do
+      expect(model.computacenter_name).to eql('name of FurtherEducationCollege')
+    end
+  end
+
+  describe '#computacenter_identifier' do
+    subject(:model) { fe_klass.new }
+
+    it 'returns first school ukprn' do
+      expect(model.computacenter_identifier).to be(12_345_678)
+    end
+  end
+end

--- a/spec/models/further_education_school_spec.rb
+++ b/spec/models/further_education_school_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe FurtherEducationSchool do
+  describe '#urn' do
+    subject(:model) { described_class.new(ukprn: 123) }
+
+    it 'falls back to show ukprn' do
+      expect(model.urn).to be(123)
+    end
+  end
+end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe PreorderInformation, type: :model do
       end
 
       context 'when all devices have been ordered' do
-        let(:allocation) { create(:school_device_allocation, :fully_ordered) }
+        let(:allocation) { build(:school_device_allocation, :fully_ordered, device_type: 'std_device') }
 
         it { is_expected.to eq('ordered') }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -445,6 +445,38 @@ RSpec.describe User, type: :model do
         expect(user_change.school).to be_blank
       end
 
+      context 'when an FE school user' do
+        it 'persists correct data' do
+          school = create(:fe_school)
+          user = create(:user, school: school, orders_devices: true)
+          user_change = Computacenter::UserChange.last
+
+          expect(user_change.user_id).to eql(user.id)
+          expect(user_change.first_name).to eql(user.first_name)
+          expect(user_change.last_name).to eql(user.last_name)
+          expect(user_change.email_address).to eql(user.email_address)
+          expect(user_change.telephone).to eql(user.telephone)
+          expect(user_change.responsible_body).to eql(school.responsible_body.name)
+          expect(user_change.responsible_body_urn.to_s).to eql(school.responsible_body.computacenter_identifier.to_s)
+          expect(user_change.cc_sold_to_number).to eql(school.responsible_body.computacenter_reference)
+          expect(user_change.school).to eql(user.school.name)
+          expect(user_change.school_urn).to eql(user.school.ukprn.to_s)
+          expect(user_change.cc_ship_to_number).to eql(user.school.computacenter_reference)
+          expect(user_change.updated_at_timestamp).to be_within(10.seconds).of(user.created_at)
+          expect(user_change.type_of_update).to eql('New')
+          expect(user_change.original_email_address).to be_nil
+          expect(user_change.original_first_name).to be_nil
+          expect(user_change.original_last_name).to be_nil
+          expect(user_change.original_telephone).to be_nil
+          expect(user_change.original_responsible_body).to be_nil
+          expect(user_change.original_responsible_body_urn).to be_nil
+          expect(user_change.original_cc_sold_to_number).to be_nil
+          expect(user_change.original_school).to be_blank
+          expect(user_change.original_school_urn).to be_blank
+          expect(user_change.original_cc_ship_to_number).to be_blank
+        end
+      end
+
       context 'not computacenter relevant' do
         it 'does not create a Computacenter::UserChange' do
           expect { create(:user, :has_not_seen_privacy_notice) }.not_to change(Computacenter::UserChange, :count)

--- a/spec/page_objects/support/schools/search_page.rb
+++ b/spec/page_objects/support/schools/search_page.rb
@@ -4,7 +4,7 @@ module PageObjects
       class SearchPage < PageObjects::BasePage
         set_url '/support/schools/search'
 
-        element :urns, 'textarea#school-search-form-urns-field'
+        element :identifiers, 'textarea#school-search-form-identifiers-field'
         element :responsible_body, 'select#school-search-form-responsible-body-id-field'
         element :order_state, 'select#school-search-form-order-state-field'
         element :submit, 'input[value=Search]'

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SchoolDataExporter, type: :model do
+  include StringUtils
+
   let(:school) { create(:school) }
   let(:filename) { Rails.root.join('tmp/school_test_data.csv') }
 
@@ -23,6 +25,22 @@ RSpec.describe SchoolDataExporter, type: :model do
     it 'includes a heading row and all of the Schools in the CSV file' do
       line_count = `wc -l "#{filename}"`.split.first.to_i
       expect(line_count).to eq(School.count + 1)
+    end
+
+    it 'exports data correctly' do
+      rows = CSV.read(filename)
+      expect(rows.last).to eql(
+        [
+          school.responsible_body.computacenter_identifier,
+          *split_string("#{school.urn} #{school.name}", limit: 35),
+          school.address_1,
+          school.address_2,
+          school.address_3,
+          school.town,
+          school.postcode,
+          'New',
+        ],
+      )
     end
   end
 

--- a/spec/services/school_update_service_spec.rb
+++ b/spec/services/school_update_service_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe SchoolUpdateService, type: :model do
+  subject(:service) { described_class.new }
+
   describe 'importing schools from staging' do
-    let(:service) { subject }
     let!(:local_authority) { create(:local_authority, name: 'Camden') }
     let!(:school) { create(:school, urn: '103001', responsible_body: local_authority) }
 
@@ -49,6 +50,7 @@ RSpec.describe SchoolUpdateService, type: :model do
 
       it 'updates the existing school record' do
         service.update_schools
+
         expect(school.reload).to have_attributes(
           urn: 103_001,
           name: staged_school.name,
@@ -63,6 +65,20 @@ RSpec.describe SchoolUpdateService, type: :model do
           status: staged_school.status,
         )
       end
+    end
+  end
+
+  describe '#create_school' do
+    let!(:staged_school) { create(:staged_school, urn: 103_001, responsible_body_name: 'Camden') }
+
+    before do
+      create(:local_authority, name: 'Camden')
+    end
+
+    it 'creates school record' do
+      expect {
+        service.send(:create_school, staged_school)
+      }.to change(School, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/R2235yoT/1075-spike-adding-fe-institutions-to-the-service
- Handle Further Education bodies

### Out of scope

- FE schools will only have one delivery address like any other school we currently have in the service

### Changes proposed in this pull request

- Introduce Single Table Inheritance to `School`
- `School` will be the parent class and abstract class
- All current schools will become `CompulsorySchool`
- Further Education schools will be added as `FurtherEducationSchool`
- Add `FurtherEducationCollection` as a child of `ResponsibleBody`

All Further Education schools will be imported to have a responsible body despite the fact that technically they do not have a responsible body. This is because the there is a lot of code that assumes the fact that a school simply has an RB

- Add `UKPRN` to `schools` table
- NOTE: an FE body must have a UKPRN and may also have a URN too

- As we have use `URN` to identify schools in URLs the look up will now search for for schools via `UKPRN` then URN as schools can now potentially have 2 identifiers

#### CC integration

- As `FurtherEducationSchool` will have an RB (FurtherEducationCollege) the generation of RB and Schools in `/computacenter` remain similar to how current RBs and Schools worl
- `UserChanges` behave the same as any current `School` only not us the RB "urn" and School "urn" identifiers will be the same 

#### Next steps

- Either add copy/content directly to schools controllers namespace OR add another controller namespace called `/further_education_schools` to give custom journey for these users
- Once list of FE bodies are finalised, these can be imported into the service

### Questions

- Where do we attach users to? As we have a placeholder RB and the school they could be on either. My thoughts are they should be added to the RB. My understanding is that RB users according CC have more permissions eg request BIOS resets?

### Guidance to review

n/a