### PR TITLE
[1277] add request_id, session id and user id to each controller log message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,4 +125,14 @@ private
   def show_parent_carer_pupil_banner?
     @show_parent_carer_pupil_banner = current_user&.new_record?
   end
+
+  # Log the user identification params to help debug intermittent issue
+  # [1277](https://trello.com/c/uIDcEmGH/1277-mno-bug-for-providers)
+  def append_info_to_payload(payload)
+    super
+    payload[:current_user_id] = @current_user&.id
+    payload[:session_user_id] = session[:user_id]
+    payload[:session_id] = session[:session_id]
+    payload[:request_id] = request.request_id
+  end
 end


### PR DESCRIPTION
### Context

There's an intermittent, hard-to-reproduce issue where users with a valid session are v. occasionally seeing a 403 Forbidden page with a different users email address at the top. 
We need to capture more information in the logs to get to the cause.

### Changes proposed in this pull request

Add a few non-personally-identifying tags to each controller log message to help us if it happens again.

### Guidance to review

I've tested this on staging, and the extra fields come through to Kibana fine (see screenshot)

![Screenshot from 2021-01-12 17-03-08](https://user-images.githubusercontent.com/134501/104347121-28ea5300-54f8-11eb-8afa-f3f5e553156b.png)