### PR TITLE
Added microsofts csv mime type

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,5 +2,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
-Mime::Type.register 'text/csv', :csv
+Mime::Type.register 'text/csv', :csv, %w[application/vnd.ms-excel]
 Mime::Type.register 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', :xlsx

--- a/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Mno::ExtraMobileDataRequestsCsvUpdateController, type: :controller do
+  let(:mno_user) { create(:mno_user) }
+  let(:local_authority_user) { create(:local_authority_user) }
+  let(:filename) { Rails.root.join('tmp/update_status.csv') }
+  let(:requests) { create_list(:extra_mobile_data_request, 2, mobile_network: mno_user.mobile_network, created_by_user: local_authority_user) }
+
+  before do
+    sign_in_as mno_user
+  end
+
+  describe 'POST create' do
+    before do
+      attrs = requests_to_attrs
+      create_extra_mobile_data_request_update_csv_file(filename, attrs)
+    end
+
+    it 'accepts the standard content-type for csv' do
+      upload = Rack::Test::UploadedFile.new(filename, 'text/csv')
+
+      post :create, params: { mno_csv_status_update_form: { upload: upload } }
+      expect(response).to render_template(:summary)
+    end
+
+    it 'accepts Microsofts content-type for csv' do
+      upload = Rack::Test::UploadedFile.new(filename, 'application/vnd.ms-excel')
+
+      post :create, params: { mno_csv_status_update_form: { upload: upload } }
+      expect(response).to render_template(:summary)
+    end
+  end
+
+  def requests_to_attrs
+    requests.map do |req|
+      {
+        id: req.id,
+        account_holder_name: req.account_holder_name,
+        device_phone_number: req.device_phone_number,
+        created_at: req.created_at,
+        updated_at: req.updated_at,
+        mobile_network_id: req.mobile_network_id,
+        status: req.status,
+        contract_type: req.contract_type,
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/lCR0HN9W/1429-mnos-reporting-issue-uploading-csv)
Fix issue for MNO users on Microsoft Windows trying to upload CSV status files

### Changes proposed in this pull request
Microsoft identify CSV files using their own `application/vnd.ms-excel` mime-type rather than the standard `text/csv`, this adds `application/vnd.ms-excel` as a synonym for the csv type.

### Guidance to review
As a MNO user upload a status update CSV file from a Windows PC with Excel installed. File should be accepted and not generate the 'Choose a CSV file` error message
