### PR TITLE
[1277] fix race condition in SessionService

### DIFF
--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -41,9 +41,9 @@ class SessionService
 
   def self.identify_user!(session)
     if is_signed_in?(session)
-      @current_user = User.find(session[:user_id])
+      user = User.find(session[:user_id])
       update_session!(session[:session_id])
-      @current_user
+      user
     end
   end
 


### PR DESCRIPTION
### Context

See [Trello card #1277 - MNO bug for providers](https://trello.com/c/uIDcEmGH/1277-mno-bug-for-providers). We've been seeing an occasional issue where a user who has a genuine valid session sometimes gets a 403 Forbidden page with another users' email address in the header. 

After much investigation, we found the potential culprit - the `SessionService.identify_user!` method is incorrectly using an instance variable in a class-scoped method. This is a potential race condition, as the class SessionService will be shared amongst the workers in the Puma threadpool.

It's conceivable that just occasionally, two threads are running this code with an offset of about 2 lines each.

- thread 1 reads current_user from user 1 's session, and sets `@current_user` to `User.find(1)`
- thread 2 reads current_user from user 2's session, and sets `@current_user` to `User.find(2)`
- thread 1 then returns `@current_user` (== `User.find(2)`) which gets set as `@current_user` in the `ApplicationController`instance for that thread

As a result, the user in thread 1 is mis-identified as the user from thread 2 for the rest of their request. 

### Changes proposed in this pull request

Change the `identify_user!` method to use a local variable instead of an instance variable.

### Guidance to review

As this issue only manifests itself occasionally under high-concurrency conditions, it's very difficult to prove that it's fixed with a test, either automated or manual. All the automated tests pass, and logging in manually works as expected - what we can do is monitor the frequency of 403 response codes before and after releasing this, through Kibana.
