### PR TITLE
[1383] rename the gov.uk paas organisation to dfe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_NAME=get-help-with-tech
 REMOTE_DOCKER_IMAGE_NAME=dfedigital/get-help-with-tech
-PAAS_ORGANISATION=dfe-teacher-services
+PAAS_ORGANISATION=dfe
 PAAS_SPACE=get-help-with-tech
 
 .PHONY: dev staging prod


### PR DESCRIPTION
### Context

[Trello card 1383](https://trello.com/c/MBZltdey/1383-rename-govuk-paas-org-dfe-teacher-services-dfe) On Monday 25th, around 3pm, the two Organisations in GOV.UK PaaS which are currently-named 'dfe-digital' and 'dfe-teacher-services' will merge into a single organisation called 'dfe'

We will need to change 'dfe-teacher-services' to 'dfe' in our release pipeline

### Changes proposed in this pull request

Change the PaaS organisation name

### Guidance to review

DO NOT MERGE THIS until we are given the heads-up on Monday that the change has happened (or releases stop working :) )