### PR TITLE
Fix issue where users use browser back buttons

### DIFF
--- a/app/controllers/support_ticket/academy_details_controller.rb
+++ b/app/controllers/support_ticket/academy_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::AcademyDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::AcademyDetailsForm.new(set_params)
     render 'support_tickets/academy_details'
@@ -28,11 +30,9 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        academy_name: session[:support_ticket]['academy_name'],
-      }
-    end
+    {
+      academy_name: session[:support_ticket]['academy_name'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/academy_details_controller.rb
+++ b/app/controllers/support_ticket/academy_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::AcademyDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::AcademyDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/base_controller.rb
+++ b/app/controllers/support_ticket/base_controller.rb
@@ -13,9 +13,7 @@ class SupportTicket::BaseController < ApplicationController
 
 private
 
-  def redirect_if_no_form_data_exists
-    return unless request.get?
-
+  def require_support_ticket_data!
     redirect_to support_ticket_path if session[:support_ticket].blank?
   end
 end

--- a/app/controllers/support_ticket/base_controller.rb
+++ b/app/controllers/support_ticket/base_controller.rb
@@ -10,4 +10,12 @@ class SupportTicket::BaseController < ApplicationController
   def thank_you
     render 'support_tickets/thank_you'
   end
+
+private
+
+  def redirect_if_no_form_data_exists
+    return unless request.get?
+
+    redirect_to support_ticket_path if session[:support_ticket].blank?
+  end
 end

--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @support_ticket = session[:support_ticket]
     @form = form

--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @support_ticket = session[:support_ticket]

--- a/app/controllers/support_ticket/college_details_controller.rb
+++ b/app/controllers/support_ticket/college_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::CollegeDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::CollegeDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/college_details_controller.rb
+++ b/app/controllers/support_ticket/college_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::CollegeDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::CollegeDetailsForm.new(set_params)
     render 'support_tickets/college_details'
@@ -29,14 +31,10 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present? && session[:support_ticket]['college_name'].present?
-      {
-        college_name: session[:support_ticket]['college_name'],
-        college_ukprn: session[:support_ticket]['college_ukprn'],
-      }
-    else
-      { college_name: nil, college_ukprn: nil }
-    end
+    {
+      college_name: session[:support_ticket]['college_name'],
+      college_ukprn: session[:support_ticket]['college_ukprn'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/contact_details_controller.rb
+++ b/app/controllers/support_ticket/contact_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::ContactDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::ContactDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/contact_details_controller.rb
+++ b/app/controllers/support_ticket/contact_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::ContactDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::ContactDetailsForm.new(set_params)
     render 'support_tickets/contact_details'
@@ -26,15 +28,11 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        full_name: session[:support_ticket]['full_name'],
-        email_address: session[:support_ticket]['email_address'],
-        telephone_number: session[:support_ticket]['telephone_number'],
-      }
-    else
-      { full_name: nil, email_address: nil, telephone_number: nil }
-    end
+    {
+      full_name: session[:support_ticket]['full_name'],
+      email_address: session[:support_ticket]['email_address'],
+      telephone_number: session[:support_ticket]['telephone_number'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/describe_yourself_controller.rb
+++ b/app/controllers/support_ticket/describe_yourself_controller.rb
@@ -26,8 +26,6 @@ private
   def set_params
     if session[:support_ticket].present? && session[:support_ticket]['user_type'].present?
       { user_type: session[:support_ticket]['user_type'] }
-    else
-      { user_type: nil }
     end
   end
 

--- a/app/controllers/support_ticket/local_authority_details_controller.rb
+++ b/app/controllers/support_ticket/local_authority_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::LocalAuthorityDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::LocalAuthorityDetailsForm.new(set_params)
     render 'support_tickets/local_authority_details'
@@ -28,11 +30,9 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        local_authority_name: session[:support_ticket]['local_authority_name'],
-      }
-    end
+    {
+      local_authority_name: session[:support_ticket]['local_authority_name'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/local_authority_details_controller.rb
+++ b/app/controllers/support_ticket/local_authority_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::LocalAuthorityDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::LocalAuthorityDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/school_details_controller.rb
+++ b/app/controllers/support_ticket/school_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::SchoolDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::SchoolDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/school_details_controller.rb
+++ b/app/controllers/support_ticket/school_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::SchoolDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::SchoolDetailsForm.new(set_params)
     render 'support_tickets/school_details'
@@ -28,12 +30,10 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        school_name: session[:support_ticket]['school_name'],
-        school_urn: session[:support_ticket]['school_urn'],
-      }
-    end
+    {
+      school_name: session[:support_ticket]['school_name'],
+      school_urn: session[:support_ticket]['school_urn'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/support_details_controller.rb
+++ b/app/controllers/support_ticket/support_details_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::SupportDetailsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::SupportDetailsForm.new(set_params)

--- a/app/controllers/support_ticket/support_details_controller.rb
+++ b/app/controllers/support_ticket/support_details_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::SupportDetailsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::SupportDetailsForm.new(set_params)
     render 'support_tickets/support_details'
@@ -24,11 +26,9 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        message: session[:support_ticket]['message'],
-      }
-    end
+    {
+      message: session[:support_ticket]['message'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/support_needs_controller.rb
+++ b/app/controllers/support_ticket/support_needs_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::SupportNeedsController < SupportTicket::BaseController
+  before_action :redirect_if_no_form_data_exists
+
   def new
     @form ||= SupportTicket::SupportNeedsForm.new(set_params)
     render 'support_tickets/support_needs'
@@ -24,11 +26,9 @@ private
   end
 
   def set_params
-    if session[:support_ticket].present?
-      {
-        support_topics: session[:support_ticket]['support_topics'],
-      }
-    end
+    {
+      support_topics: session[:support_ticket]['support_topics'],
+    }
   end
 
   def next_step

--- a/app/controllers/support_ticket/support_needs_controller.rb
+++ b/app/controllers/support_ticket/support_needs_controller.rb
@@ -1,5 +1,5 @@
 class SupportTicket::SupportNeedsController < SupportTicket::BaseController
-  before_action :redirect_if_no_form_data_exists
+  before_action :require_support_ticket_data!, only: :new
 
   def new
     @form ||= SupportTicket::SupportNeedsForm.new(set_params)

--- a/spec/controllers/support_ticket/academy_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/academy_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::AcademyDetailsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::AcademyDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/academy_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/academy_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::AcademyDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/check_your_request_controller_spec.rb
+++ b/spec/controllers/support_ticket/check_your_request_controller_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
   describe '#new' do
     before do
-      get :new, session: { support_ticket: { hello: 'world' } }
+      session[:support_ticket] = { hello: 'world' }
+      get :new
     end
 
     it 'responds successfully' do

--- a/spec/controllers/support_ticket/check_your_request_controller_spec.rb
+++ b/spec/controllers/support_ticket/check_your_request_controller_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
     it 'assigns the session data to a variable to play back all the details to the user' do
       expect(assigns(:support_ticket)).to eq({ hello: 'world' })
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/college_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/college_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::CollegeDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/college_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/college_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::CollegeDetailsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::CollegeDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/contact_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/contact_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::ContactDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/contact_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/contact_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::ContactDetailsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::ContactDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
+++ b/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::DescribeYourselfController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
+++ b/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::DescribeYourselfController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::DescribeYourselfForm)
     end
+
+    it 'does not redirect to get support home page because its the first page in the wizard' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'does not redirect to the get support home page' do
+        expect(response).not_to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::LocalAuthorityDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/local_authority_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::LocalAuthorityDetailsController, type: :controller
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::LocalAuthorityDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/school_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/school_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::SchoolDetailsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::SchoolDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/school_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/school_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::SchoolDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/support_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_details_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::SupportDetailsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/support_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_details_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::SupportDetailsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::SupportDetailsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/controllers/support_ticket/support_needs_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_needs_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::SupportNeedsController, type: :controller do
   describe '#new' do
     before do
+      session[:support_ticket] = { user_type: '' }
       get :new
     end
 

--- a/spec/controllers/support_ticket/support_needs_controller_spec.rb
+++ b/spec/controllers/support_ticket/support_needs_controller_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SupportTicket::SupportNeedsController, type: :controller do
     it 'creates a form object' do
       expect(assigns(:form)).to be_instance_of(SupportTicket::SupportNeedsForm)
     end
+
+    it 'does not redirect to get support home page (using the wizard with existing data)' do
+      expect(response).not_to redirect_to(support_ticket_path)
+    end
+
+    describe 'when attempting to access the page directly without using the wizard' do
+      before do
+        session[:support_ticket] = nil
+        get :new
+      end
+
+      it 'redirects to the get support home page' do
+        expect(response).to redirect_to(support_ticket_path)
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
### Context
Issue https://sentry.io/organizations/dfe-get-help-with-tech/issues/2138267573/?project=5320558

I managed to replicate this error by going through the full "Get support" journey right up to the point where a zendesk ticket is created. After
I saw the "Thank you" page, I clicked on the browser back button and saw
this error.

What happens is as a user goes through the get support wizard we store the
form data in session (`session[:support_ticket]`) but once the zendesk api
has been used we clear the session. So using the back button or trying to
access other parts of the wizard may raise similar issues.

The solution I came up with is to add a `before_action` across all the
controllers which check if the `session[:support_ticket]` is present. if
it's not then we redirect the user back to the start page.

### Changes proposed in this pull request

### Guidance to review

visit https://dfe-ghwt-pr-1099.herokuapp.com/get-support, 
- fill in all the forms until you get to "Thank you" page (don't worry review apps aren't configured to use Zendesk API)
- use the browser back button (no error should be raised and you should be taken back to the get support start page