### PR TITLE
Extract an ExtraMobileDataRequestStatusComponent view component

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.html.erb
+++ b/app/components/extra_mobile_data_request_status_component.html.erb
@@ -1,0 +1,3 @@
+<span class="govuk-tag govuk-tag--<%= colour %> request-status-<%= status %>">
+  <%= label %>
+</span>

--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -1,0 +1,28 @@
+class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
+  def initialize(extra_mobile_data_request:)
+    @extra_mobile_data_request = extra_mobile_data_request
+  end
+
+  def colour
+    {
+      requested: 'blue',
+      in_progress: 'yellow',
+      complete: 'green',
+      queried: 'red',
+      cancelled: 'grey',
+      unavailable: 'grey',
+    }[@extra_mobile_data_request.status.to_sym]
+  end
+
+  def status
+    @extra_mobile_data_request.status
+  end
+
+  def label
+    if @extra_mobile_data_request.queried?
+      I18n.t(@extra_mobile_data_request.problem, scope: %i[activerecord attributes extra_mobile_data_request problem_tags])
+    else
+      @extra_mobile_data_request.translated_enum_value(:status)
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,17 +16,6 @@ module ApplicationHelper
     ]
   end
 
-  def extra_mobile_data_request_status_class(status)
-    {
-      requested: 'govuk-tag--blue',
-      in_progress: 'govuk-tag--yellow',
-      complete: 'govuk-tag--green',
-      queried: 'govuk-tag--red',
-      cancelled: 'govuk-tag--grey',
-      unavailable: 'govuk-tag--grey',
-    }[status.to_sym]
-  end
-
   def api_token_status_class(status)
     {
       active: 'govuk-tag--green',

--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -16,7 +16,7 @@
     <%= l(extra_mobile_data_request.created_at, format: :short) %>
   </td>
   <td class="govuk-table__cell" class="request-status">
-    <%= render partial: 'shared/extra_mobile_data_request_status', locals: {extra_mobile_data_request: extra_mobile_data_request} %>
+    <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: extra_mobile_data_request) %>
   </td>
   <td class="govuk-table__cell">
     <%- if extra_mobile_data_request.complete? || extra_mobile_data_request.cancelled? %>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -38,7 +38,7 @@
         <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
         <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
         <td class="govuk-table__cell">
-          <%= render partial: 'shared/extra_mobile_data_request_status', locals: {extra_mobile_data_request: emd_request} %>
+          <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>
         </td>
       </tr>
     <%- end %>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -41,7 +41,7 @@
           <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
           <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell">
-            <%= render partial: 'shared/extra_mobile_data_request_status', locals: {extra_mobile_data_request: emd_request} %>
+            <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>
           </td>
         </tr>
       <%- end %>

--- a/app/views/shared/_extra_mobile_data_request_status.html.erb
+++ b/app/views/shared/_extra_mobile_data_request_status.html.erb
@@ -1,7 +1,0 @@
-<span class="govuk-tag <%= extra_mobile_data_request_status_class(extra_mobile_data_request.status) %> request-status-<%= extra_mobile_data_request.status %>">
-  <%- if extra_mobile_data_request.queried? %>
-    <%= t( extra_mobile_data_request.problem, scope: %i[activerecord attributes extra_mobile_data_request problem_tags] ) %>
-  <%- else %>
-    <%= extra_mobile_data_request.translated_enum_value(:status) %>
-  <%- end %>
-</span>

--- a/spec/components/extra_mobile_data_request_status_component_spec.rb
+++ b/spec/components/extra_mobile_data_request_status_component_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
+  subject(:component) { described_class.new(extra_mobile_data_request: extra_mobile_data_request) }
+
+  context 'for a queried request' do
+    let(:extra_mobile_data_request) do
+      create(:extra_mobile_data_request, status: :queried, problem: :incorrect_phone_number)
+    end
+
+    it 'is coloured red' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'govuk-tag--red'
+    end
+
+    it 'shows the relevant label' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'Invalid number'
+    end
+  end
+
+  context 'for a complete request' do
+    let(:extra_mobile_data_request) do
+      create(:extra_mobile_data_request, status: :complete, problem: :incorrect_phone_number)
+    end
+
+    it 'is coloured green' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'govuk-tag--green'
+    end
+
+    it 'shows the relevant label' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'Complete'
+    end
+  end
+end


### PR DESCRIPTION
### Context

We show the status of MNO requests in 3 different places (MNO area, school are and RB area).

### Changes proposed in this pull request

Extract an ExtraMobileDataRequestStatusComponent view component. This will make it easier to change the code, to test it and better follows our current patterns.

### Guidance to review

