### PR TITLE
[1291] Suppress MNO bulk update error

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -36,7 +36,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
     ExtraMobileDataRequest.transaction do
       new_attributes = { status: bulk_update_params[:status] }
       new_attributes[:problem] = nil unless bulk_update_params[:status] == 'queried'
-      ids = bulk_update_params[:extra_mobile_data_request_ids].reject(&:empty?)
+      ids = (bulk_update_params[:extra_mobile_data_request_ids] || []).reject(&:empty?)
       extra_mobile_data_request_scope
                .where('extra_mobile_data_requests.id IN (?)', ids)
                .update_all(new_attributes)

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -51,6 +51,22 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
     end
     let(:extra_mobile_data_request_statusses) { extra_mobile_data_requests.map { |r| r.reload.status } }
 
+    context 'when no requests are selected' do
+      let(:params) do
+        {
+          mno_extra_mobile_data_requests_form: {
+            status: 'cancelled',
+          },
+        }
+      end
+
+      it 'does not throw an error' do
+        expect {
+          put :bulk_update, params: params
+        }.not_to raise_error
+      end
+    end
+
     context 'with extra_mobile_data_request_ids from the same MNO as the user' do
       let(:extra_mobile_data_requests) { [extra_mobile_data_request_1_for_mno, extra_mobile_data_request_2_for_mno] }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/ks3uY0pJ/1291-mno-bulk-update-correctly-handle-processing-when-no-request-is-selected

### Changes proposed in this pull request

- If no requests are selected supply an empty collection so it duck types

### Guidance to review

- Login as mno user
- Make sure there are some requests
- Do not select any requests in the checkboxes
- Hit update
- Should not see error
- No records should be updated