### PR TITLE
Add page to view schools history

### DIFF
--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -52,7 +52,44 @@ class Support::SchoolsController < Support::BaseController
     redirect_to support_responsible_body_path(school.responsible_body)
   end
 
+  def history
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @history_object = object_for_view_mode
+  end
+
 private
+
+  def view_mode
+    @view_mode ||= parse_view_mode
+  end
+
+  def parse_view_mode
+    available = %w[school std_device coms_device std_device_pool coms_device_pool caps ordered]
+    mode = params[:view]
+    mode = 'all' unless mode.in?(available)
+    mode
+  end
+
+  def object_for_view_mode
+    case view_mode
+    when 'school'
+      @school
+    when 'std_device'
+      @school&.std_device_allocation
+    when 'coms_device'
+      @school&.coms_device_allocation
+    when 'std_device_pool'
+      @school.responsible_body&.std_device_pool
+    when 'coms_device_pool'
+      @school.responsible_body&.coms_device_pool
+    when 'caps'
+      @school&.std_device_allocation&.cap_update_calls
+    when 'ordered'
+      @school.devices_ordered_updates
+    else
+      @school
+    end
+  end
 
   def search_params
     params.require(:school_search_form).permit(:identifiers, :responsible_body_id, :order_state)

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -3,6 +3,8 @@ class VirtualCapPool < ApplicationRecord
   include DeviceType
   include DeviceCount
 
+  has_paper_trail
+
   belongs_to :responsible_body
   has_many :school_virtual_caps, dependent: :destroy
   has_many :school_device_allocations, through: :school_virtual_caps

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -13,6 +13,7 @@ class SchoolPolicy < SupportPolicy
   alias_method :results?, :readable?
   alias_method :invite?, :editable?
   alias_method :confirm_invitation?, :editable?
+  alias_method :history?, :editable?
 
   def update_computacenter_reference?
     user.is_computacenter?

--- a/app/views/support/schools/_history.html.erb
+++ b/app/views/support/schools/_history.html.erb
@@ -1,0 +1,68 @@
+<% if object %>
+  <% Array(object).each do |obj| %>
+    <h2 class="govuk-heading-m"><%= obj.created_at.to_s(:govuk_date_and_time) %></h2>
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-one-half">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Field</th>
+              <th scope="col" class="govuk-table__header">Value</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% obj.attributes.each do |(field, value)| %>
+              <% if value.present? %>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><%= field %></td>
+                  <td class="govuk-table__cell"><%= value %></td>
+                </tr>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+
+  <% if object.respond_to?(:versions) && object.versions.any? %>
+    <h2 class="govuk-heading-m">History</h2>
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-one-half">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Time</th>
+              <th scope="col" class="govuk-table__header">Field</th>
+              <th scope="col" class="govuk-table__header">From</th>
+              <th scope="col" class="govuk-table__header">To</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% object.versions.each do |v| %>
+                  <% v.changeset.except(:updated_at, :created_at).each do |(field, changes)| %>
+                    <tr class="govuk-table__row">
+                      <td class="govuk-table__cell"><%= v.created_at.to_s(:govuk_date_and_time) %></td>
+                      <td class="govuk-table__cell"><%= field %></td>
+                      <% changes.each do |change| %>
+                        <td class="govuk-table__cell">
+                          <span class="govuk-tag govuk-tag--<%= cycle('grey', 'green') %>">
+                            <% if change.present? %>
+                              <%= change %>
+                            <% else %>
+                              Blank
+                            <% end %>
+                          </span>
+                        </td>
+                      <% end %>
+                    </tr>
+                  <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <p class="govuk-body">History not available.</p>
+<% end %>

--- a/app/views/support/schools/history.html.erb
+++ b/app/views/support/schools/history.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "#{@school.name} – Support" %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { 'Support home' => support_home_path },
+    { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
+    { @school.responsible_body.name => support_responsible_body_path(@school.responsible_body) },
+    @school.name,
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.responsible_body.name %></span>
+      <%= @school.name %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <%= render TabComponent.new(
+          label: 'School',
+          path: support_school_history_path(view: 'school'),
+          selected: @view_mode.blank? || @view_mode == 'school')
+        %>
+        <%= render TabComponent.new(
+          label: 'Devices',
+          path: support_school_history_path(view: 'std_device'),
+          selected: @view_mode == 'std_device')
+        %>
+        <%= render TabComponent.new(
+          label: 'Dev. Caps',
+          path: support_school_history_path(view: 'caps'),
+          selected: @view_mode == 'caps')
+        %>
+        <%= render TabComponent.new(
+          label: 'Routers',
+          path: support_school_history_path(view: 'coms_device'),
+          selected: @view_mode == 'coms_device')
+        %>
+        <%= render TabComponent.new(
+          label: 'Devices (v-cap)',
+          path: support_school_history_path(view: 'std_device_pool'),
+          selected: @view_mode == 'std_device_pool')
+        %>
+        <%= render TabComponent.new(
+          label: 'Routers (v-cap)',
+          path: support_school_history_path(view: 'coms_device_pool'),
+          selected: @view_mode == 'coms_device_pool')
+        %>
+        <%= render TabComponent.new(
+          label: 'Ordered (CC)',
+          path: support_school_history_path(view: 'ordered'),
+          selected: @view_mode == 'ordered')
+        %>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<%= render partial: 'history', locals: { object: @history_object } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,8 @@ Rails.application.routes.draw do
       post '/invite', to: 'schools#invite'
       resources :users, only: %i[new create], controller: 'users'
 
+      get '/history', to: 'schools#history', as: :history
+
       get '/devices/enable-orders', to: 'schools/devices/order_status#edit', as: :enable_orders
       get '/devices/enable-orders/confirm', to: 'schools/devices/order_status#confirm', as: :confirm_enable_orders
       patch '/devices/enable-orders', to: 'schools/devices/order_status#update'

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -94,4 +94,22 @@ RSpec.describe Support::SchoolsController, type: :controller do
       end
     end
   end
+
+  describe 'history' do
+    before do
+      sign_in_as create(:dfe_user)
+    end
+
+    it 'responds successfully' do
+      get :history, params: { school_urn: school.urn }
+      expect(response).to be_successful
+    end
+
+    it 'responds successfully with each view' do
+      %w[school std_device coms_device std_device_pool coms_device_pool caps ordered].each do |view|
+        get :history, params: { school_urn: school.urn, view: view }
+        expect(response).to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Currently we have to inspect the database to get historical information about a school and its related objects. This PR adds a page to see everything in one place. When viewing a school in support add `/history` to the URL.

It includes changes on:

- School
- Device allocations
- Virtual pools
- Cap updates
- Devices ordered updates

It's not linked to from anywhere because it's just for us, and testing is limited beyond 'does it render'.

🤫 

![screencapture-localhost-3000-support-schools-100000-history-2021-01-19-15_15_47](https://user-images.githubusercontent.com/31316/105053774-3c05a180-5a69-11eb-8d85-d391491d878a.png)
![screencapture-localhost-3000-support-schools-100000-history-2021-01-19-15_16_13](https://user-images.githubusercontent.com/31316/105053838-4aec5400-5a69-11eb-8e34-bce5d07f2948.png)

### Changes proposed in this pull request

### Guidance to review

