### PR TITLE
[1419] Can search by UKPRN when add user to school

### DIFF
--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -16,7 +16,7 @@ class Support::SchoolsController < Support::BaseController
         end
       end
     elsif request.get?
-      @form = Support::SchoolSuggestionForm.new(name_or_urn: params[:query])
+      @form = Support::SchoolSuggestionForm.new(name_or_urn_or_ukprn: params[:query])
       if @form.valid?
         @schools = @form.matching_schools
         render json: @schools.as_json(only: %i[id name urn postcode town])

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -36,7 +36,7 @@ class Support::Users::SchoolsController < Support::BaseController
       end
       redirect_to support_user_path(@user)
     else
-      redirect_to action: :new, support_school_suggestion_form: { name_or_urn: user_school_params[:name_or_urn] }
+      redirect_to action: :new, support_school_suggestion_form: { name_or_urn_or_ukprn: user_school_params[:name_or_urn_or_ukprn] }
     end
   end
 
@@ -54,7 +54,7 @@ private
   end
 
   def user_school_params
-    params.fetch('support_school_suggestion_form', {}).permit(:name_or_urn, :school_urn)
+    params.fetch('support_school_suggestion_form', {}).permit(:name_or_urn_or_ukprn, :school_urn)
   end
 
   def set_school

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -3,12 +3,12 @@ class Support::SchoolSuggestionForm
 
   MAX_NUMBER_OF_SUGGESTED_SCHOOLS = 20
 
-  attr_accessor :name_or_urn, :school_urn, :except
+  attr_accessor :name_or_urn_or_ukprn, :school_urn, :except
 
-  validates :name_or_urn, length: { minimum: 3 }, unless: ->(form) { form.school_urn.present? }
+  validates :name_or_urn_or_ukprn, length: { minimum: 3 }, unless: ->(form) { form.school_urn.present? }
 
   def matching_schools
-    schools = school_by_urn.presence || schools_by_name_or_urn
+    schools = school_by_urn.presence || schools_by_name_or_urn_or_ukprn
     schools.where.not(id: ids_of_schools_to_exclude)
   end
 
@@ -44,9 +44,9 @@ private
     end
   end
 
-  def schools_by_name_or_urn
+  def schools_by_name_or_urn_or_ukprn
     School
-      .matching_name_or_urn(@name_or_urn)
+      .matching_name_or_urn_or_ukprn(@name_or_urn_or_ukprn)
       .includes(:responsible_body)
       .order(:name)
       .limit(MAX_NUMBER_OF_SUGGESTED_SCHOOLS)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -20,7 +20,7 @@ class School < ApplicationRecord
 
   validates :name, presence: true
 
-  pg_search_scope :matching_name_or_urn, against: %i[name urn], using: { tsearch: { prefix: true } }
+  pg_search_scope :matching_name_or_urn_or_ukprn, against: %i[name urn ukprn], using: { tsearch: { prefix: true } }
 
   before_create :set_computacenter_change
 

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -18,7 +18,7 @@
 
     <%= form_for @user_school_form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+        <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit %>
       <%- end %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -10,7 +10,7 @@
     </h1>
 
     <p class="govuk-body">
-      You searched for “<%= @form.name_or_urn %>”.
+      You searched for “<%= @form.name_or_urn_or_ukprn %>”.
     </p>
 
     <%- if @school_options.present? %>
@@ -47,7 +47,7 @@
 
     <%= govuk_details(summary: 'Try another school') do %>
       <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
-        <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+        <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit 'Search again' %>
       <%- end %>

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -11,7 +11,7 @@
 
     <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name or URN' } %>
+      <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
       <%= f.hidden_field :school_urn %>
       <%= f.govuk_submit 'Search again' %>
     <%- end %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -16,7 +16,7 @@ initSelectAllNone();
 initResponsibleBodiesAutocomplete();
 initSchoolAutocomplete(
   {
-    input: "support-school-suggestion-form-name-or-urn-field",
+    input: "support-school-suggestion-form-name-or-urn-or-ukprn-field",
     path: "/support/schools/results",
     hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
   }
@@ -24,7 +24,7 @@ initSchoolAutocomplete(
 
 initSchoolAutocomplete(
   {
-    input: "support-school-suggestion-form-name-or-urn-field-error",
+    input: "support-school-suggestion-form-name-or-urn-or-ukprn-field-error",
     path: "/support/schools/results",
     hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,7 +483,7 @@ en:
               greater_than: Enter an allocation that’s non-negative
         support/school_suggestion_form:
           attributes:
-            name_or_urn:
+            name_or_urn_or_ukprn:
               too_short: Enter a school name that is at least %{count} characters
   activerecord:
     attributes:
@@ -718,7 +718,7 @@ en:
         device_cap: How many devices can they order?
         router_cap: How many routers can they order?
       support_school_suggestion_form:
-        name_or_urn: School name or URN
+        name_or_urn_or_ukprn: School name, URN or UKPRN
       support_user_responsible_body_form:
         name: Responsible body name
   banners:

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe Support::SchoolsController, type: :controller do
         }])
       end
 
+      context 'when FE school exists' do
+        let!(:school) { create(:fe_school) }
+
+        it 'returns the FE school when searching by UKPRN' do
+          get :results, params: { query: school.ukprn }, format: :json
+
+          expect(response).to be_successful
+          expect(response.content_type).to eq 'application/json; charset=utf-8'
+
+          body = JSON.parse(response.body)
+
+          expect(body).to eq([{
+            'id' => school.id,
+            'name' => school.name,
+            'urn' => school.urn,
+            'town' => school.town,
+            'postcode' => school.postcode,
+          }])
+        end
+      end
+
       it 'returns an error when the query string is too short' do
         get :results, params: { query: 'aa' }, format: :json
 
@@ -57,7 +78,7 @@ RSpec.describe Support::SchoolsController, type: :controller do
 
         body = JSON.parse(response.body)
         expect(body).to eq({
-          'errors' => ["'Name or urn' Enter a school name that is at least 3 characters"],
+          'errors' => ["'Name or urn or ukprn' Enter a school name that is at least 3 characters"],
         })
       end
     end

--- a/spec/controllers/support/users/schools_controller_spec.rb
+++ b/spec/controllers/support/users/schools_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Support::Users::SchoolsController, type: :controller do
 
   describe '#new' do
     it 'validates that the name or URN param is 3 characters or longer' do
-      get :new, params: { user_id: trust_user.id, support_school_suggestion_form: { name_or_urn: 'ab' } }
+      get :new, params: { user_id: trust_user.id, support_school_suggestion_form: { name_or_urn_or_ukprn: 'ab' } }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(:search_again)
@@ -24,7 +24,7 @@ RSpec.describe Support::Users::SchoolsController, type: :controller do
     it 'grants user access to the school when the support agent provides a URN via the text box (no JS)' do
       get :create, params: {
         user_id: trust_user.id,
-        support_school_suggestion_form: { name_or_urn: school_to_add.urn.to_s },
+        support_school_suggestion_form: { name_or_urn_or_ukprn: school_to_add.urn.to_s },
       }
 
       expect(trust_user.schools.reload).to include(school_to_add)
@@ -49,7 +49,7 @@ RSpec.describe Support::Users::SchoolsController, type: :controller do
 
       get :create, params: {
         user_id: trust_user.id,
-        support_school_suggestion_form: { name_or_urn: 'ABC' },
+        support_school_suggestion_form: { name_or_urn_or_ukprn: 'ABC' },
       }
 
       expect(trust_user.schools.reload).to include(school_to_add)
@@ -63,16 +63,16 @@ RSpec.describe Support::Users::SchoolsController, type: :controller do
 
       get :create, params: {
         user_id: trust_user.id,
-        support_school_suggestion_form: { name_or_urn: 'school' },
+        support_school_suggestion_form: { name_or_urn_or_ukprn: 'school' },
       }
 
-      expect(response).to redirect_to(new_support_user_school_path(trust_user, 'support_school_suggestion_form[name_or_urn]' => 'school'))
+      expect(response).to redirect_to(new_support_user_school_path(trust_user, 'support_school_suggestion_form[name_or_urn_or_ukprn]' => 'school'))
     end
 
     it 'prompts to search again if the support agent enters a school name that is too short' do
       get :create, params: {
         user_id: trust_user.id,
-        support_school_suggestion_form: { name_or_urn: 'ab' },
+        support_school_suggestion_form: { name_or_urn_or_ukprn: 'ab' },
       }
 
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/features/support/changing_a_users_associated_organisations_spec.rb
+++ b/spec/features/support/changing_a_users_associated_organisations_spec.rb
@@ -155,12 +155,12 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_enter_a_partial_school_name_that_matches_only_one_school
-    fill_in 'School name or URN', with: other_school_1.name.first(3).downcase
+    fill_in 'School name, URN or UKPRN', with: other_school_1.name.first(3).downcase
     user_schools_page.submit_school_name_or_urn.click
   end
 
   def and_i_enter_a_partial_school_name_that_matches_multiple_schools
-    fill_in 'School name or URN', with: 'school'
+    fill_in 'School name, URN or UKPRN', with: 'school'
     user_schools_page.submit_school_name_or_urn.click
   end
 
@@ -183,7 +183,7 @@ RSpec.feature 'Changing users’ associated organisations' do
   end
 
   def and_i_enter_a_school_urn_that_the_user_already_has
-    fill_in 'School name or URN', with: trust_school_1.urn
+    fill_in 'School name, URN or UKPRN', with: trust_school_1.urn
     user_schools_page.submit_school_name_or_urn.click
   end
 

--- a/spec/form_objects/support/school_suggestion_form_spec.rb
+++ b/spec/form_objects/support/school_suggestion_form_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Support::SchoolSuggestionForm, type: :model do
   subject(:form) { described_class.new }
 
-  it { is_expected.to validate_length_of(:name_or_urn).is_at_least(3) }
+  it { is_expected.to validate_length_of(:name_or_urn_or_ukprn).is_at_least(3) }
 
-  it 'allows name_or_urn to be nil if school_urn is set' do
+  it 'allows name_or_urn_or_ukprn to be nil if school_urn is set' do
     expect(described_class.new(school_urn: '123456')).to be_valid
   end
 
@@ -14,7 +14,7 @@ RSpec.describe Support::SchoolSuggestionForm, type: :model do
     school2 = create(:school, name: 'Southdean School')
     create(:school, name: 'Northfields School')
 
-    form = Support::SchoolSuggestionForm.new(name_or_urn: 'South')
+    form = Support::SchoolSuggestionForm.new(name_or_urn_or_ukprn: 'South')
 
     expect(form.matching_schools).to contain_exactly(school1, school2)
   end
@@ -24,7 +24,7 @@ RSpec.describe Support::SchoolSuggestionForm, type: :model do
 
     create_list(:school, 4, name: 'AA School')
 
-    form = Support::SchoolSuggestionForm.new(name_or_urn: 'AA')
+    form = Support::SchoolSuggestionForm.new(name_or_urn_or_ukprn: 'AA')
 
     expect(form.maximum_matching_schools).to eq(2)
     expect(form.matching_schools.size).to eq(2)
@@ -44,7 +44,7 @@ RSpec.describe Support::SchoolSuggestionForm, type: :model do
     matching_school = create(:school, name: 'Southmead School', urn: 123_456)
     excluded_school = create(:school, name: 'Southdean School', urn: 654_321)
 
-    form = Support::SchoolSuggestionForm.new(name_or_urn: 'South', except: [excluded_school])
+    form = Support::SchoolSuggestionForm.new(name_or_urn_or_ukprn: 'South', except: [excluded_school])
 
     expect(form.matching_schools).to contain_exactly(matching_school)
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -355,12 +355,12 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe '.matching_name_or_urn' do
+  describe '#matching_name_or_urn_or_ukprn' do
     it 'returns schools with the provided URN' do
       matched_school = create(:school, urn: 123_456)
       create(:school, urn: 123_458) # non-matching school
 
-      expect(School.matching_name_or_urn(123_456)).to eq([matched_school])
+      expect(School.matching_name_or_urn_or_ukprn(123_456)).to eq([matched_school])
     end
 
     it 'returns schools which match the name partially or exactly' do
@@ -368,7 +368,7 @@ RSpec.describe School, type: :model do
       matched_school2 = create(:school, name: 'Southside Primary')
       create(:school, name: 'Northside') # non-matching school
 
-      expect(School.matching_name_or_urn('Southside')).to contain_exactly(matched_school1, matched_school2)
+      expect(School.matching_name_or_urn_or_ukprn('Southside')).to contain_exactly(matched_school1, matched_school2)
     end
   end
 end

--- a/spec/page_objects/support/users/schools_page.rb
+++ b/spec/page_objects/support/users/schools_page.rb
@@ -4,7 +4,7 @@ module PageObjects
       class SchoolsPage < PageObjects::BasePage
         set_url '/support/users/{id}/schools'
 
-        element :school_name_or_urn, 'input#support-school-suggestion-form-name-or-urn-field'
+        element :school_name_or_urn, 'input#support-school-suggestion-form-name-or-urn-or-ukprn-field'
         element :school_urn, 'input#support_school_suggestion_form_school_urn'
         element :submit_school_name_or_urn, '#new_support_school_suggestion_form input[value=Continue]'
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/owl7cZGa/1419-cannot-add-users-to-fe-schools-as-autocomplete-does-not-search-by-ukprn

### Changes proposed in this pull request

- When adding to users to schools can now search for schools by UKPRN

### Guidance to review

- Login as support agent
- Find a user
- Edit the user
- Add the user to a school by searching for a school by UKPRN
- Both JS autocomplete option and non-js option should work
- User should now be associated with the selected school