### PR TITLE
Display the zendesk ticket reference after a ticket has been created

### DIFF
--- a/app/controllers/support_ticket/check_your_request_controller.rb
+++ b/app/controllers/support_ticket/check_your_request_controller.rb
@@ -8,11 +8,12 @@ class SupportTicket::CheckYourRequestController < SupportTicket::BaseController
   end
 
   def save
-    if form.valid?
-      form.create_ticket
+    if form.valid? && form.create_ticket
       session[:support_ticket] = nil
+      session[:support_ticket_number] = form.ticket_number
       redirect_to next_step
     else
+      flash[:warning] = 'There was a problem trying to log your request. Please try again.'
       render 'support_tickets/check_your_request'
     end
   end

--- a/app/form_objects/support_ticket/check_your_request_form.rb
+++ b/app/form_objects/support_ticket/check_your_request_form.rb
@@ -1,15 +1,18 @@
 class SupportTicket::CheckYourRequestForm
   include ActiveModel::Model
 
-  attr_accessor :ticket
+  attr_accessor :ticket, :ticket_number
 
   validates :ticket, presence: true
 
   def create_ticket
     if Settings.zendesk&.username.present? && Settings.zendesk&.token.present?
       ticket['subject'] = build_subject
-      ZendeskService.send!(ticket)
+      @ticket_number = ZendeskService.send!(ticket)&.id
+    else
+      @ticket_number = rand(10_000..99_999)
     end
+    @ticket_number
   end
 
 private

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -1,23 +1,38 @@
-<% content_for :title,  'Thank you for completing this form' %>
+<% content_for :title,  'Support request complete' %>
 
 <%- content_for :before_content do %>
   <% breadcrumbs([{ 'Home' => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
-                  'Thank you for completing this form',
+                  'Support request sent',
                  ]) %>
 <% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
+    <%=render GovukComponent::Panel.new(
+      title: 'Support request sent',
+      body: "Your reference number #{session[:support_ticket_number]}")
+    %>
+  </div>
+</div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">
-      Thank you for completing this form
-    </h1>
-    <p class="govuk-body">Our support team has received your request. If you do not receive an email from us within that time, please check your spam or junk folder.</p>
+    <h2 class="govuk-heading-m">
+      What happens next?
+    </h2>
 
-    <p class="govuk-body">We aim to respond within 5 working days.</p>
+    <p class="govuk-body">
+      Our support team has received your message. We aim to respond to you by email within 5 working days.
+      If you have not heard from us within that time, please check your spam or junk folder.
+    </p>
+    <p class="govuk-body">
+      We’re experiencing high demand at the moment. We know that 5 days is a bit of a long time to ask you to wait, but we appreciate your patience.
+    </p>
 
     <!-- @TODO TRACK LINK ? -->
-    <p class="govuk-body">Access further resources on
+    <p class="govuk-body">
+      Find further resources on
       <a href="https://get-help-with-tech.education.gov.uk/" rel="noreferrer noopener" target="_blank">Get help with technology</a>
     </p>
   </div>

--- a/spec/controllers/support_ticket/check_your_request_controller_spec.rb
+++ b/spec/controllers/support_ticket/check_your_request_controller_spec.rb
@@ -36,16 +36,72 @@ RSpec.describe SupportTicket::CheckYourRequestController, type: :controller do
   end
 
   describe '#save' do
-    it 'clears the data in session state' do
-      session[:support_ticket] = { hello: 'world' }
-      post :save
-      expect(session[:support_ticket]).to be_nil
+    describe 'when form is valid and ticket has been created' do
+      it 'clears the data in session state' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(true)
+        allow(stubbed_form).to receive(:create_ticket).and_return(12_345)
+        allow(stubbed_form).to receive(:ticket_number).and_return(12_345)
+        controller.instance_variable_set(:@form, stubbed_form)
+        session[:support_ticket] = { hello: 'world' }
+        post :save
+        expect(session[:support_ticket]).to be_nil
+      end
+
+      it 'stores the zendesk ticket number in session' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(true)
+        allow(stubbed_form).to receive(:create_ticket).and_return(12_345)
+        allow(stubbed_form).to receive(:ticket_number).and_return(12_345)
+        controller.instance_variable_set(:@form, stubbed_form)
+        post :save
+        expect(session[:support_ticket_number]).to eq(12_345)
+      end
+
+      it 'redirects to thank you page' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(true)
+        allow(stubbed_form).to receive(:create_ticket).and_return(12_345)
+        allow(stubbed_form).to receive(:ticket_number).and_return(12_345)
+        controller.instance_variable_set(:@form, stubbed_form)
+        post :save
+        expect(response).to redirect_to(support_ticket_thank_you_path)
+      end
     end
 
-    it 'redirects to thank you page' do
-      session[:support_ticket] = { hello: 'world' }
-      post :save
-      expect(response).to redirect_to(support_ticket_thank_you_path)
+    describe 'when form is invalid' do
+      it 'sets a flash message' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(false)
+        controller.instance_variable_set(:@form, stubbed_form)
+        post :save
+        expect(flash[:warning]).to be_present
+      end
+
+      it 'renders the check your request partial again' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(false)
+        controller.instance_variable_set(:@form, stubbed_form)
+        expect(post(:save)).to render_template('support_tickets/check_your_request')
+      end
+    end
+
+    describe 'when create_ticket fails' do
+      it 'sets a flash message' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(true)
+        allow(stubbed_form).to receive(:create_ticket).and_return(nil)
+        controller.instance_variable_set(:@form, stubbed_form)
+        post :save
+        expect(flash[:warning]).to be_present
+      end
+
+      it 'renders the check your request partial again' do
+        stubbed_form = SupportTicket::CheckYourRequestForm.new
+        allow(stubbed_form).to receive(:valid?).and_return(false)
+        controller.instance_variable_set(:@form, stubbed_form)
+        expect(post(:save)).to render_template('support_tickets/check_your_request')
+      end
     end
   end
 end

--- a/spec/form_objects/support_ticket/check_your_request_form_spec.rb
+++ b/spec/form_objects/support_ticket/check_your_request_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
 
     describe '#create_ticket' do
       it 'calls the zendesk service to create a ticket in zendesk' do
-        allow(ZendeskService).to receive(:send!).and_return( double ZendeskAPI::Request, id: 56789)
+        allow(ZendeskService).to receive(:send!).and_return(instance_double('ZendeskAPI::Request', id: 56_789))
         described_class.new(ticket: mock_ticket).create_ticket
         expect(ZendeskService).to have_received(:send!)
       end
@@ -55,8 +55,6 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
         end
       end
     end
-
-
 
     context 'Subject' do
       it 'sets the email subject line to include just school name' do
@@ -96,7 +94,6 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
       expect(ZendeskService).not_to have_received(:send!)
     end
 
-
     it 'sets ticket_number instance variable to a random 5 digit  number' do
       form_object = described_class.new(ticket: mock_ticket)
       form_object.create_ticket
@@ -105,7 +102,7 @@ RSpec.describe SupportTicket::CheckYourRequestForm do
 
     it 'returns a random 5 digit number' do
       ticket_number = described_class.new(ticket: mock_ticket).create_ticket
-      expect(ticket_number).to be_between(10000,99999)
+      expect(ticket_number).to be_between(10_000, 99_999)
     end
   end
 end


### PR DESCRIPTION
### Context
The "Thank you" page content was a bit confusing for some users and as it didn't give them a reference number there was no confidence that their issue was logged even though they would have received a confirmation email with the ticket reference.

What was happened is that when we posted the form data to Zendesk, Zendesk would respond to the post request with an "OK" status along with the newly created ticket information. We just didn't relay that information back to the user.

### Changes proposed in this pull request
- Display the zendesk ticket reference number on the "Thank you" page
- Improve error handling if the action fails to create a ticket.

### Guidance to review
- visit https://dfe-ghwt-pr-1201.herokuapp.com/ 
- Create a new support ticket (For the shortest journey, select "I'm none of the above")
### Before
![image](https://user-images.githubusercontent.com/3441519/105989304-d6349d80-6098-11eb-8589-42b8050feeb1.png)
### After
![image](https://user-images.githubusercontent.com/3441519/105989062-7dfd9b80-6098-11eb-8fc1-b66cc418d460.png)
