### PR TITLE
[1280] Increased allocations interstitials

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,7 +10,6 @@ class FeatureFlag
     secondary_mass_testing_banner
     ipad_stock_message
     schools_closed_for_national_lockdown
-    sixth_form_interstitial
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,12 +6,12 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if user.associated_schools.where(increased_sixth_form_feature_flag: true).any?(&:can_order_devices_right_now?)
+    @call ||= if user.associated_schools.where(increased_sixth_form_feature_flag: true).any? # (&:can_order_devices_right_now?) # enable after user research
                 OpenStruct.new(
                   title: 'You can now order laptops and tablets for students in years 12 and 13',
                   partial: 'interstitials/increased_sixth_form_allocation',
                 )
-              elsif user.associated_schools.where(increased_fe_feature_flag: true).any?(&:can_order_devices_right_now?)
+              elsif user.associated_schools.where(increased_fe_feature_flag: true).any? # (&:can_order_devices_right_now?) # enable after user research
                 OpenStruct.new(
                   title: 'You can now order laptops and tablets for learners in further education',
                   partial: 'interstitials/increased_fe_allocation',

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,10 +6,15 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if FeatureFlag.active?(:sixth_form_interstitial) && user.associated_schools.where(phase: 'sixteen_plus').any?(&:can_order_devices_right_now?)
+    @call ||= if user.associated_schools.where(increased_sixth_form_feature_flag: true).any?(&:can_order_devices_right_now?)
                 OpenStruct.new(
                   title: 'You can now order laptops and tablets for students in years 12 and 13',
                   partial: 'interstitials/increased_sixth_form_allocation',
+                )
+              elsif user.associated_schools.where(increased_fe_feature_flag: true).any?(&:can_order_devices_right_now?)
+                OpenStruct.new(
+                  title: 'You can now order laptops and tablets for learners in further education',
+                  partial: 'interstitials/increased_fe_allocation',
                 )
               elsif user.is_school_user?
                 OpenStruct.new(

--- a/app/views/interstitials/_increased_fe_allocation.html.erb
+++ b/app/views/interstitials/_increased_fe_allocation.html.erb
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>
+
+<p class="govuk-body">
+  We’re expanding the support available through the Get help with technology programme.
+</p>
+
+<p class="govuk-body">
+  We’ve increased your allocation of devices to help provide laptops and tablets for learners who are:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>aged 16 to 19 and get free meals in further education</li>
+  <li>over the age of 19, get free meals, and have an education, health and care plan (EHCP)</li>
+</ul>

--- a/app/views/school/details/show.html.erb
+++ b/app/views/school/details/show.html.erb
@@ -20,15 +20,27 @@
       About allocations
     </h2>
 
-    <p class="govuk-body">
-      Allocations are based on:
-    </p>
+    <% if @school.increased_sixth_form_feature_flag? || @school.increased_fe_feature_flag? %>
+      <p class="govuk-body">
+        Allocations are based on an estimate of the number of devices your school or college already has and the number of pupils:
+      </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the number of children in years 3 to 11</li>
-      <li>free school meals data</li>
-      <li>an estimate of the number of devices a school already has</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>in years 3 to 13</li>
+        <li>who get free school meals</li>
+        <li>who get free meals in further education</li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">
+        Allocations are based on:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the number of children in years 3 to 11</li>
+        <li>free school meals data</li>
+        <li>an estimate of the number of devices a school already has</li>
+      </ul>
+    <% end %>
 
     <p class="govuk-body">
       If the number of pupils unable to attend school and in need of laptops and tablets is greater than your allocation, you can <%= govuk_link_to 'request more devices', devices_allocation_and_specification_path(anchor: 'how-to-query-an-allocation') %>.

--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -9,13 +9,25 @@
         <%= title %>
       </h1>
 
-      <p class="govuk-body">Your allocation of <%= @allocation %> is based on:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <li>the number of children in years 3 to 11</li>
-        <li>free school meals data</li>
-        <li>an estimate of the number of devices your school already has</li>
-      </ul>
-      <p class="govuk-body">This allocation could change. If there are widespread school closures, we might reduce it.</p>
+      <% if @school.increased_sixth_form_feature_flag? || @school.increased_fe_feature_flag? %>
+        <p class="govuk-body">Your allocation of <%= @allocation %> is based on an estimate of the number of devices your school or college already has and the number of pupils:</p>
+
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+          <li>in years 3 to 13</li>
+          <li>who get free school meals</li>
+          <li>who get free meals in further education</li>
+        </ul>
+      <% else %>
+        <p class="govuk-body">Your allocation of <%= @allocation %> is based on:</p>
+
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+          <li>the number of children in years 3 to 11</li>
+          <li>free school meals data</li>
+          <li>an estimate of the number of devices your school already has</li>
+        </ul>
+
+        <p class="govuk-body">This allocation could change. If there are widespread school closures, we might reduce it.</p>
+      <% end %>
 
       <p class="govuk-body govuk-!-margin-bottom-6">
         <%= govuk_link_to 'Read more about allocations', devices_allocation_and_specification_path, target: '_blank' %>

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -9,13 +9,11 @@
         <%= title %>
       </h1>
 
-      <p class="govuk-body">We’ll contact you as soon as you’re able to place orders.</p>
       <p class="govuk-body">You can continue to use this service to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
         <li>check how many devices you can order</li>
         <li>add more users</li>
         <li>change your Chromebook settings</li>
-        <li>request devices for clinically vulnerable children who are shielding</li>
       </ul>
 
       <%= f.govuk_submit (@current_user.has_multiple_schools? ? 'Finish and go to school page' : 'Finish and go to homepage' ) %>

--- a/app/views/shared/_school_without_allocation.html.erb
+++ b/app/views/shared/_school_without_allocation.html.erb
@@ -4,7 +4,11 @@
 
 <p class="govuk-body">Reasons for a 0 allocation include:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>the school has no children in the eligible year groups, years 3 to 11</li>
+  <% if @school.increased_sixth_form_feature_flag? || @school.increased_fe_feature_flag? %>
+    <li>the school has no children in the eligible year groups, years 3 to 13</li>
+  <% else %>
+    <li>the school has no children in the eligible year groups, years 3 to 11</li>
+  <% end %>
   <li>there are very few children on free school meals according to the most recent census data</li>
   <li>there was not enough data to calculate an allocation – for example it’s a new school</li>
 </ul>

--- a/db/migrate/20210112164816_add_allocation_feature_flags_to_schools.rb
+++ b/db/migrate/20210112164816_add_allocation_feature_flags_to_schools.rb
@@ -1,0 +1,6 @@
+class AddAllocationFeatureFlagsToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :increased_sixth_form_feature_flag, :boolean, default: false
+    add_column :schools, :increased_fe_feature_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_161018) do
+ActiveRecord::Schema.define(version: 2021_01_12_164816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,8 +202,8 @@ ActiveRecord::Schema.define(version: 2021_01_05_161018) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
@@ -289,6 +289,8 @@ ActiveRecord::Schema.define(version: 2021_01_05_161018) do
     t.string "status", default: "open", null: false
     t.string "computacenter_change", default: "none", null: false
     t.boolean "increased_allocations_feature_flag", default: false
+    t.boolean "increased_sixth_form_feature_flag", default: false
+    t.boolean "increased_fe_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -232,7 +232,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def then_i_see_information_about_what_happens_next
     expect(page).to have_current_path(welcome_wizard_what_happens_next_school_path(urn: school.urn))
-    expect(page).to have_text('We’ll contact you as soon as you’re able to place orders')
+    expect(page).to have_text('check how many devices you can order')
   end
 
   def when_i_choose_yes_and_click_continue

--- a/spec/services/interstitial_picker_spec.rb
+++ b/spec/services/interstitial_picker_spec.rb
@@ -1,25 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe InterstitialPicker do
-  let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
-  let(:school) { create(:school, :in_lockdown, phase: 'sixteen_plus', device_allocations: [allocation]) }
-  let(:school_user) { create(:school_user, school: school) }
-  let(:rb) { create(:trust, schools: [school]) }
-  let(:rb_user) { create(:trust_user, responsible_body: rb) }
+  context 'with increased_sixth_form_feature_flag' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
+    let(:school) { create(:school, :in_lockdown, phase: 'sixteen_plus', device_allocations: [allocation], increased_sixth_form_feature_flag: true) }
+    let(:school_user) { create(:school_user, school: school) }
+    let(:rb) { create(:trust, schools: [school]) }
+    let(:rb_user) { create(:trust_user, responsible_body: rb) }
 
-  context 'when user has sixth form school that can order', with_feature_flags: { sixth_form_interstitial: 'active' } do
-    subject(:service) { described_class.new(user: school_user) }
+    context 'when user has school that can order' do
+      subject(:service) { described_class.new(user: school_user) }
 
-    it 'shows increased allocation screen' do
-      expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+      it 'shows increased allocation screen' do
+        expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+      end
+    end
+
+    context 'when rb user has school that can order' do
+      subject(:service) { described_class.new(user: rb_user) }
+
+      it 'shows increased allocation screen' do
+        expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+      end
     end
   end
 
-  context 'when rb user has sixth form school that can order', with_feature_flags: { sixth_form_interstitial: 'active' } do
-    subject(:service) { described_class.new(user: rb_user) }
+  context 'with increased_fe_feature_flag' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
+    let(:school) { create(:school, :in_lockdown, phase: 'sixteen_plus', device_allocations: [allocation], increased_fe_feature_flag: true) }
+    let(:school_user) { create(:school_user, school: school) }
+    let(:rb) { create(:trust, schools: [school]) }
+    let(:rb_user) { create(:trust_user, responsible_body: rb) }
 
-    it 'shows increased allocation screen' do
-      expect(service.call.partial).to eql('interstitials/increased_sixth_form_allocation')
+    context 'when user has school that can order' do
+      subject(:service) { described_class.new(user: school_user) }
+
+      it 'shows increased allocation screen' do
+        expect(service.call.partial).to eql('interstitials/increased_fe_allocation')
+      end
+    end
+
+    context 'when rb user has school that can order' do
+      subject(:service) { described_class.new(user: rb_user) }
+
+      it 'shows increased allocation screen' do
+        expect(service.call.partial).to eql('interstitials/increased_fe_allocation')
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/TX4JVPVh/1280-interstitial-sign-in-page-for-fe-providers-who-are-already-using-the-service
- https://trello.com/c/ThIADjmi/1251-increase-allocation-for-schools-with-sixth-form-students

### Changes proposed in this pull request

- My understanding is that there are 2 feature flags `increased_sixth_form_feature_flag` and `increased_fe_feature_flag`
- Depending on which is enabled for the school they get different interstitial screens
- It's implemented so if the user has both conditions it shows the sixth form version page
- There is then some conditional content in other places so if either condition is met then this is shown
- I have removed the global feature flag as it doesn't seem like its needed

### Guidance to review

#### `increased_sixth_form_feature_flag`

- Enable feature `increased_sixth_form_feature_flag` for a school
- Ensure this school can order devices
- Login as user of this school
- Should see interstitial page for sixth form allocation increase

#### `increased_fe_feature_flag`

- Enable feature `increased_fe_feature_flag` for a school
- Ensure this school can order devices
- Login as user of this school
- Should see interstitial page for fe allocation increase