### PR TITLE
[1469] fix occasional name collision in spec

### DIFF
--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Support::UsersController do
-  let(:support_user) { create(:support_user) }
+  let(:support_user) { create(:support_user, full_name: 'Jenny Jones') }
   let(:user_who_has_seen_privacy_notice) { create(:school_user, :has_seen_privacy_notice, full_name: 'Jane Smith') }
   let(:user_who_has_not_seen_privacy_notice) { create(:school_user, :has_not_seen_privacy_notice, full_name: 'John Smith') }
   let(:user_who_is_deleted) { create(:school_user, :has_seen_privacy_notice, :deleted, full_name: 'July Smith') }


### PR DESCRIPTION
### Context

[Trello card 1469](https://trello.com/c/PBgytxRA/1469-intermittent-spec-failure-when-randomly-generated-name-contains-smith) - although `support/users_controller_spec.rb` is fixing the names of users in the specific cases it's testing for (all have surname Smith), it's leaving Faker to generate a random name for the user that the spec is signing in as. This works fine for most of the time, but just occasionally that name contains 'Smith' too - which causes a spec failure.

### Changes proposed in this pull request

Fix the name of the `support_user` to be 'Jones'

### Guidance to review

