### PR TITLE
Allow support users to find permanently closed schools

### DIFF
--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -18,7 +18,6 @@ class Support::ResponsibleBodiesController < Support::BaseController
     @schools = @responsible_body
       .schools
       .includes(:device_allocations, :preorder_information)
-      .gias_status_open
       .order(name: :asc)
   end
 end

--- a/app/form_objects/school_search_form.rb
+++ b/app/form_objects/school_search_form.rb
@@ -25,7 +25,7 @@ class SchoolSearchForm
   end
 
   def schools
-    school_records = School.gias_status_open.includes(:responsible_body, :std_device_allocation)
+    school_records = School.includes(:responsible_body, :std_device_allocation)
 
     if search_type == 'multiple'
       school_records = school_records.where('urn IN (?) OR ukprn in (?)', array_of_identifiers, array_of_identifiers) if array_of_identifiers.present?

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -19,6 +19,16 @@
   </div>
 </div>
 
+<% if @school.gias_status_closed? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      This <%= @school.institution_type %> has permanently closed
+    </strong>
+  </div>
+<% end %>
+
 <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
 
 <%- if @school.show_mno? && @school.extra_mobile_data_requests.present? %>

--- a/spec/controllers/support/responsible_bodies_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Support::ResponsibleBodiesController, type: :controller do
     it 'excludes closed schools' do
       get :show, params: { id: rb.id }
       expect(assigns(:schools)).to include(school)
-      expect(assigns(:schools)).not_to include(closed_school)
+      expect(assigns(:schools)).to include(closed_school)
     end
   end
 end

--- a/spec/features/support/managing_schools_spec.rb
+++ b/spec/features/support/managing_schools_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
   let(:local_authority) { create(:local_authority, name: 'Coventry') }
   let(:responsible_bodies_page) { PageObjects::Support::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::ResponsibleBodyPage.new }
-  let(:school_contact) { School.find_by_name('Alpha School').contacts.first }
+  let(:school) { School.find_by_name('Alpha School') }
+  let(:school_contact) { school.contacts.first }
 
   scenario 'DfE users see school users' do
     given_a_responsible_body
@@ -90,6 +91,18 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
     then_i_see_the_school_users_with_updated_details
   end
 
+  scenario 'DfE users can see that a school is permanently closed' do
+    given_a_responsible_body
+    and_it_has_a_school_with_users
+    and_the_school_is_closed
+
+    when_i_sign_in_as_a_dfe_user
+    and_i_visit_the_responsible_body_page
+    and_i_visit_the_school_page
+
+    then_i_see_that_the_school_is_permanently_closed
+  end
+
   def given_a_responsible_body
     local_authority
   end
@@ -112,6 +125,10 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
                     responsible_body: local_authority)
     create(:school_user, school: school, full_name: 'James P. Sullivan', email_address: 'sully@alpha.sch.uk')
     create(:school_user, school: school, full_name: 'Mike Wazowski', email_address: 'mike@alpha.sch.uk', privacy_notice_seen_at: nil)
+  end
+
+  def and_the_school_is_closed
+    school.update! status: :closed
   end
 
   def and_the_school_contact_is_already_a_user_on_another_school
@@ -164,6 +181,10 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
 
     expect(page).to have_text('Mike Wazowski')
     expect(page).to have_text('mike@alpha.sch.uk')
+  end
+
+  def then_i_see_that_the_school_is_permanently_closed
+    expect(page).to have_text('has permanently closed')
   end
 
   def then_i_see_the_school_users_who_have_seen_the_privacy_policy

--- a/spec/form_objects/school_search_form_spec.rb
+++ b/spec/form_objects/school_search_form_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe SchoolSearchForm, type: :model do
         described_class.new(identifiers: "#{school.urn}\r\n#{closed_school.urn}\r\n", search_type: 'multiple')
       end
 
-      it 'only includes schools matching those identifiers which are not closed' do
-        expect(form.schools.map(&:urn)).to eq([school.urn])
+      it 'includes schools matching those identifiers' do
+        expect(form.schools.map(&:urn)).to eq([school.urn, closed_school.urn])
       end
     end
 
@@ -67,18 +67,18 @@ RSpec.describe SchoolSearchForm, type: :model do
 
     context 'given an order_state' do
       let!(:school_that_can_order) { create(:school, :in_lockdown) }
+      let!(:school_that_can_order_but_closed) { create(:school, :in_lockdown, status: :closed) }
 
       before do
         create(:school, :can_order_for_specific_circumstances)
-        create(:school, :in_lockdown, status: :closed)
       end
 
       subject(:form) do
         described_class.new(order_state: 'can_order', search_type: 'responsible_body_or_order_state')
       end
 
-      it 'only includes schools matching that order_state which are not closed' do
-        expect(form.schools.map(&:urn)).to eq([school_that_can_order.urn])
+      it 'only includes schools matching that order_state regardless of state' do
+        expect(form.schools.map(&:urn)).to eq([school_that_can_order.urn, school_that_can_order_but_closed.urn])
       end
     end
   end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/DF6lRrlF/1437-support-improvement-be-clear-when-school-is-closed

A few months ago we decided to hide closed schools in the support console.

Since then schools users have been navigating to schools directly using the URN in the URL so that they can view details on closed schools. We do not show when a school is permanently closed so this is particularly confusing.

### Changes proposed in this pull request

- This PR allows support users to navigate and search to schools that are marked as permanently closed by GIAS.
- It also adds a warning to the top of the school page to indicate if a school is closed.

### Guidance to review

- Search for closed school in the support console
- You should see results including the closed school

- Navigate to a responsible body with a closed school in support
- You should see the closed school listed on the RB

- You should see a warning at the top of the page that the school is permanently closed