### PR TITLE
make UserChange records use now as the timestamp, rather than user.updated_at

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -89,7 +89,7 @@ private
   def meta_attributes
     {
       user_id: user.id,
-      updated_at_timestamp: user.updated_at,
+      updated_at_timestamp: Time.zone.now.utc,
       type_of_update: type_of_update,
     }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -327,6 +327,8 @@ RSpec.describe User, type: :model do
 
     context 'creating user' do
       context 'computacenter relevant' do
+        let(:expected_time) { 2.seconds.ago }
+
         it 'creates a Computacenter::UserChange of type new' do
           expect { create(:user, :relevant_to_computacenter) }.to change(Computacenter::UserChange, :count).by(1)
         end
@@ -337,7 +339,9 @@ RSpec.describe User, type: :model do
         end
 
         it 'persists correct data for RB user' do
+          Timecop.travel(expected_time)
           user = create(:trust_user, orders_devices: true)
+          Timecop.return
           user_change = Computacenter::UserChange.last
 
           expect(user_change.user_id).to eql(user.id)
@@ -351,7 +355,7 @@ RSpec.describe User, type: :model do
           expect(user_change.school).to be_blank
           expect(user_change.school_urn).to be_blank
           expect(user_change.cc_ship_to_number).to be_blank
-          expect(user_change.updated_at_timestamp).to eql(user.created_at)
+          expect(user_change.updated_at_timestamp).to be_within(1.second).of(expected_time)
           expect(user_change.type_of_update).to eql('New')
           expect(user_change.original_email_address).to be_nil
           expect(user_change.original_first_name).to be_blank
@@ -366,7 +370,10 @@ RSpec.describe User, type: :model do
         end
 
         it 'persists correct data for school user' do
+          Timecop.travel(expected_time)
           user = create(:school_user, orders_devices: true)
+          Timecop.return
+
           user_change = Computacenter::UserChange.last
 
           expect(user_change.user_id).to eql(user.id)
@@ -380,7 +387,7 @@ RSpec.describe User, type: :model do
           expect(user_change.school).to eql(user.school.name)
           expect(user_change.school_urn).to eql(user.school.urn.to_s)
           expect(user_change.cc_ship_to_number).to eql(user.school.computacenter_reference)
-          expect(user_change.updated_at_timestamp).to eql(user.created_at)
+          expect(user_change.updated_at_timestamp).to be_within(1.second).of(expected_time)
           expect(user_change.type_of_update).to eql('New')
           expect(user_change.original_email_address).to be_nil
           expect(user_change.original_first_name).to be_blank


### PR DESCRIPTION
### Context

See [Trello card 1275 - Multiple user changes with the same timestamp](https://trello.com/c/mKBnxiOK/1275-multiple-userchanges-being-generated-with-the-same-user-timestamp). Computacenter have reported an issue with receiving multiple userchanges for the same user, each of which has the same timestamp. This appears to be the code acting as designed - it currently uses the `user.updated_at` as the timestamp` - but it makes it difficult for them to see what the latest state is meant to be, when several changes are committed at once.

The original behaviour made sense when UserChange records were only triggered by updating the user record, but since then we've refactored and expanded functionality, to the point where they can be generated as a result of moving schools between ResponsibleBodies, or the ResponsibleBody getting a new `computacenter_reference`, or by the schools converting to Academies..... all of which do not touch the user record at all. 

### Changes proposed in this pull request

Make UserChange records use the current time as the `updated_at_timestamp`, rather than user.updated_at.


### Guidance to review

