### PR TITLE
[1411] School users cannot be added if RB orders

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -8,6 +8,8 @@ class Support::UsersController < Support::BaseController
     set_school_if_present
     set_responsible_body_if_present
 
+    deny_access_if_school_cannot_invite_users
+
     @form = Support::NewUserForm.new(
       school: @school,
       responsible_body: @responsible_body,
@@ -121,6 +123,12 @@ private
     if params[:school_urn]
       @school = School.gias_status_open.where_urn_or_ukprn(params[:school_urn]).first!
       authorize @school, :show?
+    end
+  end
+
+  def deny_access_if_school_cannot_invite_users
+    if @school && !@school.can_invite_users?
+      not_found
     end
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -202,6 +202,12 @@ class School < ApplicationRecord
     !hide_mno?
   end
 
+  def can_invite_users?
+    return true if preorder_information.nil?
+
+    preorder_information.school_will_order_devices?
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -38,7 +38,7 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
 
-<% if policy(User).new? %>
+<% if policy(User).new? && @school.can_invite_users? %>
   <%= govuk_button_link_to 'Invite a new user', new_support_school_user_path(school_urn: @school.urn) %>
 <% end %>
 

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Support::UsersController do
           get :new, params: { school_urn: school.urn }
         }.to be_forbidden_for(create(:computacenter_user))
       end
+
+      context 'when RB orders' do
+        before do
+          create(:preorder_information, :rb_will_order, school: school)
+        end
+
+        it 'does not allow school users to be added' do
+          sign_in_as support_user
+          get :new, params: { school_urn: school.urn }
+          expect(response).not_to be_successful
+        end
+      end
     end
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -371,4 +371,32 @@ RSpec.describe School, type: :model do
       expect(School.matching_name_or_urn_or_ukprn('Southside')).to contain_exactly(matched_school1, matched_school2)
     end
   end
+
+  describe '#can_invite_users?' do
+    subject(:school) { build(:school, preorder_information: preorder) }
+
+    context 'RB orders' do
+      let(:preorder) { build(:preorder_information, :rb_will_order) }
+
+      it 'returns false' do
+        expect(school.can_invite_users?).to be_falsey
+      end
+    end
+
+    context 'school orders' do
+      let(:preorder) { build(:preorder_information, :school_will_order) }
+
+      it 'returns true' do
+        expect(school.can_invite_users?).to be_truthy
+      end
+    end
+
+    context 'we do not know who orders' do
+      let(:preorder) { nil }
+
+      it 'returns true' do
+        expect(school.can_invite_users?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/views/support/schools/show.html.erb_spec.rb
+++ b/spec/views/support/schools/show.html.erb_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe 'support/schools/show.html.erb' do
       end
     end
   end
+
+  describe 'when school#can_invite_users? is true' do
+    it 'shows Invite a new user button' do
+      allow(school).to receive(:can_invite_users?).and_return(true)
+
+      render
+      expect(rendered).to include('Invite a new user')
+    end
+  end
+
+  describe 'when school#can_invite_users? is false' do
+    it 'does not show Invite a new user button' do
+      allow(school).to receive(:can_invite_users?).and_return(false)
+
+      render
+      expect(rendered).not_to include('Invite a new user')
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/NPSW33Ku/1411-remove-support-functionality-to-add-users-to-school-when-rb-ordering-centrally

### Changes proposed in this pull request

- Support agents cannot invite school users if RB orders
- Button is not displayed and controller access to the form is denied

### Guidance to review

- Login as support agent
- Find a school where RB orders
- Cannot invite new users to the school
- Find a school where school orders OR who will order has not been decided
- In both cases users can be invited to these schools