### PR TITLE
Send distinct can order email to new FE institutions

### DIFF
--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -19,6 +19,16 @@ class CanOrderDevicesMailer < ApplicationMailer
                           personalisation: personalisation)
   end
 
+  def user_can_order_in_fe_college
+    @user = params[:user]
+    @school = params[:school]
+
+    tracked_template_mail('can_order_in_fe_college',
+                          can_order_devices_in_fe_college_template_id,
+                          to: @user.email_address,
+                          personalisation: personalisation)
+  end
+
   def user_can_order_but_action_needed
     @user = params[:user]
     @school = params[:school]
@@ -72,7 +82,7 @@ private
   def personalisation
     {
       school: @school.name,
-      urn: @school.urn,
+      urn: @school.ukprn_or_urn,
     }
   end
 
@@ -90,6 +100,10 @@ private
 
   def can_order_devices_in_virtual_cap_template_id
     Settings.govuk_notify.templates.devices.can_order_devices_in_virtual_cap
+  end
+
+  def can_order_devices_in_fe_college_template_id
+    Settings.govuk_notify.templates.devices.can_order_devices_in_fe_college
   end
 
   def can_order_but_action_needed_template_id

--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -51,7 +51,11 @@ private
     elsif status?('rb_can_order', school: school) && school.responsible_body.has_virtual_cap_feature_flags? && user.in?(school.order_users_with_active_techsource_accounts)
       :user_can_order_in_virtual_cap
     elsif status?('ready', 'school_ready', 'rb_can_order', 'school_can_order', school: school) && user.in?(school.order_users_with_active_techsource_accounts)
-      :user_can_order
+      if school.responsible_body.new_fe_wave?
+        :user_can_order_in_fe_college
+      else
+        :user_can_order
+      end
     end
   end
 

--- a/app/models/user_can_order_devices_notifications.rb
+++ b/app/models/user_can_order_devices_notifications.rb
@@ -35,7 +35,11 @@ private
     if %w[rb_can_order].include?(school.preorder_information&.status) && school.responsible_body.has_virtual_cap_feature_flags?
       :user_can_order_in_virtual_cap
     elsif %w[rb_can_order school_can_order].include?(school.preorder_information&.status)
-      :user_can_order
+      if school.responsible_body.new_fe_wave?
+        :user_can_order_in_fe_college
+      else
+        :user_can_order
+      end
     elsif %w[needs_info].include?(school.preorder_information&.status)
       :user_can_order_but_action_needed
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -678,6 +678,7 @@ en:
     user_can_order_event: We emailed a user to tell them that they can place orders for %{school}
     user_can_order_but_action_needed_event: We emailed a user to tell them that action is needed before %{school} can place orders
     user_can_order_in_virtual_cap: We emailed a user to tell them that they can place orders for %{school}
+    user_can_order_in_fe_college: We emailed a user to tell them that they can place orders for %{school}
     nudge_rb_to_add_school_contact_event: We emailed a responsible body user asking them to add a contact for %{school}
     nudge_user_to_read_privacy_policy_event: We emailed a user asking them to sign in and read the privacy policy so that %{school} can place orders
   helpers:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,6 +47,7 @@ govuk_notify:
       school_nominated_contact: '61eb33fc-87a0-488c-8121-354dd67093ef'
       can_order_devices: '9df2c08a-c457-4b13-9270-c5a20687d168'
       can_order_devices_in_virtual_cap: 'ab40ae48-6086-4fd7-b391-b29883572d86'
+      can_order_devices_in_fe_college: 'a33a1ef1-2de2-44d4-90c4-1627f1d34e0e'
       user_added_to_additional_school: 'f3ec0c69-17f8-424d-9c33-f17438355c2c'
       can_order_but_action_needed: '9096f09c-0b36-486c-9395-a6626198fd86'
       user_added_to_additional_school: 'f3ec0c69-17f8-424d-9c33-f17438355c2c'

--- a/db/migrate/20210122115602_add_new_fe_wave_to_responsible_body.rb
+++ b/db/migrate/20210122115602_add_new_fe_wave_to_responsible_body.rb
@@ -1,0 +1,5 @@
+class AddNewFeWaveToResponsibleBody < ActiveRecord::Migration[6.0]
+  def change
+    add_column :responsible_bodies, :new_fe_wave, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_111312) do
+ActiveRecord::Schema.define(version: 2021_01_22_115602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,8 +201,9 @@ ActiveRecord::Schema.define(version: 2021_01_21_111312) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
+    t.boolean "new_fe_wave", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
     t.index ["gias_group_uid"], name: "index_responsible_bodies_on_gias_group_uid", unique: true
@@ -290,10 +291,10 @@ ActiveRecord::Schema.define(version: 2021_01_21_111312) do
     t.boolean "increased_allocations_feature_flag", default: false
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
+    t.boolean "hide_mno", default: false
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
     t.text "fe_type"
-    t.boolean "hide_mno", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -60,5 +60,9 @@ FactoryBot.define do
     type { 'FurtherEducationCollege' }
     name { [Faker::App.unique.name, 'FE College'].join(' ') }
     organisation_type { 'FurtherEducationSchool' }
+
+    trait :new_fe_wave do
+      new_fe_wave { true }
+    end
   end
 end

--- a/spec/mailers/can_order_devices_mailer_spec.rb
+++ b/spec/mailers/can_order_devices_mailer_spec.rb
@@ -53,6 +53,55 @@ RSpec.describe CanOrderDevicesMailer, type: :mailer do
     end
   end
 
+  describe '#user_can_order_in_fe_college' do
+    let(:responsible_body) { create(:further_education_college, :new_fe_wave) }
+    let(:school) { create(:fe_school, responsible_body: responsible_body) }
+    let(:user) { create(:school_user, school: school) }
+
+    it 'adds an email audit record' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_now
+      }.to change { EmailAudit.count }.by(1)
+    end
+
+    it 'sets the correct values on the email audit record' do
+      described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_now
+      expect(EmailAudit.last).to have_attributes(message_type: 'can_order_in_fe_college',
+                                                 template: Settings.govuk_notify.templates.devices.can_order_devices_in_fe_college,
+                                                 user_id: user.id,
+                                                 school_id: school.id,
+                                                 email_address: user.email_address)
+    end
+
+    it 'enqueues mailer job with #deliver_later' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_later
+      }.to have_enqueued_job.on_queue('mailers')
+    end
+
+    it 'sends mail with #deliver_now' do
+      expect {
+        described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_now
+      }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+
+    context 'when user is deleted' do
+      let(:user) { create(:school_user, deleted_at: 1.second.ago) }
+
+      it 'enqueues mailer job with #deliver_later' do
+        expect {
+          described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_later
+        }.to have_enqueued_job.on_queue('mailers')
+      end
+
+      it 'does not send mail with #deliver_now' do
+        expect {
+          described_class.with(user: user, school: school).user_can_order_in_fe_college.deliver_now
+        }.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+    end
+  end
+
   describe '#user_can_order_in_virtual_cap' do
     it 'adds an email audit record' do
       expect {

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -21,10 +21,24 @@ RSpec.describe UserCanOrderDevicesNotifications do
     let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }
     let(:user) { create(:trust_user, orders_devices: true, responsible_body: responsible_body) }
 
-    it 'sends :user_can_order email' do
+    it 'sends :user_can_order_in_virtual_cap email' do
       expect {
         service.call
       }.to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'user_can_order_in_virtual_cap', 'deliver_now', params: { user: user, school: school }, args: [])
+    end
+  end
+
+  context 'when orders can be placed within a new FE college' do
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:preorder) { create(:preorder_information, :school_will_order, status: :rb_can_order) }
+    let(:responsible_body) { create(:further_education_college, :new_fe_wave) }
+    let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }
+    let(:user) { create(:fe_college_user, orders_devices: true, responsible_body: responsible_body) }
+
+    it 'sends :user_can_order_in_fe_college email' do
+      expect {
+        service.call
+      }.to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'user_can_order_in_fe_college', 'deliver_now', params: { user: user, school: school }, args: [])
     end
   end
 


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/KhV0QWqj/1328-invite-to-order-email-fe-providers-build-logic-to-automate-email

We'd like to send out a slightly modified email to FE institutions when they can order. There are a mix of new and old FE institutions on the service now so I have introduced a new column called `new_fe_wave` on responsible bodies so that we can identify them.

Aside from that, this PR adds the new template and conditionally sends the new email when the new column is true.

---

Once deployed we need to ensure all new institutions have that column set to true.