### PR TITLE
Link to google form to request routers

### DIFF
--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -146,7 +146,7 @@
     </p>
 
     <p class="govuk-body">
-      <a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a>
+      <%= govuk_link_to 'Request a 4G wireless router', 'https://forms.gle/LE1hi2FAKdedUvCz6' %>
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -13,7 +13,7 @@
     </h1>
 
     <p class="govuk-body">
-      The Department for Education (DfE) is providing 4G wireless routers for disadvantaged children and young people to help them get online and access remote education
+      The Department for Education (DfE) is providing 4G wireless routers for disadvantaged children and young people to help them get online and access remote education.
     </p>
       
     <h2 class="govuk-heading-l">
@@ -35,7 +35,7 @@
     </ul>
 
     <p class="govuk-body">
-      Routers are available to:
+      Routers are available to those:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -96,7 +96,7 @@
      <a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request 4G wireless routers</a>
    </p>
 
-   <h3 class="govuk-heading-l">
+   <h3 class="govuk-heading-m">
       For schools, colleges and other FE institutions
     </h3>
 

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -93,7 +93,7 @@
    </p>
 
    <p class="govuk-body">
-     <a href="https://forms.gle/EYdmBfj1jQFoZCYe7" class="govuk-link">Request 4G wireless routers</a>
+     <a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request 4G wireless routers</a>
    </p>
 
    <h3 class="govuk-heading-l">
@@ -146,7 +146,7 @@
     </p>
 
     <p class="govuk-body">
-      <a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router</a>
+      <a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a>
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -53,7 +53,7 @@
       The process for ordering 4G wireless routers is different to that for ordering laptops and tablets. Routers may be dispatched separately to any laptops and tablets you order, and may arrive at a later date.
     </p>
 
-    <h3 class="govuk-heading-l">
+    <h3 class="govuk-heading-m">
       For local authorities and academy trusts
     </h3>
 
@@ -61,8 +61,12 @@
       Local authorities and academy trusts that received 4G wireless routers from DfE during the 2020 summer term are expected to reallocate any unused routers to children in need before ordering new ones. Your key contact can log in to the <%= govuk_link_to 'Support Portal', 'https://computacenterprod.service-now.com/dfe' %> to check router use.
     </p>
 
+    <h3 class="govuk-heading-s">
+      How to make a request
+    </h3>
+
     <p class="govuk-body">
-      To request 4G wireless routers, send the following information to <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a>:
+      To make a request you will need:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -81,21 +85,46 @@
     </ul>
 
     <p class="govuk-body">
-    Please do not send us any personal information, like names of children or dates of birth.
+      Please do not send us any personal information, like names of children or dates of birth.
+   </p>
+
+   <p class="govuk-body">
+     Note that if you don’t have a service reference number, you can leave this field in the form blank.
+   </p>
+
+   <p class="govuk-body">
+     <a href="https://forms.gle/EYdmBfj1jQFoZCYe7" class="govuk-link">Request 4G wireless routers (form for local authorities and academy trust staff)</a>
    </p>
 
    <h3 class="govuk-heading-l">
-      For schools and colleges and FE providers
+      For schools, colleges and other FE institutions
     </h3>
 
-   <p class="govuk-body">
-      To request 4G wireless routers, send the following information to <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a>:
+    <p class="govuk-body">
+      Once schools, colleges and FE institutions have placed an order for devices through the Get help with technology service, they can request 4G wireless routers.
+    </p>
+
+    <p class="govuk-body">
+      Unlike allocations for laptops and tablets (which are based on free meals data), we distribute wireless routers based on actual need. This is because the need for connectivity is lower than the need for devices.
+    </p>
+
+    <p class="govuk-body">
+      To make a request for wireless routers for your students, you need to provide information about how you’ve identified the number of learners requiring help with connectivity.
+    </p>
+
+    <h3 class="govuk-heading-s">
+      How to make a request
+    </h3>
+
+    <p class="govuk-body">
+      To make a request you will need:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>your unique reference number (URN), this is normally 6 digits. If you’re a further education college, this will be your 8-digit UKPRN. If you don’t know your URN or UKPRN, you can find these on the <%= govuk_link_to 'Get Information about Schools', 'https://www.get-information-schools.service.gov.uk/' %> site</li>
       <li>the name of your school or college</li>
       <li>the number of children and young people needing a router</li>
+      <li>to confirm that you’ve identified which disadvantaged learners do not have broadband at home through, for example, contact with students/parents, surveys, etc.</li>
     </ul>
 
     <p class="govuk-body">
@@ -110,6 +139,14 @@
 
     <p class="govuk-body">
       Please do not send us any personal information, like names of children and young people or dates of birth.
+    </p>
+
+    <p class="govuk-body">
+      Note that if you don’t have a service reference number, you can leave this field in the form blank.
+    </p>
+
+    <p class="govuk-body">
+      <a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router (request form for school, college and other FE institution staff)</a>
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -93,7 +93,7 @@
    </p>
 
    <p class="govuk-body">
-     <a href="https://forms.gle/EYdmBfj1jQFoZCYe7" class="govuk-link">Request 4G wireless routers (form for local authorities and academy trust staff)</a>
+     <a href="https://forms.gle/EYdmBfj1jQFoZCYe7" class="govuk-link">Request 4G wireless routers</a>
    </p>
 
    <h3 class="govuk-heading-l">
@@ -146,7 +146,7 @@
     </p>
 
     <p class="govuk-body">
-      <a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router (request form for school, college and other FE institution staff)</a>
+      <a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router</a>
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -40,7 +40,7 @@
       You can request 4G wireless routers for children and young people who do not have internet access at home and whose <span class="app-no-wrap">face-to-face education</span> has been disrupted. This option might also be suitable for those who cannot get a mobile data increase.
     </p>
     <p class="govuk-body"><%= govuk_link_to 'What you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
-    <p class="govuk-body"><a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a></p>
+    <p class="govuk-body"><%= govuk_link_to 'Request a 4G wireless router', 'https://forms.gle/LE1hi2FAKdedUvCz6' %></p>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="app-related">

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -20,7 +20,7 @@
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       When to make requests for schools
     </h2>
-    <p class="govuk-body">If you are ordering devices for a school, you must also make their requests for extra mobile data and routers.</p>
+    <p class="govuk-body">If you are ordering devices, you must also make their requests for extra mobile data and routers.</p>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       Extra data for mobile devices

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -23,16 +23,24 @@
     <p class="govuk-body">If you are ordering devices for a school, you must also make their requests for extra mobile data and routers.</p>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_internet_mobile_extra_data_guidance_path %>
+      Extra data for mobile devices
     </h2>
-
     <%= render partial: 'shared/internet/mno_information' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Request extra data for mobile devices', responsible_body_internet_mobile_extra_data_guidance_path %>
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Check your requests', responsible_body_internet_mobile_extra_data_requests_path %>
+    </p>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
     </h2>
-
-    <p class="govuk-body">If a school is facing disruption to education and you’ve been invited to order devices, you can request 4G wireless routers.</p>
+    <p class="govuk-body">
+      You can request 4G wireless routers for children and young people who do not have internet access at home and whose <span class="app-no-wrap">face-to-face education</span> has been disrupted. This option might also be suitable for those who cannot get a mobile data increase.
+    </p>
+    <p class="govuk-body"><%= govuk_link_to 'What you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
+    <p class="govuk-body"><a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a></p>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="app-related">

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -34,7 +34,7 @@
     </p>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
+      4G wireless routers
     </h2>
     <p class="govuk-body">
       You can request 4G wireless routers for children and young people who do not have internet access at home and whose <span class="app-no-wrap">face-to-face education</span> has been disrupted. This option might also be suitable for those who cannot get a mobile data increase.

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -25,7 +25,7 @@
     </h2>
 
     <p class="govuk-body"><%= govuk_link_to 'Who is eligible and what you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
-    <p class="govuk-body"><a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router</a></p>
+    <p class="govuk-body"><a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a></p>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -14,18 +14,20 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @school.show_mno? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
+        Extra data for mobile devices
       </h2>
-
       <%= render partial: 'shared/internet/mno_information' %>
+      <p class="govuk-body"><%= govuk_link_to 'Request extra data for mobile devices and check your requests', extra_data_guidance_internet_mobile_school_path(@school) %></p>
     <% end %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
+      4G wireless routers
     </h2>
 
-    <p class="govuk-body">If your school is facing disruption to education and you’ve been invited to order devices, you can request 4G wireless routers.</p>
+    <p class="govuk-body"><%= govuk_link_to 'Who is eligible and what you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
+    <p class="govuk-body"><a href="https://forms.gle/KmpWzVYR3gygAdRe6" class="govuk-link">Request a 4G wireless router</a></p>
   </div>
+
   <div class="govuk-grid-column-one-third">
     <div class="app-related">
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Guidance</h2>
@@ -34,4 +36,5 @@
       </p>
     </div>
   </div>
+
 </div>

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -32,7 +32,7 @@
       You can request 4G wireless routers for children and young people who do not have internet access at home and whose <span class="app-no-wrap">face-to-face education</span> has been disrupted. This option might also be suitable for those who cannot get a mobile data increase.
     </p>
     <p class="govuk-body"><%= govuk_link_to 'What you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
-    <p class="govuk-body"><a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a></p>
+    <p class="govuk-body"><%= govuk_link_to 'Request a 4G wireless router', 'https://forms.gle/LE1hi2FAKdedUvCz6' %></p>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -17,14 +17,21 @@
         Extra data for mobile devices
       </h2>
       <%= render partial: 'shared/internet/mno_information' %>
-      <p class="govuk-body"><%= govuk_link_to 'Request extra data for mobile devices and check your requests', extra_data_guidance_internet_mobile_school_path(@school) %></p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
+        </p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Check your requests', extra_data_requests_internet_mobile_school_path(@school) %>
+       </p>
     <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
+    <h2 class="govuk-heading-l govuk-!-font-size-27 govuk-!-margin-top-6">
       4G wireless routers
     </h2>
-
-    <p class="govuk-body"><%= govuk_link_to 'Who is eligible and what you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
+    <p class="govuk-body">
+      You can request 4G wireless routers for children and young people who do not have internet access at home and whose <span class="app-no-wrap">face-to-face education</span> has been disrupted. This option might also be suitable for those who cannot get a mobile data increase.
+    </p>
+    <p class="govuk-body"><%= govuk_link_to 'What you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %></p>
     <p class="govuk-body"><a href="https://forms.gle/LE1hi2FAKdedUvCz6" class="govuk-link">Request a 4G wireless router</a></p>
   </div>
 

--- a/app/views/shared/internet/_mno_information.html.erb
+++ b/app/views/shared/internet/_mno_information.html.erb
@@ -1,5 +1,1 @@
-<p class="govuk-body">We’re working with mobile companies to temporarily increase data allowances on certain networks. This is so children in years 3 to 11 can continue their remote education without incurring extra data charges.</p>
-
-<p class="govuk-body">If they do not have their own phone, we can increase data on a family member’s phone, as long as they’re in the same household.</p>
-
-<p class="govuk-body">If they do not have access to a mobile device, or are not on a participating network, a 4G wireless router might be more suitable.</p>
+<p class="govuk-body">Temporarily increase data allowances on certain mobile networks so children in years 3 to 11 can continue their remote education without incurring extra data charges.</p>

--- a/spec/features/school/wireless_router_requests_spec.rb
+++ b/spec/features/school/wireless_router_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Accessing the 4G wireless routers requests area as a school user'
 
   scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
     click_on 'Get internet access'
-    click_on 'Request 4G wireless routers'
+    click_on 'What you need to know to request 4G wireless routers'
 
     expect(page).to have_css('h1', text: 'How to request 4G wireless routers')
     expect(page).to have_http_status(:ok)


### PR DESCRIPTION
### Context

- current content implies that 4G routers can be ordered (we talk about using this section to 'request 4G wireless routers')
- users expect this service to be automated, similar to ordering devices
- current service adds to support burden (sending users to covid technology inbox, each request taking multiple support replies)

This causes delays for children who need internet access

### Changes proposed in this pull request

Add links to google form that allows users to make a request and update content on:
- How to request 4G wireless routers
- Get internet access (for schools etc)
- Get internet access (for RBs)


Guidance page:

![localhost_3000_how-to-request-4g-wireless-routers (2)](https://user-images.githubusercontent.com/8417288/106485564-a4607400-64a8-11eb-8910-ba0c3a05b547.png)


Get internet access (for schools etc)

![localhost_3000_schools_106575_internet](https://user-images.githubusercontent.com/8417288/106485905-fd300c80-64a8-11eb-807b-16a850430bd8.png)


Get internet access (for RBs)

![localhost_3000_responsible-body_internet (1)](https://user-images.githubusercontent.com/8417288/106578969-0916df80-6538-11eb-9bff-3a770c22c413.png)



