### PR TITLE
Add support ticket model so that we can better handle defaults

### DIFF
--- a/app/controllers/support_ticket/base_controller.rb
+++ b/app/controllers/support_ticket/base_controller.rb
@@ -1,4 +1,6 @@
 class SupportTicket::BaseController < ApplicationController
+  before_action :set_support_ticket
+
   def start
     render 'support_tickets/start'
   end
@@ -15,5 +17,11 @@ private
 
   def require_support_ticket_data!
     redirect_to support_ticket_path if session[:support_ticket].blank?
+  end
+
+  def set_support_ticket
+    return unless session[:support_ticket]
+
+    @support_ticket = SupportTicket.new(params: session[:support_ticket])
   end
 end

--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -2,7 +2,6 @@ class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
   before_action :require_support_ticket_data!, only: :new
 
   def new
-    @support_ticket = session[:support_ticket]
     @form = form
     @school_details_path = school_details_path
     render 'support_tickets/check_your_request'
@@ -33,7 +32,7 @@ private
   end
 
   def school_details_path
-    case @support_ticket['user_type']
+    case @support_ticket.user_type
     when 'school_or_single_academy_trust'
       support_ticket_school_details_path
     when 'multi_academy_trust'

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -1,0 +1,41 @@
+class SupportTicket
+  def initialize(params:)
+    @params = ActiveSupport::HashWithIndifferentAccess.new(params)
+  end
+
+  def user_type
+    @params.fetch(:user_type, 'other_type_of_user')
+  end
+
+  def school_name
+    @params.fetch(:school_name, '')
+  end
+
+  def school_unique_id
+    @params.fetch(:school_unique_id, '')
+  end
+
+  def full_name
+    @params.fetch(:full_name, '')
+  end
+
+  def email_address
+    @params.fetch(:email_address, '')
+  end
+
+  def telephone_number
+    @params.fetch(:telephone_number, '')
+  end
+
+  def support_topics
+    @params.fetch(:support_topics, [])
+  end
+
+  def message
+    @params.fetch(:message, '')
+  end
+
+  def requires_school?
+    %w[parent_or_guardian_or_carer_or_pupil_or_care_leaver other_type_of_user].exclude? user_type
+  end
+end

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -23,18 +23,17 @@
       <% component.slot(
          :row,
          key: "Which of these best describes you?",
-         value: SupportTicket::DescribeYourselfForm.new.selected_option_label(@support_ticket["user_type"]),
+         value: SupportTicket::DescribeYourselfForm.new.selected_option_label(@support_ticket.user_type),
          action: govuk_link_to("Change", support_ticket_describe_yourself_path),
          classes: "Which of these best describes you".to_s.downcase.gsub(/ /, "-"),
          )
       %>
 
-      <% unless [ 'parent_or_guardian_or_carer_or_pupil_or_care_leaver', 'other_type_of_user'].include?  @support_ticket["user_type"] %>
-
+      <% if !@support_ticket.requires_school? %>
         <% component.slot(
            :row,
            key: "Which school do you work for?",
-           value: "#{@support_ticket["school_name"]} (URN: #{ @support_ticket["school_unique_id"]})",
+           value: "#{@support_ticket.school_name} (URN: #{ @support_ticket.school_unique_id})",
            action: govuk_link_to("Change", @school_details_path),
            classes: "Which of these best describes you".to_s.downcase.gsub(/ /, "-"),
            )
@@ -44,7 +43,7 @@
       <% component.slot(
          :row,
          key: "How can we contact you?",
-         value: "#{ @support_ticket["full_name"]}<br>#{ @support_ticket["email_address"]}<br>#{ @support_ticket["telephone_number"]}".html_safe ,
+         value: "#{ @support_ticket.full_name}<br>#{ @support_ticket.email_address}<br>#{ @support_ticket.telephone_number}".html_safe ,
          action: govuk_link_to("Change", support_ticket_contact_details_path),
          classes: "Name".to_s.downcase.gsub(/ /, "-"),
        ) %>
@@ -53,7 +52,7 @@
          :row,
          key: "What do you need help with?",
          value: content_tag(:ul, :class => 'govuk-list govuk-list--bullet') do
-           @support_ticket["support_topics"].collect do |topic|
+           @support_ticket.support_topics.collect do |topic|
              content_tag(:li, SupportTicket::SupportNeedsForm.new.selected_option_label(topic))
            end.join.html_safe
          end ,
@@ -64,7 +63,7 @@
       <% component.slot(
          :row,
          key: "How can we help you?",
-         value: @support_ticket["message"] ,
+         value: @support_ticket.message ,
          action: govuk_link_to("Change", support_ticket_support_details_path),
          classes: "Name".to_s.downcase.gsub(/ /, "-"),
          ) %>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -18,7 +18,7 @@
       </h1>
 
       <%= f.govuk_text_field :college_name, label: {text: 'College name', size: 's'} %>
-      <%= f.govuk_text_field :college_ukprn,
+      <%= f.govuk_number_field :college_ukprn,
                              label: {text: 'College UKPRN', size: 's'},
                              hint: { text: 'This 8-digit number helps us to locate your college. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">UKPRN</a>.'.html_safe },
                              width: 5 %>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -18,7 +18,7 @@
       </h1>
 
       <%= f.govuk_text_field :school_name, label: {text: 'School name', size: 's'} %>
-      <%= f.govuk_text_field :school_urn,
+      <%= f.govuk_number_field :school_urn,
                              label: {text: 'School URN', size: 's'},
                              hint: { text: 'This 6-digit number helps us to locate your school. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">URN</a>.'.html_safe },
                              width: 5 %>

--- a/spec/controllers/support_ticket/check_your_request_controller_spec.rb
+++ b/spec/controllers/support_ticket/check_your_request_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
   describe '#new' do
     before do
-      session[:support_ticket] = { hello: 'world' }
+      session[:support_ticket] = { full_name: 'My name' }
       get :new
     end
 
@@ -16,7 +16,7 @@ RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
     end
 
     it 'assigns the session data to a variable to play back all the details to the user' do
-      expect(assigns(:support_ticket)).to eq({ hello: 'world' })
+      expect(assigns(:support_ticket).full_name).to eq('My name')
     end
 
     it 'does not redirect to get support home page (using the wizard with existing data)' do

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe SupportTicket do
+  it 'has sensible defaults' do
+    expect(support_ticket.user_type).to eq 'other_type_of_user'
+    expect(support_ticket.school_name).to eq ''
+    expect(support_ticket.school_unique_id).to eq ''
+    expect(support_ticket.full_name).to eq ''
+    expect(support_ticket.email_address).to eq ''
+    expect(support_ticket.telephone_number).to eq ''
+    expect(support_ticket.support_topics).to eq []
+    expect(support_ticket.message).to eq ''
+  end
+
+  describe '#requires_school?' do
+    it 'returns true for applicable user types' do
+      %w[school_or_single_academy_trust multi_academy_trust local_authority college].each do |user_type|
+        expect(support_ticket(user_type: user_type).requires_school?).to eq true
+      end
+    end
+
+    it 'returns false for types that do not require school details' do
+      %w[other_type_of_user parent_or_guardian_or_carer_or_pupil_or_care_leaver].each do |user_type|
+        expect(support_ticket(user_type: user_type).requires_school?).to eq false
+      end
+    end
+  end
+
+private
+
+  def support_ticket(params = {})
+    SupportTicket.new(params: params)
+  end
+end


### PR DESCRIPTION
### Context

- Introduce a model to decorate the support ticket session values. Add sensible for each field so that we fail gracefully from missing values.
- URN and UKPRN fields should only accept numbers.
