### PR TITLE
MNO design tweaks

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -1,6 +1,7 @@
 class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
-  def initialize(extra_mobile_data_request:)
+  def initialize(extra_mobile_data_request:, viewer: :school_or_mno_user)
     @extra_mobile_data_request = extra_mobile_data_request
+    @viewer = viewer
   end
 
   def colour
@@ -18,9 +19,16 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
   end
 
   def label
-    I18n.t!(
-      "#{@extra_mobile_data_request.status}.tag_label",
-      scope: %i[activerecord attributes extra_mobile_data_request status],
-    )
+    if @viewer == :school_or_mno_user && @extra_mobile_data_request.new_status?
+      # This override only happens for one status and it felt better to put
+      # the logic here rather than have separate `tag_status` values for MNO
+      # and school/RB users in en.yml
+      'Requested'
+    else
+      I18n.t!(
+        "#{@extra_mobile_data_request.status}.tag_label",
+        scope: %i[activerecord attributes extra_mobile_data_request status],
+      )
+    end
   end
 end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -63,7 +63,7 @@ private
 
   def mno_status_options
     ExtraMobileDataRequest
-      .statuses_available_to_mnos
+      .statuses_that_mno_users_can_assign
       .map do |status|
         OpenStruct.new(
           value: status,

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -36,8 +36,8 @@ class ExtraMobileDataRequest < ApplicationRecord
     statuses.keys.select { |k| k.start_with?('problem') }
   end
 
-  def self.statuses_available_to_mnos
-    statuses.keys - %w[cancelled unavailable]
+  def self.statuses_that_mno_users_can_assign
+    statuses.keys - %w[new cancelled unavailable]
   end
 
   enum contract_type: {

--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -16,7 +16,7 @@
     <%= l(extra_mobile_data_request.created_at, format: :short) %>
   </td>
   <td class="govuk-table__cell" class="request-status">
-    <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: extra_mobile_data_request) %>
+    <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: extra_mobile_data_request, viewer: :mno_user) %>
   </td>
   <td class="govuk-table__cell">
     <%- if extra_mobile_data_request.in_end_state? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -491,8 +491,8 @@ en:
       extra_mobile_data_request:
          status:
            new:
-             tag_label: Requested
-             dropdown_label: Requested
+             tag_label: New
+             dropdown_label: New
              description: Request not processed yet
            in_progress:
              tag_label: In progress

--- a/spec/components/extra_mobile_data_request_status_component_spec.rb
+++ b/spec/components/extra_mobile_data_request_status_component_spec.rb
@@ -3,20 +3,18 @@ require 'rails_helper'
 RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
   subject(:component) { described_class.new(extra_mobile_data_request: extra_mobile_data_request) }
 
+  let(:html) { render_inline(component).to_html }
+
   context 'for a request with a problem' do
     let(:extra_mobile_data_request) do
       create(:extra_mobile_data_request, status: :problem_incorrect_phone_number)
     end
 
     it 'is coloured red' do
-      html = render_inline(component).to_html
-
       expect(html).to include 'govuk-tag--red'
     end
 
     it 'shows the relevant label' do
-      html = render_inline(component).to_html
-
       expect(html).to include 'Invalid number'
     end
   end
@@ -27,15 +25,35 @@ RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
     end
 
     it 'is coloured green' do
-      html = render_inline(component).to_html
-
       expect(html).to include 'govuk-tag--green'
     end
 
     it 'shows the relevant label' do
-      html = render_inline(component).to_html
-
       expect(html).to include 'Complete'
+    end
+  end
+
+  context 'for a new request shown to a school or RB user' do
+    let(:extra_mobile_data_request) do
+      create(:extra_mobile_data_request, status: :new)
+    end
+
+    it 'shows a “Requested” label to school or RB users' do
+      expect(html).to include 'Requested'
+    end
+  end
+
+  context 'for a new request shown to an MNO user' do
+    subject(:component) do
+      described_class.new(extra_mobile_data_request: extra_mobile_data_request, viewer: :mno_user)
+    end
+
+    let(:extra_mobile_data_request) do
+      create(:extra_mobile_data_request, status: :new)
+    end
+
+    it 'shows a “New” label to school or RB users' do
+      expect(html).to include 'New'
     end
   end
 end

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -14,11 +14,10 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
   end
 
   describe 'GET index' do
-    it 'does not "cancelled" and "unavailable" as possible statuses to transition a request into' do
+    it 'only contains statuses that MNO users are allowed to transition a request into' do
       get :index
 
       expect(assigns(:statuses).map(&:value)).to contain_exactly(
-        'new',
         'in_progress',
         'complete',
         'problem_no_longer_on_network',


### PR DESCRIPTION
### Context

The MNO user interface is not in line with the designs.

### Changes proposed in this pull request

MNO users should see newly raised MNO requests as 'New'. School and RB users still see them as 'Requested'.
MNO users shouldn't have the 'New' status in the dropdown below their table of requests.

### Guidance to review

**What the MNO users see**

![image](https://user-images.githubusercontent.com/23801/105218636-52852900-5b4d-11eb-8050-a3de62710d77.png)

**What school/RB users see**

![image](https://user-images.githubusercontent.com/23801/105218734-6cbf0700-5b4d-11eb-8551-aec606433f4b.png)
