### PR TITLE
Add radio button options to school search in the support console

### DIFF
--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -92,6 +92,11 @@ private
   end
 
   def search_params
-    params.require(:school_search_form).permit(:identifiers, :responsible_body_id, :order_state)
+    params.require(:school_search_form).permit(
+      :search_type,
+      :identifiers,
+      :responsible_body_id,
+      :order_state,
+    )
   end
 end

--- a/app/views/support/schools/results.html.erb
+++ b/app/views/support/schools/results.html.erb
@@ -77,6 +77,7 @@
                                 urns: params[:school_search_form][:urns],
                                 responsible_body_id: params[:school_search_form][:responsible_body_id],
                                 order_state: params[:school_search_form][:order_state],
+                                search_type: params[:school_search_form][:search_type],
                               },
                             },
                             method: :post,

--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -10,29 +10,31 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= title %>
-    </h1>
-
     <%= form_with model: @search_form, url: results_support_schools_path do |f| %>
-      <%= f.govuk_text_area :identifiers,
-                            label: { text: 'URNs or UKPRNs', size: 'm' },
-                            hint: {
-                              text: 'Search by entering URNs or UKPRNs. Use one line per identifier.'
-                            },
-                            rows: 10 %>
+      <%= f.govuk_radio_buttons_fieldset(:search_type, legend: { size: 'xl', text: title, tag: 'h1' }) do %>
+        <%= f.govuk_radio_button :search_type, :multiple, label: { text: 'Search for multiple schools by URN or UKPRN' } do %>
+          <%= f.govuk_text_area :identifiers,
+                                label: { text: 'URNs or UKPRNs', size: 'm' },
+                                hint: {
+                                  text: 'Search by entering URNs or UKPRNs. Use one line per identifier.'
+                                },
+                                rows: 10 %>
+        <% end %>
+        <%= f.govuk_radio_button :search_type, :responsible_body_or_order_state, label: { text: 'Search by responsible body or order state' } do %>
+          <%= f.govuk_collection_select   :responsible_body_id,
+                                          @search_form.select_responsible_body_options,
+                                          :id,
+                                          :name,
+                                          label: { text: 'Responsible body' } %>
 
-      <%= f.govuk_collection_select   :responsible_body_id,
-                                      @search_form.select_responsible_body_options,
-                                      :id,
-                                      :name,
-                                      label: { text: 'Responsible body' } %>
+          <%= f.govuk_collection_select   :order_state,
+                                          @search_form.select_order_state_options,
+                                          :value,
+                                          :label,
+                                          label: { text: 'Order state' } %>
+        <% end %>
+      <% end %>
 
-      <%= f.govuk_collection_select   :order_state,
-                                      @search_form.select_order_state_options,
-                                      :value,
-                                      :label,
-                                      label: { text: 'Order state' } %>
       <%= f.govuk_submit 'Search' %>
     <% end %>
   </div>

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Support::SchoolsController, type: :controller do
     end
 
     it 'renders HTML results when POSTing' do
-      post :results, params: { school_search_form: { identifiers: "#{school.urn}\r\n#{another_school.urn}" } }
+      post :results, params: { school_search_form: { identifiers: "#{school.urn}\r\n#{another_school.urn}", search_type: 'multiple' } }
 
       expect(response).to be_successful
       expect(response).to render_template('results')

--- a/spec/features/support/searching_schools_spec.rb
+++ b/spec/features/support/searching_schools_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
   let(:bad_urn) { '12492903' }
   let(:schools_who_can_order) { create_list(:school, 2, responsible_body: responsible_body, order_state: 'can_order') }
 
-  scenario 'happy journey' do
+  scenario 'support agent searches by multiple URNs' do
     given_i_am_signed_in_as_a_support_user
     when_i_follow_the_links_to_find_schools
     then_i_see_the_schools_search_page
@@ -26,7 +26,7 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     then_i_see_the_schools_search_page
   end
 
-  scenario 'searching by other criteria' do
+  scenario 'support agent searches by order state and responsible body' do
     given_i_am_signed_in_as_a_support_user
     and_multiple_schools_from_the_same_responsible_body_in_different_order_states
     when_i_follow_the_links_to_find_schools
@@ -42,7 +42,7 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     then_i_see_the_schools_search_page
   end
 
-  scenario 'exporting allocations as csv' do
+  scenario 'support agent exports allocations as CSV' do
     given_i_am_signed_in_as_a_support_user
     and_multiple_schools_from_the_same_responsible_body_in_different_order_states
     when_i_follow_the_links_to_find_schools
@@ -77,11 +77,13 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
   end
 
   def when_i_fill_in_some_urns
+    search_page.search_by_urn_or_ukprn.choose
     data = schools.map(&:urn).append(bad_urn).join("\r\n")
     search_page.identifiers.set data
   end
 
   def when_i_choose_an_order_state_and_responsible_body
+    search_page.search_by_rb_or_order_state.choose
     select responsible_body.name, from: 'Responsible body'
     select 'They can order their full allocation because a closure or group of self-isolating children has been reported', from: 'Order state'
   end

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SchoolSearchForm do
 
   describe '#array_of_identifiers' do
     subject(:form) do
-      described_class.new(identifiers: "   123  \r\ \r\n456\r\n")
+      described_class.new(identifiers: "   123  \r\ \r\n456\r\n", search_type: 'multiple')
     end
 
     it 'returns correct array of identifiers' do
@@ -16,7 +16,7 @@ RSpec.describe SchoolSearchForm do
 
   describe '#missing_identifiers' do
     subject(:form) do
-      described_class.new(identifiers: "   #{school.urn}  \r\ \r\n456\r\n")
+      described_class.new(identifiers: "   #{school.urn}  \r\ \r\n456\r\n", search_type: 'multiple')
     end
 
     it 'returns array of identifiers with no matches' do
@@ -27,7 +27,7 @@ RSpec.describe SchoolSearchForm do
   describe '#schools' do
     context 'given identifiers' do
       subject(:form) do
-        described_class.new(identifiers: "#{school.urn}\r\n#{closed_school.urn}\r\n")
+        described_class.new(identifiers: "#{school.urn}\r\n#{closed_school.urn}\r\n", search_type: 'multiple')
       end
 
       it 'only includes schools matching those identifiers which are not closed' do
@@ -40,7 +40,7 @@ RSpec.describe SchoolSearchForm do
       let!(:open_school_from_different_rb) { create(:school, responsible_body: create(:local_authority)) }
 
       subject(:form) do
-        described_class.new(responsible_body_id: school.responsible_body_id)
+        described_class.new(responsible_body_id: school.responsible_body_id, search_type: 'responsible_body_or_order_state')
       end
 
       it 'only includes schools matching that responsible_body_id which are not closed' do
@@ -58,7 +58,7 @@ RSpec.describe SchoolSearchForm do
       end
 
       subject(:form) do
-        described_class.new(order_state: 'can_order')
+        described_class.new(order_state: 'can_order', search_type: 'responsible_body_or_order_state')
       end
 
       it 'only includes schools matching that order_state which are not closed' do
@@ -71,7 +71,7 @@ RSpec.describe SchoolSearchForm do
     let(:urns) { nil }
     let(:responsible_body_id) { nil }
     let(:order_state) { nil }
-    let(:form) { SchoolSearchForm.new(identifiers: urns, responsible_body_id: responsible_body_id, order_state: order_state) }
+    let(:form) { SchoolSearchForm.new(identifiers: urns, responsible_body_id: responsible_body_id, order_state: order_state, search_type: 'multiple') }
     let(:expected_timestamp) { Time.zone.now.utc.iso8601 }
 
     before do

--- a/spec/page_objects/support/schools/search_page.rb
+++ b/spec/page_objects/support/schools/search_page.rb
@@ -4,6 +4,9 @@ module PageObjects
       class SearchPage < PageObjects::BasePage
         set_url '/support/schools/search'
 
+        element :search_by_urn_or_ukprn, '#school-search-form-search-type-multiple-field'
+        element :search_by_rb_or_order_state, '#school-search-form-search-type-responsible-body-or-order-state-field'
+
         element :identifiers, 'textarea#school-search-form-identifiers-field'
         element :responsible_body, 'select#school-search-form-responsible-body-id-field'
         element :order_state, 'select#school-search-form-order-state-field'


### PR DESCRIPTION
### Context

Support agents can search for schools by URNs, UKPRNs, responsible body and order state.

### Changes proposed in this pull request

Split the 'search schools' form with radio button options.

This is to pave the way for adding a third option shortly. This also
reflects the fact that it doesn't make sense for a user to be trying to
find schools both by URN/UKPRN and their RB or state...

### Guidance to review

**Before:**

![image](https://user-images.githubusercontent.com/23801/106008508-451cf100-60af-11eb-8812-a960fd4b816f.png)


**After:**

![image](https://user-images.githubusercontent.com/23801/106008168-f1120c80-60ae-11eb-9590-680f45b84637.png)

![image](https://user-images.githubusercontent.com/23801/106008205-f96a4780-60ae-11eb-990e-0a99859a8092.png)

Out of scope of this PR, will be done shortly as a follow-up PR:

- form validations (these are also currently missing so it's not a regression)