### PR TITLE
1270 fix issue with cloudfront not caching anything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ setup_paas_app: set_cf_target
 
 setup_cdn_route: set_cf_target
 	# tell it to forward all headers from Cloudfront, otherwise we only get Host
-	cf update-service $(APP_NAME)-$(env_stub)-cdn-route -c '{"headers": ["*"]}'
+	cf update-service $(APP_NAME)-$(env_stub)-cdn-route -c '{"headers": ["Content-Type", "Host", "Set-Cookie", "X-Forwarded-Host", "Authorization"]}'
 
 setup_paas_redis: set_cf_target
 	cf create-service redis $(redis_plan) $(APP_NAME)-$(env_stub)-redis

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,8 +9,8 @@ Rails.application.configure do
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance..
-  .
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
 
   # Full error reports are disabled and caching is turned on.
@@ -28,7 +28,7 @@ Rails.application.configure do
   # tell CDNs (and browsers) to cache static assets for 1hr by default
   if Settings.static_file_cache_ttl.present?
     config.public_file_server.headers = {
-      '+' => 'public, max-age=' + Settings.static_file_cache_ttl
+      'Cache-Control' => 'public, max-age=' + Settings.static_file_cache_ttl
     }
   end
   # Compress CSS using a preprocessor.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,8 +9,9 @@ Rails.application.configure do
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  # Rake tasks automatically ignore this option for performance..
+  .
+
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
@@ -25,9 +26,9 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # tell CDNs (and browsers) to cache static assets for 1hr by default
-  if ENV['STATIC_FILE_CACHE_TTL'].present?
+  if Settings.static_file_cache_ttl.present?
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=' + Settings.static_file_cache_ttl
+      '+' => 'public, max-age=' + Settings.static_file_cache_ttl
     }
   end
   # Compress CSS using a preprocessor.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,8 +11,6 @@ Rails.application.configure do
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
-
-
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,3 +2,5 @@ hostname_for_urls: get-help-with-tech.education.gov.uk
 slack:
   event_notifications:
     channel: get-help-with-tech-notifications
+# Tell Cloudfront to cache all static assets for 1hr
+static_file_cache_ttl: 3600

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,5 +2,3 @@ hostname_for_urls: get-help-with-tech.education.gov.uk
 slack:
   event_notifications:
     channel: get-help-with-tech-notifications
-# Tell Cloudfront to cache all static assets for 1hr
-static_file_cache_ttl: 3600

--- a/spec/features/static_asset_cache_headers_spec.rb
+++ b/spec/features/static_asset_cache_headers_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Cache header on static assets', type: :feature do
+  context 'when requesting a static asset' do
+    before do
+      visit('/')
+      first_image = page.html.match(/.+"(\/packs\/[^\"]+)".+/).captures.first
+      visit(first_image)
+    end
+
+    it 'has a Cache-Control header with a max-age value' do
+      expect(response_headers['Cache-Control']).to include('max-age=')
+    end
+  end
+end


### PR DESCRIPTION
### Context

See [Trello card 1242](https://trello.com/c/Q0lJyeVV/1242-improve-our-use-of-caching-and-cloudfront) and [Trello card 1270](https://trello.com/c/sUYcBBYo/1270-fix-issue-with-cloudfront-not-caching-anything) - Cloudfront is currently forwarding _all_ headers to our app, which means that it's not actually caching anything. 

### Changes proposed in this pull request

Change the Makefile task `setup_cdn_route` to forward just the set of headers that we know our application needs - 
`"Content-Type", "Host", "Set-Cookie", "X-Forwarded-Host", "Authorization"`

### Guidance to review

Note that this just changes the Makefile task, which by itself will not change anything until it is manually run.
We can (and should) run the task in a low-traffic period and manually test that all the header-sensitive points - authentication, API authentication, sessions, CSV downloads - continue to work.

If there any problems, the rollback plan is simply to run the previous version of the command (`cf cf update-service $(APP_NAME)-$(env_stub)-cdn-route -c '{"headers": ["*"]}` )
