### PR TITLE
[1317] Hide mno from certain schools

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -2,7 +2,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
   def rows
     array = super
     array << headteacher_row if headteacher.present?
-    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row)
+    array.insert(array.find_index { |row| row[:key] == 'Can place orders?' }, mno_row) if @school.show_mno?
     array.map { |row| remove_change_links_if_read_only(row) }
   end
 

--- a/app/controllers/school/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/bulk_requests_controller.rb
@@ -1,4 +1,6 @@
 class School::Internet::Mobile::BulkRequestsController < School::BaseController
+  before_action { not_found if @school.hide_mno? }
+
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -1,4 +1,6 @@
 class School::Internet::Mobile::ExtraDataRequestsController < School::BaseController
+  before_action { not_found if @school.hide_mno? }
+
   def index
     @extra_mobile_data_requests = @school.extra_mobile_data_requests
   end

--- a/app/controllers/school/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/manual_requests_controller.rb
@@ -1,4 +1,6 @@
 class School::Internet::Mobile::ManualRequestsController < School::BaseController
+  before_action { not_found if @school.hide_mno? }
+
   def index
     @extra_mobile_data_requests = @current_user.extra_mobile_data_requests
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -185,6 +185,10 @@ class School < ApplicationRecord
     preorder_information&.school_or_rb_domain if preorder_information&.will_need_chromebooks?
   end
 
+  def show_mno?
+    !hide_mno?
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -28,7 +28,9 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>request extra data for mobile devices</li>
+      <% if @school.show_mno? %>
+        <li>request extra data for mobile devices</li>
+      <% end %>
       <li>request 4G wireless routers</li>
     </ul>
 

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -12,11 +12,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
-    </h2>
+    <% if @school.show_mno? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
+      </h2>
 
-    <%= render partial: 'shared/internet/mno_information' %>
+      <%= render partial: 'shared/internet/mno_information' %>
+    <% end %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>

--- a/db/migrate/20210115140815_add_hide_mno_to_schools.rb
+++ b/db/migrate/20210115140815_add_hide_mno_to_schools.rb
@@ -1,0 +1,5 @@
+class AddHideMnoToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :hide_mno, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_164816) do
+ActiveRecord::Schema.define(version: 2021_01_15_140815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,6 +291,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_164816) do
     t.boolean "increased_allocations_feature_flag", default: false
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
+    t.boolean "hide_mno", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -168,6 +168,16 @@ describe Support::SchoolDetailsSummaryListComponent do
   end
 
   describe 'extra mobile data' do
+    context 'when school is not using mno_feature' do
+      before do
+        allow(school).to receive(:show_mno?).and_return(false)
+      end
+
+      it 'does not display row' do
+        expect(result.text).not_to include('Extra mobile data requests')
+      end
+    end
+
     context 'when there are no requests' do
       let(:school) { build(:school) }
 

--- a/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
@@ -9,7 +9,19 @@ RSpec.describe School::Internet::Mobile::BulkRequestsController, type: :controll
       sign_in_as user
     end
 
-    describe 'create' do
+    describe '#new' do
+      context 'when school.hide_mno?' do
+        let(:school) { create(:school, hide_mno: true) }
+        let(:user) { create(:school_user, schools: [school]) }
+
+        it 'returns 404' do
+          get :new, params: { urn: school.urn }
+          expect(response).to be_not_found
+        end
+      end
+    end
+
+    describe '#create' do
       let(:upload) { Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), Mime[:xlsx]) }
       let(:request_data) { { urn: school.urn, bulk_upload_form: { upload: upload } } }
 

--- a/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe School::Internet::Mobile::ExtraDataRequestsController, type: :con
         expect(controller).to render_template(:index)
         expect(response).to have_http_status(:ok)
       end
+
+      context 'when school.hide_mno?' do
+        let(:school) { create(:school, hide_mno: true) }
+        let(:user) { create(:school_user, schools: [school]) }
+
+        it 'returns 404' do
+          get :new, params: { urn: school.urn }
+          expect(response).to be_not_found
+        end
+      end
     end
 
     describe '#guidance' do

--- a/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
@@ -9,10 +9,20 @@ RSpec.describe School::Internet::Mobile::ManualRequestsController, type: :contro
       sign_in_as user
     end
 
-    describe 'create' do
+    describe '#create' do
       let(:mno) { create(:mobile_network) }
       let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
       let(:request_data) { { urn: school.urn, extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
+
+      context 'when school.hide_mno?' do
+        let(:school) { create(:school, hide_mno: true) }
+        let(:user) { create(:school_user, schools: [school]) }
+
+        it 'returns 404' do
+          post :create, params: request_data
+          expect(response).to be_not_found
+        end
+      end
 
       it 'sends an SMS to the account holder of the request' do
         expect {


### PR DESCRIPTION
### Context

- https://trello.com/c/8lpCnlCn/1317-hide-mno
- We need to hide mno from certain schools

### Changes proposed in this pull request

- We have a list of schools to hide mno from
- This list was determined by GIAS data where `StatutoryLowAge` was 16 or higher
- We currently do not have this data in our system so this is a stop gap implementation until we import this data 

### Guidance to review

- Login as a school with the `hide_mno` `true`
- Navigate to and `/schools/URN` and `/schools/URN/internet`
- Should not see references to MNO but should see 4G routers