### PR TITLE
Introduce 'new' status on MNO requests

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -5,7 +5,7 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
 
   def colour
     case @extra_mobile_data_request.status.to_sym
-    when :requested then 'blue'
+    when :new, :requested then 'blue'
     when :in_progress then 'yellow'
     when :complete then 'green'
     when :problem_incorrect_phone_number, :problem_no_match_for_number, :problem_no_match_for_account_name, :problem_not_eligible, :problem_no_longer_on_network then 'red'

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -17,12 +17,13 @@ private
 
   def mno_value
     description = [
-      "Requested: #{@school.extra_mobile_data_requests.requested.count}",
-      "In progress: #{@school.extra_mobile_data_requests.in_progress.count}",
+      "New: #{@school.extra_mobile_data_requests.new_status.count}",
+      "Requested: #{@school.extra_mobile_data_requests.requested_status.count}",
+      "In progress: #{@school.extra_mobile_data_requests.in_progress_status.count}",
       "With a problem: #{@school.extra_mobile_data_requests.in_a_problem_state.count}",
-      "Complete: #{@school.extra_mobile_data_requests.complete.count}",
-      "Cancelled: #{@school.extra_mobile_data_requests.cancelled.count}",
-      "Unavailable: #{@school.extra_mobile_data_requests.unavailable.count}",
+      "Complete: #{@school.extra_mobile_data_requests.complete_status.count}",
+      "Cancelled: #{@school.extra_mobile_data_requests.cancelled_status.count}",
+      "Unavailable: #{@school.extra_mobile_data_requests.unavailable_status.count}",
     ].join('<br>').html_safe
 
     govuk_details(summary: pluralize(@school.extra_mobile_data_requests.count, 'request'), description: description, classes: 'app-details-in-summary-list')

--- a/app/jobs/notify_mnos_job.rb
+++ b/app/jobs/notify_mnos_job.rb
@@ -3,7 +3,7 @@ class NotifyMnosJob < ApplicationJob
 
   def perform
     users.each do |user|
-      number_of_new_requests = user.mobile_network.extra_mobile_data_requests.requested.where('created_at > ?', since_last_email_for_user(user)).count
+      number_of_new_requests = user.mobile_network.extra_mobile_data_requests.requested_status.where('created_at > ?', since_last_email_for_user(user)).count + user.mobile_network.extra_mobile_data_requests.new_status.where('created_at > ?', since_last_email_for_user(user)).count
 
       if number_of_new_requests.positive?
         MnoMailer.notify_new_requests(user: user, number_of_new_requests: number_of_new_requests).deliver_now

--- a/app/services/extra_mobile_data_request_status_migration_service.rb
+++ b/app/services/extra_mobile_data_request_status_migration_service.rb
@@ -1,0 +1,9 @@
+class ExtraMobileDataRequestStatusMigrationService
+  def call
+    ExtraMobileDataRequest
+      .where(status: 'requested')
+      .find_each do |request|
+        request.update!(status: :new)
+      end
+  end
+end

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['requested'] || 0,
+                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['requested'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['new'] || 0),
                  label: 'new',
                  size: :reduced) %>
   </div>
@@ -74,7 +74,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['requested'] || 0,
+                 count: (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['requested'] || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['new'] || 0),
                  label: 'new',
                  size: :reduced) %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,10 @@ en:
           revoked: Revoked
       extra_mobile_data_request:
          status:
+           new:
+             tag_label: Requested
+             dropdown_label: Requested
+             description: Request not processed yet
            requested:
              tag_label: Requested
              dropdown_label: Requested

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -18,7 +18,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
       get :index
 
       expect(assigns(:statuses).map(&:value)).to contain_exactly(
-        'requested',
+        'new',
         'in_progress',
         'complete',
         'problem_no_longer_on_network',

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
 
     before do
       @requests = create_list(:extra_mobile_data_request, 5, status: 'requested', created_by_user: rb_user)
-      @requests.last.unavailable!
+      @requests.last.unavailable_status!
     end
 
     scenario 'the user can see their previous requests' do

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
 
     before do
       @requests = create_list(:extra_mobile_data_request, 5, status: 'requested', created_by_user: user, school: school)
-      @requests.last.unavailable!
+      @requests.last.unavailable_status!
     end
 
     scenario 'the user can navigate to their previous requests from the home page' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
         }.to change { ExtraMobileDataRequest.count }.by(1)
       end
 
-      it 'does not change the status from requested' do
+      it 'does not change the status from new' do
         request.save_and_notify_account_holder!
-        expect(request.requested?).to be true
+        expect(request.new_status?).to be true
       end
 
       it 'enqueues a job to message the account holder' do
@@ -200,7 +200,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
       it 'changes the status to unavailable' do
         request.save_and_notify_account_holder!
-        expect(request.unavailable?).to be true
+        expect(request.unavailable_status?).to be true
       end
 
       it 'enqueues a job to message the account holder' do

--- a/spec/services/extra_mobile_data_request_status_migration_service_spec.rb
+++ b/spec/services/extra_mobile_data_request_status_migration_service_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ExtraMobileDataRequestStatusMigrationService do
+  subject(:service) { described_class.new }
+
+  it 'maps any requested MNO requests to the new status' do
+    requested = create(:extra_mobile_data_request, status: :requested)
+
+    service.call
+
+    expect(requested.reload.new_status?).to be_truthy
+  end
+
+  it 'does not change the status of any MNO requests in non-requested status' do
+    request = create(:extra_mobile_data_request, status: :in_progress)
+
+    service.call
+
+    expect(request.reload.in_progress_status?).to be_truthy
+  end
+end


### PR DESCRIPTION
### Context

When a new MNO request is made, the designs call for showing its status as 'Requested' to school and RB users, and as 'New' to MNO users.

#1150 is introducing CSV upload functionality for MNO users and we want to use `new` as the status there. This is going to be easier if the underlying status is called `new`.

### Changes proposed in this pull request

Introduce a `new` status on MNO requests and make it the default.
Introduce a service class that can be run on production to migrate all `requested` statuses to `new`.

### Guidance to review

Once the data migration has been released and run on production, there will be a follow-up PR which will get rid of the `requested` status.