### PR TITLE
Bump msgpack to 1.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
-    msgpack (1.4.1)
+    msgpack (1.4.2)
     multipart-post (2.1.1)
     nio4r (2.5.4)
     nokogiri (1.11.1)


### PR DESCRIPTION
1.4.1 is no longer available and was preventing `bundle install` from working