### PR TITLE
Explain MNO request statuses to school and RB users

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -1,11 +1,13 @@
 class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
-  def initialize(extra_mobile_data_request:, viewer: :school_or_mno_user)
-    @extra_mobile_data_request = extra_mobile_data_request
+  attr_reader :status
+
+  def initialize(status:, viewer: :school_or_mno_user)
+    @status = status.to_sym
     @viewer = viewer
   end
 
   def colour
-    case @extra_mobile_data_request.status.to_sym
+    case @status
     when :new then 'blue'
     when :in_progress then 'yellow'
     when :complete then 'green'
@@ -14,19 +16,15 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
     end
   end
 
-  def status
-    @extra_mobile_data_request.status
-  end
-
   def label
-    if @viewer == :school_or_mno_user && @extra_mobile_data_request.new_status?
+    if @viewer == :school_or_mno_user && @status == :new
       # This override only happens for one status and it felt better to put
       # the logic here rather than have separate `tag_status` values for MNO
       # and school/RB users in en.yml
       'Requested'
     else
       I18n.t!(
-        "#{@extra_mobile_data_request.status}.tag_label",
+        "#{@status}.tag_label",
         scope: %i[activerecord attributes extra_mobile_data_request status],
       )
     end

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -60,7 +60,7 @@ private
   def option_for(status)
     OpenStruct.new(
       value: status,
-      label: I18n.t!("#{status}.description", scope: %i[activerecord attributes extra_mobile_data_request status]),
+      label: I18n.t!("#{status}.mno_user_description", scope: %i[activerecord attributes extra_mobile_data_request status]),
     )
   end
 

--- a/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_csv_update_controller.rb
@@ -41,7 +41,7 @@ private
         [
           status,
           I18n.t!(
-            "#{status}.description",
+            "#{status}.mno_user_description",
             scope: %i[activerecord attributes extra_mobile_data_request status],
           ),
         ]

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -3,6 +3,7 @@ class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < Responsib
 
   def index
     @pagination, @extra_mobile_data_requests = pagy(@responsible_body.extra_mobile_data_requests.order(:created_at))
+    @statuses_with_descriptions = statuses_with_descriptions
   end
 
   def guidance; end
@@ -35,5 +36,19 @@ private
     params.fetch(:extra_mobile_data_submission_form, {}).permit(%i[
       submission_type
     ])
+  end
+
+  def statuses_with_descriptions
+    ExtraMobileDataRequest
+      .statuses_that_school_and_rb_users_can_see
+      .collect do |status|
+        [
+          status,
+          I18n.t!(
+            "#{status}.school_or_rb_user_description",
+            scope: %i[activerecord attributes extra_mobile_data_request status],
+          ),
+        ]
+      end
   end
 end

--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -3,6 +3,7 @@ class School::Internet::Mobile::ExtraDataRequestsController < School::BaseContro
 
   def index
     @pagination, @extra_mobile_data_requests = pagy(@school.extra_mobile_data_requests.order(:created_at))
+    @statuses_with_descriptions = statuses_with_descriptions
   end
 
   def guidance; end
@@ -35,5 +36,19 @@ private
     params.fetch(:extra_mobile_data_submission_form, {}).permit(%i[
       submission_type
     ])
+  end
+
+  def statuses_with_descriptions
+    ExtraMobileDataRequest
+      .statuses_that_school_and_rb_users_can_see
+      .collect do |status|
+        [
+          status,
+          I18n.t!(
+            "#{status}.school_or_rb_user_description",
+            scope: %i[activerecord attributes extra_mobile_data_request status],
+          ),
+        ]
+      end
   end
 end

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -46,6 +46,10 @@ class ExtraMobileDataRequest < ApplicationRecord
     statuses.keys - %w[cancelled unavailable]
   end
 
+  def self.statuses_that_school_and_rb_users_can_see
+    statuses.keys - %w[cancelled]
+  end
+
   enum contract_type: {
     pay_as_you_go_payg: 'pay_as_you_go_payg',
     pay_monthly: 'pay_monthly',

--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_request.html.erb
@@ -16,7 +16,7 @@
     <%= l(extra_mobile_data_request.created_at, format: :short) %>
   </td>
   <td class="govuk-table__cell" class="request-status">
-    <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: extra_mobile_data_request, viewer: :mno_user) %>
+    <%= render ExtraMobileDataRequestStatusComponent.new(status: extra_mobile_data_request.status, viewer: :mno_user) %>
   </td>
   <td class="govuk-table__cell">
     <%- if extra_mobile_data_request.in_end_state? %>

--- a/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
@@ -65,7 +65,7 @@
           <td class="govuk-table__cell"><%= row.id %></td>
           <td class="govuk-table__cell"><%= row.account_holder_name %></td>
           <td class="govuk-table__cell"><%= row.device_phone_number %></td>
-          <td class="govuk-table__cell"><%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: row) %></td>
+          <td class="govuk-table__cell"><%= render ExtraMobileDataRequestStatusComponent.new(status: row.status) %></td>
         </tr>
       <%- end %>
     </tbody>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -40,7 +40,7 @@
         <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>
         <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
         <td class="govuk-table__cell">
-          <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>
+          <%= render ExtraMobileDataRequestStatusComponent.new(status: emd_request.status) %>
         </td>
       </tr>
     <%- end %>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% if @extra_mobile_data_requests.any? %>
-<table class="govuk-table">
+<table class="govuk-table requests">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Account holder</th>

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -8,6 +8,7 @@
                    title
                  ]) %>
 <% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
@@ -19,8 +20,13 @@
         responsible_body_internet_mobile_extra_data_requests_type_path
       %>
     </p>
+
+    <% if @extra_mobile_data_requests.any? %>
+      <%= render partial: 'shared/internet/help_with_statuses', locals: { statuses_with_descriptions: @statuses_with_descriptions } %>
+    <% end %>
   </div>
 </div>
+
 <% if @extra_mobile_data_requests.any? %>
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -21,6 +21,10 @@
         extra_data_requests_type_internet_mobile_school_path(@school)
       %>
     </p>
+
+    <% if @extra_mobile_data_requests.any? %>
+      <%= render partial: 'shared/internet/help_with_statuses', locals: { statuses_with_descriptions: @statuses_with_descriptions } %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -43,7 +43,7 @@
           <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>
           <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell">
-            <%= render ExtraMobileDataRequestStatusComponent.new(extra_mobile_data_request: emd_request) %>
+            <%= render ExtraMobileDataRequestStatusComponent.new(status: emd_request.status) %>
           </td>
         </tr>
       <%- end %>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -29,7 +29,7 @@
 </div>
 
 <% if @extra_mobile_data_requests.any? %>
-  <table class="govuk-table">
+  <table class="govuk-table requests">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Account holder</th>

--- a/app/views/shared/internet/_help_with_statuses.html.erb
+++ b/app/views/shared/internet/_help_with_statuses.html.erb
@@ -1,0 +1,18 @@
+<%= govuk_details(summary: 'Help with statuses') do %>
+  <table class="govuk-table govuk-!-margin-bottom-0">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Status</th>
+        <th class="govuk-table__header">Description</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% statuses_with_descriptions.each do |status, description| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell app-no-wrap"><%= render ExtraMobileDataRequestStatusComponent.new(status: status) %></td>
+          <td class="govuk-table__cell"><%= description %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,47 +495,58 @@ en:
            new:
              tag_label: New
              dropdown_label: New
-             description: Request not processed yet
+             mno_user_description: Request not processed yet
+             school_or_rb_user_description: Request has not been processed yet
            in_progress:
              tag_label: In progress
              dropdown_label: In progress
-             description: Request is being processed
+             mno_user_description: Request is being processed
+             school_or_rb_user_description: Network is currently processing this request
            complete:
              tag_label: Complete
              dropdown_label: Complete
-             description: Request processed successfully
+             mno_user_description: Request processed successfully
+             school_or_rb_user_description: Request succesful and offer activated
            cancelled:
              tag_label: Cancelled
              dropdown_label: Cancelled
-             description: Request has been cancelled
+             mno_user_description: Request has been cancelled
+             school_or_rb_user_description: Request has been cancelled
            unavailable:
              tag_label: Unavailable
              dropdown_label: Unavailable
-             description: Request is for a network that is unavailable
+             mno_user_description: Request is for a network that is unavailable
+             school_or_rb_user_description: This network is not supporting the offer yet
            problem_no_match_for_number:
              tag_label: Unknown number
              dropdown_label: Problem – No account with this number
-             description: We couldn’t find an account with this number
+             mno_user_description: We couldn’t find an account with this number
+             school_or_rb_user_description: No account was found with number given
            problem_not_eligible:
              tag_label: Not eligible
              dropdown_label: Problem – Not eligible
-             description: This account is not eligible
+             mno_user_description: This account is not eligible
+             school_or_rb_user_description: The network reported this request was not eligible
            problem_incorrect_phone_number:
              tag_label: Invalid number
              dropdown_label: Problem – Not a valid mobile number
-             description: This is not a valid mobile number
+             mno_user_description: This is not a valid mobile number
+             school_or_rb_user_description: The network reported this request had an invalid mobile number
            problem_no_match_for_account_name:
              tag_label: Unknown name
              dropdown_label: Problem – No account with this name
-             description: We couldn’t find an account with this name
+             mno_user_description: We couldn’t find an account with this name
+             school_or_rb_user_description: No account was found with name given
            problem_no_longer_on_network:
              tag_label: Not on network
              dropdown_label: Problem – Not on network
-             description: This account is no longer on our network
+             mno_user_description: This account is no longer on our network
+             school_or_rb_user_description: The network reported this account was now with a different network
            problem_other:
              tag_label: Other problem
              dropdown_label: Problem – Other
-             description: Another reason
+             mno_user_description: Another reason
+             school_or_rb_user_description: The network could not process this request but did not give a reason why
       mobile_network:
         participation_in_pilots:
           participating: 'Offers data now'

--- a/spec/components/extra_mobile_data_request_status_component_spec.rb
+++ b/spec/components/extra_mobile_data_request_status_component_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
-  subject(:component) { described_class.new(extra_mobile_data_request: extra_mobile_data_request) }
+  subject(:component) { described_class.new(status: status) }
 
   let(:html) { render_inline(component).to_html }
 
   context 'for a request with a problem' do
-    let(:extra_mobile_data_request) do
-      create(:extra_mobile_data_request, status: :problem_incorrect_phone_number)
-    end
+    let(:status) { :problem_incorrect_phone_number }
 
     it 'is coloured red' do
       expect(html).to include 'govuk-tag--red'
@@ -20,9 +18,7 @@ RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
   end
 
   context 'for a complete request' do
-    let(:extra_mobile_data_request) do
-      create(:extra_mobile_data_request, status: :complete)
-    end
+    let(:status) { :complete }
 
     it 'is coloured green' do
       expect(html).to include 'govuk-tag--green'
@@ -34,9 +30,7 @@ RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
   end
 
   context 'for a new request shown to a school or RB user' do
-    let(:extra_mobile_data_request) do
-      create(:extra_mobile_data_request, status: :new)
-    end
+    let(:status) { :new }
 
     it 'shows a “Requested” label to school or RB users' do
       expect(html).to include 'Requested'
@@ -45,11 +39,7 @@ RSpec.describe ExtraMobileDataRequestStatusComponent, type: :component do
 
   context 'for a new request shown to an MNO user' do
     subject(:component) do
-      described_class.new(extra_mobile_data_request: extra_mobile_data_request, viewer: :mno_user)
-    end
-
-    let(:extra_mobile_data_request) do
-      create(:extra_mobile_data_request, status: :new)
+      described_class.new(status: :new, viewer: :mno_user)
     end
 
     it 'shows a “New” label to school or RB users' do

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
   let(:rb_user) { create(:local_authority_user, responsible_body: responsible_body) }
   let(:mobile_network) { create(:mobile_network) }
   let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: responsible_body) }
+  let(:my_requests_page) { PageObjects::School::Internet::YourRequestsPage.new }
 
   before do
     school.preorder_information.responsible_body_will_order_devices!
@@ -49,17 +50,20 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
     scenario 'the user can see their previous requests' do
       visit responsible_body_internet_mobile_extra_data_requests_path
 
-      expect(page).to have_css('h1', text: 'Your requests')
+      expect(my_requests_page.heading.text).to eq('Your requests')
 
       @requests.each do |request|
-        request_row = page.find("tr#request-#{request.id}")
+        request_row = my_requests_page.row_for(request)
         expect(request_row).not_to be_nil
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
         expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
       end
-      expect(page).to have_text('Requested').exactly(5).times
-      expect(page).to have_text('Unavailable').once
+
+      within my_requests_page.requests_table do
+        expect(page).to have_text('Requested').exactly(5).times
+        expect(page).to have_text('Unavailable').once
+      end
     end
 
     scenario 'another user from the same responsible body can also see the raised requests' do

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Accessing the extra mobile data requests area as a school user', type: :feature do
   let(:user) { create(:school_user) }
   let(:school) { user.school }
+  let(:my_requests_page) { PageObjects::School::Internet::YourRequestsPage.new }
 
   before do
     sign_in_as user
@@ -57,18 +58,22 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
 
     scenario 'the user can see their previous requests' do
       visit extra_data_requests_internet_mobile_school_path(school)
+      expect(my_requests_page).to be_displayed
 
-      expect(page).to have_css('h1', text: 'Your requests')
+      expect(my_requests_page.heading.text).to eq('Your requests')
 
       @requests.each do |request|
-        request_row = page.find("tr#request-#{request.id}")
+        request_row = my_requests_page.row_for(request)
         expect(request_row).not_to be_nil
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
         expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
       end
-      expect(page).to have_text('Requested').exactly(5).times
-      expect(page).to have_text('Unavailable').once
+
+      within my_requests_page.requests_table do
+        expect(page).to have_text('Requested').exactly(5).times
+        expect(page).to have_text('Unavailable').once
+      end
     end
 
     scenario 'another user from the same school can also see the raised requests' do

--- a/spec/page_objects/school/internet/your_requests_page.rb
+++ b/spec/page_objects/school/internet/your_requests_page.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module School
+    module Internet
+      class YourRequestsPage < PageObjects::BasePage
+        set_url '/schools{/urn}/internet/mobile/requests'
+
+        element :heading, 'h1'
+        element :requests_table, '.requests'
+
+        def row_for(request)
+          requests_table.find("tr#request-#{request.id}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Once an school or RB user makes an MNO request, the mobile network will either action it or provide feedback on it. It's not always obvious what each status means.

### Changes proposed in this pull request

Display a table of statuses and descriptions to school and RB users.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/105506557-1a532700-5cc2-11eb-91dd-70e9dbbc3139.png)
