### PR TITLE
[1244] Add address to school support view

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -3,6 +3,7 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
     array = super
     array << headteacher_row if headteacher.present?
     array.map { |row| remove_change_links_if_read_only(row) }
+    array << { key: 'Address', value: @school.address_components }
   end
 
 private

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -180,8 +180,12 @@ class School < ApplicationRecord
     responsible_body.has_school_in_virtual_cap_pools?(self)
   end
 
+  def address_components
+    [address_1, address_2, address_3, town, county, postcode].reject(&:blank?)
+  end
+
   def address
-    [address_1, address_2, address_3, town, postcode].reject(&:blank?).join(', ')
+    address_components.join(', ')
   end
 
   def update_computacenter_reference!(new_value)

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -166,4 +166,15 @@ describe Support::SchoolDetailsSummaryListComponent do
       end
     end
   end
+
+  describe 'address' do
+    it 'is displayed' do
+      expect(result.text).to include(school.address_1.to_s)
+      expect(result.text).to include(school.address_2.to_s)
+      expect(result.text).to include(school.address_3.to_s)
+      expect(result.text).to include(school.town.to_s)
+      expect(result.text).to include(school.county.to_s)
+      expect(result.text).to include(school.postcode.to_s)
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/dsWURzNG/1244-allow-admin-users-to-see-the-address-of-a-school

### Changes proposed in this pull request

- Add address to school view for support staff

### Screenshots

![image](https://user-images.githubusercontent.com/92580/105748003-6c51b200-5f39-11eb-807d-148d82ac1df2.png)

### Guidance to review

- Login as support user
- View a school
- Should see adddress