### PR TITLE
Show a new page when RB has no devices left to order

### DIFF
--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -19,7 +19,7 @@ class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
         "#{allocation.available_devices_count} #{allocation.device_type_name.pluralize(allocation.available_devices_count)}"
       }.join(' and <br/>') + ' available to order'
     else
-      'All devices ordered'
+      'No devices left to order'
     end
   end
 

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -11,7 +11,13 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::BaseControll
 
         # There is no seperate 'specific circumstances' page if we're using virtual caps.
         if @responsible_body.has_virtual_cap_feature_flags? || @schools.can_order.count.positive?
-          render 'order_devices'
+
+          # There is no seperate 'cannot order anymore' page if we're not using virtual caps.
+          if !@responsible_body.has_virtual_cap_feature_flags? || @responsible_body.has_devices_available_to_order?
+            render 'order_devices'
+          else
+            render 'cannot_order_anymore'
+          end
         else
           render 'specific_circumstances'
         end

--- a/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
@@ -1,0 +1,25 @@
+<%= render partial: 'heading' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= t('page_titles.order_devices.title') %></span>
+      You’ve ordered all the devices you can
+    </h1>
+
+    <%= render partial: 'shared/techsource_unavailable_banner' %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
+
+    <p class="govuk-body">We’ll contact you if you can place more orders.</p>
+
+    <% if @current_user.orders_devices? && @current_user.techsource_account_confirmed? %>
+      <p class="govuk-body"><%= link_to 'View your order history on TechSource', techsource_start_path %></p>
+    <% end %>
+  </div>
+</div>

--- a/spec/components/responsible_body/pooled_device_count_component_spec.rb
+++ b/spec/components/responsible_body/pooled_device_count_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ResponsibleBody::PooledDeviceCountComponent, type: :component do
     it 'renders availability' do
       html = render_inline(component).to_html
 
-      expect(html).to include 'All devices ordered'
+      expect(html).to include 'No devices left to order'
     end
 
     it 'renders state' do
@@ -89,7 +89,7 @@ RSpec.describe ResponsibleBody::PooledDeviceCountComponent, type: :component do
     it 'renders availability' do
       html = render_inline(component).to_html
 
-      expect(html).to include 'All devices ordered'
+      expect(html).to include 'No devices left to order'
     end
 
     it 'renders state' do

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Viewing your schools' do
     coms_count = responsible_body.coms_device_pool.cap - responsible_body.coms_device_pool.devices_ordered
     expected =
       if std_count == 0 && coms_count == 0
-        'All devices ordered'
+        'No devices left to order'
       else
         "#{std_count} #{'device'.pluralize(std_count)} and #{coms_count} #{'router'.pluralize(coms_count)} available to order"
       end


### PR DESCRIPTION
### Context

Follows the design history created by @fofr in https://github.com/DFE-Digital/get-help-with-tech-prototype/pull/33
Trello card: https://trello.com/c/E5WSVEwO/1226-build-design-for-when-rbs-have-ordered-all-devices

### Changes proposed in this pull request

Show a new page when an RB using virtual caps has no more devices to order. Previously it would show the default 'Can order devices' page with links to TechSource.

This change brings the RB v-cap ordering journey inline with a similar page to one that schools see when ordering has been devolved to them.

### Guidance to review

1. Open 'Order now' page
2. Update devices ordered = cap
3. New page should show instead of 'Can order' page

![screencapture-localhost-3000-responsible-body-devices-order-devices-2021-01-18-12_23_25](https://user-images.githubusercontent.com/31316/104915046-f91fcd00-5987-11eb-830e-1d5d848fe02b.png)
