### PR TITLE
Fix missing translation when a MNO request spreadsheet cannot be processed

### DIFF
--- a/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
@@ -14,7 +14,7 @@ class ResponsibleBody::Internet::Mobile::BulkRequestsController < ResponsibleBod
         render :summary
       rescue StandardError => e
         Rails.logger.error(e.message)
-        @upload_form.errors.add(:upload, I18n.t('errors.bulk_upload_form.theres_a_problem_with_that_spreadsheet'))
+        @upload_form.errors.add(:upload, :theres_a_problem_with_that_spreadsheet)
         render :new, status: :unprocessable_entity
       end
     else

--- a/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
@@ -18,11 +18,22 @@ RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: 
         end
       end
 
-      it 'sends an sms to the account holder of each valid request in the spreadsheet' do
+      it 'sends an SMS to the account holder of each valid request in the spreadsheet' do
         # file has 4 valid requests, 1 invalid
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob).exactly(4).times
+      end
+
+      it 'throws a catch-all error message if something unexpected goes wrong with the import' do
+        importer = instance_double(ExtraDataRequestSpreadsheetImporter)
+        allow(ExtraDataRequestSpreadsheetImporter).to receive(:new).and_return(importer)
+        allow(importer).to receive(:import!).and_raise(StandardError)
+
+        post :create, params: request_data
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(assigns[:upload_form].errors.full_messages).to eq(["'Upload' There’s a problem with that spreadsheet"])
       end
     end
   end

--- a/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
@@ -19,11 +19,22 @@ RSpec.describe School::Internet::Mobile::BulkRequestsController, type: :controll
         end
       end
 
-      it 'sends an sms to the account holder of each valid request in the spreadsheet' do
+      it 'sends an SMS to the account holder of each valid request in the spreadsheet' do
         # file has 4 valid requests, 1 invalid
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob).exactly(4).times
+      end
+
+      it 'throws a catch-all error message if something unexpected goes wrong with the import' do
+        importer = instance_double(ExtraDataRequestSpreadsheetImporter)
+        allow(ExtraDataRequestSpreadsheetImporter).to receive(:new).and_return(importer)
+        allow(importer).to receive(:import!).and_raise(StandardError)
+
+        post :create, params: request_data
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(assigns[:upload_form].errors.full_messages).to eq(["'Upload' There’s a problem with that spreadsheet"])
       end
     end
   end


### PR DESCRIPTION
### Context

A user reported seeing a 'missing translation' error when uploading an MNO requests spreadsheet that couldn't be processed.

### Changes proposed in this pull request

There was an i18n string that was being used in two similar controllers. One controller was updated and the string moved, but I forgot to update the other controller, so users are seeing a 'missing translation' error.

I've added spec coverage around both controllers to prevent this from regressing in future.

### Guidance to review

