### PR TITLE
[1251] Only show FE/6th form screens if can order

### DIFF
--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,12 +6,12 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if user.associated_schools.where(increased_sixth_form_feature_flag: true).any? # (&:can_order_devices_right_now?) # enable after user research
+    @call ||= if user.associated_schools.where(increased_sixth_form_feature_flag: true).any?(&:can_order_devices_right_now?)
                 OpenStruct.new(
                   title: 'You can now order laptops and tablets for students in years 12 and 13',
                   partial: 'interstitials/increased_sixth_form_allocation',
                 )
-              elsif user.associated_schools.where(increased_fe_feature_flag: true).any? # (&:can_order_devices_right_now?) # enable after user research
+              elsif user.associated_schools.where(increased_fe_feature_flag: true).any?(&:can_order_devices_right_now?)
                 OpenStruct.new(
                   title: 'You can now order laptops and tablets for learners in further education',
                   partial: 'interstitials/increased_fe_allocation',


### PR DESCRIPTION
### Context

- https://trello.com/c/ThIADjmi/1251-increase-allocation-for-schools-with-sixth-form-students

### Changes proposed in this pull request

- User research has finished
- We now only show these interstitial screens if those school can order at the moment on login
- No new tests are it should already be covered, the commented out code loosened the requirement

### Guidance to review

- Login as a school with feature flag enabled but cannot order right now
- Should not see screen
- Login as a school with feature flag enabled AND can order right now
- Should see screen