### PR TITLE
Use consistent who_will_order values

### DIFF
--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -10,7 +10,7 @@ class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::
   def update
     @form = ResponsibleBody::Devices::WhoWillOrderForm.new(who_will_order_params)
     if @form.valid?
-      @school.preorder_information.change_who_will_order_devices!(@form.who_will_order.singularize)
+      @school.preorder_information.change_who_will_order_devices!(@form.who_will_order)
 
       flash[:success] = I18n.t(:success, scope: %i[responsible_body devices who_will_order update])
       redirect_to responsible_body_devices_school_path(@school.urn)
@@ -29,8 +29,7 @@ private
   end
 
   def who_will_order
-    who = @school.preorder_information.who_will_order_devices
-    who == 'school' ? 'schools' : who
+    @school.preorder_information.who_will_order_devices
   end
 
   def who_will_order_params(opts = params)

--- a/app/form_objects/responsible_body/devices/who_will_order_form.rb
+++ b/app/form_objects/responsible_body/devices/who_will_order_form.rb
@@ -3,5 +3,5 @@ class ResponsibleBody::Devices::WhoWillOrderForm
 
   attr_accessor :who_will_order
 
-  validates :who_will_order, inclusion: %w[responsible_body schools]
+  validates :who_will_order, inclusion: %w[responsible_body school]
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -91,7 +91,7 @@ module ViewHelper
   def who_will_order_devices_options(show_recommendation: true)
     [
       OpenStruct.new(
-        id: 'schools',
+        id: 'school',
         label: "Most schools and colleges will place their own orders#{' (recommended)' if show_recommendation}",
         description: 'We’ll need contact details for each school or college',
       ),
@@ -107,8 +107,8 @@ module ViewHelper
     scope = 'page_titles.change_who_will_order_edit'
     [
       OpenStruct.new(
-        id: 'schools',
-        label: t('schools', scope: scope),
+        id: 'school',
+        label: t('school', scope: scope),
       ),
       OpenStruct.new(
         id: 'responsible_body',

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -79,7 +79,7 @@ class ResponsibleBody < ApplicationRecord
     update!(who_will_order_devices: who_will_order)
     schools.each do |school|
       school.preorder_information&.destroy!
-      school.create_preorder_information!(who_will_order_devices: who_will_order.singularize)
+      school.create_preorder_information!(who_will_order_devices: who_will_order)
     end
   end
 

--- a/app/models/who_will_order_event.rb
+++ b/app/models/who_will_order_event.rb
@@ -18,6 +18,6 @@ private
   end
 
   def schools_will_order?
-    @params[:responsible_body].who_will_order_devices == 'schools'
+    @params[:responsible_body].who_will_order_devices == 'school'
   end
 end

--- a/app/services/onboard_single_school_responsible_body_service.rb
+++ b/app/services/onboard_single_school_responsible_body_service.rb
@@ -81,7 +81,7 @@ private
   end
 
   def devolve_ordering_to_the_school
-    responsible_body.update_who_will_order_devices('schools')
+    responsible_body.update_who_will_order_devices('school')
   end
 
   def single_school_responsible_body?

--- a/app/services/school_to_sat_converter.rb
+++ b/app/services/school_to_sat_converter.rb
@@ -21,7 +21,7 @@ private
     Trust.create!(name: name,
                   companies_house_number: companies_house_number,
                   organisation_type: 'single_academy_trust',
-                  who_will_order_devices: 'schools',
+                  who_will_order_devices: 'school',
                   address_1: school.address_1,
                   address_2: school.address_2,
                   address_3: school.address_3,

--- a/app/views/responsible_body/devices/who_will_order/show.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/show.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%- if @responsible_body.who_will_order_devices == 'schools' %>
+    <%- if @responsible_body.who_will_order_devices == 'school' %>
       <p class="govuk-body">If a school or college cannot order its own devices, you can change this setting on an individual basis.</p>
 
       <h2 class="govuk-heading-m">What you need to do now</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,12 +105,12 @@ en:
       multi_domain_chromebooks: Responsible bodies managing multiple Chromebook domains
     who_will_order: Who will place orders for laptops and tablets?
     who_will_order_show:
-      schools: Each school or college will place their own orders
+      school: Each school or college will place their own orders
       responsible_body: Orders will be placed centrally
     request_a_change: Contact our support team to request this change
     change_who_will_order: Who will place orders for laptops and tablets?
     change_who_will_order_edit:
-      schools: The school will place their own orders
+      school: The school will place their own orders
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
     national_lockdown_school_cannot_order_yet: Your school cannot order devices yet

--- a/db/migrate/20210121111312_change_responsible_body_who_can_order.rb
+++ b/db/migrate/20210121111312_change_responsible_body_who_can_order.rb
@@ -1,0 +1,5 @@
+class ChangeResponsibleBodyWhoCanOrder < ActiveRecord::Migration[6.0]
+  def change
+    ResponsibleBody.where(who_will_order_devices: 'schools').update_all(who_will_order_devices: 'school')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_19_173825) do
+ActiveRecord::Schema.define(version: 2021_01_21_111312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     trait :devolves_management do
-      who_will_order_devices      { 'schools' }
+      who_will_order_devices      { 'school' }
     end
 
     trait :vcap_feature_flag do

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -279,7 +279,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def given_the_responsible_body_has_decided_to_order_centrally
-    responsible_body.update!(who_will_order_devices: 'schools')
+    responsible_body.update!(who_will_order_devices: 'school')
     responsible_body.schools.each do |school|
       school.create_preorder_information!(who_will_order_devices: 'school')
     end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe PreorderInformation, type: :model do
       let(:user) { create(:user) }
 
       before do
-        trust.update!(who_will_order_devices: 'schools')
+        trust.update!(who_will_order_devices: 'school')
         preorder_info.update!(who_will_order_devices: 'school', will_need_chromebooks: nil)
         preorder_info.refresh_status!
       end

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
     end
 
     it 'marks the responsible body as having devolved ordering to schools' do
-      expect(responsible_body.who_will_order_devices).to eq('schools')
+      expect(responsible_body.who_will_order_devices).to eq('school')
     end
 
     it 'sets one of the users as a school contact' do
@@ -120,7 +120,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
     end
 
     it 'marks the responsible body as having devolved ordering to schools' do
-      expect(responsible_body.who_will_order_devices).to eq('schools')
+      expect(responsible_body.who_will_order_devices).to eq('school')
     end
 
     it 'sets the headteacher as a school contact' do

--- a/spec/services/school_to_sat_converter_spec.rb
+++ b/spec/services/school_to_sat_converter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SchoolToSatConverter, type: :model do
       expect(trust.name).to eq(school.name)
       expect(trust.companies_house_number).to be_blank
       expect(trust.organisation_type).to eq('single_academy_trust')
-      expect(trust.who_will_order_devices).to eq('schools')
+      expect(trust.who_will_order_devices).to eq('school')
       expect(trust.address_1).to eq(school.address_1)
       expect(trust.address_2).to eq(school.address_2)
       expect(trust.address_3).to eq(school.address_3)
@@ -36,7 +36,7 @@ RSpec.describe SchoolToSatConverter, type: :model do
       expect(trust.name).to eq(trust_name)
       expect(trust.companies_house_number).to be_blank
       expect(trust.organisation_type).to eq('single_academy_trust')
-      expect(trust.who_will_order_devices).to eq('schools')
+      expect(trust.who_will_order_devices).to eq('school')
       school.reload
       expect(school.preorder_information.who_will_order_devices).to eq('school')
       expect(school.std_device_allocation.allocation).to eq(0)
@@ -57,7 +57,7 @@ RSpec.describe SchoolToSatConverter, type: :model do
       expect(trust.name).to eq(trust_name)
       expect(trust.companies_house_number).to eq(companies_house_number)
       expect(trust.organisation_type).to eq('single_academy_trust')
-      expect(trust.who_will_order_devices).to eq('schools')
+      expect(trust.who_will_order_devices).to eq('school')
       school.reload
       expect(school.preorder_information.who_will_order_devices).to eq('school')
       expect(school.std_device_allocation.allocation).to eq(0)


### PR DESCRIPTION
### Context

We have a mix of `schools` on RB and `school` on PreorderInformation. This brings both inline to be the singular `schools`.

Unfortunately we currently have a mix on production:

```
ResponsibleBody.group(:who_will_order_devices).count
=> {"school"=>433, nil=>2, "schools"=>2607, "responsible_body"=>616}
```

### Changes proposed in this pull request

### Guidance to review

