### PR TITLE
Add problem statuses for MNO requests

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -4,14 +4,13 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
   end
 
   def colour
-    {
-      requested: 'blue',
-      in_progress: 'yellow',
-      complete: 'green',
-      queried: 'red',
-      cancelled: 'grey',
-      unavailable: 'grey',
-    }[@extra_mobile_data_request.status.to_sym]
+    case @extra_mobile_data_request.status.to_sym
+    when :requested then 'blue'
+    when :in_progress then 'yellow'
+    when :complete then 'green'
+    when :queried, :problem_incorrect_phone_number, :problem_no_match_for_number, :problem_no_match_for_account_name, :problem_not_eligible, :problem_no_longer_on_network then 'red'
+    when :cancelled, :unavailable then 'grey'
+    end
   end
 
   def status
@@ -19,8 +18,10 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
   end
 
   def label
-    if @extra_mobile_data_request.queried?
-      I18n.t(@extra_mobile_data_request.problem, scope: %i[activerecord attributes extra_mobile_data_request problem_tags])
+    if @extra_mobile_data_request.status.start_with?('problem')
+      I18n.t!(@extra_mobile_data_request.status, scope: %i[activerecord attributes extra_mobile_data_request problem_tags])
+    elsif @extra_mobile_data_request.queried?
+      I18n.t!("problem_#{@extra_mobile_data_request.problem}", scope: %i[activerecord attributes extra_mobile_data_request problem_tags])
     else
       @extra_mobile_data_request.translated_enum_value(:status)
     end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -15,7 +15,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
         )
         @statuses = ExtraMobileDataRequest
           .translated_enum_values(:statuses)
-          .reject { |status| status.value.in?(%w[queried cancelled]) }
+          .reject { |status| status.value.in?(%w[queried cancelled unavailable]) }
       end
     end
   end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -27,7 +27,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
 
   def update
     load_extra_mobile_data_request(params[:id])
-    @extra_mobile_data_request.update!(extra_mobile_data_request_params.merge(status: :queried))
+    @extra_mobile_data_request.update!(extra_mobile_data_request_params)
     redirect_to mno_extra_mobile_data_requests_path
   rescue ActiveModel::ValidationError, ActionController::ParameterMissing
     @options = problem_options
@@ -54,7 +54,11 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
 private
 
   def problem_options
-    ExtraMobileDataRequest.translated_enum_values(:problems)
+    ExtraMobileDataRequest
+      .statuses
+      .keys
+      .select { |key| key.start_with?('problem') }
+      .map { |key| OpenStruct.new(value: key, label: I18n.t!(key, scope: %i[activerecord attributes extra_mobile_data_request problems])) }
   end
 
   def extra_mobile_data_request_scope
@@ -103,9 +107,7 @@ private
     }[order_param]
   end
 
-  def extra_mobile_data_request_params(opts = params)
-    opts.require(:extra_mobile_data_request).permit(
-      :problem,
-    )
+  def extra_mobile_data_request_params
+    params.require(:extra_mobile_data_request).permit(:status)
   end
 end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -22,6 +22,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
 
   def report_problem
     load_extra_mobile_data_request(params[:extra_mobile_data_request_id])
+    @options = problem_options
   end
 
   def update
@@ -29,6 +30,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
     @extra_mobile_data_request.update!(extra_mobile_data_request_params.merge(status: :queried))
     redirect_to mno_extra_mobile_data_requests_path
   rescue ActiveModel::ValidationError, ActionController::ParameterMissing
+    @options = problem_options
     render :report_problem, status: :unprocessable_entity
   end
 
@@ -50,6 +52,10 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
   end
 
 private
+
+  def problem_options
+    ExtraMobileDataRequest.translated_enum_values(:problems)
+  end
 
   def extra_mobile_data_request_scope
     @mobile_network.extra_mobile_data_requests

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -103,6 +103,14 @@ class ExtraMobileDataRequest < ApplicationRecord
     )
   end
 
+  def in_end_state?
+    complete? || cancelled?
+  end
+
+  def in_a_problem_state?
+    queried? || status.start_with?('problem')
+  end
+
 private
 
   def validate_school_or_rb_present

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -24,6 +24,11 @@ class ExtraMobileDataRequest < ApplicationRecord
     complete: 'complete',
     cancelled: 'cancelled',
     unavailable: 'unavailable',
+    problem_no_match_for_number: 'problem_no_match_for_number',
+    problem_not_eligible: 'problem_not_eligible',
+    problem_incorrect_phone_number: 'problem_incorrect_phone_number',
+    problem_no_match_for_account_name: 'problem_no_match_for_account_name',
+    problem_no_longer_on_network: 'problem_no_longer_on_network',
   }
 
   # These codes were worked out by the NHSx team & the MNOs,

--- a/app/services/extra_mobile_data_request_status_migration_service.rb
+++ b/app/services/extra_mobile_data_request_status_migration_service.rb
@@ -1,0 +1,9 @@
+class ExtraMobileDataRequestStatusMigrationService
+  def call
+    ExtraMobileDataRequest
+      .queried
+      .find_each do |request|
+        request.update!(status: "problem_#{request.problem}")
+      end
+  end
+end

--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -19,10 +19,10 @@
     <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: extra_mobile_data_request) %>
   </td>
   <td class="govuk-table__cell">
-    <%- if extra_mobile_data_request.complete? || extra_mobile_data_request.cancelled? %>
+    <%- if extra_mobile_data_request.in_end_state? %>
       <%- # nothing to show %>
     <%- else %>
-      <%= govuk_link_to (extra_mobile_data_request.queried? ? 'Change problem' : 'Report a problem'), mno_extra_mobile_data_request_report_problem_path(extra_mobile_data_request) %>
+      <%= govuk_link_to (extra_mobile_data_request.in_a_problem_state? ? 'Change problem' : 'Report a problem'), mno_extra_mobile_data_request_report_problem_path(extra_mobile_data_request) %>
     <%- end %>
   </td>
 </tr>

--- a/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
@@ -13,7 +13,7 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons :problem,
-      ExtraMobileDataRequest.translated_enum_values(:problems),
+      @options,
       :value,
       :label %>
 

--- a/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
@@ -12,7 +12,7 @@
     <%= form_for @extra_mobile_data_request, url: mno_extra_mobile_data_request_path(@extra_mobile_data_request) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_radio_buttons :problem,
+      <%= f.govuk_collection_radio_buttons :status,
       @options,
       :value,
       :label %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,11 +489,11 @@ en:
           revoked: Revoked
       extra_mobile_data_request:
         problems:
-          incorrect_phone_number: This is not a valid mobile number
-          no_match_for_number: We couldn’t find an account with this number
-          no_match_for_account_name: We couldn’t find an account with this name
-          not_eligible: This account is not eligible
-          no_longer_on_network: This account is no longer on our network
+          problem_incorrect_phone_number: This is not a valid mobile number
+          problem_no_match_for_number: We couldn’t find an account with this number
+          problem_no_match_for_account_name: We couldn’t find an account with this name
+          problem_not_eligible: This account is not eligible
+          problem_no_longer_on_network: This account is no longer on our network
         problem_tags:
           problem_incorrect_phone_number: Invalid number
           problem_no_match_for_number: Unknown number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,11 +495,11 @@ en:
           not_eligible: This account is not eligible
           no_longer_on_network: This account is no longer on our network
         problem_tags:
-          incorrect_phone_number: Invalid number
-          no_match_for_number: Unknown number
-          no_match_for_account_name: Unknown name
-          not_eligible: Not eligible
-          no_longer_on_network: Not on network
+          problem_incorrect_phone_number: Invalid number
+          problem_no_match_for_number: Unknown number
+          problem_no_match_for_account_name: Unknown name
+          problem_not_eligible: Not eligible
+          problem_no_longer_on_network: Not on network
         statuses:
           requested: Requested
           in_progress: In progress
@@ -507,6 +507,11 @@ en:
           complete: Complete
           cancelled: Cancelled
           unavailable: Unavailable
+          problem_no_match_for_number: Problem – No account with this number
+          problem_not_eligible: Problem – Not eligible
+          problem_incorrect_phone_number: Problem – Not a valid mobile number
+          problem_no_match_for_account_name: Problem – No account with this name
+          problem_no_longer_on_network: Problem – Not on network
       mobile_network:
         participation_in_pilots:
           participating: 'Offers data now'

--- a/spec/components/extra_mobile_data_request_status_component_spec.rb
+++ b/spec/components/extra_mobile_data_request_status_component_spec.rb
@@ -21,9 +21,27 @@ RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
     end
   end
 
+  context 'for a request with a problem' do
+    let(:extra_mobile_data_request) do
+      create(:extra_mobile_data_request, status: :problem_incorrect_phone_number)
+    end
+
+    it 'is coloured red' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'govuk-tag--red'
+    end
+
+    it 'shows the relevant label' do
+      html = render_inline(component).to_html
+
+      expect(html).to include 'Invalid number'
+    end
+  end
+
   context 'for a complete request' do
     let(:extra_mobile_data_request) do
-      create(:extra_mobile_data_request, status: :complete, problem: :incorrect_phone_number)
+      create(:extra_mobile_data_request, status: :complete)
     end
 
     it 'is coloured green' do

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -22,7 +22,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
         'in_progress',
         'complete',
         'unavailable',
-        'problem_another_reason',
+        'problem_no_longer_on_network',
         'problem_incorrect_phone_number',
         'problem_no_match_for_account_name',
         'problem_no_match_for_number',
@@ -36,7 +36,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
       {
         id: extra_mobile_data_request_1_for_mno.id,
         extra_mobile_data_request: {
-          problem: 'no_match_for_number',
+          status: 'problem_no_match_for_number',
         },
       }
     end
@@ -44,8 +44,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
     context 'for a request from an approved user' do
       it 'updates the status to queried' do
         patch :update, params: params
-        expect(extra_mobile_data_request_1_for_mno.reload.problem).to eq('no_match_for_number')
-        expect(extra_mobile_data_request_1_for_mno.reload.status).to eq('queried')
+        expect(extra_mobile_data_request_1_for_mno.reload.status).to eq('problem_no_match_for_number')
       end
     end
   end

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -21,7 +21,6 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
         'requested',
         'in_progress',
         'complete',
-        'unavailable',
         'problem_no_longer_on_network',
         'problem_incorrect_phone_number',
         'problem_no_match_for_account_name',

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -17,7 +17,17 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
     it 'does not list "queried" and "cancelled" as possible statuses to transition a request into' do
       get :index
 
-      expect(assigns(:statuses).map(&:value)).to match_array(%w[requested in_progress complete unavailable])
+      expect(assigns(:statuses).map(&:value)).to contain_exactly(
+        'requested',
+        'in_progress',
+        'complete',
+        'unavailable',
+        'problem_another_reason',
+        'problem_incorrect_phone_number',
+        'problem_no_match_for_account_name',
+        'problem_no_match_for_number',
+        'problem_not_eligible',
+      )
     end
   end
 

--- a/spec/services/extra_mobile_data_request_status_migration_service_spec.rb
+++ b/spec/services/extra_mobile_data_request_status_migration_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ExtraMobileDataRequestStatusMigrationService do
+  subject(:service) { described_class.new }
+
+  it 'maps any queried MNO requests to corresponding problem statuses' do
+    incorrect_number = create(:extra_mobile_data_request, status: :queried, problem: :incorrect_phone_number)
+    no_match_for_account_name = create(:extra_mobile_data_request, status: :queried, problem: :no_match_for_account_name)
+
+    service.call
+
+    expect(incorrect_number.reload.problem_incorrect_phone_number?).to be_truthy
+    expect(no_match_for_account_name.reload.problem_no_match_for_account_name?).to be_truthy
+  end
+
+  it 'does not change the status of any non-queried MNO requests' do
+    request = create(:extra_mobile_data_request, status: :requested)
+
+    service.call
+
+    expect(request.reload.requested?).to be_truthy
+  end
+end


### PR DESCRIPTION
### Context

MNO requests currently have a `queried` status, and a separate `problem` attribute for storing the specific nature of the problem.

MNO users would like to be able to bulk-update requests with specific problems.

Trello: https://trello.com/c/5R2cI9PT

### Changes proposed in this pull request

Introduce additional statuses on `ExtraMobileDataRequest`, which correspond to the existing 5 problem types.
Update the 'report a problem' form to use these problem types.
Make the new statuses appear in the bulk-change drop-down on the requests table.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/104927822-cc74b100-5999-11eb-8405-a2baf52ce3f3.png)
