### PR TITLE
1375 update chromebook question and validation

### DIFF
--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -4,7 +4,7 @@ class ChromebookInformationForm
   attr_accessor :school, :will_need_chromebooks
   attr_reader :school_or_rb_domain, :recovery_email_address
 
-  validates :will_need_chromebooks, presence: { message: lambda(object, _) do
+  validates :will_need_chromebooks, presence: { message: lambda do |object, _|
                                                            I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
                                                          end }
 

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -37,8 +37,8 @@ class ChromebookInformationForm
 
   def chromebook_domain_label
     label = Array(school.institution_type.capitalize)
-    label << "or #{school.responsible_body.humanized_type}" if !school.is_a?(FurtherEducationSchool)
-    label << "email domain registered for <span class=‘app-no-wrap’>G Suite for Education</span>"
+    label << "or #{school.responsible_body.humanized_type}" unless school.is_a?(FurtherEducationSchool)
+    label << 'email domain registered for <span class="app-no-wrap">G Suite for Education</span>'
     label.join(' ').html_safe
   end
 end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -34,11 +34,4 @@ class ChromebookInformationForm
       errors.add(:recovery_email_address, :cannot_be_same_domain_as_school_or_rb)
     end
   end
-
-  def chromebook_domain_label
-    label = Array(school.institution_type.capitalize)
-    label << "or #{school.responsible_body.humanized_type}" unless school.is_a?(FurtherEducationSchool)
-    label << 'email domain registered for <span class="app-no-wrap">G Suite for Education</span>'
-    label.join(' ').html_safe
-  end
 end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -34,4 +34,11 @@ class ChromebookInformationForm
       errors.add(:recovery_email_address, :cannot_be_same_domain_as_school_or_rb)
     end
   end
+
+  def chromebook_domain_label
+    label = Array(school.institution_type.capitalize)
+    label << "or #{school.responsible_body.humanized_type}" if !school.is_a?(FurtherEducationSchool)
+    label << "email domain registered for <span class=‘app-no-wrap’>G Suite for Education</span>"
+    label.join(' ').html_safe
+  end
 end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -4,7 +4,9 @@ class ChromebookInformationForm
   attr_accessor :school, :will_need_chromebooks
   attr_reader :school_or_rb_domain, :recovery_email_address
 
-  validates :will_need_chromebooks, presence: true
+  validates :will_need_chromebooks, presence: { message: lambda(object, _) do
+                                                           I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
+                                                         end }
 
   with_options if: :will_need_chromebooks? do |condition|
     condition.validates :recovery_email_address,

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -176,6 +176,13 @@ module ViewHelper
     govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status'
   end
 
+  def chromebook_domain_label(school)
+    label = Array(school.institution_type.capitalize)
+    label << "or #{school.responsible_body.humanized_type}" unless school.is_a?(FurtherEducationSchool)
+    label << 'email domain registered for <span class="app-no-wrap">G Suite for Education</span>'
+    label.join(' ').html_safe
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -178,7 +178,7 @@ module ViewHelper
 
   def chromebook_domain_label(school)
     label = Array(school.institution_type.capitalize)
-    label << "or #{school.responsible_body.humanized_type}" unless school.is_a?(FurtherEducationSchool)
+    label << "or #{school.responsible_body.humanized_type}" unless school.is_further_education?
     label << 'email domain registered for <span class="app-no-wrap">G Suite for Education</span>'
     label.join(' ').html_safe
   end

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -122,7 +122,7 @@ private
       errors.add(:will_need_chromebooks, I18n.t('chromebooks.errors.choice', scope: i18n_scope))
       false
     elsif chromebook_information.invalid?
-      errors.copy!(chromebook_information.errors)
+      errors.merge!(chromebook_information)
       false
     else
       update_preorder_information!(cb_params)

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -12,7 +12,7 @@
                               'yes',
                               label: { text: t(:yes, scope: scope) } do %>
       <%= f.govuk_text_field  :school_or_rb_domain,
-                              label: { text: "School, #{local_assigns[:form_object].school.responsible_body.humanized_type} or college domain registered for G Suite for Education", size: 's' },
+                              label: { text: local_assigns[:form_object].chromebook_domain_label, size: 's' },
                               hint: { text: "For example, ‘school.co.uk’" } %>
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -16,7 +16,7 @@
                               hint: { text: "For example, ‘school.co.uk’" } %>
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },
-                              hint: { text: "This email address must be on a different domain to the school or college domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." } %>
+                              hint: { text: "This email address must be on a different domain to the #{@school.institution_type} domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’." } %>
       <p class="govuk-body govuk-!-margin-top-4">
         If you need help finding these details, speak to the people you usually contact for IT support.
       </p>

--- a/app/views/shared/_chromebook_information_form.html.erb
+++ b/app/views/shared/_chromebook_information_form.html.erb
@@ -12,7 +12,7 @@
                               'yes',
                               label: { text: t(:yes, scope: scope) } do %>
       <%= f.govuk_text_field  :school_or_rb_domain,
-                              label: { text: local_assigns[:form_object].chromebook_domain_label, size: 's' },
+                              label: { text: chromebook_domain_label(local_assigns[:form_object].school), size: 's' },
                               hint: { text: "For example, ‘school.co.uk’" } %>
       <%= f.govuk_text_field  :recovery_email_address,
                               label: { text: "Recovery email address", size: 's' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,9 +452,9 @@ en:
             phone_number:
               blank: Enter the contact’s telephone
         chromebook_information_form:
+          custom_errors:
+            will_need_chromebooks: Tell us whether the %{institution_type} will need Chromebooks
           attributes:
-            will_need_chromebooks:
-              blank: Tell us whether the school will need Chromebooks
             school_or_rb_domain:
               blank: Enter an email domain registered for G Suite for Education, like myschool.org.uk
               invalid: Enter an email domain registered for G Suite for Education, like myschool.org.uk

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,9 +456,9 @@ en:
             will_need_chromebooks:
               blank: Tell us whether the school will need Chromebooks
             school_or_rb_domain:
-              blank: Enter an email domain registered for G Suite for Education
-              invalid: Enter an email domain registered for G Suite for Education
-              invalid_domain: Enter an email domain registered for G Suite for Education
+              blank: Enter an email domain registered for G Suite for Education, like myschool.org.uk
+              invalid: Enter an email domain registered for G Suite for Education, like myschool.org.uk
+              invalid_domain: Enter an email domain registered for G Suite for Education, like myschool.org.uk
             recovery_email_address:
               blank: Enter an email address in the correct format, like name@example.com
               invalid: Enter an email address in the correct format, like name@example.com

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,9 +456,9 @@ en:
             will_need_chromebooks:
               blank: Tell us whether the school will need Chromebooks
             school_or_rb_domain:
-              blank: Enter a domain in the right format, like myschool.org.uk
-              invalid: Enter a domain in the right format, like myschool.org.uk
-              invalid_domain: Enter a domain registered for G Suite for Education
+              blank: Enter an email domain registered for G Suite for Education
+              invalid: Enter an email domain registered for G Suite for Education
+              invalid_domain: Enter an email domain registered for G Suite for Education
             recovery_email_address:
               blank: Enter an email address in the correct format, like name@example.com
               invalid: Enter an email address in the correct format, like name@example.com

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def it_shows_me_fields_for_domain_and_recovery_email_address
-    expect(page).to have_field('School, local authority or college domain')
+    expect(page).to have_field('School or local authority email domain registered for G Suite for Education')
     expect(page).to have_field('Recovery email address')
   end
 
@@ -101,7 +101,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def when_i_provide_valid_entries_for_both_fields
-    fill_in 'School, local authority or college domain', with: 'somedomain.com'
+    fill_in 'School or local authority email domain registered for G Suite for Education', with: 'somedomain.com'
     fill_in 'Recovery email address', with: 'someone@someotherdomain.com'
     click_on 'Save'
   end

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature 'Change school Chromebook information' do
         click_on 'Save'
         expect(page).to have_http_status(:unprocessable_entity)
         expect(page).to have_content('There is a problem')
+        expect(page).to have_content('Enter an email domain registered for G Suite for Education')
       end
 
       it 'goes back to the school details page when I save valid information' do

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Change school Chromebook information' do
         end
 
         context 'and the school is a Further Education School' do
-          let(:school) { create(:fe_school, ) }
+          let(:school) { create(:fe_school) }
 
           it 'shows the correct label for domain' do
             expect(page).to have_field("#{school.institution_type.capitalize} email domain registered for G Suite for Education")

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -30,15 +30,33 @@ RSpec.feature 'Change school Chromebook information' do
         expect(page).to have_field('No, we will not order Chromebooks')
       end
 
-      it 'shows fields for domain and recovery email when I choose Yes' do
-        choose('Yes, we will order Chromebooks')
-        expect(page).to have_field('School, local authority or college domain')
-        expect(page).to have_field('Recovery email address')
+      context 'when I choose Yes' do
+        before do
+          choose('Yes, we will order Chromebooks')
+        end
+
+        it 'shows a recovery email field' do
+          expect(page).to have_field('Recovery email address')
+        end
+
+        context 'and the school is a Further Education School' do
+          let(:school) { create(:fe_school, ) }
+
+          it 'shows the correct label for domain' do
+            expect(page).to have_field("#{school.institution_type.capitalize} email domain registered for G Suite for Education")
+          end
+        end
+
+        context 'when the school is not a Further Education School' do
+          it 'shows the correct label for domain' do
+            expect(page).to have_field('School or local authority email domain registered for G Suite for Education')
+          end
+        end
       end
 
       it 'shows an error when I do not supply valid information' do
         choose('Yes, we will order Chromebooks')
-        fill_in('School, local authority or college domain', with: '')
+        fill_in('School or local authority email domain registered for G Suite for Education', with: '')
         click_on 'Save'
         expect(page).to have_http_status(:unprocessable_entity)
         expect(page).to have_content('There is a problem')
@@ -46,7 +64,7 @@ RSpec.feature 'Change school Chromebook information' do
 
       it 'goes back to the school details page when I save valid information' do
         choose('Yes, we will order Chromebooks')
-        fill_in('School, local authority or college domain', with: 'some.domain.org')
+        fill_in('School or local authority email domain registered for G Suite for Education', with: 'some.domain.org')
         fill_in('Recovery email address', with: 'someone@someotherdomain.org')
         click_on 'Save'
         expect(page).to have_http_status(:ok)

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature 'Navigate school welcome wizard' do
   def when_i_choose_yes_and_submit_the_chromebooks_form
     choose 'Yes, we will need Chromebooks'
     within('#school-welcome-wizard-will-need-chromebooks-yes-conditional') do
-      fill_in "School, #{school.responsible_body.humanized_type} or college domain registered for G Suite for Education", with: 'example.com'
+      fill_in "School or #{school.responsible_body.humanized_type} email domain registered for G Suite for Education", with: 'example.com'
       fill_in 'Recovery email address', with: 'admin@trust.com'
     end
     click_on 'Continue'

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -115,6 +115,37 @@ RSpec.feature 'Navigate school welcome wizard' do
     then_i_see_the_school_home_page
   end
 
+  scenario 'filling in invalid chromebook information' do
+    given_my_school_has_an_unavailable_allocation
+    as_a_subsequent_school_user
+    when_i_sign_in_for_the_first_time
+    then_i_see_a_welcome_page_for_my_school
+
+    when_i_click_continue
+    then_i_see_a_privacy_notice
+
+    when_i_click_continue
+    then_i_see_the_allocation_for_my_school
+
+    when_i_click_continue
+    then_i_see_the_order_your_own_page
+
+    when_i_click_continue
+    then_i_see_information_about_devices_i_can_order
+
+    when_i_click_continue
+    then_im_asked_whether_my_school_will_order_chromebooks
+
+    when_i_choose_yes_and_submit_invalid_chromebooks_information
+    then_i_see_appropriate_error_messages
+
+    when_i_provide_valid_chromebooks_information
+    then_i_see_information_about_what_happens_next
+
+    when_i_click_to_finish_and_go_to_homepage
+    then_i_see_the_school_home_page
+  end
+
   scenario 'the wizard resumes where left off' do
     given_my_school_has_an_unavailable_allocation
     as_a_new_school_user
@@ -223,6 +254,28 @@ RSpec.feature 'Navigate school welcome wizard' do
       fill_in 'Recovery email address', with: 'admin@trust.com'
     end
     click_on 'Continue'
+  end
+
+  def when_i_choose_yes_and_submit_invalid_chromebooks_information
+    choose 'Yes, we will need Chromebooks'
+    within('#school-welcome-wizard-will-need-chromebooks-yes-conditional') do
+      fill_in "School or #{school.responsible_body.humanized_type} email domain registered for G Suite for Education", with: ''
+      fill_in 'Recovery email address', with: ''
+    end
+    click_on 'Continue'
+  end
+
+  def when_i_provide_valid_chromebooks_information
+    within('#school-welcome-wizard-will-need-chromebooks-yes-conditional') do
+      fill_in "School or #{school.responsible_body.humanized_type} email domain registered for G Suite for Education", with: 'example.com'
+      fill_in 'Recovery email address', with: 'admin@trust.com'
+    end
+    click_on 'Continue'
+  end
+
+  def then_i_see_appropriate_error_messages
+    expect(page).to have_text 'Enter an email domain registered for G Suite for Education, like myschool.org.uk'
+    expect(page).to have_text 'Enter an email address in the correct format, like name@example.com'
   end
 
   def when_i_choose_no_and_submit_the_chromebooks_form

--- a/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
+++ b/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Editing a school’s Chromebook details from the support area' do
       .follow_action_link
 
     choose 'Yes, we will order Chromebooks'
-    fill_in 'School, local authority or college domain', with: 'somedomain.com'
+    fill_in 'School or local authority', with: 'somedomain.com'
     fill_in 'Recovery email address', with: 'someone@someotherdomain.com'
     click_on 'Save'
   end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -27,4 +27,45 @@ RSpec.describe ChromebookInformationForm do
 
     expect(request).to have_been_made
   end
+
+  describe '#chromebook_domain_label' do
+    let(:school) { build(:school, :la_maintained) }
+    let(:form) { described_class.new(school: school) }
+
+    it 'starts with the capitalized institution_type' do
+      expect(form.chromebook_domain_label).to start_with('School')
+    end
+
+    it 'ends with email domain registered for <span class="app-no-wrap">G Suite for Education</span>' do
+      expect(form.chromebook_domain_label).to end_with('email domain registered for <span class="app-no-wrap">G Suite for Education</span>')
+    end
+
+    context 'when the school is not a FurtherEducationSchool' do
+      context 'and the responsible body is a local authority' do
+        it 'starts with School or local authority' do
+          expect(form.chromebook_domain_label).to start_with('School or local authority')
+        end
+      end
+
+      context 'and the responsible body is a trust' do
+        let(:school) { build(:school, :academy) }
+
+        it 'starts with School or local authority' do
+          expect(form.chromebook_domain_label).to start_with('School or trust')
+        end
+      end
+    end
+
+    context 'when the school is a FurtherEducationSchool' do
+      let(:school) { build(:fe_school, fe_type: 'sixth_form_college') }
+
+      it 'starts with College' do
+        expect(form.chromebook_domain_label).to start_with('College')
+      end
+
+      it 'does not include " or "' do
+        expect(form.chromebook_domain_label).not_to include(' or ')
+      end
+    end
+  end
 end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -27,45 +27,4 @@ RSpec.describe ChromebookInformationForm do
 
     expect(request).to have_been_made
   end
-
-  describe '#chromebook_domain_label' do
-    let(:school) { build(:school, :la_maintained) }
-    let(:form) { described_class.new(school: school) }
-
-    it 'starts with the capitalized institution_type' do
-      expect(form.chromebook_domain_label).to start_with('School')
-    end
-
-    it 'ends with email domain registered for <span class="app-no-wrap">G Suite for Education</span>' do
-      expect(form.chromebook_domain_label).to end_with('email domain registered for <span class="app-no-wrap">G Suite for Education</span>')
-    end
-
-    context 'when the school is not a FurtherEducationSchool' do
-      context 'and the responsible body is a local authority' do
-        it 'starts with School or local authority' do
-          expect(form.chromebook_domain_label).to start_with('School or local authority')
-        end
-      end
-
-      context 'and the responsible body is a trust' do
-        let(:school) { build(:school, :academy) }
-
-        it 'starts with School or local authority' do
-          expect(form.chromebook_domain_label).to start_with('School or trust')
-        end
-      end
-    end
-
-    context 'when the school is a FurtherEducationSchool' do
-      let(:school) { build(:fe_school, fe_type: 'sixth_form_college') }
-
-      it 'starts with College' do
-        expect(form.chromebook_domain_label).to start_with('College')
-      end
-
-      it 'does not include " or "' do
-        expect(form.chromebook_domain_label).not_to include(' or ')
-      end
-    end
-  end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -120,4 +120,45 @@ RSpec.describe ViewHelper do
       end
     end
   end
+
+  describe '#chromebook_domain_label' do
+    let(:school) { build(:school, :la_maintained) }
+    let(:result) { helper.chromebook_domain_label(school) }
+
+    it 'starts with the capitalized institution_type' do
+      expect(result).to start_with('School')
+    end
+
+    it 'ends with email domain registered for <span class="app-no-wrap">G Suite for Education</span>' do
+      expect(result).to end_with('email domain registered for <span class="app-no-wrap">G Suite for Education</span>')
+    end
+
+    context 'when the school is not a FurtherEducationSchool' do
+      context 'and the responsible body is a local authority' do
+        it 'starts with School or local authority' do
+          expect(result).to start_with('School or local authority')
+        end
+      end
+
+      context 'and the responsible body is a trust' do
+        let(:school) { build(:school, :academy) }
+
+        it 'starts with School or local authority' do
+          expect(result).to start_with('School or trust')
+        end
+      end
+    end
+
+    context 'when the school is a FurtherEducationSchool' do
+      let(:school) { build(:fe_school, fe_type: 'sixth_form_college') }
+
+      it 'starts with College' do
+        expect(result).to start_with('College')
+      end
+
+      it 'does not include " or "' do
+        expect(result).not_to include(' or ')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

[Trello card 1375](https://trello.com/c/oaDQbQTn/1375-update-chromebook-question-and-validation) -  In user research, we saw users getting confused by what the G Suite for Education domain was. Improve the labelling to make it clearer.

### Changes proposed in this pull request

* label the domain field appropriately using the `institution_type` and `responsible_body.humanized_type` where appropriate 
* new `chromebook_domain_label` method on `ChromebookInformationForm` to encapsulate the logic
* improve wording on error message when the domain is invalid

### Guidance to review

(see the Trello card and [Slack thread](https://ukgovernmentdfe.slack.com/archives/C01A7DVKE9J/p1611761686137200) for discussion)

When the school's responsible body is a Local Authority:
![Screenshot from 2021-01-28 10-36-29](https://user-images.githubusercontent.com/134501/106126042-cbd7d980-6154-11eb-9da0-0535238670d9.png)

When it's a Further Education school:
![Screenshot from 2021-01-28 10-39-37](https://user-images.githubusercontent.com/134501/106126407-3c7ef600-6155-11eb-8757-e0d6e388d23e.png)


