### PR TITLE
[1075] Finalise CC IDs/references

### DIFF
--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -50,7 +50,11 @@ module Computacenter::ResponsibleBodyUrns
         end
       when 'FurtherEducationCollege'
         # potential n+1
-        schools.first&.ukprn
+        if schools.first&.ukprn
+          "FE#{schools.first&.ukprn}"
+        else
+          ''
+        end
       when 'DfE'
         'DfE'
       end

--- a/app/models/further_education_school.rb
+++ b/app/models/further_education_school.rb
@@ -6,8 +6,4 @@ class FurtherEducationSchool < School
   def urn
     ukprn
   end
-
-  def computacenter_identifier
-    "fe#{ukprn}"
-  end
 end

--- a/spec/models/computacenter/responsible_body_urns_spec.rb
+++ b/spec/models/computacenter/responsible_body_urns_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Computacenter::ResponsibleBodyUrns do
     subject(:model) { fe_klass.new }
 
     it 'returns first school ukprn' do
-      expect(model.computacenter_identifier).to be(12_345_678)
+      expect(model.computacenter_identifier).to eql('FE12345678')
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/R2235yoT/1075-spike-adding-fe-institutions-to-the-service

### Changes proposed in this pull request

- Prefix RB with `FE` to match CC
- This will match spreadsheets provided to CC
- Turns outs School does not need `computacenter_identifier` as a remnant of a previous spike as URN/UKPRN are used instead

### Guidance to review

n/a