### PR TITLE
removes feature flag as content applies to all education settings

### DIFF
--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -9,7 +9,6 @@
         <%= title %>
       </h1>
 
-      <% if @school.increased_sixth_form_feature_flag? || @school.increased_fe_feature_flag? %>
         <p class="govuk-body">Your allocation of <%= @allocation %> is based on an estimate of the number of devices your school, college or <span class="app-no-wrap">further education provider</span> already has and the number of:</p>
 
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
@@ -18,17 +17,6 @@
           <li>students in 16 to 19 further education</li>
           <li>students who get free meals in further education</li>
         </ul>
-      <% else %>
-        <p class="govuk-body">Your allocation of <%= @allocation %> is based on:</p>
-
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-          <li>the number of children in years 3 to 11</li>
-          <li>free school meals data</li>
-          <li>an estimate of the number of devices your school already has</li>
-        </ul>
-
-        <p class="govuk-body">This allocation could change. If there are widespread school closures, we might reduce it.</p>
-      <% end %>
 
       <p class="govuk-body govuk-!-margin-bottom-6">
         <%= govuk_link_to 'Read more about allocations', devices_allocation_and_specification_path, target: '_blank' %>


### PR DESCRIPTION
### Context

We've added FE and had a feature flag for some participants in user research on the content of this page.

### Changes proposed in this pull request

Removes feature flag that confuses users when they see allocation description that doesn't apply.

### Guidance to review

