### PR TITLE
Fix missing translation when uploading an invalid MNO requests file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,6 +434,7 @@ en:
           attributes:
             upload:
               theres_a_problem_with_that_csv: There’s a problem with that CSV
+              unsupported_file_type: Choose a CSV file
         responsible_body/devices/who_will_order_form:
           attributes:
             who_will_order:

--- a/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_csv_update_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Update MNO Requests via CSV', type: :feature do
   let(:mno_user) { create(:mno_user) }
   let(:local_authority_user) { create(:local_authority_user) }
   let(:filename) { Rails.root.join('tmp/update_status.csv') }
+  let(:invalid_filename) { Rails.root.join('tmp/update_status.doc') }
 
   scenario 'navigating to the CSV update page' do
     given_i_have_some_mobile_data_requests
@@ -38,6 +39,15 @@ RSpec.feature 'Update MNO Requests via CSV', type: :feature do
     and_i_select_my_large_csv_file_with_errors
     and_i_click_the_upload_and_update_requests_button
     then_i_see_a_summary_page_with_the_first_50_errors_displayed
+  end
+
+  scenario 'submitting an invalid file' do
+    given_i_have_some_mobile_data_requests
+    given_i_am_signed_in_as_a_mno_user
+    when_i_visit_the_csv_update_page
+    and_i_select_an_invalid_file
+    and_i_click_the_upload_and_update_requests_button
+    then_i_see_an_invalid_error
   end
 
   def given_i_am_signed_in_as_a_mno_user
@@ -83,6 +93,16 @@ RSpec.feature 'Update MNO Requests via CSV', type: :feature do
 
     create_extra_mobile_data_request_update_csv_file(filename, attrs)
     attach_file('CSV file', filename)
+  end
+
+  def and_i_select_an_invalid_file
+    File.write(invalid_filename, 'test')
+    attach_file('CSV file', invalid_filename)
+  end
+
+  def then_i_see_an_invalid_error
+    expect(page).to have_text('Choose a CSV file')
+    remove_file(invalid_filename)
   end
 
   def and_i_click_the_upload_and_update_requests_button


### PR DESCRIPTION
### Context

We were missing a translation for an error message when a MNO uploads an invalid CSV file. This PR adds the string and a test case.

### Changes proposed in this pull request

### Guidance to review

