### PR TITLE
Allow MNO requests with invalid phone numbers to be updated

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -9,7 +9,7 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   validates :status, presence: true
   validates :account_holder_name, presence: true
-  validates :device_phone_number, presence: true, phone: { types: [:mobile], countries: [:gb] }
+  validates :device_phone_number, presence: true, phone: { types: [:mobile], countries: [:gb] }, on: :create
   # we have to validate on _id so that the govuk_error_summary component renders & links the error to the field correctly
   validates :mobile_network_id, presence: true
   validates :contract_type, presence: true, on: :create

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     context 'for non-UK numbers' do
       it { is_expected.not_to allow_value('+49 1521 5678901').for(:device_phone_number) }
     end
+
+    it 'skips validation when updating the record for an already invalid number' do
+      request = build(:extra_mobile_data_request, device_phone_number: '12345')
+        .tap { |record| record.save!(validate: false) }
+
+      expect(request.update(status: :complete)).to be_truthy
+    end
   end
 
   def mno_request_for_number(device_phone_number)


### PR DESCRIPTION
### Context

PR https://github.com/DFE-Digital/get-help-with-tech/pull/1118 tightened up validation of device phone numbers so that some phone numbers (numbers starting with `07xxx` but which weren't mobile numbers) suddenly became invalid.

Because the validation triggered for updates as well, an MNO user wasn't able to update a request with an invalid phone number:

https://sentry.io/organizations/dfe-get-help-with-tech/issues/2154600108/?environment=production&project=5320558

### Changes proposed in this pull request

Changes the device phone number validation to only fire on create.

### Guidance to review
