### PR TITLE
Refactoring of MNO request status labels and descriptions

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -18,10 +18,9 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
   end
 
   def label
-    if @extra_mobile_data_request.status.start_with?('problem')
-      I18n.t!(@extra_mobile_data_request.status, scope: %i[activerecord attributes extra_mobile_data_request problem_tags])
-    else
-      @extra_mobile_data_request.translated_enum_value(:status)
-    end
+    I18n.t!(
+      "#{@extra_mobile_data_request.status}.tag_label",
+      scope: %i[activerecord attributes extra_mobile_data_request status],
+    )
   end
 end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -15,7 +15,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
         )
         @statuses = ExtraMobileDataRequest
           .translated_enum_values(:statuses)
-          .reject { |status| status.value.in?(%w[cancelled unavailable]) }
+          .select { |status| status.value.in?(ExtraMobileDataRequest.statuses_available_to_mnos) }
       end
     end
   end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -13,9 +13,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
           extra_mobile_data_requests: @extra_mobile_data_requests,
           extra_mobile_data_request_ids: selected_extra_mobile_data_request_ids(@extra_mobile_data_requests, params),
         )
-        @statuses = ExtraMobileDataRequest
-          .translated_enum_values(:statuses)
-          .select { |status| status.value.in?(ExtraMobileDataRequest.statuses_available_to_mnos) }
+        @statuses = mno_status_options
       end
     end
   end
@@ -54,10 +52,24 @@ private
 
   def problem_options
     ExtraMobileDataRequest
-      .statuses
-      .keys
-      .select { |key| key.start_with?('problem') }
-      .map { |key| OpenStruct.new(value: key, label: I18n.t!(key, scope: %i[activerecord attributes extra_mobile_data_request problems])) }
+      .problem_statuses
+      .map do |status|
+        OpenStruct.new(
+          value: status,
+          label: I18n.t!("#{status}.description", scope: %i[activerecord attributes extra_mobile_data_request status]),
+        )
+      end
+  end
+
+  def mno_status_options
+    ExtraMobileDataRequest
+      .statuses_available_to_mnos
+      .map do |status|
+        OpenStruct.new(
+          value: status,
+          label: I18n.t!("#{status}.dropdown_label", scope: %i[activerecord attributes extra_mobile_data_request status]),
+        )
+      end
   end
 
   def extra_mobile_data_request_scope

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -36,6 +36,10 @@ class ExtraMobileDataRequest < ApplicationRecord
     statuses.keys.select { |k| k.start_with?('problem') }
   end
 
+  def self.statuses_available_to_mnos
+    statuses.keys - %w[cancelled unavailable]
+  end
+
   enum contract_type: {
     pay_as_you_go_payg: 'pay_as_you_go_payg',
     pay_monthly: 'pay_monthly',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,29 +489,47 @@ en:
           active: Active
           revoked: Revoked
       extra_mobile_data_request:
-        problems:
-          problem_incorrect_phone_number: This is not a valid mobile number
-          problem_no_match_for_number: We couldn’t find an account with this number
-          problem_no_match_for_account_name: We couldn’t find an account with this name
-          problem_not_eligible: This account is not eligible
-          problem_no_longer_on_network: This account is no longer on our network
-        problem_tags:
-          problem_incorrect_phone_number: Invalid number
-          problem_no_match_for_number: Unknown number
-          problem_no_match_for_account_name: Unknown name
-          problem_not_eligible: Not eligible
-          problem_no_longer_on_network: Not on network
-        statuses:
-          requested: Requested
-          in_progress: In progress
-          complete: Complete
-          cancelled: Cancelled
-          unavailable: Unavailable
-          problem_no_match_for_number: Problem – No account with this number
-          problem_not_eligible: Problem – Not eligible
-          problem_incorrect_phone_number: Problem – Not a valid mobile number
-          problem_no_match_for_account_name: Problem – No account with this name
-          problem_no_longer_on_network: Problem – Not on network
+         status:
+           requested:
+             tag_label: Requested
+             dropdown_label: Requested
+             description: Request not processed yet
+           in_progress:
+             tag_label: In progress
+             dropdown_label: In progress
+             description: Request is being processed
+           complete:
+             tag_label: Complete
+             dropdown_label: Complete
+             description: Request processed successfully
+           cancelled:
+             tag_label: Cancelled
+             dropdown_label: Cancelled
+             description: Request has been cancelled
+           unavailable:
+             tag_label: Unavailable
+             dropdown_label: Unavailable
+             description: Request is for a network that is unavailable
+           problem_no_match_for_number:
+             tag_label: Unknown number
+             dropdown_label: Problem – No account with this number
+             description: We couldn’t find an account with this number
+           problem_not_eligible:
+             tag_label: Not eligible
+             dropdown_label: Problem – Not eligible
+             description: This account is not eligible
+           problem_incorrect_phone_number:
+             tag_label: Invalid number
+             dropdown_label: Problem – Not a valid mobile number
+             description: This is not a valid mobile number
+           problem_no_match_for_account_name:
+             tag_label: Unknown name
+             dropdown_label: Problem – No account with this name
+             description: We couldn’t find an account with this name
+           problem_no_longer_on_network:
+             tag_label: Not on network
+             dropdown_label: Problem – Not on network
+             description: This account is no longer on our network
       mobile_network:
         participation_in_pilots:
           participating: 'Offers data now'


### PR DESCRIPTION
### Context

MNO request statuses are presented to various users (school, RB and MNO users) and in various UI element contexts (on status tags, drop-downs and form options).

### Changes proposed in this pull request

Add an explicit method which reflects which MNO request statuses are available to MNO users to use (they shouldn't be using `cancelled` and `unavailable` statuses).
DRY up how the various status labels are stored and retrieved, to make it easier if a label is missing or not.

### Guidance to review

This should help with #1150 and follow-up MNO improvements.