### PR TITLE
[1433] Extend users session Part 1/2

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -4,6 +4,10 @@ class Session < ApplicationRecord
     || (updated_at.utc + ttl.seconds) < Time.zone.now.utc
   end
 
+  # def expired?
+  #   expires_at < Time.zone.now.utc
+  # end
+
   def ttl
     Settings.session_ttl_seconds
   end

--- a/db/migrate/20210129105958_add_expires_at_to_sessions.rb
+++ b/db/migrate/20210129105958_add_expires_at_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToSessions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :sessions, :expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_115602) do
+ActiveRecord::Schema.define(version: 2021_01_29_105958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -307,6 +307,7 @@ ActiveRecord::Schema.define(version: 2021_01_22_115602) do
   create_table "sessions", id: :string, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "expires_at"
   end
 
   create_table "staged_school_links", force: :cascade do |t|

--- a/spec/services/session_service_spec.rb
+++ b/spec/services/session_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SessionService do
+  describe '::ttl_for_user' do
+    context 'when support user' do
+      let(:user) { build(:support_user) }
+
+      it 'returns 7200' do
+        expect(described_class.ttl_for_user(user)).to eql(7200.seconds)
+      end
+    end
+
+    context 'when not a support user' do
+      let(:user) { build(:school_user) }
+
+      it 'returns 3600' do
+        expect(described_class.ttl_for_user(user)).to eql(3600.seconds)
+      end
+    end
+  end
+
+  describe '::create_session!' do
+    let(:user) { build(:support_user) }
+    let(:session_id) { SecureRandom.hex }
+
+    it 'sets expires_at' do
+      described_class.create_session!(session_id: session_id, user: user)
+      session = Session.find(session_id)
+      expect(session.expires_at).to be_within(10.seconds).of(Time.zone.now + 2.hours)
+    end
+  end
+
+  describe '::update_session!' do
+    let!(:session) { Session.create(id: SecureRandom.hex, created_at: 30.minutes.ago, updated_at: 30.minutes.ago) }
+
+    it 'updates expires_at' do
+      ttl = 3.days
+      described_class.update_session!(session.id, ttl)
+      session.reload
+      expect(session.expires_at).to be_within(10.seconds).of(Time.zone.now + ttl)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/MgxnyGhN/1433-support-improvement-increase-log-in-time-for-support-agents

### Changes proposed in this pull request

- A two part change is needed to allow different users to have different session durations
- This creates `expires_at` on the session and populates it on next use
- It cannot be populated immediately as postgres does not allow for default values based on other data on the row hence a two part change
- Next change will modify `Session#expired?`, remove `ttl` from `Session`, update `DeleteOldSessionsJob`

### Guidance to review

- Signing in, out and expiration should behave as normal as no change has been made
- We are simply setting up new data to be added which be hooked on to later