### PR TITLE
Add autocomplete to Multi-Academy Trust and Local Authority pages - Get support - 

### DIFF
--- a/app/controllers/support_ticket/academy_details_controller.rb
+++ b/app/controllers/support_ticket/academy_details_controller.rb
@@ -9,8 +9,8 @@ class SupportTicket::AcademyDetailsController < SupportTicket::BaseController
   def save
     if form.valid?
       session[:support_ticket].merge!({
-        academy_name: form.academy_name,
-        school_name: form.academy_name,
+        academy_name: form.academy_name.titleize,
+        school_name: form.academy_name.titleize,
         school_unique_id: '',
       })
       redirect_to next_step

--- a/app/form_objects/support_ticket/academy_details_form.rb
+++ b/app/form_objects/support_ticket/academy_details_form.rb
@@ -4,4 +4,8 @@ class SupportTicket::AcademyDetailsForm
   attr_accessor :academy_name
 
   validates :academy_name, presence: { message: 'Enter your academy trust name' }
+
+  def multi_academy_trust_list
+    Trust.gias_status_open.multi_academy_trust.order(:name)
+  end
 end

--- a/app/form_objects/support_ticket/local_authority_details_form.rb
+++ b/app/form_objects/support_ticket/local_authority_details_form.rb
@@ -4,4 +4,8 @@ class SupportTicket::LocalAuthorityDetailsForm
   attr_accessor :local_authority_name
 
   validates :local_authority_name, presence: { message: 'Enter your local authority name' }
+
+  def local_authority_list
+    LocalAuthority.all.order(:name)
+  end
 end

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -17,8 +17,9 @@
         Which academy trust do you work for?
       </h1>
 
-      <%= f.govuk_collection_select :academy_name, @form.multi_academy_trust_list,
-                                    :name, :name, label: {text: 'Academy trust name', size: 's'} %>
+      <%= f.govuk_collection_select :academy_name, @form.multi_academy_trust_list, :name, :name,
+                                    label: {text: 'Academy trust name', size: 's'},
+                                    options: { include_blank: true }%>
 
       <%= f.govuk_submit 'Next' %>
     <% end %>

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -17,7 +17,8 @@
         Which academy trust do you work for?
       </h1>
 
-      <%= f.govuk_text_field :academy_name, label: {text: 'Academy trust name', size: 's'} %>
+      <%= f.govuk_collection_select :academy_name, @form.multi_academy_trust_list,
+                                    :name, :name, label: {text: 'Academy trust name', size: 's'} %>
 
       <%= f.govuk_submit 'Next' %>
     <% end %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -17,7 +17,8 @@
         Which local authority do you work for?
       </h1>
 
-      <%= f.govuk_text_field :local_authority_name, label: {text: 'Local authority name', size: 's'} %>
+      <%= f.govuk_collection_select :local_authority_name, @form.local_authority_list,
+                                    :name, :name, label: {text: 'Local authority name', size: 's'} %>
 
       <%= f.govuk_submit 'Next' %>
     <% end %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -17,8 +17,9 @@
         Which local authority do you work for?
       </h1>
 
-      <%= f.govuk_collection_select :local_authority_name, @form.local_authority_list,
-                                    :name, :name, label: {text: 'Local authority name', size: 's'} %>
+      <%= f.govuk_collection_select :local_authority_name, @form.local_authority_list, :name, :name,
+                                    label: {text: 'Local authority name', size: 's'},
+                                    options: { include_blank: true } %>
 
       <%= f.govuk_submit 'Next' %>
     <% end %>

--- a/app/webpacker/scripts/responsible-bodies-autocomplete.js
+++ b/app/webpacker/scripts/responsible-bodies-autocomplete.js
@@ -4,7 +4,8 @@ const initResponsibleBodiesAutocomplete = () => {
   try {
     const inputIds = [
       "#support-user-responsible-body-form-responsible-body-id-field",
-      '#school-search-form-responsible-body-id-field'
+      '#school-search-form-responsible-body-id-field',
+      '#support-ticket-academy-details-form-academy-name-field'
     ];
 
     inputIds.forEach(inputId => {
@@ -14,7 +15,9 @@ const initResponsibleBodiesAutocomplete = () => {
       accessibleAutocomplete.enhanceSelectElement({
         selectElement: responsibleBodiesSelect,
         showAllValues: true,
-        confirmOnBlur: false
+        confirmOnBlur: false,
+        dropdownArrow: () => '',
+        displayMenu: 'overlay'
       });
     });
   } catch (err) {

--- a/app/webpacker/scripts/responsible-bodies-autocomplete.js
+++ b/app/webpacker/scripts/responsible-bodies-autocomplete.js
@@ -5,7 +5,10 @@ const initResponsibleBodiesAutocomplete = () => {
     const inputIds = [
       "#support-user-responsible-body-form-responsible-body-id-field",
       '#school-search-form-responsible-body-id-field',
-      '#support-ticket-academy-details-form-academy-name-field'
+      '#support-ticket-academy-details-form-academy-name-field',
+      '#support-ticket-academy-details-form-academy-name-field-error',
+      '#support-ticket-local-authority-details-form-local-authority-name-field',
+      '#support-ticket-local-authority-details-form-local-authority-name-field-error'
     ];
 
     inputIds.forEach(inputId => {


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Adds autocomplete to multi-academy trust page
- Adds autocomplete to Local Authority page

This feature is just an enhanced select list so if JS were to fail or not load for whatever reason the user would still see a list of options in a select list to choose from.

### Guidance to review

- Visit https://dfe-ghwt-pr-1122.herokuapp.com/get-support
- Attempt to create a ticket on behalf of Multi-academy trust user  (NO TICKET WILL ACTUALLY BE CREATED)
- Attempt to create a ticket on behalf of a local authority user