### PR TITLE
Single school search in support

### DIFF
--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -101,6 +101,8 @@ private
       :identifiers,
       :responsible_body_id,
       :order_state,
+      :name_or_identifier,
+      :identifier,
     )
   end
 end

--- a/app/views/support/schools/results.html.erb
+++ b/app/views/support/schools/results.html.erb
@@ -78,6 +78,8 @@
                                 responsible_body_id: params[:school_search_form][:responsible_body_id],
                                 order_state: params[:school_search_form][:order_state],
                                 search_type: params[:school_search_form][:search_type],
+                                name_or_identifier: params[:school_search_form][:name_or_identifier],
+                                identifier: params[:school_search_form][:identifier],
                               },
                             },
                             method: :post,

--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -13,6 +13,10 @@
     <%= form_with model: @search_form, url: results_support_schools_path do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:search_type, legend: { size: 'xl', text: title, tag: 'h1' }) do %>
+        <%= f.govuk_radio_button :search_type, :single, label: { text: 'Search by name, URN or UKPRN' } do %>
+          <%= f.govuk_text_field :name_or_identifier, hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+          <%= f.hidden_field :identifier %>
+        <% end %>
         <%= f.govuk_radio_button :search_type, :multiple, label: { text: 'Search for multiple schools by URN or UKPRN' } do %>
           <%= f.govuk_text_area :identifiers,
                                 label: { text: 'URNs or UKPRNs', size: 'm' },

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -29,3 +29,19 @@ initSchoolAutocomplete(
     hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
   }
 );
+
+initSchoolAutocomplete(
+  {
+    input: "school-search-form-name-or-identifier-field",
+    path: "/support/schools/results",
+    hiddenFieldForURN: 'school_search_form_identifier'
+  }
+);
+
+initSchoolAutocomplete(
+  {
+    input: "school-search-form-name-or-identifier-field-error",
+    path: "/support/schools/results",
+    hiddenFieldForURN: 'school_search_form_identifier'
+  }
+);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,6 +494,8 @@ en:
             identifiers:
               blank: Enter at least one URN or UKPRN
               invalid: Enter URN or UKPRN in correct format
+            name_or_identifier:
+              blank: Enter at least one URN or UKPRN
   activerecord:
     attributes:
       api_token:
@@ -723,6 +725,8 @@ en:
     nudge_user_to_read_privacy_policy_event: We emailed a user asking them to sign in and read the privacy policy so that %{school} can place orders
   helpers:
     label:
+      school_search_form:
+        name_or_identifier: School name, URN or UKPRN
       support_enable_orders_form:
         device_cap: How many devices can they order?
         router_cap: How many routers can they order?

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -21,7 +21,14 @@ RSpec.describe Support::SchoolsController, type: :controller do
       sign_in_as support_user
     end
 
-    it 'renders HTML results when POSTing' do
+    it 'renders HTML results when POSTing a search for single school' do
+      post :results, params: { school_search_form: { identifier: school.urn, name_or_identifier: school.name, search_type: 'single' } }
+
+      expect(response).to be_successful
+      expect(response).to render_template('results')
+    end
+
+    it 'renders HTML results when POSTing a search for multiple schools' do
       post :results, params: { school_search_form: { identifiers: "#{school.urn}\r\n#{another_school.urn}", search_type: 'multiple' } }
 
       expect(response).to be_successful

--- a/spec/page_objects/support/schools/search_page.rb
+++ b/spec/page_objects/support/schools/search_page.rb
@@ -4,9 +4,11 @@ module PageObjects
       class SearchPage < PageObjects::BasePage
         set_url '/support/schools/search'
 
-        element :search_by_urn_or_ukprn, '#school-search-form-search-type-multiple-field'
+        element :search_by_name_urn_or_ukprn, '#school-search-form-search-type-single-field'
+        element :search_by_multiple_urn_or_ukprns, '#school-search-form-search-type-multiple-field'
         element :search_by_rb_or_order_state, '#school-search-form-search-type-responsible-body-or-order-state-field'
 
+        element :name_or_identifier, 'input#school-search-form-name-or-identifier-field'
         element :identifiers, 'textarea#school-search-form-identifiers-field'
         element :responsible_body, 'select#school-search-form-responsible-body-id-field'
         element :order_state, 'select#school-search-form-order-state-field'


### PR DESCRIPTION
### Context

Support agents need a way to quickly find a school by its name.

### Changes proposed in this pull request

Add an extra option to the school search in the support console, which has auto-complete and allows searching by a partial name, URN or UKPRN

### Guidance to review

https://user-images.githubusercontent.com/23801/106288458-fce10880-623f-11eb-9442-02f63a9b2a9e.mp4

