### PR TITLE
Mno extra mobile data requests bulk update status by csv

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
@@ -4,7 +4,7 @@ class Mno::ExtraMobileDataRequestsCsvUpdateController < Mno::BaseController
   end
 
   def create
-    @upload_form = Mno::CsvStatusUploadForm.new(upload_form_params)
+    @upload_form = Mno::CsvStatusUpdateForm.new(upload_form_params)
 
     if @upload_form.valid?
       importer = importer_for(@upload_form.csv)
@@ -13,7 +13,7 @@ class Mno::ExtraMobileDataRequestsCsvUpdateController < Mno::BaseController
         render :summary
       rescue StandardError => e
         Rails.logger.error(e.message)
-        @upload_form.errors.add(:upload, :theres_a_problem_wuth_that_csv)
+        @upload_form.errors.add(:upload, :theres_a_problem_with_that_csv)
         render :new, status: :unprocessable_entity
       end
     else
@@ -24,7 +24,7 @@ class Mno::ExtraMobileDataRequestsCsvUpdateController < Mno::BaseController
 private
 
   def upload_form_params
-    params.fetch(:bulk_upload_form, {}).permit(%i[upload])
+    params.fetch(:mno_csv_status_update_form, {}).permit(%i[upload])
   end
 
   def importer_for(csv)

--- a/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
@@ -1,0 +1,33 @@
+class Mno::ExtraMobileDataRequestsCsvUpdateController < Mno::BaseController
+  def new
+    @upload_form = Mno::CsvStatusUpdateForm.new
+  end
+
+  def create
+    @upload_form = Mno::CsvStatusUploadForm.new(upload_form_params)
+
+    if @upload_form.valid?
+      importer = importer_for(@upload_form.csv)
+      begin
+        @summary = importer.import!
+        render :summary
+      rescue StandardError => e
+        Rails.logger.error(e.message)
+        @upload_form.errors.add(:upload, :theres_a_problem_wuth_that_csv)
+        render :new, status: :unprocessable_entity
+      end
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def upload_form_params
+    params.fetch(:bulk_upload_form, {}).permit(%i[upload])
+  end
+
+  def importer_for(csv)
+    @importer ||= ExtraMobileDataRequestStatusImporter.new(mobile_network: @mobile_network, datasource: csv)
+  end
+end

--- a/app/form_objects/mno/csv_status_update_form.rb
+++ b/app/form_objects/mno/csv_status_update_form.rb
@@ -1,0 +1,29 @@
+class Mno::CsvStatusUpdateForm
+  include ActiveModel::Model
+
+  attr_accessor :upload
+
+  validates :upload, presence: true
+  validate :appropriate_file_type, :csv_file_valid, if: ->(form) { form.upload.present? }
+
+  def csv
+    @csv ||= ExtraMobileDataRequestStatusFile.new(path: upload.tempfile.path)
+  end
+
+private
+
+  def appropriate_file_type
+    Rails.logger.debug("ExtraMobileDataRequestsCsvUpdate content-type: #{upload.content_type}")
+    errors.add(:upload, :unsupported_file_type) unless csv_uploaded?
+  end
+
+  def csv_file_valid
+    if csv.invalid?
+      errors.copy!(csv.errors)
+    end
+  end
+
+  def csv_uploaded?
+    upload.content_type == Mime::Type.lookup_by_extension(:csv)
+  end
+end

--- a/app/form_objects/mno/csv_status_update_form.rb
+++ b/app/form_objects/mno/csv_status_update_form.rb
@@ -3,11 +3,11 @@ class Mno::CsvStatusUpdateForm
 
   attr_accessor :upload
 
-  validates :upload, presence: true
+  validates :upload, presence: { message: 'Select a CSV file' }
   validate :appropriate_file_type, :csv_file_valid, if: ->(form) { form.upload.present? }
 
   def csv
-    @csv ||= ExtraMobileDataRequestStatusFile.new(path: upload.tempfile.path)
+    @csv ||= ExtraMobileDataRequestStatusFile.new(upload.tempfile.path)
   end
 
 private
@@ -18,9 +18,7 @@ private
   end
 
   def csv_file_valid
-    if csv.invalid?
-      errors.copy!(csv.errors)
-    end
+    errors.add(:upload, 'File has no content') unless File.size?(upload.tempfile.path)
   end
 
   def csv_uploaded?

--- a/app/form_objects/mno/csv_status_update_summary.rb
+++ b/app/form_objects/mno/csv_status_update_summary.rb
@@ -19,7 +19,11 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def add_error_record(extra_mobile_data_request)
-    @errors << presenter(extra_mobile_data_request)
+    # to preserve incoming values these are a hash not a ExtraMobileDataRequest
+    error = extra_mobile_data_request
+    error[:error_message] = error[:error].join('<br/>').html_safe
+
+    @errors << OpenStruct.new(error)
   end
 
   def add_unchanged_record(extra_mobile_data_request)
@@ -43,7 +47,7 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def updated_count_text
-    "#{updated_count} #{'was'.pluralize(updated_count)}"
+    "#{updated_count} #{'was'.pluralize(updated_count)} updated successfully"
   end
 
   def unchanged_count
@@ -51,7 +55,7 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def unchanged_count_text
-    "#{unchanged_count} #{'was'.pluralize(unchanged_count)}"
+    "#{unchanged_count} #{'was'.pluralize(unchanged_count)} not changed"
   end
 
   def errors_count
@@ -59,15 +63,15 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def errors_count_text
-    "#{errors_count} #{'contains'.pluralize(errors_count)}"
+    "#{errors_count} #{'contains'.pluralize(errors_count)} errors"
   end
 
   def errors_section_heading_text
     "#{errors_count} #{'request'.pluralize(errors_count)} #{'contains'.pluralize(errors_count)} errors"
   end
 
-  def uploaded_section_heading_text
-    "#{updated_count} #{'request'.pluralize(updated_count)} uploaded"
+  def updated_section_heading_text
+    "#{updated_count} #{'request'.pluralize(updated_count)} updated"
   end
 
 private

--- a/app/form_objects/mno/csv_status_update_summary.rb
+++ b/app/form_objects/mno/csv_status_update_summary.rb
@@ -1,0 +1,78 @@
+class Mno::CsvStatusUpdateSummary
+  attr_reader :errors, :unchanged, :updated
+  def initialize
+    @errors = []
+    @unchanged = []
+    @updated = []
+  end
+
+  def has_errors?
+    @errors.present?
+  end
+
+  def has_unchanged_requests?
+    @unchanged.present?
+  end
+
+  def has_updated_requests?
+    @updated.present?
+  end
+
+  def add_error_record(extra_mobile_data_request)
+    @errors << presenter(extra_mobile_data_request)
+  end
+
+  def add_unchanged_record(extra_mobile_data_request)
+    @unchanged << extra_mobile_data_request
+  end
+
+  def add_updated_record(extra_mobile_data_request)
+    @updated << presenter(extra_mobile_data_request)
+  end
+
+  def requests_count
+    @updated.count + @unchanged.count + @errors.count
+  end
+
+  def requests_count_text
+    "#{requests_count} #{'row'.pluralize(requests_count)}"
+  end
+
+  def updated_count
+    @updated.count
+  end
+
+  def updated_count_text
+    "#{updated_count} #{'was'.pluralize(updated_count)}"
+  end
+
+  def unchanged_count
+    @unchanged.count
+  end
+
+  def unchanged_count_text
+    "#{unchanged_count} #{'was'.pluralize(unchanged_count)}"
+  end
+
+  def errors_count
+    @errors.count
+  end
+
+  def errors_count_text
+    "#{errors_count} #{'contains'.pluralize(errors_count)}"
+  end
+
+  def errors_section_heading_text
+    "#{errors_count} #{'request'.pluralize(errors_count)} #{'contains'.pluralize(errors_count)} errors"
+  end
+
+  def uploaded_section_heading_text
+    "#{updated_count} #{'request'.pluralize(updated_count)} uploaded"
+  end
+
+private
+
+  def presenter(extra_mobile_data_request)
+    ExtraMobileDataRequestPresenter.new(extra_mobile_data_request)
+  end
+end

--- a/app/form_objects/mno/csv_status_update_summary.rb
+++ b/app/form_objects/mno/csv_status_update_summary.rb
@@ -31,7 +31,7 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def add_updated_record(extra_mobile_data_request)
-    @updated << presenter(extra_mobile_data_request)
+    @updated << extra_mobile_data_request
   end
 
   def requests_count
@@ -72,11 +72,5 @@ class Mno::CsvStatusUpdateSummary
 
   def updated_section_heading_text
     "#{updated_count} #{'request'.pluralize(updated_count)} updated"
-  end
-
-private
-
-  def presenter(extra_mobile_data_request)
-    ExtraMobileDataRequestPresenter.new(extra_mobile_data_request)
   end
 end

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -40,6 +40,10 @@ class ExtraMobileDataRequest < ApplicationRecord
     statuses.keys - %w[new cancelled unavailable]
   end
 
+  def self.statuses_that_mno_users_can_use_in_csv_uploads
+    statuses.keys - %w[cancelled unavailable]
+  end
+
   enum contract_type: {
     pay_as_you_go_payg: 'pay_as_you_go_payg',
     pay_monthly: 'pay_monthly',

--- a/app/models/extra_mobile_data_request_status_file.rb
+++ b/app/models/extra_mobile_data_request_status_file.rb
@@ -5,6 +5,12 @@ class ExtraMobileDataRequestStatusFile < CsvDataFile
     records(&block)
   end
 
+  def skip?(row)
+    row['ID'].blank? &&
+      row['Account holder name'].blank? &&
+      row['Device phone number'].blank?
+  end
+
 protected
 
   def extract_record(row)

--- a/app/models/extra_mobile_data_request_status_file.rb
+++ b/app/models/extra_mobile_data_request_status_file.rb
@@ -1,0 +1,19 @@
+class ExtraMobileDataRequestStatusFile < CsvDataFile
+  attr_accessor :path
+
+  def requests(&block)
+    records(&block)
+  end
+
+protected
+
+  def extract_record(row)
+    {
+      id: row['ID'],
+      account_holder_name: row['Account holder name'],
+      device_phone_number: row['Device phone number'],
+      mobile_network_id: row['Mobile network ID'],
+      status: row['Status'],
+    }
+  end
+end

--- a/app/services/extra_mobile_data_request_status_importer.rb
+++ b/app/services/extra_mobile_data_request_status_importer.rb
@@ -61,7 +61,7 @@ private
       request[:error] = ['No status provided']
       summary.add_error_record(request)
       false
-    elsif ExtraMobileDataRequest.statuses.include? status
+    elsif status.in?(ExtraMobileDataRequest.statuses_that_mno_users_can_use_in_csv_uploads)
       true
     else
       request[:error] = ["'#{status}' is not a valid status"]

--- a/app/services/extra_mobile_data_request_status_importer.rb
+++ b/app/services/extra_mobile_data_request_status_importer.rb
@@ -11,18 +11,9 @@ class ExtraMobileDataRequestStatusImporter
     @datasource.requests do |request|
       record = @mno.extra_mobile_data_requests.find_by(id: request[:id])
       if record
-        if record.account_holder_name != request[:account_holder_name]
-          request[:error] = ['Account holder does not match our records',
-                             "We expected #{record.account_holder_name}"]
-          summary.add_error_record(request)
-        elsif record.device_phone_number != request[:device_phone_number]
-          request[:error] = ['Phone number does not match our records',
-                             "We expected #{record.device_phone_number}"]
-          summary.add_error_record(request)
-        elsif request[:status].blank?
-          request[:error] = ['No status provided']
-          summary.add_error_record(request)
-        elsif is_valid_status?(request[:status])
+        if account_holder_valid?(record, request) &&
+            phone_number_valid?(record, request) &&
+            status_valid?(record, request)
           if record.status != request[:status]
             record.status = request[:status]
             record.save!
@@ -30,11 +21,11 @@ class ExtraMobileDataRequestStatusImporter
           else
             summary.add_unchanged_record(record)
           end
-        else
-          # invalid status
-          request[:error] = ["'#{request[:status]}' is not a valid status"]
-          summary.add_error_record(request)
         end
+      else
+        # could not find record
+        request[:error] = ['We could not find this request']
+        summary.add_error_record(request)
       end
     end
     summary
@@ -42,7 +33,40 @@ class ExtraMobileDataRequestStatusImporter
 
 private
 
-  def is_valid_status?(status)
-    ExtraMobileDataRequest.statuses.include? status
+  def account_holder_valid?(record, request)
+    if record.account_holder_name == request[:account_holder_name]
+      true
+    else
+      request[:error] = ['Account holder does not match our records',
+                         "We expected #{record.account_holder_name}"]
+      summary.add_error_record(request)
+      false
+    end
+  end
+
+  def phone_number_valid?(record, request)
+    if Phonelib.parse(record.device_phone_number).national(false) == Phonelib.parse(request[:device_phone_number]).national(false)
+      true
+    else
+      request[:error] = ['Phone number does not match our records',
+                         "We expected #{record.device_phone_number}"]
+      summary.add_error_record(request)
+      false
+    end
+  end
+
+  def status_valid?(_record, request)
+    status = request[:status]
+    if status.blank?
+      request[:error] = ['No status provided']
+      summary.add_error_record(request)
+      false
+    elsif ExtraMobileDataRequest.statuses.include? status
+      true
+    else
+      request[:error] = ["'#{status}' is not a valid status"]
+      summary.add_error_record(request)
+      false
+    end
   end
 end

--- a/app/services/extra_mobile_data_request_status_importer.rb
+++ b/app/services/extra_mobile_data_request_status_importer.rb
@@ -1,0 +1,48 @@
+class ExtraMobileDataRequestStatusImporter
+  attr_reader :summary
+
+  def initialize(mobile_network:, datasource:)
+    @mno = mobile_network
+    @datasource = datasource
+    @summary = Mno::CsvStatusUpdateSummary.new
+  end
+
+  def import!
+    @datasource.requests do |request|
+      record = @mno.extra_mobile_data_requests.find_by(id: request[:id])
+      if record
+        if record.account_holder_name != request[:account_holder_name]
+          request[:error] = ['Account holder does not match our records',
+                             "We expected #{record.account_holder_name}"]
+          summary.add_error_record(request)
+        elsif record.device_phone_number != request[:device_phone_number]
+          request[:error] = ['Phone number does not match our records',
+                             "We expected #{record.device_phone_number}"]
+          summary.add_error_record(request)
+        elsif request[:status].blank?
+          request[:error] = ['No status provided']
+          summary.add_error_record(request)
+        elsif is_valid_status?(request[:status])
+          if record.status != request[:status]
+            record.status = request[:status]
+            record.save!
+            summary.add_updated_record(record)
+          else
+            summary.add_unchanged_record(record)
+          end
+        else
+          # invalid status
+          request[:error] = ["'#{request[:status]}' is not a valid status"]
+          summary.add_error_record(request)
+        end
+      end
+    end
+    summary
+  end
+
+private
+
+  def is_valid_status?(status)
+    ExtraMobileDataRequest.statuses.include? status
+  end
+end

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -15,6 +15,7 @@
   </p>
 <% else %>
   <%= govuk_button_link_to 'Download requests as CSV', sort: params[:sort], dir: params[:dir], format: :csv %>
+  <p class="govuk-body"><%= govuk_link_to t('page_titles.extra_mobile_data_requests_csv_update'), new_mno_extra_mobile_data_requests_csv_update_path %></p>
 
   <h2 class="govuk-heading-l govuk-!-margin-top-4">
     <%= pagy_info(@pagination, "requests").capitalize.html_safe %>

--- a/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
@@ -1,0 +1,74 @@
+<% title = t('page_titles.extra_mobile_data_requests_csv_update') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_link_to('Back', mno_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <h2 class="govuk-heading-l">Upload CSV file</h2>
+    <div class="govuk-grid-row">
+      <%= form_for @upload_form,
+        url: mno_extra_mobile_data_requests_csv_update_index_path,
+        html: {
+          class: 'app-card govuk-!-margin-bottom-6',
+          multipart: true
+        } do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_file_field :upload,
+          label: { text: 'CSV file', size: 'm' },
+          accept: Mime::Type.lookup_by_extension(:csv)
+        %>
+
+        <%= f.govuk_submit 'Upload and update requests' %>
+      <%- end %>
+
+      <h2 class="govuk-heading-l">Help updating the CSV</h2>
+        <p class="govuk-body">You can modify and re-upload your <%= govuk_link_to('CSV of requests', mno_extra_mobile_data_requests_path(format: :csv)) %>. Only changes to a request’s status will be processed.</p>
+
+      <h3 class="govuk-heading-m">Statuses you can use</h3>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Status</th>
+            <th class="govuk-table__header">Description</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">new</td>
+            <td class="govuk-table__cell">Request not processed yet</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">in_progress</td>
+            <td class="govuk-table__cell">Request is being processed</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">completed</td>
+            <td class="govuk-table__cell">Request processed successfully</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">problem_not_eligible</td>
+            <td class="govuk-table__cell">Account is not eligible</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">problem_no_account_with_number</td>
+            <td class="govuk-table__cell">No account with this number</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">problem_no_account_with_name</td>
+            <td class="govuk-table__cell">No account with this name</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">problem_invalid_number</td>
+            <td class="govuk-table__cell">Not a valid mobile number</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">problem</td>
+            <td class="govuk-table__cell">Request could not be processed but no reason specified</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
@@ -35,38 +35,12 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">new</td>
-            <td class="govuk-table__cell">Request not processed yet</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">in_progress</td>
-            <td class="govuk-table__cell">Request is being processed</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">completed</td>
-            <td class="govuk-table__cell">Request processed successfully</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">problem_not_eligible</td>
-            <td class="govuk-table__cell">Account is not eligible</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">problem_no_account_with_number</td>
-            <td class="govuk-table__cell">No account with this number</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">problem_no_account_with_name</td>
-            <td class="govuk-table__cell">No account with this name</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">problem_invalid_number</td>
-            <td class="govuk-table__cell">Not a valid mobile number</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">problem</td>
-            <td class="govuk-table__cell">Request could not be processed but no reason specified</td>
-          </tr>
+          <% @statuses_with_descriptions.each do |status, description| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= status %></td>
+              <td class="govuk-table__cell"><%= description %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>

--- a/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
@@ -1,19 +1,19 @@
-<% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', new_mno_extra_mobile_data_requests_csv_update_path class: 'govuk-back-link') %>
+  <%= govuk_link_to('Back', new_mno_extra_mobile_data_requests_csv_update_path, class: 'govuk-back-link') %>
 <% end %>
+<% content_for :title, t('page_titles.weve_processed_your_csv') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.weve_processed_your_spreadsheet') %>
+      <%= t('page_titles.weve_processed_your_csv') %>
     </h1>
 
     <p class="govuk-body">We found <%= @summary.requests_count_text %> in your CSV:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= @summary.unchanged_count_text %> were not changed</li>
-      <li><%= @summary.errors_count_text %> errors</li>
-      <li><%= @summary.updated_count_text %> updated successfully</li>
+      <li><%= @summary.unchanged_count_text %></li>
+      <li><%= @summary.errors_count_text %></li>
+      <li><%= @summary.updated_count_text %></li>
     </ul>
   </div>
 </div>
@@ -49,7 +49,7 @@
 <%- end %>
 
 <% if @summary.has_updated_requests? %>
-  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @summary.uploaded_section_heading_text %></h2>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @summary.updated_section_heading_text %></h2>
   <table class="govuk-table requests-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
@@ -65,7 +65,7 @@
           <td class="govuk-table__cell"><%= row.id %></td>
           <td class="govuk-table__cell"><%= row.account_holder_name %></td>
           <td class="govuk-table__cell"><%= row.device_phone_number %></td>
-          <td class="govuk-table__cell"><%= row.status %></td>
+          <td class="govuk-table__cell"><%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: row) %></td>
         </tr>
       <%- end %>
     </tbody>

--- a/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
+<%- content_for :before_content do %>
+  <%= govuk_link_to('Back', new_mno_extra_mobile_data_requests_csv_update_path class: 'govuk-back-link') %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.weve_processed_your_spreadsheet') %>
+    </h1>
+
+    <p class="govuk-body">We found <%= @summary.requests_count_text %> in your CSV:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= @summary.unchanged_count_text %> were not changed</li>
+      <li><%= @summary.errors_count_text %> errors</li>
+      <li><%= @summary.updated_count_text %> updated successfully</li>
+    </ul>
+  </div>
+</div>
+
+<% if @summary.has_errors? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @summary.errors_section_heading_text %></h2>
+  <div class="govuk-form-group--error">
+    <p class="govuk-error-message">Fix the errors in your CSV and try uploading again</p>
+
+    <table class="govuk-table requests-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">ID</th>
+          <th class="govuk-table__header">Account holder</th>
+          <th class="govuk-table__header">Mobile number</th>
+          <th class="govuk-table__header">Error</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @summary.errors.each do |row| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= row.id %></td>
+            <td class="govuk-table__cell"><%= row.account_holder_name %></td>
+            <td class="govuk-table__cell"><%= row.device_phone_number %></td>
+            <td class="govuk-table__cell">
+              <span class="govuk-error-message govuk-!-margin-bottom-0"><%= row.error_message %></span>
+            </td>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+  </div>
+<%- end %>
+
+<% if @summary.has_updated_requests? %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @summary.uploaded_section_heading_text %></h2>
+  <table class="govuk-table requests-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">ID</th>
+        <th class="govuk-table__header">Account holder</th>
+        <th class="govuk-table__header">Mobile number</th>
+        <th class="govuk-table__header">New status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @summary.updated.each do |row| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= row.id %></td>
+          <td class="govuk-table__cell"><%= row.account_holder_name %></td>
+          <td class="govuk-table__cell"><%= row.device_phone_number %></td>
+          <td class="govuk-table__cell"><%= row.status %></td>
+        </tr>
+      <%- end %>
+    </tbody>
+  </table>
+<%- end %>
+<%= govuk_button_link_to('Finish', mno_extra_mobile_data_requests_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     edit_responsible_body_user: Edit user
     responsible_body_schools_list: Your schools and colleges
     requests_for_extra_mobile_data: Requests for extra mobile data
+    extra_mobile_data_requests_csv_update: Update requests using a CSV
     suggested_email_to_schools: A suggested email for you to send to schools
     request_extra_mobile_data: Request extra data for mobile devices
     your_requests: Your requests

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
     how_would_you_like_to_submit_information: How would you like to submit information?
     upload_a_spreadsheet_of_extra_data_requests: Upload a spreadsheet of extra data requests
     weve_processed_your_spreadsheet: We’ve processed your spreadsheet
+    weve_processed_your_csv: We’ve processed your CSV
     guide_to_collecting_mobile_information: Guide to collecting mobile information
     start: Get help with technology
     internet_access: Get internet access

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
       put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
       get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
     end
+    resources :extra_mobile_data_requests_csv_update, only: %i[new create show], path: '/extra-mobile-data-requests-csv-update'
   end
 
   namespace :responsible_body, path: '/responsible-body' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
       put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
       get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
     end
-    resources :extra_mobile_data_requests_csv_update, only: %i[new create show], path: '/extra-mobile-data-requests-csv-update'
+    resources :extra_mobile_data_requests_csv_update, only: %i[new create], path: '/extra-mobile-data-requests-csv-update'
   end
 
   namespace :responsible_body, path: '/responsible-body' do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,8 +201,8 @@ ActiveRecord::Schema.define(version: 2021_01_19_173825) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
@@ -290,10 +290,10 @@ ActiveRecord::Schema.define(version: 2021_01_19_173825) do
     t.boolean "increased_allocations_feature_flag", default: false
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
-    t.boolean "hide_mno", default: false
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
     t.text "fe_type"
+    t.boolean "hide_mno", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'Update MNO Requests via CSV', type: :feature do
+  let(:mno_user) { create(:mno_user) }
+  let(:local_authority_user) { create(:local_authority_user) }
+
+  scenario 'navigating to the CSV update page' do
+    given_i_have_some_mobile_data_requests
+    given_i_am_signed_in_as_a_mno_user
+    when_i_follow_the_csv_update_link
+    then_i_see_a_form_to_upload_a_csv_file
+  end
+
+  def given_i_am_signed_in_as_a_mno_user
+    sign_in_as mno_user
+  end
+
+  def given_i_have_some_mobile_data_requests
+    create_list(:extra_mobile_data_request, 2, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+  end
+
+  def when_i_follow_the_csv_update_link
+    click_on 'Update requests using a CSV'
+  end
+
+  def then_i_see_a_form_to_upload_a_csv_file
+    expect(page).to have_selector('h1', text: 'Update requests using a CSV')
+    expect(page).to have_field('CSV file')
+  end
+end

--- a/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
@@ -4,6 +4,7 @@ require 'shared/expect_download'
 RSpec.feature 'Update MNO Requests via CSV', type: :feature do
   let(:mno_user) { create(:mno_user) }
   let(:local_authority_user) { create(:local_authority_user) }
+  let(:filename) { Rails.root.join('tmp/update_status.csv') }
 
   scenario 'navigating to the CSV update page' do
     given_i_have_some_mobile_data_requests
@@ -12,20 +13,75 @@ RSpec.feature 'Update MNO Requests via CSV', type: :feature do
     then_i_see_a_form_to_upload_a_csv_file
   end
 
+  scenario 'submitting a CSV with status updates' do
+    given_i_have_some_mobile_data_requests
+    given_i_am_signed_in_as_a_mno_user
+    when_i_visit_the_csv_update_page
+    and_i_select_my_csv_file
+    and_i_click_the_upload_and_update_requests_button
+    then_i_see_a_summary_page
+  end
+
   def given_i_am_signed_in_as_a_mno_user
     sign_in_as mno_user
   end
 
   def given_i_have_some_mobile_data_requests
-    create_list(:extra_mobile_data_request, 2, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+    @requests = create_list(:extra_mobile_data_request, 2, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
   end
 
   def when_i_follow_the_csv_update_link
     click_on 'Update requests using a CSV'
   end
 
+  def when_i_visit_the_csv_update_page
+    visit new_mno_extra_mobile_data_requests_csv_update_path
+  end
+
+  def and_i_select_my_csv_file
+    attrs = requests_to_attrs
+    attrs[0][:status] = 'in_progress'
+    attrs[1][:status] = 'problem_no_match_for_number'
+
+    create_extra_mobile_data_request_update_csv_file(filename, attrs)
+    attach_file('CSV file', filename)
+  end
+
+  def and_i_click_the_upload_and_update_requests_button
+    click_on 'Upload and update requests'
+  end
+
   def then_i_see_a_form_to_upload_a_csv_file
     expect(page).to have_selector('h1', text: 'Update requests using a CSV')
     expect(page).to have_field('CSV file')
+  end
+
+  def then_i_see_a_summary_page
+    expect(page).to have_selector('h1', text: 'We’ve processed your CSV')
+    expect(page).to have_text('0 were not changed')
+    expect(page).to have_text('0 contain errors')
+    expect(page).to have_text('2 were updated successfully')
+
+    row0 = "#{@requests[0].id} #{@requests[0].account_holder_name} #{@requests[0].device_phone_number} In progress"
+    row1 = "#{@requests[1].id} #{@requests[1].account_holder_name} #{@requests[1].device_phone_number} Unknown number"
+    expect(page).to have_selector('tr', text: row0)
+    expect(page).to have_selector('tr', text: row1)
+
+    remove_file(filename)
+  end
+
+  def requests_to_attrs
+    @requests.map do |req|
+      {
+        id: req.id,
+        account_holder_name: req.account_holder_name,
+        device_phone_number: req.device_phone_number,
+        created_at: req.created_at,
+        updated_at: req.updated_at,
+        mobile_network_id: req.mobile_network_id,
+        status: req.status,
+        contract_type: req.contract_type,
+      }
+    end
   end
 end

--- a/spec/services/extra_mobile_data_request_status_importer_spec.rb
+++ b/spec/services/extra_mobile_data_request_status_importer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
   let(:importer) { described_class.new(mobile_network: mno, datasource: datasource) }
 
   before do
-    create_extra_mobile_data_request_update_csv_file(filename, [attrs])
+    create_extra_mobile_data_request_update_csv_file(filename, attrs)
   end
 
   after do
@@ -29,18 +29,18 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
 
   context 'when a vaild status change is in the csv file' do
     let(:attrs) do
-      {
+      [{
         id: request.id,
         account_holder_name: request.account_holder_name,
         device_phone_number: request.device_phone_number,
         mobile_network_id: request.mobile_network_id,
         status: 'complete',
-      }
+      }]
     end
 
     it 'updates the status of the matching requests' do
       importer.import!
-    
+
       expect(request.reload.status).to eq('complete')
     end
 
@@ -55,19 +55,19 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
 
   context 'when no status changes are in the csv file' do
     let(:attrs) do
-      {
+      [{
         id: request.id,
         account_holder_name: request.account_holder_name,
         device_phone_number: request.device_phone_number,
         mobile_network_id: request.mobile_network_id,
-        status: request.status
-      }
+        status: request.status,
+      }]
     end
 
     it 'does not update the status of the matching requests' do
       importer.import!
-    
-      expect(request.reload.status).to eq 'requested'
+
+      expect(request.reload.status).to eq 'new'
     end
 
     it 'returns a summary of the import' do
@@ -81,19 +81,19 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
 
   context 'when the status changes contain invalid status' do
     let(:attrs) do
-      {
+      [{
         id: request.id,
         account_holder_name: request.account_holder_name,
         device_phone_number: request.device_phone_number,
         mobile_network_id: request.mobile_network_id,
         status: 'too_high',
-      }
+      }]
     end
 
     it 'does not update the status of the matching requests' do
       importer.import!
-    
-      expect(request.reload.status).to eq 'requested'
+
+      expect(request.reload.status).to eq 'new'
     end
 
     it 'returns a summary of the import' do
@@ -102,6 +102,52 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
       expect(summary.has_unchanged_requests?).to be false
       expect(summary.has_errors?).to be true
       expect(summary.errors.first[:error]).to eq ["'too_high' is not a valid status"]
+    end
+  end
+
+  context 'when the attributes do not match the original request' do
+    let(:requests) { create_list(:extra_mobile_data_request, 3, mobile_network: mno) }
+
+    let(:attrs) do
+      [{
+        id: requests[0].id,
+        account_holder_name: 'Geoffrey Falstaff',
+        device_phone_number: requests[0].device_phone_number,
+        mobile_network_id: requests[0].mobile_network_id,
+        status: 'in_progress',
+      },
+       {
+         id: requests[1].id,
+         account_holder_name: requests[1].account_holder_name,
+         device_phone_number: '07890123123',
+         mobile_network_id: requests[1].mobile_network_id,
+         status: 'in_progress',
+       },
+       {
+         id: 9_302_909,
+         account_holder_name: requests[2].account_holder_name,
+         device_phone_number: requests[2].device_phone_number,
+         mobile_network_id: requests[2].mobile_network_id,
+         status: 'in_progress',
+       }]
+    end
+
+    it 'does not update the status of the matching requests' do
+      importer.import!
+
+      requests.each do |request|
+        expect(request.reload.status).to eq 'new'
+      end
+    end
+
+    it 'returns a summary of the import' do
+      summary = importer.import!
+      expect(summary.has_updated_requests?).to be false
+      expect(summary.has_unchanged_requests?).to be false
+      expect(summary.has_errors?).to be true
+      expect(summary.errors.first[:error]).to eq ['Account holder does not match our records', "We expected #{requests[0].account_holder_name}"]
+      expect(summary.errors.second[:error]).to eq ['Phone number does not match our records', "We expected #{requests[1].device_phone_number}"]
+      expect(summary.errors.third[:error]).to eq ['We could not find this request']
     end
   end
 end

--- a/spec/services/extra_mobile_data_request_status_importer_spec.rb
+++ b/spec/services/extra_mobile_data_request_status_importer_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
+  let(:user) { create(:local_authority_user) }
+  let(:mno) { create(:mobile_network) }
+  let(:request) { create(:extra_mobile_data_request, mobile_network: mno) }
+
+  let(:attrs) do
+    {
+      id: request.id,
+      account_holder_name: request.account_holder_name,
+      device_phone_number: request.device_phone_number,
+      mobile_network_id: request.mobile_network_id,
+      status: 'complete',
+    }
+  end
+
+  let(:filename) { Rails.root.join('tmp/extra-mobile-data-request-update.csv') }
+  let(:datasource) { ExtraMobileDataRequestStatusFile.new(filename) }
+  let(:importer) { described_class.new(mobile_network: mno, datasource: datasource) }
+
+  before do
+    create_extra_mobile_data_request_update_csv_file(filename, [attrs])
+  end
+
+  after do
+    remove_file(filename)
+  end
+
+  context 'when a vaild status change is in the csv file' do
+    let(:attrs) do
+      {
+        id: request.id,
+        account_holder_name: request.account_holder_name,
+        device_phone_number: request.device_phone_number,
+        mobile_network_id: request.mobile_network_id,
+        status: 'complete',
+      }
+    end
+
+    it 'updates the status of the matching requests' do
+      importer.import!
+    
+      expect(request.reload.status).to eq('complete')
+    end
+
+    it 'returns a summary of the import' do
+      summary = importer.import!
+      expect(summary.has_updated_requests?).to be true
+      expect(summary.has_unchanged_requests?).to be false
+      expect(summary.has_errors?).to be false
+      expect(summary.updated.first).to eq request
+    end
+  end
+
+  context 'when no status changes are in the csv file' do
+    let(:attrs) do
+      {
+        id: request.id,
+        account_holder_name: request.account_holder_name,
+        device_phone_number: request.device_phone_number,
+        mobile_network_id: request.mobile_network_id,
+        status: request.status
+      }
+    end
+
+    it 'does not update the status of the matching requests' do
+      importer.import!
+    
+      expect(request.reload.status).to eq 'requested'
+    end
+
+    it 'returns a summary of the import' do
+      summary = importer.import!
+      expect(summary.has_updated_requests?).to be false
+      expect(summary.has_unchanged_requests?).to be true
+      expect(summary.has_errors?).to be false
+      expect(summary.unchanged.first).to eq request
+    end
+  end
+
+  context 'when the status changes contain invalid status' do
+    let(:attrs) do
+      {
+        id: request.id,
+        account_holder_name: request.account_holder_name,
+        device_phone_number: request.device_phone_number,
+        mobile_network_id: request.mobile_network_id,
+        status: 'too_high',
+      }
+    end
+
+    it 'does not update the status of the matching requests' do
+      importer.import!
+    
+      expect(request.reload.status).to eq 'requested'
+    end
+
+    it 'returns a summary of the import' do
+      summary = importer.import!
+      expect(summary.has_updated_requests?).to be false
+      expect(summary.has_unchanged_requests?).to be false
+      expect(summary.has_errors?).to be true
+      expect(summary.errors.first[:error]).to eq ["'too_high' is not a valid status"]
+    end
+  end
+end

--- a/spec/support/csv_file_helper.rb
+++ b/spec/support/csv_file_helper.rb
@@ -43,6 +43,17 @@ module CSVFileHelper
     link_type: 'LinkType',
   }.freeze
 
+  EXTRA_MOBILE_DATA_REQUEST_STATUS_UPDATE_ATTRS = {
+    id: 'ID',
+    account_holder_name: 'Account holder name',
+    device_phone_number: 'Device phone number',
+    created_at: 'Requested',
+    updated_at: 'Last updated',
+    mobile_network_id: 'Mobile network ID',
+    status: 'Status',
+    contract_type: 'Contract type',
+  }.freeze
+
   def create_school_csv_file(filename, array_of_hashes)
     create_csv_file(filename, SCHOOL_ATTRS.values, array_of_hashes)
   end
@@ -53,6 +64,11 @@ module CSVFileHelper
 
   def create_trust_csv_file(filename, array_of_hashes)
     attrs = TrustDataFile::ATTR_MAP
+    create_csv_file(filename, attrs.values, array_of_hashes, attrs)
+  end
+
+  def create_extra_mobile_data_request_update_csv_file(filename, array_of_hashes)
+    attrs = EXTRA_MOBILE_DATA_REQUEST_STATUS_UPDATE_ATTRS
     create_csv_file(filename, attrs.values, array_of_hashes, attrs)
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/w80Ydy7m/1288-mno-bulk-allow-mno-users-to-upload-a-csv-of-requests-to-update-their-statuses) Enable MNOs to bulk update their request statuses.

### Changes proposed in this pull request
Adds CSV upload and bulk update process with summary of changes made.

### Guidance to review
As a MNO with some `ExtraMobileDataRequest`s, sign in to the service and download your requests as CSV.
Update the status column of one or more and then upload the CSV through the new feature. Any valid changes to status will be saved to your requests and a summary of unchanged, updated and errors will be presented.

_Might need to update valid statuses and reflect these on the upload page as I think they might've changed since starting this?_

![image](https://user-images.githubusercontent.com/333931/105071988-33b76180-5a7d-11eb-9202-aba1eb5f79f9.png)
![image](https://user-images.githubusercontent.com/333931/105072076-521d5d00-5a7d-11eb-9dbc-13a628d51844.png)
![image](https://user-images.githubusercontent.com/333931/105072186-7711d000-5a7d-11eb-963f-cd9ae273a329.png)
