### PR TITLE
Validate MNO request uniqueness within the same school or RB

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -16,6 +16,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   validates :agrees_with_privacy_statement, inclusion: { in: [true] }
 
   validate :validate_school_or_rb_present
+  validate :validate_request_uniqueness, on: :create
 
   enum status: {
     new: 'new',
@@ -77,11 +78,13 @@ class ExtraMobileDataRequest < ApplicationRecord
     notification.deliver_later
   end
 
-  def has_already_been_made?
+  def has_already_been_made?(extra_conditions = {})
     self.class.exists?(
-      account_holder_name: account_holder_name,
-      device_phone_number: device_phone_number,
-      mobile_network_id: mobile_network_id,
+      {
+        account_holder_name: account_holder_name,
+        device_phone_number: device_phone_number,
+        mobile_network_id: mobile_network_id,
+      }.merge(extra_conditions),
     )
   end
 
@@ -100,6 +103,11 @@ private
       errors.add(:school, 'school or responsible body must be present')
       errors.add(:responsible_body, 'school or responsible body must be present')
     end
+  end
+
+  def validate_request_uniqueness
+    scope = school_id.present? ? { school_id: school_id } : { responsible_body_id: responsible_body_id }
+    errors.add(:device_phone_number, 'duplicate request already made') if has_already_been_made?(scope)
   end
 
   def update_status_from_mobile_network_participation

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -107,7 +107,7 @@ private
 
   def validate_request_uniqueness
     scope = school_id.present? ? { school_id: school_id } : { responsible_body_id: responsible_body_id }
-    errors.add(:device_phone_number, 'duplicate request already made') if has_already_been_made?(scope)
+    errors.add(:device_phone_number, :duplicate) if has_already_been_made?(scope)
   end
 
   def update_status_from_mobile_network_participation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -576,7 +576,7 @@ en:
             device_phone_number:
               blank: Enter a UK mobile number, like 07700 900999
               invalid: Enter a UK mobile number, like 07700 900999
-              duplicate: A request for this number has already been made
+              duplicate: A request with these details has already been made
             contract_type:
               blank: Select whether the contract is pay monthly or pay as you go (PAYG)
             agrees_with_privacy_statement:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -576,6 +576,7 @@ en:
             device_phone_number:
               blank: Enter a UK mobile number, like 07700 900999
               invalid: Enter a UK mobile number, like 07700 900999
+              duplicate: A request for this number has already been made
             contract_type:
               blank: Select whether the contract is pay monthly or pay as you go (PAYG)
             agrees_with_privacy_statement:

--- a/spec/factories/extra_mobile_data_requests.rb
+++ b/spec/factories/extra_mobile_data_requests.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :extra_mobile_data_request, class: 'ExtraMobileDataRequest' do
     account_holder_name               { Faker::Name.name }
-    device_phone_number               { '07123 456789' }
+    device_phone_number               { Faker::Base.numerify('07891 ######') }
     agrees_with_privacy_statement     { true }
     status                            { :new }
     contract_type                     { :pay_as_you_go_payg }

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
         model.mobile_network_id = existing_request.mobile_network_id
         model.valid?
-        expect(model.errors[:device_phone_number]).to include 'A request for this number has already been made'
+        expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
         model.mobile_network_id = existing_request.mobile_network_id
         model.valid?
-        expect(model.errors[:device_phone_number]).to include 'A request for this number has already been made'
+        expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
       end
     end
   end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
         model.mobile_network_id = existing_request.mobile_network_id
         model.valid?
-        expect(model.errors[:device_phone_number]).to include 'duplicate request already made'
+        expect(model.errors[:device_phone_number]).to include 'A request for this number has already been made'
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
         model.mobile_network_id = existing_request.mobile_network_id
         model.valid?
-        expect(model.errors[:device_phone_number]).to include 'duplicate request already made'
+        expect(model.errors[:device_phone_number]).to include 'A request for this number has already been made'
       end
     end
   end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -74,6 +74,61 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
   end
 
+  describe 'validate request uniqueness' do
+    let(:school) { create(:school) }
+    let(:rb) { create(:trust) }
+
+    context 'when rb present' do
+      let(:existing_request) do
+        create(:extra_mobile_data_request, account_holder_name: 'Person', device_phone_number: '07123456788', responsible_body: rb)
+      end
+
+      subject(:model) { build(:extra_mobile_data_request, school: nil, responsible_body: existing_request.responsible_body) }
+
+      it 'is invalid' do
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.account_holder_name = 'Person'
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.device_phone_number = '07123456788'
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.mobile_network_id = existing_request.mobile_network_id
+        model.valid?
+        expect(model.errors[:device_phone_number]).to include 'duplicate request already made'
+      end
+    end
+
+    context 'when school present' do
+      let(:existing_request) do
+        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456789', school: school)
+      end
+
+      subject(:model) { build(:extra_mobile_data_request, school: existing_request.school, responsible_body: nil) }
+
+      it 'is invalid' do
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.account_holder_name = 'Person 2'
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.device_phone_number = '07123456789'
+        model.valid?
+        expect(model.errors[:device_phone_number]).to be_blank
+
+        model.mobile_network_id = existing_request.mobile_network_id
+        model.valid?
+        expect(model.errors[:device_phone_number]).to include 'duplicate request already made'
+      end
+    end
+  end
+
   describe 'validating device_phone_number' do
     it { is_expected.to validate_presence_of(:device_phone_number) }
 


### PR DESCRIPTION
### Context

Card: https://trello.com/c/ZHeihTzs/1353-mnos-receiving-duplicate-requests

We were allowing duplicate requests via the manual entry method. This PR adds a validation to check whether a request is unique within the school or RB in which it is created.
