### PR TITLE
Send virtual cap updates regardless of school status

### DIFF
--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -57,7 +57,7 @@ private
   def notify_computacenter!
     if responsible_body.has_virtual_cap_feature_flags?
       if notify_computacenter_of_cap_changes?
-        allocation_ids = school_device_allocations.joins(:school).where(schools: { order_state: %w[can_order can_order_for_specific_circumstances] }).pluck(:id)
+        allocation_ids = school_device_allocations.pluck(:id)
         update_cap_on_computacenter!(allocation_ids)
       end
     else


### PR DESCRIPTION
### Context

We allowed schools of any state to be added to virtual pools in https://github.com/DFE-Digital/get-help-with-tech/pull/945 Following that, this PR sends updates to CC for all schools within a pool regardless of their status.

### Changes proposed in this pull request

### Guidance to review

