### PR TITLE
Rename "Home" to "Get help with technology"

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, t('page_titles.devices_guidance_how_to_order') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   "Get laptops and tablets",
                  ]) %>
 <% end %>

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :devices_service, true %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   t('landing_pages.get_support_guides.title'),
                  ]) %>
 <% end %>

--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "#{@title} – #{t('page_titles.guide_to_collecting_mobile_information')}" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   { t('page_titles.about_increasing_mobile_data_short') => about_increasing_mobile_data_path },
                   t('page_titles.guide_to_collecting_mobile_information'),

--- a/app/views/layouts/multipage_guide.html.erb
+++ b/app/views/layouts/multipage_guide.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },
                   @page.title,
                  ]) %>

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-breadcrumbs ">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Home", guidance_page_path, class: 'govuk-breadcrumbs__link' %>
+        <%= link_to "Get help with technology", guidance_page_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item">
         <%= @title %>

--- a/app/views/pages/about_increasing_mobile_data.html.erb
+++ b/app/views/pages/about_increasing_mobile_data.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.about_increasing_mobile_data') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.about_increasing_mobile_data_short'),
                  ]) %>

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.choosing_help_with_internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.choosing_help_with_internet_access'),
                  ]) %>

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.how_request_4g_routers') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.how_request_4g_routers'),
                  ]) %>

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   t('page_titles.internet_access'),
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which academy trust do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which academy trust do you work for?',
                  ]) %>

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Check your answers, then submit your request' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Check your answers, then submit your request',
                  ]) %>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which college do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which college do you work for?',
                  ]) %>

--- a/app/views/support_tickets/contact_details.html.erb
+++ b/app/views/support_tickets/contact_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we contact you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we contact you?',
                  ]) %>

--- a/app/views/support_tickets/describe_yourself.html.erb
+++ b/app/views/support_tickets/describe_yourself.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.describe_yourself')%>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   t('landing_pages.get_support.describe_yourself'),
                  ]) %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which local authority do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which local authority do you work for?',
                  ]) %>

--- a/app/views/support_tickets/parent_support.html.erb
+++ b/app/views/support_tickets/parent_support.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Contact your school, college or local authority for support' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Contact your school, college or local authority for support',
                  ]) %>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which school do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which school do you work for?',
                  ]) %>

--- a/app/views/support_tickets/start.html.erb
+++ b/app/views/support_tickets/start.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.start') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   t('landing_pages.get_support.start'),
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/support_details.html.erb
+++ b/app/views/support_tickets/support_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we help you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we help you?',
                  ]) %>

--- a/app/views/support_tickets/support_needs.html.erb
+++ b/app/views/support_tickets/support_needs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "What do you need help with?" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   "What do you need help with?",
                  ]) %>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title,  'Support request complete' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Support request sent',
                  ]) %>


### PR DESCRIPTION
Sometimes "Home" is interpreted as the signed in home page, which uses the same text and link.

Make the two link texts unique by renaming the signed out version.