### PR TITLE
FE college users should have the same view as SAT users

### DIFF
--- a/app/components/school/school_breadcrumbs_component.rb
+++ b/app/components/school/school_breadcrumbs_component.rb
@@ -16,7 +16,7 @@ class School::SchoolBreadcrumbsComponent < ViewComponent::Base
   end
 
   def scope
-    if user.responsible_body.present? && !user.is_a_single_academy_trust_user?
+    if user.responsible_body.present? && !user.is_a_single_school_user?
       responsible_body_and_school_scope
     elsif user.has_multiple_schools?
       multiple_schools_scope

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,7 +99,7 @@ private
 
   def root_url_for_responsible_body(user)
     if user.is_school_user?
-      if user.is_a_single_academy_trust_user?
+      if user.is_a_single_school_user?
         school_root_url_for(user)
       else
         schools_path

--- a/app/controllers/responsible_body/base_controller.rb
+++ b/app/controllers/responsible_body/base_controller.rb
@@ -11,7 +11,7 @@ private
   end
 
   def deny_single_academy_trust_user!
-    render 'errors/forbidden', status: :forbidden if @current_user.is_a_single_academy_trust_user?
+    render 'errors/forbidden', status: :forbidden if @current_user.is_a_single_school_user?
   end
 
   def require_rb_user!

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,7 +4,7 @@ class SchoolsController < ApplicationController
   def index
     @schools = @current_user.schools
     if @current_user.schools.size == 1 && \
-        (@current_user.is_a_single_academy_trust_user? || !@current_user.is_responsible_body_user?)
+        (@current_user.is_a_single_school_user? || !@current_user.is_responsible_body_user?)
       redirect_to home_school_path(@current_user.schools.first)
     end
   end

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -38,7 +38,7 @@ private
   def change_needed?
     @user&.id.present? && \
       (is_addition? || is_removal? || (is_change? && computacenter_fields_have_changed?)) && \
-      (!user_has_a_school_but_no_ship_to? || user.is_a_single_academy_trust_user?)
+      (!user_has_a_school_but_no_ship_to? || user.is_a_single_school_user?)
   end
 
   def user_has_a_school_but_no_ship_to?
@@ -76,14 +76,14 @@ private
       responsible_body_urn: user.effective_responsible_bodies.map(&:computacenter_identifier).join('|'),
       cc_sold_to_number: user.effective_responsible_bodies.map(&:computacenter_reference).join('|'),
       # NOTE: we must loop round user_schools (which may be dirty) not schools (which won't be)
-      school: (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.name }.join('|')),
-      school_urn: (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.urn }.join('|')),
+      school: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.name }.join('|')),
+      school_urn: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.urn }.join('|')),
       cc_ship_to_number: cc_ship_to_number_list,
     }
   end
 
   def cc_ship_to_number_list
-    (user.is_a_single_academy_trust_user? ? '' : user.user_schools.map { |us| us.school.computacenter_reference }.join('|'))
+    (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.computacenter_reference }.join('|'))
   end
 
   def meta_attributes

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -68,6 +68,10 @@ class ResponsibleBody < ApplicationRecord
     type == 'LocalAuthority'
   end
 
+  def is_a_further_education_college?
+    type == 'FurtherEducationCollege'
+  end
+
   def next_school_sorted_ascending_by_name(school)
     schools
       .where('name > ?', school.name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,8 +162,8 @@ class User < ApplicationRecord
     orders_devices? && techsource_account_confirmed?
   end
 
-  def is_a_single_academy_trust_user?
-    user_schools.size == 1 && responsible_body&.is_a_single_academy_trust? && school.responsible_body_id == responsible_body.id
+  def is_a_single_school_user?
+    user_schools.size == 1 && (responsible_body&.is_a_single_academy_trust? || responsible_body&.is_a_further_education_college?) && school.responsible_body_id == responsible_body.id
   end
 
   # Wrapper methods to ease the transition from 'user belongs_to school',

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -32,7 +32,7 @@ class InterstitialPicker
 private
 
   def title_for_default
-    i18n_key = user.is_school_user? || (user.is_responsible_body_user? && !user.is_a_single_academy_trust_user?) ? :related_organisation : :standard
+    i18n_key = user.is_school_user? || (user.is_responsible_body_user? && !user.is_a_single_school_user?) ? :related_organisation : :standard
     I18n.t(i18n_key, scope: %i[page_titles click_to_sign_in], organisation: user.organisation_name)
   end
 end

--- a/spec/controllers/responsible_body/base_controller_spec.rb
+++ b/spec/controllers/responsible_body/base_controller_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe ResponsibleBody::BaseController do
       expect(response).to be_forbidden
     end
   end
+
+  context 'when user is a fe college user' do
+    let(:user) { create(:fe_college_user) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'returns forbidden' do
+      get :index
+      expect(response).to be_forbidden
+    end
+  end
 end

--- a/spec/controllers/sign_in_tokens_controller_spec.rb
+++ b/spec/controllers/sign_in_tokens_controller_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe SignInTokensController, type: :controller do
         end
       end
     end
+
+    context 'when FE college user is associated with RB and school' do
+      let(:trust) { create(:further_education_college) }
+      let(:school) { create(:fe_school, responsible_body: trust) }
+      let(:user) do
+        create(:fe_college_user,
+               :who_has_requested_a_magic_link,
+               orders_devices: true,
+               responsible_body: trust,
+               school: school)
+      end
+
+      it 'redirects them to the school journey' do
+        delete :destroy, params: valid_token_params
+        expect(response).to redirect_to(home_school_path(school))
+      end
+
+      context 'when they have not accepted privacy policies' do
+        let(:user) do
+          create(:fe_college_user,
+                 :who_has_requested_a_magic_link,
+                 orders_devices: true,
+                 privacy_notice_seen_at: nil,
+                 school: school)
+        end
+
+        it 'redirects them to the privacy policy' do
+          delete :destroy, params: valid_token_params
+          expect(response).to redirect_to(privacy_notice_path)
+        end
+      end
+    end
   end
 
   describe 'GET #validate' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,6 +47,12 @@ FactoryBot.define do
       orders_devices { true }
     end
 
+    factory :fe_college_user do
+      association :responsible_body, factory: %i[further_education_college in_connectivity_pilot]
+      school { build(:fe_school, responsible_body: responsible_body) }
+      orders_devices { true }
+    end
+
     factory :school_user do
       transient do
         school { build(:school) }

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
   let(:local_authority_school) { create(:school, :la_maintained, responsible_body: user.responsible_body) }
   let(:single_academy_trust) { create(:school, :single_academy_trust) }
   let(:single_academy_trust_user) { create(:user, :single_academy_trust_user) }
+  let(:fe_college_user) { create(:user, :fe_college_user) }
+
   let(:token) { user.generate_token! }
   let(:identifier) { user.sign_in_identifier(token) }
   let(:validate_token_url) { validate_sign_in_token_url(token: token, identifier: identifier) }
@@ -194,6 +196,19 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
 
   context 'as a single_academy_trust user' do
     let(:user) { create(:single_academy_trust_user, :has_not_seen_privacy_notice) }
+
+    scenario 'logging in for the first time' do
+      visit validate_token_url_for(user)
+      expect(page).to have_text("You’re signed in as #{user.school.name}")
+      click_on 'Continue'
+      expect(page).to have_text('Before you continue, please read the privacy notice.')
+      click_on 'Continue'
+      expect(page).to have_text('You’ve been allocated 0 laptops and tablets')
+    end
+  end
+
+  context 'as a fe college user' do
+    let(:user) { create(:fe_college_user, :has_not_seen_privacy_notice) }
 
     scenario 'logging in for the first time' do
       visit validate_token_url_for(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'is_a_single_academy_trust_user?' do
+  describe 'is_a_single_school_user?' do
     context 'when the user has a responsible_body that is a single_academy_trust, but the user has no schools' do
       let(:user) { create(:single_academy_trust_user, schools: []) }
 
       it 'is false' do
-        expect(user.is_a_single_academy_trust_user?).to be_falsey
+        expect(user.is_a_single_school_user?).to be_falsey
       end
     end
 
@@ -69,7 +69,15 @@ RSpec.describe User, type: :model do
         let(:responsible_body) { create(:trust, :single_academy_trust) }
 
         it 'is true' do
-          expect(user.is_a_single_academy_trust_user?).to be_truthy
+          expect(user.is_a_single_school_user?).to be_truthy
+        end
+      end
+
+      context 'and the responsible_body is a FE academy college' do
+        let(:responsible_body) { create(:further_education_college) }
+
+        it 'is true' do
+          expect(user.is_a_single_school_user?).to be_truthy
         end
       end
 
@@ -77,7 +85,7 @@ RSpec.describe User, type: :model do
         let(:responsible_body) { create(:trust, :multi_academy_trust) }
 
         it 'is false' do
-          expect(user.is_a_single_academy_trust_user?).to be_falsey
+          expect(user.is_a_single_school_user?).to be_falsey
         end
       end
 
@@ -85,7 +93,7 @@ RSpec.describe User, type: :model do
         let(:responsible_body) { create(:local_authority) }
 
         it 'is false' do
-          expect(user.is_a_single_academy_trust_user?).to be_falsey
+          expect(user.is_a_single_school_user?).to be_falsey
         end
       end
     end

--- a/spec/services/onboard_single_school_responsible_body_service_spec.rb
+++ b/spec/services/onboard_single_school_responsible_body_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
 
     it 'adds all the RB users as school users' do
       User.all.each do |user|
-        expect(user.is_a_single_academy_trust_user?).to be_truthy
+        expect(user.is_a_single_school_user?).to be_truthy
         expect(user.school).to eq(school)
         expect(user.responsible_body).to eq(responsible_body)
       end
@@ -137,7 +137,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
     it 'adds the headteacher as a single_academy_trust user who can order' do
       user = User.find_by!(email_address: @headteacher.email_address)
 
-      expect(user.is_a_single_academy_trust_user?).to be_truthy
+      expect(user.is_a_single_school_user?).to be_truthy
       expect(user.school).to eq(school)
       expect(user.responsible_body).to eq(responsible_body)
     end
@@ -157,7 +157,7 @@ RSpec.describe OnboardSingleSchoolResponsibleBodyService, type: :model do
     it 'adds the headteacher as a single_academy_trust user who can order under their lowercase email' do
       user = User.find_by!(email_address: 'jsmith@school.sch.uk')
 
-      expect(user.is_a_single_academy_trust_user?).to be_truthy
+      expect(user.is_a_single_school_user?).to be_truthy
       expect(user.school).to eq(school)
       expect(user.responsible_body).to eq(responsible_body)
     end


### PR DESCRIPTION
### Context

We have some code that narrows the views RB users have only a singular view of its school. We need to do the same thing for FE institutions so they see one school vs an index of schools.

### Changes proposed in this pull request

- Update and rename `User#is_a_single_academy_trust_user?` to accommodate FE users so that they don't see the schools index view like normal RB users.

### Guidance to review

1. Log in as FE college user
2. See no list of schools, essentially looks as if you're a school user.
