### PR TITLE
[1379] Only hide 'Devices ordered' on a school if the school is actually in a virtual cap pool

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -92,7 +92,7 @@ private
   end
 
   def display_devices_ordered_row?
-    !@school.responsible_body.has_virtual_cap_feature_flags? && @school.std_device_allocation&.devices_ordered.to_i.positive?
+    !@school.in_virtual_cap_pool? && @school.std_device_allocation&.devices_ordered.to_i.positive?
   end
 
   def display_router_allocation_row?

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -169,14 +169,30 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       end
     end
 
-    context 'when devices orders' do
+    context 'when devices_ordered > 0' do
       before do
         alloc = school.build_std_device_allocation(devices_ordered: 3, cap: 100, allocation: 100)
         alloc.save!
       end
 
-      it 'shows devices ordered row with count' do
-        expect(value_for_row(result, 'Devices ordered').text).to include('3 devices')
+      context 'when the school is not in a virtual_cap_pool' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(false)
+        end
+
+        it 'shows devices ordered row with count' do
+          expect(value_for_row(result, 'Devices ordered').text).to include('3 devices')
+        end
+      end
+
+      context 'when the school is in a virtual_cap_pool' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(true)
+        end
+
+        it 'does not show devices ordered row' do
+          expect(result.text).not_to include('Devices ordered')
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

[Trello card 1379](https://trello.com/c/DAEmCZ19/1379-only-hide-devices-ordered-on-a-school-if-the-school-is-actually-in-a-virtual-cap-pool) - In support/school/(urn), we're not showing the 'Devices ordered' row for a school if it belongs to an RB which has the virtual cap feature flags set - even if the school itself is not actually in a virtual cap pool.

This ticket came about as a result of investigating the support ticket [Ordered figure not showing at school level](https://get-help-with-tech-education.zendesk.com/agent/tickets/36094) in [Trello card 1374](https://trello.com/c/QxhXUEpk/1374-support-batch-tickets)

### Changes proposed in this pull request

Change the criteria so that we only hide 'Devices ordered' if the specific school is actually in a virtual cap

### Guidance to review

