### PR TITLE
1289 mno bulk add feature to search for multiple requests

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -139,7 +139,7 @@ private
     form_params = params.fetch(:mno_find_requests_form, {}).permit(:phone_numbers)
     # once on the find requests page we could get sorting requests for the table of results
     form_params = params.permit(:phone_numbers) if form_params.empty?
-    
+
     form_params
   end
 

--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -1,6 +1,7 @@
 class Mno::ExtraMobileDataRequestsController < Mno::BaseController
   def index
-    @extra_mobile_data_requests = extra_mobile_data_request_scope.order(safe_order)
+    @find_requests_form = Mno::FindRequestsForm.new(find_requests_params)
+    @extra_mobile_data_requests = extra_mobile_data_request_search_scope.order(safe_order)
 
     respond_to do |format|
       format.csv do
@@ -14,6 +15,11 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
           extra_mobile_data_request_ids: selected_extra_mobile_data_request_ids(@extra_mobile_data_requests, params),
         )
         @statuses = mno_status_options
+        if @find_requests_form.phone_number_list.any?
+          render 'search_results'
+        else
+          render
+        end
       end
     end
   end
@@ -39,12 +45,30 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
       extra_mobile_data_request_scope
                .where('extra_mobile_data_requests.id IN (?)', ids)
                .update_all(new_attributes)
-      redirect_to mno_extra_mobile_data_requests_path
+      redirect_to mno_extra_mobile_data_requests_path(find_requests_params)
     rescue ActiveRecord::StatementInvalid, ArgumentError => e
       logger.error e
       flash[:error] = "I couldn't apply that update"
       render :index, status: :unprocessable_entity
       raise ActiveRecord::Rollback
+    end
+  end
+
+  def find_requests
+    @find_requests_form = Mno::FindRequestsForm.new(find_requests_params)
+    if @find_requests_form.phone_number_list.any?
+      redirect_to mno_extra_mobile_data_requests_path(find_requests_params)
+    else
+      @find_requests_form.phone_numbers = nil
+      @find_requests_form.valid?
+      @extra_mobile_data_requests = extra_mobile_data_request_search_scope.order(safe_order)
+      @pagination, @extra_mobile_data_requests = pagy(@extra_mobile_data_requests)
+      @extra_mobile_data_requests_form = Mno::ExtraMobileDataRequestsForm.new(
+        extra_mobile_data_requests: @extra_mobile_data_requests,
+        extra_mobile_data_request_ids: selected_extra_mobile_data_request_ids(@extra_mobile_data_requests, params),
+      )
+      @statuses = mno_status_options
+      render :index
     end
   end
 
@@ -79,6 +103,17 @@ private
     @mobile_network.extra_mobile_data_requests
   end
 
+  def extra_mobile_data_request_search_scope
+    base_scope = extra_mobile_data_request_scope
+    requested_numbers = @find_requests_form.phone_number_list
+
+    if requested_numbers.any?
+      # a search filter has been applied
+      base_scope = base_scope.where(device_phone_number: requested_numbers)
+    end
+    base_scope
+  end
+
   def load_extra_mobile_data_request(emdr_id)
     @extra_mobile_data_request = extra_mobile_data_request_scope.find(emdr_id)
   end
@@ -98,6 +133,14 @@ private
       :status,
       extra_mobile_data_request_ids: [],
     )
+  end
+
+  def find_requests_params
+    form_params = params.fetch(:mno_find_requests_form, {}).permit(:phone_numbers)
+    # once on the find requests page we could get sorting requests for the table of results
+    form_params = params.permit(:phone_numbers) if form_params.empty?
+    
+    form_params
   end
 
   def safe_order(opts = params)

--- a/app/form_objects/mno/find_requests_form.rb
+++ b/app/form_objects/mno/find_requests_form.rb
@@ -17,6 +17,7 @@ private
 
   def parse_phone_numbers
     return [] if phone_numbers.blank?
+
     phone_numbers.split("\r\n").map(&:strip).reject(&:blank?).map { |num| Phonelib.parse(num).national(false) }
   end
 end

--- a/app/form_objects/mno/find_requests_form.rb
+++ b/app/form_objects/mno/find_requests_form.rb
@@ -1,0 +1,22 @@
+class Mno::FindRequestsForm
+  include ActiveModel::Model
+
+  attr_accessor :phone_numbers
+
+  validates :phone_numbers, presence: { message: 'Enter the telephone numbers, one per line' }
+
+  def initialize(args = {})
+    @phone_numbers = args[:phone_numbers]
+  end
+
+  def phone_number_list
+    @phone_number_list ||= parse_phone_numbers
+  end
+
+private
+
+  def parse_phone_numbers
+    return [] if phone_numbers.blank?
+    phone_numbers.split("\r\n").map(&:strip).reject(&:blank?).map { |num| Phonelib.parse(num).national(false) }
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -48,6 +48,8 @@ module ViewHelper
   end
 
   def sortable_extra_mobile_data_requests_table_header(title, value = title, opts = params)
+    phone_numbers = opts[:phone_numbers]
+
     if opts[:sort] == value.to_s
       if opts[:dir] == 'd'
         suffix = '▲'
@@ -56,9 +58,9 @@ module ViewHelper
         suffix = '▼'
         dir = 'd'
       end
-      safe_join([govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value, dir: dir)), suffix], ' ')
+      safe_join([govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value, dir: dir, phone_numbers: phone_numbers)), suffix], ' ')
     else
-      govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value))
+      govuk_link_to(title, mno_extra_mobile_data_requests_path(sort: value, phone_numbers: phone_numbers))
     end
   end
 

--- a/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_requests_bulk_table.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/_extra_mobile_data_requests_bulk_table.html.erb
@@ -1,0 +1,52 @@
+<table class="govuk-table" data-module="app-select-all-none">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="non-js-only">
+          Select
+          <br />
+          <%= govuk_link_to 'all', mno_extra_mobile_data_requests_path(select: 'all', phone_numbers: phone_numbers) %>
+          |
+          <%= govuk_link_to 'none', mno_extra_mobile_data_requests_path(select: 'none', phone_numbers: phone_numbers) %>
+        </div>
+        <div class="js-only govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows"></label>
+        </div>
+      </th>
+      <th class="govuk-table__header">
+        <%= sortable_extra_mobile_data_requests_table_header('Account holder', :account_holder_name) %>
+      </th>
+      <th class="govuk-table__header govuk-table__header--numeric">
+        <%= sortable_extra_mobile_data_requests_table_header('Mobile number', :mobile_number) %>
+      </th>
+      <th class="govuk-table__header">
+        <%= sortable_extra_mobile_data_requests_table_header('Requested', :requested) %>
+      </th>
+      <th class="govuk-table__header">
+        <%= sortable_extra_mobile_data_requests_table_header('Status', :status) %>
+      </th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <%= render partial: 'extra_mobile_data_request', collection: requests, locals: {form: form} %>
+  </tbody>
+  <tfoot class="govuk-table__footer">
+    <td class="govuk-table__footer" colspan="7">
+    </td>
+  </tfoot>
+</table>
+<div class="govuk-body govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group govuk-!-margin-bottom-0 display-child-forms-inline">
+      <label for="mno-extra-mobile-data-requests-form-status-field" class="govuk-label">Set status of selected to</label>
+      <%= form.govuk_collection_select :status, statuses, :value, :label, label: {text: ''} %>
+      <input type="hidden" name="phone_numbers", value="<%= phone_numbers %>"/>
+      <%= form.govuk_submit 'Update' %>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render partial: 'shared/pagination', locals: { pagination: pagination } %>
+  </div>
+</div>

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -14,10 +14,10 @@
     (There are no matching requests at the moment)
   </p>
 <% else %>
-  <%= govuk_button_link_to 'Download requests as CSV', sort: params[:sort], dir: params[:dir], format: :csv %>
   <p class="govuk-body"><%= govuk_link_to t('page_titles.extra_mobile_data_requests_csv_update'), new_mno_extra_mobile_data_requests_csv_update_path %></p>
+  <%= govuk_button_link_to 'Download requests as CSV', sort: params[:sort], dir: params[:dir], format: :csv %>
 
-  <div class="app-card govuk-!-margin-bottom-4">
+  <div class="app-card govuk-!-margin-bottom-4 govuk-!-margin-top-2">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= form_for @find_requests_form, url: find_requests_mno_extra_mobile_data_requests_path, method: :put do |f| %>
@@ -28,15 +28,15 @@
               hint: { text: 'One per line' },
               label: { text: 'Telephone numbers', size: 's' },
               rows: 5 %>
-            <%= f.govuk_submit 'Find requests' %>
+            <%= f.govuk_submit 'Find requests', classes: 'govuk-!-margin-bottom-0' %>
           <%- end %>
         <%- end %>
       </div>
     </div>
   </div>
 
-  <h2 class="govuk-heading-l govuk-!-margin-top-4">
-    All requests (<%= @pagination.count %>)
+  <h2 class="govuk-heading-l govuk-!-margin-top-6">
+    All requests (<%= number_with_delimiter(@pagination.count, delimiter: ',') %>)
   </h2>
 
   <div class="govuk-grid-row">

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -42,57 +42,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= form_for @extra_mobile_data_requests_form, url: bulk_update_mno_extra_mobile_data_requests_path, method: :put do |f| %>
-        <table class="govuk-table" data-module="app-select-all-none">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th class="govuk-table__header">
-                <div class="non-js-only">
-                  Select
-                  <br />
-                  <%= govuk_link_to 'all', mno_extra_mobile_data_requests_path(select: 'all') %>
-                  |
-                  <%= govuk_link_to 'none', mno_extra_mobile_data_requests_path(select: 'none') %>
-                </div>
-                <div class="js-only govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-                  <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows"></label>
-                </div>
-              </th>
-              <th class="govuk-table__header">
-                <%= sortable_extra_mobile_data_requests_table_header('Account holder', :account_holder_name) %>
-              </th>
-              <th class="govuk-table__header govuk-table__header--numeric">
-                <%= sortable_extra_mobile_data_requests_table_header('Mobile number', :mobile_number) %>
-              </th>
-              <th class="govuk-table__header">
-                <%= sortable_extra_mobile_data_requests_table_header('Requested', :requested) %>
-              </th>
-              <th class="govuk-table__header">
-                <%= sortable_extra_mobile_data_requests_table_header('Status', :status) %>
-              </th>
-              <th class="govuk-table__header">Actions</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <%= render partial: 'extra_mobile_data_request', collection: @extra_mobile_data_requests, locals: {form: f} %>
-          </tbody>
-          <tfoot class="govuk-table__footer">
-            <td class="govuk-table__footer" colspan="7">
-            </td>
-          </tfoot>
-        </table>
-        <div class="govuk-body govuk-grid-row">
-          <div class="govuk-grid-column-one-half">
-            <div class="govuk-form-group govuk-!-margin-bottom-0 display-child-forms-inline">
-              <label for="mno-extra-mobile-data-requests-form-status-field" class="govuk-label">Set status of selected to</label>
-              <%= f.govuk_collection_select :status, @statuses, :value, :label, label: {text: ''} %>
-              <%= f.govuk_submit 'Update' %>
-            </div>
-          </div>
-          <div class="govuk-grid-column-one-half">
-            <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
-          </div>
-        </div>
+        <%= render partial: 'extra_mobile_data_requests_bulk_table', locals: { form: f, requests: @extra_mobile_data_requests, phone_numbers: @find_requests_form.phone_numbers, statuses: @statuses, pagination: @pagination } %>
       <% end %>
     </div>
   </div>

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -20,7 +20,7 @@
   <div class="app-card govuk-!-margin-bottom-4 govuk-!-margin-top-2">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= form_for @find_requests_form, url: find_requests_mno_extra_mobile_data_requests_path, method: :put do |f| %>
+        <%= form_for @find_requests_form, url: find_requests_mno_extra_mobile_data_requests_path, method: :post do |f| %>
           <%= f.govuk_error_summary %>
 
           <%= f.govuk_fieldset(legend: { text: 'Find requests by telephone number', size: 'l'}) do %>

--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -17,8 +17,26 @@
   <%= govuk_button_link_to 'Download requests as CSV', sort: params[:sort], dir: params[:dir], format: :csv %>
   <p class="govuk-body"><%= govuk_link_to t('page_titles.extra_mobile_data_requests_csv_update'), new_mno_extra_mobile_data_requests_csv_update_path %></p>
 
+  <div class="app-card govuk-!-margin-bottom-4">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_for @find_requests_form, url: find_requests_mno_extra_mobile_data_requests_path, method: :put do |f| %>
+          <%= f.govuk_error_summary %>
+
+          <%= f.govuk_fieldset(legend: { text: 'Find requests by telephone number', size: 'l'}) do %>
+            <%= f.govuk_text_area :phone_numbers,
+              hint: { text: 'One per line' },
+              label: { text: 'Telephone numbers', size: 's' },
+              rows: 5 %>
+            <%= f.govuk_submit 'Find requests' %>
+          <%- end %>
+        <%- end %>
+      </div>
+    </div>
+  </div>
+
   <h2 class="govuk-heading-l govuk-!-margin-top-4">
-    <%= pagy_info(@pagination, "requests").capitalize.html_safe %>
+    All requests (<%= @pagination.count %>)
   </h2>
 
   <div class="govuk-grid-row">

--- a/app/views/mno/extra_mobile_data_requests/search_results.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/search_results.html.erb
@@ -4,14 +4,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= pagy_info(@pagination, "requests").capitalize.html_safe %> found
+      <% if @pagination.count.zero? %>
+        No requests found
+      <% else %>
+        <%= pagy_info(@pagination, "requests").capitalize.html_safe %> found
+      <% end %>
     </h1>
   </div>
 </div>
 
 <% if @extra_mobile_data_requests.any? %>
-  <%= govuk_button_link_to 'Download requests as CSV', mno_extra_mobile_data_requests_path(sort: params[:sort], dir: params[:dir], phone_numbers: params[:phone_numbers], format: :csv) %>
   <p class="govuk-body"><%= govuk_link_to t('page_titles.extra_mobile_data_requests_csv_update'), new_mno_extra_mobile_data_requests_csv_update_path %></p>
+  <%= govuk_button_link_to 'Download requests as CSV', mno_extra_mobile_data_requests_path(sort: params[:sort], dir: params[:dir], phone_numbers: params[:phone_numbers], format: :csv) %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/mno/extra_mobile_data_requests/search_results.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/search_results.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, t('page_titles.requests_for_extra_mobile_data') %>
+<% content_for :before_content, govuk_link_to('Back', mno_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= pagy_info(@pagination, "requests").capitalize.html_safe %> found
+    </h1>
+  </div>
+</div>
+
+<% if @extra_mobile_data_requests.any? %>
+  <%= govuk_button_link_to 'Download requests as CSV', mno_extra_mobile_data_requests_path(sort: params[:sort], dir: params[:dir], phone_numbers: params[:phone_numbers], format: :csv) %>
+  <p class="govuk-body"><%= govuk_link_to t('page_titles.extra_mobile_data_requests_csv_update'), new_mno_extra_mobile_data_requests_csv_update_path %></p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= form_for @extra_mobile_data_requests_form, url: bulk_update_mno_extra_mobile_data_requests_path, method: :put do |f| %>
+        <%= render partial: 'extra_mobile_data_requests_bulk_table', locals: { form: f, requests: @extra_mobile_data_requests, phone_numbers: @find_requests_form.phone_numbers, statuses: @statuses, pagination: @pagination } %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
     resources :extra_mobile_data_requests, only: %i[index show edit update], path: '/extra-mobile-data-requests' do
       put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
       get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
+      put 'find-requests', to: 'extra_mobile_data_requests#find_requests', on: :collection
     end
     resources :extra_mobile_data_requests_csv_update, only: %i[new create], path: '/extra-mobile-data-requests-csv-update'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
     resources :extra_mobile_data_requests, only: %i[index show edit update], path: '/extra-mobile-data-requests' do
       put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
       get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
-      put 'find-requests', to: 'extra_mobile_data_requests#find_requests', on: :collection
+      post 'find-requests', to: 'extra_mobile_data_requests#find_requests', on: :collection
     end
     resources :extra_mobile_data_requests_csv_update, only: %i[new create], path: '/extra-mobile-data-requests-csv-update'
   end

--- a/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
+++ b/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
@@ -19,9 +19,107 @@ RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
   scenario 'finding requests by telephone number' do
     given_i_am_signed_in_as_an_mno_user
     and_i_click_on_the_your_requests_link
-    when_I_enter_the_phone_numbers_of_the_requests_I_want_to_find
+    when_i_enter_the_phone_numbers_of_the_requests_i_want_to_find
     and_i_click_the_find_requests_button
     then_i_see_a_list_of_requests_matching_those_phone_numbers
+  end
+
+  scenario 'mass selecting the matching requests' do
+    given_i_am_signed_in_as_an_mno_user
+    and_i_click_on_the_your_requests_link
+    when_i_enter_the_phone_numbers_of_the_requests_i_want_to_find
+    and_i_click_the_find_requests_button
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+
+    when_i_click_on_select_all
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+    and_all_checkboxes_are_selected
+
+    when_i_click_on_select_none
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+    and_none_of_the_checkboxes_are_selected
+  end
+
+  scenario 'sorting the list of matching requests' do
+    given_i_am_signed_in_as_an_mno_user
+    and_i_click_on_the_your_requests_link
+    when_i_enter_the_phone_numbers_of_the_requests_i_want_to_find
+    and_i_click_the_find_requests_button
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+
+    when_i_click_on_a_column_header
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+    and_sorted_by_that_column
+
+    when_i_click_on_a_column_header_again
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+    and_sort_order_is_reversed
+  end
+
+  scenario 'updating selected matching requests' do
+    given_i_am_signed_in_as_an_mno_user
+    and_i_click_on_the_your_requests_link
+    when_i_enter_the_phone_numbers_of_the_requests_i_want_to_find
+    and_i_click_the_find_requests_button
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+
+    when_i_click_on_select_all
+    and_i_select_the_in_progress_status
+    and_i_click_the_update_button
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+    and_the_statuses_are_set_to_in_progress
+  end
+
+  def and_i_select_the_in_progress_status
+    select('In progress', from: 'Set status of selected to')
+  end
+
+  def and_i_click_the_update_button
+    click_on 'Update'
+  end
+
+  def and_the_statuses_are_set_to_in_progress
+    expect(all('.extra_mobile_data_request-status')).to all(have_content('In progress'))
+  end
+
+  def when_i_click_on_a_column_header
+    click_on 'Account holder'
+  end
+
+  def when_i_click_on_a_column_header_again
+    click_on 'Account holder'
+  end
+
+  def and_sorted_by_that_column
+    expect(rendered_ids).to eq(requests_to_find.sort { |r1, r2| r1.account_holder_name <=> r2.account_holder_name }.pluck(:id))
+  end
+
+  def and_sort_order_is_reversed
+    expect(rendered_ids).to eq(requests_to_find.sort { |r1, r2| r2.account_holder_name <=> r1.account_holder_name }.pluck(:id))
+  end
+
+  def rendered_ids
+    all('tbody tr').map { |e| e[:id].split('-').last.to_i }
+  end
+
+  def when_i_click_on_select_all
+    click_on 'all'
+  end
+
+  def and_all_checkboxes_are_selected
+    all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
+      expect(e.checked?).to eq(true)
+    end
+  end
+
+  def when_i_click_on_select_none
+    click_on 'none'
+  end
+
+  def and_none_of_the_checkboxes_are_selected
+    all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
+      expect(e.checked?).to eq(false)
+    end
   end
 
   def given_i_am_signed_in_as_an_mno_user
@@ -35,6 +133,10 @@ RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
   def then_i_see_my_list_of_requests
     expect(page).to have_content(mno_user.mobile_network.brand)
     expect(page).to have_content('Requests for extra mobile data')
+    expect(page).to have_link('Download requests as CSV')
+    expect(page).to have_link('Update requests using a CSV')
+    expect(page).to have_content("All requests (#{extra_mobile_data_requests_for_mno.count})")
+
     extra_mobile_data_requests_for_mno.each do |request|
       expect(page).to have_content(request.account_holder_name)
       expect(page).to have_content(request.device_phone_number)
@@ -47,11 +149,14 @@ RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
     expect(page).to have_button('Find requests')
   end
 
-  def when_I_enter_the_phone_numbers_of_the_requests_I_want_to_find
-    phones = [extra_mobile_data_requests_for_mno.first.device_phone_number,
-              extra_mobile_data_requests_for_mno.second.device_phone_number].join("\r\n")
+  def when_i_enter_the_phone_numbers_of_the_requests_i_want_to_find
+    phones = requests_to_find.map(&:device_phone_number).join("\r\n")
 
     fill_in 'Telephone numbers', with: phones
+  end
+
+  def requests_to_find
+    extra_mobile_data_requests_for_mno[0..1]
   end
 
   def and_i_click_the_find_requests_button
@@ -60,143 +165,19 @@ RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
 
   def then_i_see_a_list_of_requests_matching_those_phone_numbers
     expect(page).to have_content('2 requests found')
-    (0..1).each do |n|
-      request = extra_mobile_data_requests_for_mno[n]
+    expect(page).to have_link('Download requests as CSV')
+    expect(page).to have_link('Update requests using a CSV')
+
+    requests_to_find.each do |request|
       expect(page).to have_content(request.account_holder_name)
       expect(page).to have_content(request.device_phone_number)
     end
+
     request = extra_mobile_data_requests_for_mno.last
     expect(page).not_to have_content(request.account_holder_name)
     expect(page).not_to have_content(request.device_phone_number)
-  end
 
-  # context 'signed in as an mno user' do
-  #   before do
-  #     sign_in_as mno_user
-  #   end
-  #
-  #   describe 'visiting Your requests' do
-  #     before do
-  #       click_on 'Your requests'
-  #     end
-  #
-  #     scenario 'shows only requests from my MNO' do
-  #       expect(page).to have_content('Requests for extra mobile data')
-  #       expect(page).to have_content(mno_user.mobile_network.brand)
-  #       expect(page).to have_content(extra_mobile_data_request_for_mno.account_holder_name)
-  #       expect(page).not_to have_content(extra_mobile_data_request_for_other_mno.account_holder_name)
-  #     end
-  #
-  #     scenario 'clicking Select All selects all checkboxes' do
-  #       click_on 'all'
-  #
-  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
-  #         expect(e.checked?).to eq(true)
-  #       end
-  #     end
-  #
-  #     scenario 'clicking Select None de-selects all checkboxes' do
-  #       check('mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]')
-  #       click_on 'none'
-  #
-  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
-  #         expect(e.checked?).to eq(false)
-  #       end
-  #     end
-  #   end
-  #
-  #   context 'with several extra_mobile_data_requests shown' do
-  #     # NOTE: a function, not a let, so that it re-runs each time
-  #     def rendered_ids
-  #       all('tbody tr').map { |e| e[:id].split('-').last.to_i }
-  #     end
-  #     let(:mno_extra_mobile_data_requests) do
-  #       ExtraMobileDataRequest.where(mobile_network: mno_user.mobile_network)
-  #     end
-  #
-  #     before do
-  #       create_list(:extra_mobile_data_request, 5, status: 'new', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
-  #       click_on 'Your requests'
-  #     end
-  #
-  #     scenario 'clicking on a header sorts by that column' do
-  #       click_on 'Account holder'
-  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:account_holder_name).pluck(:id))
-  #
-  #       click_on 'Requested'
-  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:created_at).pluck(:id))
-  #     end
-  #
-  #     scenario 'clicking on a header twice sorts by that column in reverse order' do
-  #       click_on 'Account holder'
-  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:account_holder_name).pluck(:id))
-  #
-  #       click_on 'Account holder'
-  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(account_holder_name: :desc).pluck(:id))
-  #     end
-  #
-  #     scenario 'updating selected extra_mobile_data_requests to a status applies that status' do
-  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').first(3).each(&:check)
-  #       select('In progress', from: 'Set status of selected to')
-  #       click_on('Update')
-  #       expect(all('.extra_mobile_data_request-status').first(3)).to all(have_content('In progress'))
-  #       expect(all('.extra_mobile_data_request-status').last(2)).to all(have_no_content('In progress'))
-  #     end
-  #
-  #     scenario 'clicking Download as CSV downloads a CSV file' do
-  #       click_on 'Download requests as CSV'
-  #       expect_download(content_type: 'text/csv')
-  #     end
-  #   end
-  #
-  #   context 'with multiple pages of extra_mobile_data_requests' do
-  #     original_pagination_value = Pagy::VARS[:items]
-  #
-  #     before do
-  #       Pagy::VARS[:items] = 20
-  #       create_list(:extra_mobile_data_request, 25, status: 'new', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
-  #       click_on 'Your requests'
-  #     end
-  #
-  #     after do
-  #       Pagy::VARS[:items] = original_pagination_value
-  #     end
-  #
-  #     it 'shows pagination' do
-  #       expect(page).to have_link('Next')
-  #     end
-  #
-  #     it 'shows all/none checkbox when on subsequent pages' do
-  #       click_on('Next')
-  #       expect { page.find('input#all-rows') }.not_to raise_error
-  #     end
-  #   end
-  #
-  #   context 'when the requests are complete or cancelled' do
-  #     let!(:complete_request) do
-  #       create(:extra_mobile_data_request, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user, status: 'complete')
-  #     end
-  #     let!(:cancelled_request) do
-  #       create(:extra_mobile_data_request, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user, status: 'cancelled')
-  #     end
-  #
-  #     before do
-  #       extra_mobile_data_request_for_mno.update!(status: 'complete')
-  #       click_on 'Your requests'
-  #     end
-  #
-  #     it 'shows the status' do
-  #       within("#request-#{complete_request.id}") do
-  #         expect(page).to have_text('Complete')
-  #       end
-  #       within("#request-#{cancelled_request.id}") do
-  #         expect(page).to have_text('Cancelled')
-  #       end
-  #     end
-  #
-  #     it 'does not show a link to Report a problem' do
-  #       expect(page).not_to have_link('Report a problem')
-  #     end
-  #   end
-  # end
+    expect(page).to have_field('Set status of selected to')
+    expect(page).to have_button('Update')
+  end
 end

--- a/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
+++ b/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
@@ -4,10 +4,7 @@ require 'shared/expect_download'
 RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
   let(:local_authority_user) { create(:local_authority_user) }
   let(:mno_user) { create(:mno_user) }
-  let(:other_mno) { create(:mobile_network, brand: 'Other MNO') }
-  let(:user_from_other_mno) { create(:mno_user, name: 'Other MNO-User', organisation: 'Other MNO', mobile_network: other_mno) }
   let!(:extra_mobile_data_requests_for_mno) { create_list(:extra_mobile_data_request, 3, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
-  let!(:extra_mobile_data_request_for_other_mno) { create(:extra_mobile_data_request, account_holder_name: 'other mno extra_mobile_data_request', mobile_network: other_mno, created_by_user: local_authority_user) }
 
   scenario 'visiting Your requests' do
     given_i_am_signed_in_as_an_mno_user

--- a/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
+++ b/spec/features/mno/find_extra_mobile_data_requests_by_telephone_number_spec.rb
@@ -1,0 +1,202 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'Find MNO Requests by telephone number', type: :feature do
+  let(:local_authority_user) { create(:local_authority_user) }
+  let(:mno_user) { create(:mno_user) }
+  let(:other_mno) { create(:mobile_network, brand: 'Other MNO') }
+  let(:user_from_other_mno) { create(:mno_user, name: 'Other MNO-User', organisation: 'Other MNO', mobile_network: other_mno) }
+  let!(:extra_mobile_data_requests_for_mno) { create_list(:extra_mobile_data_request, 3, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
+  let!(:extra_mobile_data_request_for_other_mno) { create(:extra_mobile_data_request, account_holder_name: 'other mno extra_mobile_data_request', mobile_network: other_mno, created_by_user: local_authority_user) }
+
+  scenario 'visiting Your requests' do
+    given_i_am_signed_in_as_an_mno_user
+    and_i_click_on_the_your_requests_link
+    then_i_see_my_list_of_requests
+    and_i_see_a_form_to_find_requests_by_telephone_number
+  end
+
+  scenario 'finding requests by telephone number' do
+    given_i_am_signed_in_as_an_mno_user
+    and_i_click_on_the_your_requests_link
+    when_I_enter_the_phone_numbers_of_the_requests_I_want_to_find
+    and_i_click_the_find_requests_button
+    then_i_see_a_list_of_requests_matching_those_phone_numbers
+  end
+
+  def given_i_am_signed_in_as_an_mno_user
+    sign_in_as mno_user
+  end
+
+  def and_i_click_on_the_your_requests_link
+    click_on 'Your requests'
+  end
+
+  def then_i_see_my_list_of_requests
+    expect(page).to have_content(mno_user.mobile_network.brand)
+    expect(page).to have_content('Requests for extra mobile data')
+    extra_mobile_data_requests_for_mno.each do |request|
+      expect(page).to have_content(request.account_holder_name)
+      expect(page).to have_content(request.device_phone_number)
+    end
+  end
+
+  def and_i_see_a_form_to_find_requests_by_telephone_number
+    expect(page).to have_content('Find requests by telephone number')
+    expect(page).to have_field('Telephone numbers')
+    expect(page).to have_button('Find requests')
+  end
+
+  def when_I_enter_the_phone_numbers_of_the_requests_I_want_to_find
+    phones = [extra_mobile_data_requests_for_mno.first.device_phone_number,
+              extra_mobile_data_requests_for_mno.second.device_phone_number].join("\r\n")
+
+    fill_in 'Telephone numbers', with: phones
+  end
+
+  def and_i_click_the_find_requests_button
+    click_on 'Find requests'
+  end
+
+  def then_i_see_a_list_of_requests_matching_those_phone_numbers
+    expect(page).to have_content('2 requests found')
+    (0..1).each do |n|
+      request = extra_mobile_data_requests_for_mno[n]
+      expect(page).to have_content(request.account_holder_name)
+      expect(page).to have_content(request.device_phone_number)
+    end
+    request = extra_mobile_data_requests_for_mno.last
+    expect(page).not_to have_content(request.account_holder_name)
+    expect(page).not_to have_content(request.device_phone_number)
+  end
+
+  # context 'signed in as an mno user' do
+  #   before do
+  #     sign_in_as mno_user
+  #   end
+  #
+  #   describe 'visiting Your requests' do
+  #     before do
+  #       click_on 'Your requests'
+  #     end
+  #
+  #     scenario 'shows only requests from my MNO' do
+  #       expect(page).to have_content('Requests for extra mobile data')
+  #       expect(page).to have_content(mno_user.mobile_network.brand)
+  #       expect(page).to have_content(extra_mobile_data_request_for_mno.account_holder_name)
+  #       expect(page).not_to have_content(extra_mobile_data_request_for_other_mno.account_holder_name)
+  #     end
+  #
+  #     scenario 'clicking Select All selects all checkboxes' do
+  #       click_on 'all'
+  #
+  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
+  #         expect(e.checked?).to eq(true)
+  #       end
+  #     end
+  #
+  #     scenario 'clicking Select None de-selects all checkboxes' do
+  #       check('mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]')
+  #       click_on 'none'
+  #
+  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').each do |e|
+  #         expect(e.checked?).to eq(false)
+  #       end
+  #     end
+  #   end
+  #
+  #   context 'with several extra_mobile_data_requests shown' do
+  #     # NOTE: a function, not a let, so that it re-runs each time
+  #     def rendered_ids
+  #       all('tbody tr').map { |e| e[:id].split('-').last.to_i }
+  #     end
+  #     let(:mno_extra_mobile_data_requests) do
+  #       ExtraMobileDataRequest.where(mobile_network: mno_user.mobile_network)
+  #     end
+  #
+  #     before do
+  #       create_list(:extra_mobile_data_request, 5, status: 'new', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+  #       click_on 'Your requests'
+  #     end
+  #
+  #     scenario 'clicking on a header sorts by that column' do
+  #       click_on 'Account holder'
+  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:account_holder_name).pluck(:id))
+  #
+  #       click_on 'Requested'
+  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:created_at).pluck(:id))
+  #     end
+  #
+  #     scenario 'clicking on a header twice sorts by that column in reverse order' do
+  #       click_on 'Account holder'
+  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(:account_holder_name).pluck(:id))
+  #
+  #       click_on 'Account holder'
+  #       expect(rendered_ids).to eq(mno_extra_mobile_data_requests.order(account_holder_name: :desc).pluck(:id))
+  #     end
+  #
+  #     scenario 'updating selected extra_mobile_data_requests to a status applies that status' do
+  #       all('input[name="mno_extra_mobile_data_requests_form[extra_mobile_data_request_ids][]"]').first(3).each(&:check)
+  #       select('In progress', from: 'Set status of selected to')
+  #       click_on('Update')
+  #       expect(all('.extra_mobile_data_request-status').first(3)).to all(have_content('In progress'))
+  #       expect(all('.extra_mobile_data_request-status').last(2)).to all(have_no_content('In progress'))
+  #     end
+  #
+  #     scenario 'clicking Download as CSV downloads a CSV file' do
+  #       click_on 'Download requests as CSV'
+  #       expect_download(content_type: 'text/csv')
+  #     end
+  #   end
+  #
+  #   context 'with multiple pages of extra_mobile_data_requests' do
+  #     original_pagination_value = Pagy::VARS[:items]
+  #
+  #     before do
+  #       Pagy::VARS[:items] = 20
+  #       create_list(:extra_mobile_data_request, 25, status: 'new', mobile_network: mno_user.mobile_network, created_by_user: local_authority_user)
+  #       click_on 'Your requests'
+  #     end
+  #
+  #     after do
+  #       Pagy::VARS[:items] = original_pagination_value
+  #     end
+  #
+  #     it 'shows pagination' do
+  #       expect(page).to have_link('Next')
+  #     end
+  #
+  #     it 'shows all/none checkbox when on subsequent pages' do
+  #       click_on('Next')
+  #       expect { page.find('input#all-rows') }.not_to raise_error
+  #     end
+  #   end
+  #
+  #   context 'when the requests are complete or cancelled' do
+  #     let!(:complete_request) do
+  #       create(:extra_mobile_data_request, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user, status: 'complete')
+  #     end
+  #     let!(:cancelled_request) do
+  #       create(:extra_mobile_data_request, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user, status: 'cancelled')
+  #     end
+  #
+  #     before do
+  #       extra_mobile_data_request_for_mno.update!(status: 'complete')
+  #       click_on 'Your requests'
+  #     end
+  #
+  #     it 'shows the status' do
+  #       within("#request-#{complete_request.id}") do
+  #         expect(page).to have_text('Complete')
+  #       end
+  #       within("#request-#{cancelled_request.id}") do
+  #         expect(page).to have_text('Cancelled')
+  #       end
+  #     end
+  #
+  #     it 'does not show a link to Report a problem' do
+  #       expect(page).not_to have_link('Report a problem')
+  #     end
+  #   end
+  # end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/gQk4sysp/1289-mno-bulk-add-feature-to-search-for-multiple-requests)
Enable MNOs to search list of requests by telephone number

### Changes proposed in this pull request
Add form to 'Your requests' page enabling MNO to add one phone number per line to search for.
Add 'results' page that has similar functionality to main 'Your requests' page - column sorting, bulk updates, download CSV etc.
From results page, downloading a CSV includes only matching requests

### Guidance to review
As a MNO user with some `ExtraMobileDataRequest`s, log in a view 'Your requests'
The 'Find requests by telephone number' form should now present.
Enter one or more phone numbers and click 'Find requests'.
Matching requests should be displayed.
You can interact with the requests the same as on the initial 'Your requests' page. The 'Find requests by telephone number' form should not be visible here.
Downloading a CSV should only include the matching requests in the CSV.

![image](https://user-images.githubusercontent.com/333931/105726523-132a5400-5f22-11eb-8579-a1e8dfcc873f.png)
![image](https://user-images.githubusercontent.com/333931/105726581-1f161600-5f22-11eb-8941-eec43fd0a18e.png)
