### PR TITLE
force retry of fake phone no. generation on failure

### DIFF
--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -1,20 +1,38 @@
 class FakeDataService
   def self.generate!(extra_mobile_data_requests: 10, mobile_network_id:, responsible_body_id:, created_by_user_id: nil)
     extra_mobile_data_requests.times do
-      name = Faker::Name.name
-      responsible_body = ResponsibleBody.find(responsible_body_id)
-      r = ExtraMobileDataRequest.create!(
-        device_phone_number: Faker::PhoneNumber.cell_phone,
-        account_holder_name: name,
-        agrees_with_privacy_statement: true,
-        mobile_network_id: mobile_network_id,
-        contract_type: ExtraMobileDataRequest.contract_types.values.sample,
-        status: ExtraMobileDataRequest.statuses.values.sample,
-        responsible_body: responsible_body,
-        created_by_user_id: created_by_user_id || responsible_body.users.sample&.id,
-      )
+      r = build_request(mobile_network_id: mobile_network_id, responsible_body_id: responsible_body_id, created_by_user_id: created_by_user_id)
+      r.save!
       r.update!(created_at: Time.zone.now.utc - rand(500_000).seconds)
       Rails.logger.info "created #{r.id} - #{r.account_holder_name}"
+    end
+  end
+
+  def self.build_request(mobile_network_id:, responsible_body_id:, created_by_user_id: nil)
+    r = ExtraMobileDataRequest.new(
+      account_holder_name: Faker::Name.name,
+      device_phone_number: Faker::PhoneNumber.cell_phone,
+      agrees_with_privacy_statement: true,
+      mobile_network_id: mobile_network_id,
+      contract_type: ExtraMobileDataRequest.contract_types.values.sample,
+      status: ExtraMobileDataRequest.statuses.values.sample,
+      responsible_body_id: responsible_body_id,
+      created_by_user_id: created_by_user_id || User.where(responsible_body_id: responsible_body_id).pluck(:id).sample,
+    )
+    # Very occasionally we get build failures on CI due to an invalid phone number -
+    # they go away on subsequent runs. So if that happens, retry up to 100 times
+    if !r.valid? && r.errors[:device_phone_number].present?
+      generate_valid_phone_number(r)
+    end
+    r
+  end
+
+  def self.generate_valid_phone_number(extra_mobile_data_request)
+    i = 0
+    while !extra_mobile_data_request.valid? && extra_mobile_data_request.errors[:device_phone_number].present?
+      extra_mobile_data_request.device_phone_number = Faker::PhoneNumber.cell_phone
+      i += 1
+      raise(ArgumentError, "Could not generate valid device_phone_number after 100 attempts #{r.device_phone_number}") if i > 100
     end
   end
 end


### PR DESCRIPTION
### Context

[Trello card 1358 - intermittent spec failure on invalid phone number](https://trello.com/c/jTAKotqZ/1358-fix-intermittent-spec-failure-due-to-mobile-phone-number-format) - we very occasionally get a build failure on CI due to Faker generating a mobile phone number that fails validation by phonelib. These errors usually go away after no more than a couple of retries, but they are annoying and a waste of time when they occur.

### Changes proposed in this pull request

Detect when this happens, and retry up to 100 times within the `FakeDataService`

### Guidance to review

