### PR TITLE
Fix MNO request bulk upload crash when the contract type column contains an unexpected value

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -3,7 +3,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   before_save :normalise_device_phone_number
 
   belongs_to :created_by_user, class_name: 'User', optional: true
-  belongs_to :mobile_network
+  belongs_to :mobile_network, optional: true # set to optional as we already validate on the presence of mobile_network_id and we don't want duplicate validation errors
   belongs_to :responsible_body, optional: true
   belongs_to :school, optional: true
 

--- a/app/models/extra_mobile_data_request_row.rb
+++ b/app/models/extra_mobile_data_request_row.rb
@@ -34,8 +34,10 @@ private
   end
 
   def contract_type
-    contract_type = @row_hash[:pay_monthly_or_payg]
-    contract_type.parameterize.gsub('-', '_') if contract_type
+    value = @row_hash[:pay_monthly_or_payg]
+      &.parameterize
+      &.gsub('-', '_')
+    value if ExtraMobileDataRequest.contract_types[value]
   end
 
   def agrees_with_privacy_statement

--- a/app/presenters/extra_mobile_data_request_presenter.rb
+++ b/app/presenters/extra_mobile_data_request_presenter.rb
@@ -19,26 +19,7 @@ class ExtraMobileDataRequestPresenter < SimpleDelegator
   end
 
   def error_message
-    return unless errors.any?
-
-    msgs = []
-    errors.messages.each_key do |k|
-      case k
-      when :device_phone_number
-        msgs << if device_phone_number.present?
-                  'Not a mobile number'
-                else
-                  'No mobile number provided'
-                end
-      when :mobile_network_id
-        msgs << 'Not a known network'
-      when :account_holder_name
-        msgs << 'No account holder provided'
-      when :agrees_with_privacy_statement
-        msgs << 'Privacy statement not shared with account holder'
-      end
-    end
-    msgs.join('<br/>').html_safe
+    errors.messages.values.join('<br>').html_safe
   end
 
   def contract_type_options

--- a/spec/models/extra_mobile_data_request_row_spec.rb
+++ b/spec/models/extra_mobile_data_request_row_spec.rb
@@ -7,17 +7,19 @@ RSpec.describe ExtraMobileDataRequestRow, type: :model do
     end
   end
 
-  subject(:row) do
-    described_class.new(
+  let(:valid_input_data) do
+    {
       account_holder_name: 'Jane Smith',
       mobile_phone_number: '07123456789',
       mobile_network: 'Virgin Mobile',
       pay_monthly_or_payg: 'Pay monthly',
       has_someone_shared_the_privacy_statement_with_the_account_holder: true,
-    )
+    }
   end
 
-  it 'builds a request' do
+  it 'builds a valid ExtraMobileDataRequest from a valid input row' do
+    row = described_class.new(valid_input_data)
+
     expect(row.build_request).to have_attributes(
       account_holder_name: 'Jane Smith',
       device_phone_number: '07123456789',
@@ -25,5 +27,13 @@ RSpec.describe ExtraMobileDataRequestRow, type: :model do
       contract_type: 'pay_monthly',
       agrees_with_privacy_statement: true,
     )
+  end
+
+  it 'builds an ExtraMobileDataRequest with a nil contract_type from an invalid input contract type' do
+    invalid_input_data = valid_input_data.merge(pay_monthly_or_payg: 'invalid')
+
+    row = described_class.new(invalid_input_data)
+
+    expect(row.build_request.contract_type).to be_nil
   end
 end

--- a/spec/models/extra_mobile_data_request_row_spec.rb
+++ b/spec/models/extra_mobile_data_request_row_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe ExtraMobileDataRequestRow, type: :model do
 
     expect(row.build_request.contract_type).to be_nil
   end
+
+  it 'builds an ExtraMobileDataRequest with a nil mobile network from an invalid network name in the input' do
+    invalid_input_data = valid_input_data.merge(mobile_network: 'invalid')
+
+    row = described_class.new(invalid_input_data)
+
+    expect(row.build_request.mobile_network).to be_nil
+  end
 end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ExtraMobileDataRequest, type: :model do
+  it { is_expected.to validate_presence_of(:mobile_network_id) }
+
+  it 'fails validation when the network is missing' do
+    request = build(:extra_mobile_data_request, mobile_network: nil)
+    expect(request).not_to be_valid
+  end
+
   describe 'to_csv' do
     let(:requests) { ExtraMobileDataRequest.all }
 


### PR DESCRIPTION
### Context

School and responsible body users can upload MNO requests in an XLSX spreadsheet. Currently, if there's an unexpected value in the 'Pay monthly or PAYG', the entire upload fails, instead of just skipping the problematic line.

https://trello.com/c/axgYg1oL

### Changes proposed in this pull request

Ensure that just the single row fails when the value in the 'Pay monthly or PAYG' is unexpected.
Refactor the mechanism of how errors are fed back to the user, so it just bubbles up the errors from the `ExtraMobileDataRequest` model directly.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/104709728-2a459680-5717-11eb-910a-35f3c55b5f3a.png)
