### PR TITLE
Gracefully handle searching for non-integer URNs

### DIFF
--- a/app/form_objects/school_search_form.rb
+++ b/app/form_objects/school_search_form.rb
@@ -4,7 +4,7 @@ class SchoolSearchForm
   attr_accessor :search_type, :identifiers, :responsible_body_id, :order_state
 
   validates :search_type, presence: true, inclusion: { in: %w[multiple responsible_body_or_order_state] }
-  validates :identifiers, presence: true, if: ->(form) { form.search_type == 'multiple' }
+  validates :identifiers, presence: true, format: { with: /\A[\d\s]*\z/ }, if: ->(form) { form.search_type == 'multiple' }
   validate :responsible_body_or_order_state_present_when_search_type_responsible_body_or_order_state
   validates :order_state, inclusion: { in: School.order_states }, allow_blank: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
               rb_or_order_state_blank: Select at least a responsible body or an order state
             identifiers:
               blank: Enter at least one URN or UKPRN
+              invalid: Enter URN or UKPRN in correct format
   activerecord:
     attributes:
       api_token:

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe SchoolSearchForm, type: :model do
     expect(described_class.new(search_type: 'multiple', identifiers: '')).not_to be_valid
   end
 
+  it 'validates the format of identifiers' do
+    expect(described_class.new(search_type: 'multiple', identifiers: '12345a')).not_to be_valid
+    expect(described_class.new(search_type: 'multiple', identifiers: "123456\12345a")).not_to be_valid
+    expect(described_class.new(search_type: 'multiple', identifiers: '123456')).to be_valid
+    expect(described_class.new(search_type: 'multiple', identifiers: "12345678\n")).to be_valid
+    expect(described_class.new(search_type: 'multiple', identifiers: "12345678\n123456")).to be_valid
+  end
+
   it 'validates the presence of either RB ID or order state when the search_type=responsible_body_or_order_state' do
     expect(described_class.new(search_type: 'responsible_body_or_order_state', responsible_body_id: nil, order_state: nil)).not_to be_valid
 


### PR DESCRIPTION
### Context

Card: https://trello.com/c/PxRskrDz/1387-display-friendly-error-when-somebody-searches-for-a-school-using-an-invalid-urn

Previously entering a non-integer URN/UKPRN in the support search form would raise an exception because Postgres was expecting us to search on an integer column using an integer.

This PR gracefully feeds back to the user if format of the input is incorrect.

