### PR TITLE
Remove Jan 13 date, update to ASAP

### DIFF
--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -8,9 +8,9 @@
     </h1>
 
     <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">We’re opening orders for primary schools gradually, and will invite all to order by 13 January.</p>
+      <p class="govuk-body">Ordering will be opened as soon as possible.</p>
 
-      <p class="govuk-body">We’ll email you as soon as you can place an order.</p>
+      <p class="govuk-body">We’ll email you when you can place an order.</p>
     <% else %>
       <p class="govuk-body">You can order a school’s full allocation when:</p>
 

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -17,9 +17,9 @@
     </h1>
 
     <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">We’re opening orders for primary schools gradually, and will invite all to order by 13 January.</p>
+      <p class="govuk-body">Ordering will be opened for your school as soon as possible.</p>
 
-      <p class="govuk-body">We’ll email you as soon as you can place an order.</p>
+      <p class="govuk-body">We’ll email you when you can place an order.</p>
     <% else %>
       <p class="govuk-body"><%= t("page_titles.#{who_cannot_order}_cannot_order_devices.can_order_when") %></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -593,7 +593,7 @@ en:
           ordering_schools_heading: Schools that can order
           specific_circumstances_heading: Schools with approved requests for specific circumstances
           cannot_order_yet_schools_heading: Schools that cannot order yet
-          cannot_order_yet_schools_text: We’re opening orders for primary schools gradually, and will invite all to order by 13 January
+          cannot_order_yet_schools_text: Ordering will be opened for these schools as soon as possible.
         who_to_contact:
           create:
             failure: "Saved. We will email %{email_address} shortly"

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -188,6 +188,6 @@ RSpec.feature 'Ordering devices' do
   end
 
   def then_i_see_that_i_will_be_able_to_order_soon
-    expect(page).to have_content('We’re opening orders for primary schools gradually, and will invite all to order by 13 January.')
+    expect(page).to have_content('Ordering will be opened as soon as possible.')
   end
 end

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Order devices' do
   end
 
   def then_i_see_that_i_will_be_able_to_order_soon
-    expect(page).to have_content('We’re opening orders for primary schools gradually, and will invite all to order by 13 January.')
+    expect(page).to have_content('Ordering will be opened for your school as soon as possible')
   end
 
   def then_i_see_techsource_ready_soon


### PR DESCRIPTION
A few schools, recently added, cannot order yet because we are waiting on data from Computacenter.

For these schools, tell them that ordering will be enabled ASAP.