### PR TITLE
Limit summary output to 50 for updates and errors

### DIFF
--- a/app/form_objects/mno/csv_status_update_summary.rb
+++ b/app/form_objects/mno/csv_status_update_summary.rb
@@ -1,4 +1,8 @@
 class Mno::CsvStatusUpdateSummary
+  include ActionView::Helpers::NumberHelper
+
+  DISPLAY_LIMIT = 50
+
   attr_reader :errors, :unchanged, :updated
   def initialize
     @errors = []
@@ -67,10 +71,26 @@ class Mno::CsvStatusUpdateSummary
   end
 
   def errors_section_heading_text
-    "#{errors_count} #{'request'.pluralize(errors_count)} #{'contains'.pluralize(errors_count)} errors"
+    if errors_count > DISPLAY_LIMIT
+      "Showing the first #{DISPLAY_LIMIT} of #{number_with_delimiter(errors_count)} requests containing errors"
+    else
+      "#{errors_count} #{'request'.pluralize(errors_count)} #{'contains'.pluralize(errors_count)} errors"
+    end
   end
 
   def updated_section_heading_text
-    "#{updated_count} #{'request'.pluralize(updated_count)} updated"
+    if updated_count > DISPLAY_LIMIT
+      "Showing the first #{DISPLAY_LIMIT} of #{number_with_delimiter(updated_count)} updated requests"
+    else
+      "#{updated_count} #{'request'.pluralize(updated_count)} updated"
+    end
+  end
+
+  def updated_display_limited
+    updated.take(DISPLAY_LIMIT)
+  end
+
+  def errors_display_limited
+    errors.take(DISPLAY_LIMIT)
   end
 end

--- a/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
@@ -23,7 +23,7 @@
   <div class="govuk-form-group--error">
     <p class="govuk-error-message">Fix the errors in your CSV and try uploading again</p>
 
-    <table class="govuk-table requests-table">
+    <table class="govuk-table requests-table" id="errors-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header">ID</th>
@@ -33,7 +33,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% @summary.errors.each do |row| %>
+        <% @summary.errors_display_limited.each do |row| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= row.id %></td>
             <td class="govuk-table__cell"><%= row.account_holder_name %></td>
@@ -50,7 +50,7 @@
 
 <% if @summary.has_updated_requests? %>
   <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @summary.updated_section_heading_text %></h2>
-  <table class="govuk-table requests-table">
+  <table class="govuk-table requests-table" id="updates-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">ID</th>
@@ -60,7 +60,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @summary.updated.each do |row| %>
+      <% @summary.updated_display_limited.each do |row| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= row.id %></td>
           <td class="govuk-table__cell"><%= row.account_holder_name %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,6 +430,10 @@ en:
             base:
               cannot_parse: Choose an ‘xlsx’ (Open XML format) Excel file
               cannot_find_expected_worksheet: Upload a spreadsheet containing a sheet called ‘%{worksheet_name}’
+        mno/csv_status_update_form:
+          attributes:
+            upload:
+              theres_a_problem_with_that_csv: There’s a problem with that CSV
         responsible_body/devices/who_will_order_form:
           attributes:
             who_will_order:


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/Noe2bGD1/1380-limit-number-of-requests-shown-to-mno-after-a-large-csv-upload)
When an MNO bulk updates `ExtraMobileDataRequest` statuses via CSV, restrict the output of summary data to 50 rows each for errors and updates.

### Changes proposed in this pull request
Provide alternative heading summary when limiting output to 50
Limit summary table records to max of 50 per table

### Guidance to review
As an MNO, with more than 50 `ExtraMobileDataRequest`s upload a CSV with more than 50 status updates and/or more than 50 errors.
The summary displayed should be limited to max of 50 and provide a heading "Showing the first 50 of n requests containing errors" or "Showing the first 50 of n updated requests" indicating the results are truncated.

![image](https://user-images.githubusercontent.com/333931/105871511-4a1b6b00-5ff1-11eb-9473-197df2ddfa1e.png)
![image](https://user-images.githubusercontent.com/333931/105871869-a41c3080-5ff1-11eb-9651-1b136ef6bfa1.png)
