### PR TITLE
Tweak language used for choosing single/bulk request

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -642,8 +642,8 @@ en:
         number_eligible_with_hotspot_access: Number who can see a BT hotspot
     extra_mobile_data_requests:
       new:
-        manual_submission: Manually (entering details one at a time)
-        bulk_submission: Using a spreadsheet
+        manual_submission: One at a time, using a form
+        bulk_submission: Many at once, using a spreadsheet
         pay_monthly: 'Pay monthly'
         pay_as_you_go_payg: 'Pay as you go (PAYG)'
       create:

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     expect(page).to have_http_status(:ok)
     click_on 'New request'
     expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Manually (entering details one at a time)'
+    choose 'One at a time, using a form'
     click_on 'Continue'
     expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
   end
@@ -33,7 +33,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     expect(page).to have_http_status(:ok)
     click_on 'New request'
     expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Using a spreadsheet'
+    choose 'Many at once, using a spreadsheet'
     click_on 'Continue'
     expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
   end

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
       visit responsible_body_internet_mobile_extra_data_requests_path
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')
-      choose('Using a spreadsheet')
+      choose('Many at once, using a spreadsheet')
       click_on('Continue')
       expect(page).to have_text('Pick a spreadsheet file')
 

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
       click_on('Request extra data for mobile devices')
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')
-      choose('Manually (entering details one at a time)')
+      choose('One at a time, using a form')
       click_on('Continue')
       expect(page).to have_text('Who needs the extra mobile data?')
     end

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     expect(page).to have_http_status(:ok)
     click_on 'New request'
     expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Manually (entering details one at a time)'
+    choose 'One at a time, using a form'
     click_on 'Continue'
     expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
   end
@@ -29,7 +29,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     expect(page).to have_http_status(:ok)
     click_on 'New request'
     expect(page).to have_css('h1', text: 'How would you like to submit information?')
-    choose 'Using a spreadsheet'
+    choose 'Many at once, using a spreadsheet'
     click_on 'Continue'
     expect(page).to have_css('h1', text: 'Upload a spreadsheet of extra data requests')
   end


### PR DESCRIPTION
"Manually" might be putting off users from using the form – in research we saw someone using a spreadsheet with only 1 row.

Make the two options more consistent, and say "One at a time, using a form"

![Screen Shot 2021-01-20 at 16 39 22](https://user-images.githubusercontent.com/319055/105206681-8c026800-5b3e-11eb-8564-cdb1ae014de8.png)
