### PR TITLE
[1435] Ignore whitespace padding on user search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   scope :deleted, -> { where.not(deleted_at: nil) }
   scope :not_deleted, -> { where(deleted_at: nil) }
   scope :search_by_email_address_or_full_name, lambda { |search_term|
-    where('email_address ILIKE ? OR full_name ILIKE ?', "%#{search_term}%", "%#{search_term}%")
+    where('email_address ILIKE ? OR full_name ILIKE ?', "%#{search_term.strip}%", "%#{search_term.strip}%")
   }
 
   validates :full_name,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1146,6 +1146,16 @@ RSpec.describe User, type: :model do
       expect(user_search('smith')).to eq([user])
       expect(user_search('bob')).to be_empty
     end
+
+    it 'ignores whitespace padding' do
+      user = create(:school_user, email_address: 'user@example.com', full_name: 'John Doe')
+      expect(user_search('  user@example.com  ')).to eq([user])
+      expect(user_search('user@example.com  ')).to eq([user])
+      expect(user_search('  user@example.com')).to eq([user])
+
+      expect(user_search('  John Doe  ')).to eq([user])
+      expect(user_search('  Doe  ')).to eq([user])
+    end
   end
 
   describe '.from_responsible_body_or_schools' do


### PR DESCRIPTION
### Context

- https://trello.com/c/Lggm08t2/1435-support-improvement-automatic-removal-of-leading-and-trailing-spaces-when-searching-by-email-or-name

### Changes proposed in this pull request

- Ignore whitespace padding on user search for support agents

### Guidance to review

- Login as support agent
- Search for existing user by name or email, add additional whitespace padding to the search query
- Should return user regardless of whitespace padding