### PR TITLE
add "Requested" column to extra mobile data requests for schools & RBs

### DIFF
--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -2,7 +2,7 @@ class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < Responsib
   before_action { render_404_unless_responsible_body_has_centrally_managed_schools(@responsible_body) }
 
   def index
-    @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests
+    @extra_mobile_data_requests = @responsible_body.extra_mobile_data_requests.order(:created_at)
   end
 
   def guidance; end

--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -2,7 +2,7 @@ class School::Internet::Mobile::ExtraDataRequestsController < School::BaseContro
   before_action { not_found if @school.hide_mno? }
 
   def index
-    @extra_mobile_data_requests = @school.extra_mobile_data_requests
+    @extra_mobile_data_requests = @school.extra_mobile_data_requests.order(:created_at)
   end
 
   def guidance; end

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -27,15 +27,17 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Account holder</th>
       <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header">Requested</th>
       <th class="govuk-table__header">Mobile Network</th>
       <th class="govuk-table__header">Status</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <%- for emd_request in @extra_mobile_data_requests do %>
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
         <td class="govuk-table__cell"><%= emd_request.account_holder_name %></td>
         <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
+        <td class="govuk-table__cell"><%= emd_request.created_at.to_s(:govuk_date_and_time) %></td>
         <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
         <td class="govuk-table__cell">
           <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -37,7 +37,7 @@
       <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
         <td class="govuk-table__cell"><%= emd_request.account_holder_name %></td>
         <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
-        <td class="govuk-table__cell"><%= emd_request.created_at.to_s(:govuk_date_and_time) %></td>
+        <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>
         <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
         <td class="govuk-table__cell">
           <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -40,7 +40,7 @@
         <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
           <td class="govuk-table__cell"><%= emd_request.account_holder_name %></td>
           <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
-          <td class="govuk-table__cell"><%= emd_request.created_at.to_s(:govuk_date_and_time) %></td>
+          <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>
           <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell">
             <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -30,15 +30,17 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Account holder</th>
         <th class="govuk-table__header">Mobile number</th>
+        <th class="govuk-table__header">Requested</th>
         <th class="govuk-table__header">Mobile Network</th>
         <th class="govuk-table__header">Status</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <%- for emd_request in @extra_mobile_data_requests do %>
-        <tr class="govuk-table__row">
+        <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
           <td class="govuk-table__cell"><%= emd_request.account_holder_name %></td>
           <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
+          <td class="govuk-table__cell"><%= emd_request.created_at.to_s(:govuk_date_and_time) %></td>
           <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell">
             <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -52,10 +52,15 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
       expect(page).to have_css('h1', text: 'Your requests')
 
       @requests.each do |request|
-        expect(page).to have_content(request.device_phone_number)
-        expect(page).to have_content(request.account_holder_name)
+        request_row = page.find("tr#request-#{request.id}")
+        expect(request_row).not_to be_nil
+        expect(request_row).to have_content(request.device_phone_number)
+        expect(request_row).to have_content(request.account_holder_name)
+        # govuk_date_and_time pads 12hr times which have single-digit hours with a leading space
+        # but Capybara's content methods treat multiple whitespace characters as one, like the browser does
+        expect(request_row).to have_content(request.created_at.to_s(:govuk_date_and_time).gsub(/  /, ' '))
       end
-      expect(page).to have_text('Requested').exactly(4).times
+      expect(page).to have_text('Requested').exactly(5).times
       expect(page).to have_text('Unavailable').once
     end
 

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -56,9 +56,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
         expect(request_row).not_to be_nil
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
-        # govuk_date_and_time pads 12hr times which have single-digit hours with a leading space
-        # but Capybara's content methods treat multiple whitespace characters as one, like the browser does
-        expect(request_row).to have_content(request.created_at.to_s(:govuk_date_and_time).gsub(/  /, ' '))
+        expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
       end
       expect(page).to have_text('Requested').exactly(5).times
       expect(page).to have_text('Unavailable').once

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -65,9 +65,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
         expect(request_row).not_to be_nil
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
-        # govuk_date_and_time pads 12hr times which have single-digit hours with a leading space
-        # but Capybara's content methods treat multiple whitespace characters as one, like the browser does
-        expect(request_row).to have_content(request.created_at.to_s(:govuk_date_and_time).gsub(/  /, ' '))
+        expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
       end
       expect(page).to have_text('Requested').exactly(5).times
       expect(page).to have_text('Unavailable').once

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -61,10 +61,15 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       expect(page).to have_css('h1', text: 'Your requests')
 
       @requests.each do |request|
-        expect(page).to have_content(request.device_phone_number)
-        expect(page).to have_content(request.account_holder_name)
+        request_row = page.find("tr#request-#{request.id}")
+        expect(request_row).not_to be_nil
+        expect(request_row).to have_content(request.device_phone_number)
+        expect(request_row).to have_content(request.account_holder_name)
+        # govuk_date_and_time pads 12hr times which have single-digit hours with a leading space
+        # but Capybara's content methods treat multiple whitespace characters as one, like the browser does
+        expect(request_row).to have_content(request.created_at.to_s(:govuk_date_and_time).gsub(/  /, ' '))
       end
-      expect(page).to have_text('Requested').exactly(4).times
+      expect(page).to have_text('Requested').exactly(5).times
       expect(page).to have_text('Unavailable').once
     end
 


### PR DESCRIPTION
### Context

[Trello card #1340](https://trello.com/c/A3ZBD6ab/1340-add-requested-column-to-list-of-mno-requests-shown-to-schools-and-rbs-order-table-by-that-column-newest-to-oldest) - Add "Requested" column to list of MNO requests shown to schools and RBs, order table by that column (newest to oldest)

### Changes proposed in this pull request

* add the 'Requested' column the list of extra mobile data requests for schools & RBs
* update the specs

### Guidance to review

![Screenshot from 2021-01-20 15-24-03](https://user-images.githubusercontent.com/134501/105196489-99febb80-5b33-11eb-9651-ad6121e7e468.png)


Note: there's a fair bit of existing duplication between the school / RB code and specs around this. In the interests of keeping this PR small and focussed, plus speedy delivery, I haven't done anything to address it in this PR - but I will log another Tech Debt ticket to refactor this.
