### PR TITLE
MNO requests: update service dashboard to support problem statuses

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -31,6 +31,10 @@ class ExtraMobileDataRequest < ApplicationRecord
     problem_no_longer_on_network: 'problem_no_longer_on_network',
   }
 
+  def self.problem_statuses
+    statuses.keys.select { |k| k.start_with?('problem') }
+  end
+
   # These codes were worked out by the NHSx team & the MNOs,
   # during their previous work to support NHS workers.
   # If/when we add file import back from the MNOs, we'll probably

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -74,4 +74,10 @@ class Support::ServicePerformance
       .sort_by { |_k, v| v }
       .reverse
   end
+
+  def total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest)
+    scope
+      .where(status: :queried).or(scope.where('status like ?', 'problem%'))
+      .count
+  end
 end

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['cancelled'] || 0),
+                 count: (@stats.total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest.from_responsible_bodies) || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['cancelled'] || 0),
                  label: 'not valid or cancelled',
                  colour: :red,
                  size: :reduced) %>
@@ -86,7 +86,7 @@
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['queried'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['cancelled'] || 0),
+                 count: (@stats.total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest.from_schools) || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['cancelled'] || 0),
                  label: 'not valid or cancelled',
                  colour: :red,
                  size: :reduced) %>

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -170,7 +170,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
     end
 
     context 'when an existing request had a problem and the new status is also :queried' do
-      let!(:request_with_problem) { create(:extra_mobile_data_request, :with_problem, mobile_network: mno_user.mobile_network) }
+      let!(:request_with_problem) { create(:extra_mobile_data_request, mobile_network: mno_user.mobile_network, status: :queried, problem: 'no_match_for_number') }
       let(:extra_mobile_data_requests) { [request_with_problem] }
       let(:valid_params) do
         {

--- a/spec/factories/extra_mobile_data_requests.rb
+++ b/spec/factories/extra_mobile_data_requests.rb
@@ -11,8 +11,7 @@ FactoryBot.define do
     association :created_by_user, factory: :local_authority_user
 
     trait :with_problem do
-      status  { :queried }
-      problem { ExtraMobileDataRequest.problems.keys.sample }
+      status { ExtraMobileDataRequest.problem_statuses.sample }
     end
 
     trait :mno_not_participating do

--- a/spec/models/support/service_performance_spec.rb
+++ b/spec/models/support/service_performance_spec.rb
@@ -123,23 +123,31 @@ RSpec.describe Support::ServicePerformance, type: :model do
                   mobile_network: create(:mobile_network, brand: '2nd Best'), status: :requested)
       create_list(:extra_mobile_data_request, 2,
                   mobile_network: create(:mobile_network, brand: 'Thirdy'), status: :in_progress)
+      create_list(:extra_mobile_data_request, 1,
+                  mobile_network: create(:mobile_network, brand: 'Lasty'), status: :queried)
       create_list(:extra_mobile_data_request, 10, :with_problem,
                   mobile_network: create(:mobile_network, brand: 'Top Telecom'))
     end
 
     describe '#total_extra_mobile_data_requests' do
       it 'returns the total number of requests' do
-        expect(stats.total_extra_mobile_data_requests).to eq(17)
+        expect(stats.total_extra_mobile_data_requests).to eq(18)
       end
     end
 
     describe '#extra_mobile_data_requests_by_status' do
       it 'returns the counts by status' do
-        expect(stats.extra_mobile_data_requests_by_status).to eq(
+        expect(stats.extra_mobile_data_requests_by_status).to include(
           'requested' => 5,
           'in_progress' => 2,
-          'queried' => 10,
+          'queried' => 1,
         )
+      end
+    end
+
+    describe '#total_extra_mobile_data_requests_with_problems' do
+      it 'returns the counts of requests with problem statuses and queried requests' do
+        expect(stats.total_extra_mobile_data_requests_with_problems).to eq(11)
       end
     end
 
@@ -150,6 +158,7 @@ RSpec.describe Support::ServicePerformance, type: :model do
             ['Top Telecom', 10],
             ['2nd Best', 5],
             ['Thirdy', 2],
+            ['Lasty', 1],
           ],
         )
       end


### PR DESCRIPTION
### Context

#1135 introduced new statuses on MNO requests. The service dashboard needs to be aware of these statuses.

### Changes proposed in this pull request

Update the service dashboard calculation code to handle MNO requests with `problem_*` statuses.

### Guidance to review

