### PR TITLE
add DeleteOldSessionsJob

### DIFF
--- a/app/jobs/delete_old_sessions_job.rb
+++ b/app/jobs/delete_old_sessions_job.rb
@@ -1,0 +1,11 @@
+class DeleteOldSessionsJob < ApplicationJob
+  queue_as :default
+
+  def perform(args = {})
+    older_than = args[:older_than] || Time.zone.now.utc - Settings.session_ttl_seconds * 4
+    # We'll play safe & only delete sessions that are 4 times older than the ttl
+    sessions = Session.where('updated_at < ?', older_than)
+    logger.info "deleting #{sessions.count} sessions older than #{older_than.iso8601}"
+    sessions.delete_all
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -18,3 +18,7 @@
     cron: '0 8 * * 1-5 Europe/London'  # every weekday at 8:00am
     queue: scheduler
     description: Notify MNOs of requests
+  DeleteOldSessionsJob:
+    cron: '0 * * * * Europe/London' # on the hour, every hour
+    queue: scheduler
+    description: Delete old sessions

--- a/spec/jobs/delete_old_sessions_job_spec.rb
+++ b/spec/jobs/delete_old_sessions_job_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe DeleteOldSessionsJob do
       Session.create!(id: SecureRandom.uuid)
       Timecop.return
 
-
       Timecop.travel(30.minutes.ago)
       2.times do
         Session.create!(id: SecureRandom.uuid)

--- a/spec/jobs/delete_old_sessions_job_spec.rb
+++ b/spec/jobs/delete_old_sessions_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe DeleteOldSessionsJob do
+  let(:job) { described_class.new }
+
+  describe '#perform' do
+    before do
+      Timecop.travel(1.hour.ago)
+      Session.create!(id: SecureRandom.uuid)
+      Timecop.return
+
+      Timecop.travel(5.hours.ago)
+      Session.create!(id: SecureRandom.uuid)
+      Timecop.return
+
+      Timecop.travel(1.day.ago)
+      Session.create!(id: SecureRandom.uuid)
+      Timecop.return
+
+
+      Timecop.travel(30.minutes.ago)
+      2.times do
+        Session.create!(id: SecureRandom.uuid)
+      end
+      Timecop.return
+    end
+
+    context 'given an :older_than param' do
+      let(:result) { job.perform(older_than: 50.minutes.ago) }
+
+      it 'deletes only the sessions older than the given param' do
+        expect { result }.to change(Session, :count).by(-3)
+      end
+    end
+
+    context 'given no :older_than param' do
+      let(:result) { job.perform }
+
+      it 'deletes only the sessions older than 4 times session_ttl_seconds Setting' do
+        expect { result }.to change(Session, :count).by(-2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

While investigating [Trello card 1277](https://trello.com/c/uIDcEmGH/1277-mno-bug-for-providers), I found that there are many old sessions way still in the DB, way past their expiry - there has been no mechanism for clearing them. 

### Changes proposed in this pull request

Add a job to run on the hour, every hour, to purge old sessions from the DB

### Guidance to review

