### PR TITLE
Hide 'Devices ordered' only if not in virtual pool and feature flag is not enabled

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -92,7 +92,7 @@ private
   end
 
   def display_devices_ordered_row?
-    !@school.in_virtual_cap_pool? && @school.std_device_allocation&.devices_ordered.to_i.positive?
+    (!@school.responsible_body.has_virtual_cap_feature_flags? || !@school.in_virtual_cap_pool?) && @school.std_device_allocation&.devices_ordered.to_i.positive?
   end
 
   def display_router_allocation_row?

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -178,6 +178,18 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       context 'when the school is not in a virtual_cap_pool' do
         before do
           allow(school).to receive(:in_virtual_cap_pool?).and_return(false)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(false)
+        end
+
+        it 'shows devices ordered row with count' do
+          expect(value_for_row(result, 'Devices ordered').text).to include('3 devices')
+        end
+      end
+
+      context 'when the responsible body is not in the virtual cap' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(true)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(false)
         end
 
         it 'shows devices ordered row with count' do
@@ -188,6 +200,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       context 'when the school is in a virtual_cap_pool' do
         before do
           allow(school).to receive(:in_virtual_cap_pool?).and_return(true)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(true)
         end
 
         it 'does not show devices ordered row' do


### PR DESCRIPTION
### Context & Changes

This PR extends on work initially done in https://github.com/DFE-Digital/get-help-with-tech/pull/1179

On the school details summary component we conditionally hide the 'devices ordered' number if the school is in the virtual cap or if the number is zero. This is because at a school level this doesn't make sense within the context of a virtual cap - schools may physically receive devices that then sent on elsewhere.

Previously it was checking whether virtual cap feature flag was disabled. We changed it so that it checked the school wasn't in the pool. We actually need _both_ to effectively determine whether a school is in the virtual cap.