### PR TITLE
Increase MNO pagination to 100 items

### DIFF
--- a/config/initializers/pagination.rb
+++ b/config/initializers/pagination.rb
@@ -2,4 +2,5 @@ require 'pagy'
 require 'pagy/extras/items'
 require 'pagy/extras/i18n'
 
+Pagy::VARS[:items] = 100
 Pagy::VARS[:max_items] = 9999

--- a/spec/features/mno/extra_mobile_data_requests_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_spec.rb
@@ -89,9 +89,16 @@ RSpec.feature 'MNO Requests view', type: :feature do
     end
 
     context 'with multiple pages of extra_mobile_data_requests' do
+      original_pagination_value = Pagy::VARS[:items]
+
       before do
-        create_list(:extra_mobile_data_request, 105, status: 'requested', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+        Pagy::VARS[:items] = 20
+        create_list(:extra_mobile_data_request, 25, status: 'requested', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
         click_on 'Your requests'
+      end
+
+      after do
+        Pagy::VARS[:items] = original_pagination_value
       end
 
       it 'shows pagination' do

--- a/spec/features/mno/extra_mobile_data_requests_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'MNO Requests view', type: :feature do
 
     context 'with multiple pages of extra_mobile_data_requests' do
       before do
-        create_list(:extra_mobile_data_request, 25, status: 'requested', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+        create_list(:extra_mobile_data_request, 105, status: 'requested', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
         click_on 'Your requests'
       end
 


### PR DESCRIPTION
https://trello.com/c/0mRLaWzh/1286-mno-bulk-update-page-limit-of-requests-from-20-to-100

20 per page is not enough. MNOs have asked for more results per page so they can bulk update more at once.

Increase from 20 to 100.