### PR TITLE
Validate form submissions for the school search form in support

### DIFF
--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -8,12 +8,16 @@ class Support::SchoolsController < Support::BaseController
   def results
     if request.post?
       @search_form = SchoolSearchForm.new(search_params)
-      @schools = policy_scope(@search_form.schools).includes(:preorder_information, :responsible_body)
-      respond_to do |format|
-        format.html {}
-        format.csv do
-          send_data AllocationsExporter.new.export(@schools), filename: @search_form.csv_filename
+      if @search_form.valid?
+        @schools = policy_scope(@search_form.schools).includes(:preorder_information, :responsible_body)
+        respond_to do |format|
+          format.html {}
+          format.csv do
+            send_data AllocationsExporter.new.export(@schools), filename: @search_form.csv_filename
+          end
         end
+      else
+        render :search, status: :unprocessable_entity
       end
     elsif request.get?
       @form = Support::SchoolSuggestionForm.new(name_or_urn_or_ukprn: params[:query])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,6 +485,13 @@ en:
           attributes:
             name_or_urn_or_ukprn:
               too_short: Enter a school name that is at least %{count} characters
+        school_search_form:
+          attributes:
+            search_type:
+              blank: Select how you would like to search for schools and colleges
+              rb_or_order_state_blank: Select at least a responsible body or an order state
+            identifiers:
+              blank: Enter at least one URN or UKPRN
   activerecord:
     attributes:
       api_token:

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Support::SchoolsController, type: :controller do
       expect(response).to render_template('results')
     end
 
+    it 'renders an error page when POSTing an invalid form submission' do
+      post :results, params: { school_search_form: { search_type: 'unexpected' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template('search')
+    end
+
     context 'GET (from a JS autocomplete)' do
       it 'returns JSON results for a valid query string' do
         # ensure schools exist

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -1,8 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe SchoolSearchForm do
-  let(:school) { create(:school) }
+RSpec.describe SchoolSearchForm, type: :model do
   let(:closed_school) { create(:school, status: :closed) }
+  let(:school) { create(:school) }
+
+  it { is_expected.to validate_presence_of(:search_type) }
+  it { is_expected.to validate_inclusion_of(:search_type).in_array(%w[multiple responsible_body_or_order_state]) }
+  it { is_expected.to validate_inclusion_of(:order_state).in_array(School.order_states.keys).allow_blank }
+
+  it 'validates the presence of identifiers when the search_type=multiple' do
+    expect(described_class.new(search_type: 'multiple', identifiers: nil)).not_to be_valid
+    expect(described_class.new(search_type: 'multiple', identifiers: '')).not_to be_valid
+  end
+
+  it 'validates the presence of either RB ID or order state when the search_type=responsible_body_or_order_state' do
+    expect(described_class.new(search_type: 'responsible_body_or_order_state', responsible_body_id: nil, order_state: nil)).not_to be_valid
+
+    expect(described_class.new(search_type: 'responsible_body_or_order_state', responsible_body_id: school.responsible_body.id)).to be_valid
+    expect(described_class.new(search_type: 'responsible_body_or_order_state', order_state: 'can_order')).to be_valid
+  end
 
   describe '#array_of_identifiers' do
     subject(:form) do


### PR DESCRIPTION
### Context

The input on the school search form in the support console wasn't being validated.

### Changes proposed in this pull request

Add validations to ensure consistency of input, to bring the form in line with all other forms in the service.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/106130930-ec566280-6159-11eb-92cd-345769291d43.png)

![image](https://user-images.githubusercontent.com/23801/106130956-f5dfca80-6159-11eb-86bf-2a184bfe4d00.png)

![image](https://user-images.githubusercontent.com/23801/106130974-0001c900-615a-11eb-8e01-3bdbbf0bb56d.png)
