### PR TITLE
fix version-lock on node/yarn/alpine-3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine3.12
+FROM ruby:2.7.2-alpine3.13
 
 ARG APPNAME=get-help-with-tech
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine3.13
+FROM ruby:2.7.2-alpine
 
 ARG APPNAME=get-help-with-tech
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   },
   "dependencies": {
     "@rails/webpacker": ">=5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "14.x"
+    "node": ">12.0"
   },
   "dependencies": {
     "@rails/webpacker": ">=5.2.1",


### PR DESCRIPTION
### Context

See [Trello card 1372](https://trello.com/c/pNhXwfHA/1372-revisit-build-hack-try-to-unlock-the-alpine-version) - a recent alpine version-bump meant the Docker build couldn't find a compatible pair of versions for node & yarn.

It turns out the version-lock was coming from inside the build(ing) all along

### Changes proposed in this pull request

* bump alpine version to 3.13, and bump the version requirement for node in yarn's `package.json` from 12.x to 14.x 

### Guidance to review

`make dev build` should complete succeffully
