### PR TITLE
make staging serve requests on custom domain

### DIFF
--- a/app/views/layouts/_service_link.html.erb
+++ b/app/views/layouts/_service_link.html.erb
@@ -1,2 +1,3 @@
 <% home_page_link = @current_user&.is_responsible_body_user? ? responsible_body_home_path : "/" %>
 <%= link_to t('service_name'), home_page_link, class: "govuk-header__link govuk-header__link--service-name" %>
+<%= Settings.service_name_suffix %>

--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -20,3 +20,4 @@ applications:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
     RAILS_LOG_TO_STDOUT: true
+    GHWT__SERVICE_NAME_SUFFIX: (dev)

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -20,3 +20,5 @@ applications:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
     RAILS_LOG_TO_STDOUT: true
+    GHWT__HOSTNAME_FOR_URLS: staging-get-help-with-tech.education.gov.uk
+    GHWT__SERVICE_NAME_SUFFIX: (staging)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,6 +66,7 @@ hostname_for_urls: http://localhost:3000
 sentry:
   dsn:
 
+service_name_suffix: 
 session_ttl_seconds: 3600
 
 # Sign-in tokens will expire after this many seconds

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,4 @@
+service_name_suffix: (local)
 computacenter:
   outgoing_api:
     # Computacenter's dev endpoint

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -202,8 +202,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_164816) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true


### PR DESCRIPTION
### Context

[Trello card 1314](https://trello.com/c/DY7lYtAT/1314-setup-staging-with-a-custom-domain) - we should have staging as prod-like as possible, which should include serving on a custom domain via Cloudfront.

The domain `staging-get-help-with-tech.education.gov.uk` has already been set up & validated (necessarily outside of this epo) and mapped to staging. I've tested it in a browser, but it's still sending emails with links pointing to the existing direct-to-paas URL 

### Changes proposed in this pull request

* configure staging to use the new education.gov.uk subdomain as its main domain for links in emails
* to help reduce any user confusion between staging & prod, add a '(dev)' or '(staging)' suffix to the main header service name, only in those environments

### Guidance to review

