### PR TITLE
Replace reference to the email address with link to contact form

### DIFF
--- a/app/views/devices_guidance/4g_user_guidance.md
+++ b/app/views/devices_guidance/4g_user_guidance.md
@@ -44,11 +44,11 @@ Children and families should raise any queries regarding 4G wireless routers wit
 
 ### For local authorities and trusts
 
-You can check the status of each router and if needed raise an issue via the [Support Portal](https://computacenterprod.service-now.com/dfe). Login details will have been provided when you placed your order, but if you’re unable to access, please email [COVID.TECHNOLOGY@education.gov.uk](covid.technology@education.gov.uk).
+You can check the status of each router and if needed, raise an issue via the [Support Portal](https://computacenterprod.service-now.com/dfe). Login details will have been provided when you placed your order, but if you’re unable to access, [please contact us](/get-support).
 
 ### For schools and colleges
 
-You will need to ask your trust or local authority to access the Support Portal on your behalf to check the status of a router or raise an issue. Email [COVID.TECHNOLOGY@education.gov.uk](covid.technology@education.gov.uk) if you’re unsure who to contact.
+You will need to ask your trust or local authority to access the Support Portal on your behalf to check the status of a router or raise an issue. [Contact us](/get-support) if you’re unsure who to contact.
 
 ## Staying safe online
 

--- a/app/views/devices_guidance/device_distribution_and_ownership.md
+++ b/app/views/devices_guidance/device_distribution_and_ownership.md
@@ -104,4 +104,4 @@ See the [guidance on preparing devices](/devices/preparing-chromebooks) for info
 
 The LA, trust and/or school should make clear to recipients of devices that it is unlawful for any device lent by an LA, trust or school to be sold by a child or their family. If a lent device is lost, stolen or sold, or where recall is not possible, LAs should follow any existing protocol they may have for lost, stolen or missing devices.
 
-Where an LA or trust has a safeguarding concern relating to a device that they suspect has been lost, stolen or sold they should contact [COVID.TECHNOLOGY@education.gov.uk](covid.technology@education.gov.uk).
+Where an LA or trust has a safeguarding concern relating to a device that they suspect has been lost, stolen or sold they should [contact us](/get-support).

--- a/app/views/devices_guidance/enrol_chromebooks_with_user_logins.md
+++ b/app/views/devices_guidance/enrol_chromebooks_with_user_logins.md
@@ -4,7 +4,7 @@ Create an organisational unit called ‘DfE Devices’ in your Google Admin Cons
 
 ## Enrol your Chromebooks
 
-Before you enrol your devices, please ensure that you have the correct number of Chrome licenses available in your domain by going to ‘Devices’ > ‘Chrome devices’ and clicking the ‘Upgrades’ button in the top right. If you do not have enough licenses for the number of devices you need to enrol and manage, please contact [COVID.technology@education.gov.uk](COVID.technology@education.gov.uk).
+Before you enrol your devices, please ensure that you have the correct number of Chrome licenses available in your domain by going to ‘Devices’ > ‘Chrome devices’ and clicking the ‘Upgrades’ button in the top right. If you do not have enough licenses for the number of devices you need to enrol and manage, [please contact us](/get-support).
 
 Follow these instructions to enrol your devices:
 

--- a/app/views/devices_guidance/enrol_chromebooks_without_user_logins.md
+++ b/app/views/devices_guidance/enrol_chromebooks_without_user_logins.md
@@ -153,7 +153,7 @@ A top-level set of web apps and Chrome extensions can be force installed for all
 
 ## Enrolling Chromebooks
 
-Before you enrol your devices, please ensure that you have the correct number of Chrome licenses available in your domain by going to ‘Devices’ > ‘Chrome devices’ and click the ‘Upgrades’ button in the top right. If you do not have enough licenses for the number of devices you need to enrol and manage, please contact [COVID.technology@education.gov.uk](mailto:COVID.technology@education.gov.uk).
+Before you enrol your devices, please ensure that you have the correct number of Chrome licenses available in your domain by going to ‘Devices’ > ‘Chrome devices’ and click the ‘Upgrades’ button in the top right. If you do not have enough licenses for the number of devices you need to enrol and manage, [please contact us](/get-support).
 
 Follow these instructions to enrol your devices:
 

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -234,7 +234,7 @@
             </p>
 
             <p class="app-step-nav__paragraph">
-              Email <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a> to make a request. Please do not email any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask for it to be resent.
+              <%= govuk_link_to "Contact us", support_ticket_path %> to make a request. Please do not submit any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask for it to be resent.
             </p>
           </div>
         </li>

--- a/app/views/devices_guidance/preparing_4g_wireless_routers.md
+++ b/app/views/devices_guidance/preparing_4g_wireless_routers.md
@@ -4,11 +4,11 @@ We recommend that trusts, local authorities and schools provide a printed copy o
 
 ### For local authorities and trusts
 
-You can check the status of each router and if needed raise an issue via the [Support Portal](https://computacenterprod.service-now.com/). Login details will have been provided when you placed your order, but if you’re unable to access the Support Portal, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.Technology@education.gov.uk).
+You can check the status of each router and if needed, raise an issue via the [Support Portal](https://computacenterprod.service-now.com/). Login details will have been provided when you placed your order, but if you’re unable to access the Support Portal, [please contact us](/get-support).
 
 ### For schools and colleges
 
-You will need to ask your trust or local authority to access the [Support Portal](https://computacenterprod.service-now.com/) on your behalf to check the status of a router or raise an issue. Email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.Technology@education.gov.uk) if you’re unsure who to contact.
+You will need to ask your trust or local authority to access the [Support Portal](https://computacenterprod.service-now.com/) on your behalf to check the status of a router or raise an issue. [Contact us](/get-support) if you’re unsure who to contact.
 
 ### For young people and families
 

--- a/app/views/devices_guidance/preparing_chromebooks.md
+++ b/app/views/devices_guidance/preparing_chromebooks.md
@@ -31,7 +31,7 @@ We will not actively monitor users' activity on the devices. Websites users visi
 
 If you decide not to use Cisco Umbrella, or you continue using the Chromebooks once Cisco Umbrella has expired, DfE will no longer support these devices. It’s your responsibility to avoid risks to the online safety of the children and young people you are providing devices to.
 
-You can report access to any inappropriate content that should not be allowed by Cisco Umbrella by emailing [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk).
+You can report access to any inappropriate content that should not be allowed by Cisco Umbrella by [contacting us](/get-support).
 
 Find out [how to access support](/devices/support-and-maintenance) to report Cisco Umbrella issues.
 

--- a/app/views/devices_guidance/preparing_ipads.md
+++ b/app/views/devices_guidance/preparing_ipads.md
@@ -27,7 +27,7 @@ You should be enrolled in Apple School Manager to order iPads. Find out [how to 
 
 ## Enrol DfE iPads in ASM using the reseller ID
 
-You need to enter the reseller ID in Apple School Manager (ASM) before you can enrol the iPads in ASM to manage them. Email [COVID.TECHNOLOGY@education.gov.uk](mailto:covid.technology@education.gov.uk) to get your reseller ID.
+You need to enter the reseller ID in Apple School Manager (ASM) before you can enrol the iPads in ASM to manage them. [Contact us](/get-support) to get your reseller ID.
 
 1. Go to https://school.apple.com
 2. Enter your ASM ID to login
@@ -79,7 +79,7 @@ Discover fun and simple activities highlighting iPad built-in features and apps.
 
 Go to [Apple service and repair](https://support.apple.com/en-gb/ipad/repair/service) to find out what to do if your device does not turn on when you receive it, develops a fault or is accidentally broken.
 
-If you need further assistance, contact [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.technology@education.gov.uk).
+If you need further assistance, [please contact us](/get-support).
 
 
 ## User guidance for iPads

--- a/app/views/devices_guidance/preparing_microsoft_windows_laptops_and_tablets.md
+++ b/app/views/devices_guidance/preparing_microsoft_windows_laptops_and_tablets.md
@@ -117,7 +117,7 @@ Your local authority, trust or school is responsible for keeping this informatio
 
 To log in to the [Support Portal](https://computacenterprod.service-now.com/dfe) for the first time, enter your email address and click ‘forgotten password’. If you’re authorised to access the support portal, you’ll receive an email with instructions on how to set up a password.
 
-If you do not have access to the portal but think you should, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk) and include the name of the school, local authority or trust that ordered the devices.
+If you do not have access to the portal but think you should, [please contact us](/get-support) and include the name of the school, local authority or trust that ordered the devices.
 
 ### How to get local admin and BIOS passwords
 

--- a/app/views/devices_guidance/replace_a_faulty_device.md
+++ b/app/views/devices_guidance/replace_a_faulty_device.md
@@ -25,7 +25,7 @@ Before placing a request for a warranty replacement, you should check the device
 ### How to access the Support Portal
 
 Go to the [Support Portal](https://computacenterprod.service-now.com/dfe) and select '‘Raise a support request’ and select ‘Faulty device (school)’. You will need to enter the serial number for the faulty laptop or tablet.
-If you have any issues accessing or using the support portal, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk) with your order tracking number.
+If you have any issues accessing or using the support portal, [please contact us](/get-support) with your order tracking number.
 
 ## Cost of replacement Windows device or Google Chromebook
 

--- a/app/views/devices_guidance/support_and_maintenance.md
+++ b/app/views/devices_guidance/support_and_maintenance.md
@@ -14,7 +14,7 @@ Those providing support should be able to solve general IT problems (such as pas
 
 ## Support for local authorities, academy trusts and schools
 
-If you work for a local authority, academy trust or school and need help with any of the devices provided by this programme, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:COVID.TECHNOLOGY@education.gov.uk). We aim to respond within 4 working days.
+If you work for a local authority, academy trust or school and need help with any of the devices provided by this programme, [please contact us](/get-support).
 
 ## Replacing a faulty device
 
@@ -39,14 +39,14 @@ Please review our [preparing 4G routers](/devices/preparing-4g-wireless-routers)
 
 ### If you receive a faulty 4G Wireless Router 
 
-If you receive a 4G wireless router that will not start, please check that it is fully charged. If it still won’t power-up, email [COVID.TECHNOLOGY@education.gov.uk](mailto:covid.technology@education.gov.uk) with the order number and IMEI number on the device.
+If you receive a 4G wireless router that will not start, please check that it is fully charged. If it still won’t power-up, [contact us](/get-support) with the order number and IMEI number on the device.
 
 ### If you have technical issues with 4G wireless routers 
 
-If a 4G wireless router has powered-up but is experiencing technical issues, trusts and local authorities can check the status of each router and if needed raise an issue via the [Support Portal](https://computacenterprod.service-now.com/dfe). Login details will have been provided when you placed your order, but if you’re unable to access, please email [COVID.TECHNOLOGY@education.gov.uk](mailto:covid.technology@education.gov.uk).
+If a 4G wireless router has powered-up but is experiencing technical issues, trusts and local authorities can check the status of each router and if needed raise an issue via the [Support Portal](https://computacenterprod.service-now.com/dfe). Login details will have been provided when you placed your order, but if you’re unable to access, [please contact us](/get-support).
 
 It is important that users do not attempt to reset their device to try to resolve issues, as this will cause both the router and the SIM to stop workin.
-Schools and colleges will need to ask their trust or local authority to access the [Support Portal](https://computacenterprod.service-now.com/dfe) on their behalf. Email [COVID.TECHNOLOGY@education.gov.uk](mailto:covid.technology@education.gov.uk) if you’re unsure who to contact.
+Schools and colleges will need to ask their trust or local authority to access the [Support Portal](https://computacenterprod.service-now.com/dfe) on their behalf. [Contact us](/get-support) if you’re unsure who to contact.
 
 We can help you to:
  

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -110,4 +110,4 @@ You can find more information about the programme and how schools are using digi
 
 [Free training and support to set up and use technology effectively](/EdTech-demonstrator-programme) is available through the EdTech Demonstrator Programme.
 
-If you have a question about this programme, please email COVID.TECHNOLOGY@education.gov.uk. We aim to respond within 4 working days.
+If you have a question about this programme, [please contact us](/get-support).

--- a/app/views/sign_in_tokens/email_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/email_not_recognised.html.erb
@@ -14,12 +14,8 @@
     </p>
     <p class="govuk-body">
       If you think your email address is correct and you should have access,
-      you can email our support team:
+      you can <%= govuk_link_to "contact our support team", support_ticket_path %>.
     </p>
-    <ul class="govuk-list">
-      <li>Email: <%= ghwt_contact_mailto %></li>
-      <li>We aim to respond within 4 working days.</li>
-    </ul>
     <h2 class="govuk-heading-m">
       Parents, carers and pupils
     </h2>


### PR DESCRIPTION
### Context
We are starting to roll out the new contact form. This doesn't cover all
references to the email address but it is a start. There are instances where we tag the email
subject with a particular reference and to ensure that we don't break any
zendesk macros/process, it was decided that we wouldn't touch this for the
time being. It might be better if we focus on building forms for those
pages where we can validate the information and then create specific
zendesk tickets from those requests.

### Changes proposed in this pull request
- Replaces the majority of references to the email address with a link to our support start page
- Removes a few references to the SLA as its mentioned on the support start page
  - There are none only 4 references to the SLA (1x Accessibility page, 2 x get support start page and 1 x "Thank you" page after the user has submitted their query.

### Guidance to review

Visit working demo https://dfe-ghwt-pr-1093.herokuapp.com/