### PR TITLE
Use raw cap and allocation in validation

### DIFF
--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -116,10 +116,4 @@ private
   def has_virtual_cap_feature_flags?
     school&.responsible_body&.has_virtual_cap_feature_flags? || false
   end
-
-  def cap_lte_allocation
-    if cap > allocation
-      errors.add(:cap, :lte_allocation, allocation: allocation)
-    end
-  end
 end

--- a/app/validators/cap_and_allocation_validator.rb
+++ b/app/validators/cap_and_allocation_validator.rb
@@ -6,8 +6,8 @@ class CapAndAllocationValidator < ActiveModel::Validator
 private
 
   def validate_cap_lte_allocation(record)
-    if record.cap.to_i > record.allocation.to_i
-      record.errors.add(:cap, :lte_allocation, allocation: record.allocation.to_i)
+    if record.raw_cap.to_i > record.raw_allocation.to_i
+      record.errors.add(:cap, :lte_allocation, allocation: record.raw_allocation.to_i)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -202,8 +202,8 @@ ActiveRecord::Schema.define(version: 2021_01_05_161018) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/MUrYMTgO/1272-fix-device-allocation-validations)
Observed that _somehow_ in 30 instances `cap` is greater than `allocation` on the `SchoolDeviceAllocation` models. Attempting to fix this at the console proved difficult because the validators were preventing the updates to the local model while validating the broken virtual pool figures.  We don't need to do this. If we ensure that the device allocations are correct then the pool will also be correct.

### Changes proposed in this pull request
Use the `raw_` cap and allocation values in the validators.

### Guidance to review
Attempting to make a cap > allocation update in a `SchoolDeviceModel` should fail with a validation error.
