### PR TITLE
[1251] Click to sign in now an interstitial page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -202,6 +202,25 @@ class User < ApplicationRecord
     deleted_at.present?
   end
 
+  def associated_schools
+    scope = School.gias_status_open.distinct
+
+    if school && responsible_body
+      scope = scope.joins(:responsible_body, user_schools: [:user])
+      scope = scope.where('user_schools.user_id = ? OR schools.responsible_body_id = ?', id, responsible_body.id)
+    elsif school
+      scope = scope.joins(user_schools: [:user])
+      scope = scope.where('user_schools.user_id = ?', id)
+    elsif responsible_body
+      scope = scope.joins(:responsible_body)
+      scope = scope.where('schools.responsible_body_id = ?', responsible_body.id)
+    else
+      scope = scope.none
+    end
+
+    scope
+  end
+
 private
 
   def cleansed_full_name

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,6 +10,7 @@ class FeatureFlag
     secondary_mass_testing_banner
     ipad_stock_message
     schools_closed_for_national_lockdown
+    sixth_form_interstitial
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -1,0 +1,33 @@
+class InterstitialPicker
+  attr_reader :user
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def call
+    @call ||= if FeatureFlag.active?(:sixth_form_interstitial) && user.associated_schools.where(phase: 'sixteen_plus').any?(&:can_order_devices_right_now?)
+                OpenStruct.new(
+                  title: 'You can now order laptops and tablets for students in years 12 and 13',
+                  partial: 'interstitials/increased_sixth_form_allocation',
+                )
+              elsif user.is_school_user?
+                OpenStruct.new(
+                  title: title_for_default,
+                  partial: 'interstitials/school_user',
+                )
+              else
+                OpenStruct.new(
+                  title: title_for_default,
+                  partial: 'interstitials/default',
+                )
+              end
+  end
+
+private
+
+  def title_for_default
+    i18n_key = user.is_school_user? || (user.is_responsible_body_user? && !user.is_a_single_academy_trust_user?) ? :related_organisation : :standard
+    I18n.t(i18n_key, scope: %i[page_titles click_to_sign_in], organisation: user.organisation_name)
+  end
+end

--- a/app/views/interstitials/_default.html.erb
+++ b/app/views/interstitials/_default.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>

--- a/app/views/interstitials/_increased_sixth_form_allocation.html.erb
+++ b/app/views/interstitials/_increased_sixth_form_allocation.html.erb
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>
+
+<p class="govuk-body">
+  We’re expanding the support available through the Get help with technology programme.
+</p>
+
+<p class="govuk-body">
+  We’ve increased your allocation of devices so you can now order laptops and tablets for disadvantaged students in years 12 and 13.
+</p>

--- a/app/views/interstitials/_school_user.html.erb
+++ b/app/views/interstitials/_school_user.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>
+
 <p class="govuk-body">You can use the ‘Get help with technology’ service to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
   <li>check how many devices you can order</li>

--- a/app/views/sign_in_tokens/click_to_sign_in.html.erb
+++ b/app/views/sign_in_tokens/click_to_sign_in.html.erb
@@ -1,15 +1,10 @@
-<%- i18n_key = (@current_user.is_school_user? || (@current_user.is_responsible_body_user? && !@current_user.is_a_single_academy_trust_user?)) ? :related_organisation : :standard %>
-<%- title = t(i18n_key, scope: %i[page_titles click_to_sign_in], organisation: @current_user.organisation_name) %>
-<%- content_for :title, title %>
+<%- picker = InterstitialPicker.new(user: @current_user) %>
+<%- content_for :title, title = picker.call.title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= title %>
-    </h1>
-    <%- if @current_user.is_school_user? %>
-      <%= render partial: 'shared/school_user_welcome_text' %>
-    <%- end %>
+    <%= render partial: picker.call.partial, locals: { title: title } %>
+
     <p class="govuk-body">
       <%= form_with url: destroy_sign_in_token_path, method: 'delete' do |f| %>
         <%= hidden_field_tag :token, params[:token] %>

--- a/spec/services/interstitial_picker_spec.rb
+++ b/spec/services/interstitial_picker_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe InterstitialPicker do
+  let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
+  let(:school) { create(:school, :in_lockdown, phase: 'sixteen_plus', device_allocations: [allocation]) }
+  let(:school_user) { create(:school_user, school: school) }
+  let(:rb) { create(:trust, schools: [school]) }
+  let(:rb_user) { create(:trust_user, responsible_body: rb) }
+
+  context 'when user has sixth form school that can order', with_feature_flags: { sixth_form_interstitial: 'active' } do
+    subject(:service) { described_class.new(user: school_user) }
+
+    it 'shows increased allocation screen' do
+      expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+    end
+  end
+
+  context 'when rb user has sixth form school that can order', with_feature_flags: { sixth_form_interstitial: 'active' } do
+    subject(:service) { described_class.new(user: rb_user) }
+
+    it 'shows increased allocation screen' do
+      expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/ThIADjmi/1251-increase-allocation-for-schools-with-sixth-form-students

### Changes proposed in this pull request

- There is a click to sign in page after clicking the email link to login
- We want to use this page to show an interstitial page instead with context specific content

### Screenshot

![image](https://user-images.githubusercontent.com/92580/104221092-596ab800-5438-11eb-9195-f8729e7f7288.png)

### Guidance to review

- Login as any user, experience should not be different
- Login as school user, same experience, should see extra text with list
- Login as school with sixth form that can order devices, should now see repurposed interstitial page
- Feature should only work when feature flag enabled