### PR TITLE
Introduce an 'other problem' status for MNO requests

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -9,7 +9,7 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
     when :new then 'blue'
     when :in_progress then 'yellow'
     when :complete then 'green'
-    when :problem_incorrect_phone_number, :problem_no_match_for_number, :problem_no_match_for_account_name, :problem_not_eligible, :problem_no_longer_on_network then 'red'
+    when :problem_incorrect_phone_number, :problem_no_match_for_number, :problem_no_match_for_account_name, :problem_not_eligible, :problem_no_longer_on_network, :problem_other then 'red'
     when :cancelled, :unavailable then 'grey'
     end
   end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -20,7 +20,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
 
   def report_problem
     load_extra_mobile_data_request(params[:extra_mobile_data_request_id])
-    @options = problem_options
+    @specific_options, @other_option = problem_options
   end
 
   def update
@@ -28,7 +28,7 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
     @extra_mobile_data_request.update!(extra_mobile_data_request_params)
     redirect_to mno_extra_mobile_data_requests_path
   rescue ActiveModel::ValidationError, ActionController::ParameterMissing
-    @options = problem_options
+    @specific_options, @other_option = problem_options
     render :report_problem, status: :unprocessable_entity
   end
 
@@ -53,12 +53,15 @@ private
   def problem_options
     ExtraMobileDataRequest
       .problem_statuses
-      .map do |status|
-        OpenStruct.new(
-          value: status,
-          label: I18n.t!("#{status}.description", scope: %i[activerecord attributes extra_mobile_data_request status]),
-        )
-      end
+      .map { |status| option_for(status) }
+      .partition { |option| option.value != 'problem_other' }
+  end
+
+  def option_for(status)
+    OpenStruct.new(
+      value: status,
+      label: I18n.t!("#{status}.description", scope: %i[activerecord attributes extra_mobile_data_request status]),
+    )
   end
 
   def mno_status_options

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -28,6 +28,7 @@ class ExtraMobileDataRequest < ApplicationRecord
     problem_incorrect_phone_number: 'problem_incorrect_phone_number',
     problem_no_match_for_account_name: 'problem_no_match_for_account_name',
     problem_no_longer_on_network: 'problem_no_longer_on_network',
+    problem_other: 'problem_other',
   }, _suffix: true
 
   scope :in_a_problem_state, -> { where('status like ?', 'problem%') }

--- a/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
@@ -12,11 +12,15 @@
     <%= form_for @extra_mobile_data_request, url: mno_extra_mobile_data_request_path(@extra_mobile_data_request) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_radio_buttons :status,
-      @options,
-      :value,
-      :label %>
-
+      <%= f.govuk_radio_buttons_fieldset :status, legend: nil do %>
+        <% @specific_options.each do |option| %>
+          <%= f.govuk_radio_button :status, option.value, label: { text: option.label }, link_errors: true %>
+        <% end %>
+        <%= f.govuk_radio_divider %>
+        <% @other_option.each do |option| %>
+          <%= f.govuk_radio_button :status, option.value, label: { text: option.label }, link_errors: true %>
+        <% end %>
+      <% end %>
       <%= f.govuk_submit 'Report problem' %>
     <%- end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -532,6 +532,10 @@ en:
              tag_label: Not on network
              dropdown_label: Problem – Not on network
              description: This account is no longer on our network
+           problem_other:
+             tag_label: Other problem
+             dropdown_label: Problem – Other
+             description: Another reason
       mobile_network:
         participation_in_pilots:
           participating: 'Offers data now'

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -25,6 +25,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
         'problem_no_match_for_account_name',
         'problem_no_match_for_number',
         'problem_not_eligible',
+        'problem_other',
       )
     end
   end


### PR DESCRIPTION
### Context

The implementation is missing the 'Another reason' problem status for MNO requests (see [prototype](https://ghwt-prototype.herokuapp.com/mno/report-a-problem)).

### Changes proposed in this pull request

Add the new status and wire it in the appropriate places.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/105365206-e9a5bb80-5bf5-11eb-935d-3f1ed68189fd.png)

![image](https://user-images.githubusercontent.com/23801/105365284-fe824f00-5bf5-11eb-8a5f-5e5ee37ee518.png)

![image](https://user-images.githubusercontent.com/23801/105365312-06da8a00-5bf6-11eb-81d1-0543d40ebba9.png)
