### PR TITLE
[1470] Third line can update school address

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -3,15 +3,31 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
     array = super
     array << headteacher_row if headteacher.present?
     array.map { |row| remove_change_links_if_read_only(row) }
-    array << {
-      key: 'Address',
-      value: @school.address_components,
-      action: 'Change <span class="govuk-visually-hidden">address</span>'.html_safe,
-      action_path: edit_support_school_addresses_path(school_urn: @school.urn)
-    }
+
+    array << if SchoolPolicy.new(viewer, @school).update_address?
+               address_editable_row
+             else
+               address_read_only_row
+             end
   end
 
 private
+
+  def address_read_only_row
+    {
+      key: 'Address',
+      value: @school.address_components,
+    }
+  end
+
+  def address_editable_row
+    {
+      key: 'Address',
+      value: @school.address_components,
+      action: 'Change <span class="govuk-visually-hidden">address</span>'.html_safe,
+      action_path: edit_support_school_addresses_path(school_urn: @school.urn),
+    }
+  end
 
   def who_will_order_row
     super.except(:change_path, :action, :action_path)

--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -3,7 +3,12 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
     array = super
     array << headteacher_row if headteacher.present?
     array.map { |row| remove_change_links_if_read_only(row) }
-    array << { key: 'Address', value: @school.address_components }
+    array << {
+      key: 'Address',
+      value: @school.address_components,
+      action: 'Change <span class="govuk-visually-hidden">address</span>'.html_safe,
+      action_path: edit_support_school_addresses_path(school_urn: @school.urn)
+    }
   end
 
 private

--- a/app/controllers/support/addresses_controller.rb
+++ b/app/controllers/support/addresses_controller.rb
@@ -1,0 +1,24 @@
+class Support::AddressesController < Support::BaseController
+  before_action { authorize School }
+
+  def edit
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+  end
+
+  def update
+    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+
+    if @school.update(school_params.merge(computacenter_change: 'amended'))
+      flash[:success] = "Address has been updated"
+      redirect_to support_school_path(urn: @school.urn)
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def school_params
+    params.require(:school).permit(:address_1, :address_2, :address_3, :town, :county, :postcode)
+  end
+end

--- a/app/controllers/support/addresses_controller.rb
+++ b/app/controllers/support/addresses_controller.rb
@@ -3,13 +3,17 @@ class Support::AddressesController < Support::BaseController
 
   def edit
     @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+
+    authorize @school, :update_address?
   end
 
   def update
     @school = School.where_urn_or_ukprn(params[:school_urn]).first!
 
+    authorize @school, :update_address?
+
     if @school.update(school_params.merge(computacenter_change: 'amended'))
-      flash[:success] = "Address has been updated"
+      flash[:success] = 'Address has been updated'
       redirect_to support_school_path(urn: @school.urn)
     else
       render :edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,11 @@
 class User < ApplicationRecord
   has_paper_trail
 
+  enum role: {
+    no: 'no',
+    third_line: 'third_line',
+  }, _suffix: true
+
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
   has_many :school_welcome_wizards, dependent: :destroy

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -18,4 +18,8 @@ class SchoolPolicy < SupportPolicy
   def update_computacenter_reference?
     user.is_computacenter?
   end
+
+  def update_address?
+    user.third_line_role?
+  end
 end

--- a/app/views/support/addresses/edit.html.erb
+++ b/app/views/support/addresses/edit.html.erb
@@ -1,6 +1,7 @@
 <%- title = t('page_titles.support.addresses.edit') %>
 <%- content_for :title, title_with_error_prefix(title, @school.errors.any?) %>
 <%- content_for :before_content do %>
+  <%= govuk_link_to('Back', support_school_path(@school), class: 'govuk-back-link') %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -9,12 +10,8 @@
       <%= title %>
     </h1>
 
-    <% if @school.computacenter_change == 'none' %>
-      <p class="govuk-inset-text">
-        <strong class="govuk-tag govuk-tag--green">ACTIVE</strong> Computacenter is using the specified address
-      </p>
-    <% else %>
-      <p class="govuk-inset-text">
+    <% unless @school.computacenter_change == 'none' %>
+      <p class="govuk-body">
         <strong class="govuk-tag govuk-tag--red">PENDING</strong> Computacenter still needs to update this address
       </p>
     <% end %>

--- a/app/views/support/addresses/edit.html.erb
+++ b/app/views/support/addresses/edit.html.erb
@@ -1,0 +1,35 @@
+<%- title = t('page_titles.support.addresses.edit') %>
+<%- content_for :title, title_with_error_prefix(title, @school.errors.any?) %>
+<%- content_for :before_content do %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <% if @school.computacenter_change == 'none' %>
+      <p class="govuk-inset-text">
+        <strong class="govuk-tag govuk-tag--green">ACTIVE</strong> Computacenter is using the specified address
+      </p>
+    <% else %>
+      <p class="govuk-inset-text">
+        <strong class="govuk-tag govuk-tag--red">PENDING</strong> Computacenter still needs to update this address
+      </p>
+    <% end %>
+
+    <%= form_with model: @school, url: support_school_addresses_path, scope: :school do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :address_1, label: { text: 'Address line 1', size: 's' } %>
+      <%= f.govuk_text_field :address_2, label: { text: 'Address line 2', size: 's' } %>
+      <%= f.govuk_text_field :address_3, label: { text: 'Address line 3', size: 's' } %>
+      <%= f.govuk_text_field :town, label: { text: 'Town', size: 's' } %>
+      <%= f.govuk_text_field :county, label: { text: 'County', size: 's' } %>
+      <%= f.govuk_text_field :postcode, label: { text: 'Postcode', size: 's' } %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
           edit: Update responsible body
       allocation:
         adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE providers
+      addresses:
+        edit: Update an address
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact
     support_devices: Devices

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
       allocation:
         adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE providers
       addresses:
-        edit: Update an address
+        edit: Update address
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact
     support_devices: Devices

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[new create], controller: 'users'
     end
     resources :schools, only: %i[show], param: :urn do
-      resource :addresses, only: [:edit, :update], path: 'address'
+      resource :addresses, only: %i[edit update], path: 'address'
 
       collection do
         get 'search'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,8 @@ Rails.application.routes.draw do
       resources :users, only: %i[new create], controller: 'users'
     end
     resources :schools, only: %i[show], param: :urn do
+      resource :addresses, only: [:edit, :update], path: 'address'
+
       collection do
         get 'search'
         get 'results'

--- a/db/migrate/20210202111622_add_role_to_users.rb
+++ b/db/migrate/20210202111622_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :role, :text, default: 'no', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_105958) do
+ActiveRecord::Schema.define(version: 2021_02_02_111622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 2021_01_29_105958) do
     t.boolean "orders_devices"
     t.datetime "techsource_account_confirmed_at"
     t.datetime "deleted_at"
+    t.text "role", default: "no", null: false
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/spec/features/support/addresses_spec.rb
+++ b/spec/features/support/addresses_spec.rb
@@ -1,14 +1,29 @@
 require 'rails_helper'
 
 RSpec.feature 'Updating addresses' do
-  let(:support_user) { create(:support_user) }
+  let(:support_user) { create(:support_user, role: 'third_line') }
   let(:school) { create(:school) }
   let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
   let(:address_page) { PageObjects::Support::AddressPage.new }
 
   before do
-    school.update(computacenter_change: 'none')
+    school.update!(computacenter_change: 'none')
     sign_in_as support_user
+  end
+
+  context 'when user is not third line' do
+    let(:support_user) { create(:support_user) }
+
+    it 'does not show change address link' do
+      visit support_school_path(school.urn)
+      expect(school_page).not_to have_text 'Change address'
+    end
+
+    it 'cannot access change address form' do
+      address_page.load(urn: school.urn)
+      expect(school_page).to have_text 'Forbidden'
+      expect(school_page).not_to have_text 'Update an address'
+    end
   end
 
   describe 'visiting a school details page' do

--- a/spec/features/support/addresses_spec.rb
+++ b/spec/features/support/addresses_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.feature 'Updating addresses' do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school) }
+  let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+  let(:address_page) { PageObjects::Support::AddressPage.new }
+
+  before do
+    school.update(computacenter_change: 'none')
+    sign_in_as support_user
+  end
+
+  describe 'visiting a school details page' do
+    before do
+      visit support_school_path(school.urn)
+    end
+
+    it 'shows the address' do
+      school.address_components.each do |line|
+        expect(school_page).to have_text line
+      end
+    end
+
+    describe 'clicking Change' do
+      before do
+        click_on 'Change address'
+      end
+
+      it 'shows me a form to update the address' do
+        expect(address_page).to be_displayed(urn: school.urn)
+        expect(address_page.h1.text).to eql('Update an address')
+      end
+
+      it 'shows Computacenter has address in sync' do
+        expect(address_page.text).to include('ACTIVE')
+      end
+
+      context 'updating the address' do
+        before do
+          address_page.address_1_field.set 'New address 1'
+          address_page.address_2_field.set 'New address 2'
+          address_page.address_3_field.set 'New address 3'
+
+          address_page.town_field.set 'New town'
+          address_page.county_field.set 'New county'
+          address_page.postcode_field.set 'NE1 6EE'
+
+          address_page.submit.click
+        end
+
+        it 'takes me back to the school details page' do
+          expect(school_page).to be_displayed(urn: school.urn)
+          expect(school_page).to have_text('Address has been updated')
+        end
+
+        it 'shows the new updated address' do
+          expect(school_page).to have_text('New address 1')
+          expect(school_page).to have_text('New address 2')
+          expect(school_page).to have_text('New address 3')
+
+          expect(school_page).to have_text('New town')
+          expect(school_page).to have_text('New county')
+          expect(school_page).to have_text('NE1 6EE')
+        end
+
+        it 'marks address as pending for CC to update' do
+          click_on 'Change address'
+          expect(address_page.text).to include('PENDING')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/addresses_spec.rb
+++ b/spec/features/support/addresses_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Updating addresses' do
     it 'cannot access change address form' do
       address_page.load(urn: school.urn)
       expect(school_page).to have_text 'Forbidden'
-      expect(school_page).not_to have_text 'Update an address'
+      expect(school_page).not_to have_text 'Update address'
     end
   end
 
@@ -44,11 +44,7 @@ RSpec.feature 'Updating addresses' do
 
       it 'shows me a form to update the address' do
         expect(address_page).to be_displayed(urn: school.urn)
-        expect(address_page.h1.text).to eql('Update an address')
-      end
-
-      it 'shows Computacenter has address in sync' do
-        expect(address_page.text).to include('ACTIVE')
+        expect(address_page.h1.text).to eql('Update address')
       end
 
       context 'updating the address' do

--- a/spec/page_objects/support/address_page.rb
+++ b/spec/page_objects/support/address_page.rb
@@ -1,0 +1,19 @@
+module PageObjects
+  module Support
+    class AddressPage < PageObjects::BasePage
+      set_url '/support/schools/{urn}/address/edit'
+
+      element :h1, 'h1'
+
+      element :address_1_field, '#school-address-1-field'
+      element :address_2_field, '#school-address-2-field'
+      element :address_3_field, '#school-address-3-field'
+
+      element :town_field, '#school-town-field'
+      element :county_field, '#school-county-field'
+      element :postcode_field, '#school-postcode-field'
+
+      element :submit, 'input[value=Save]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/P4uNQa6B/1470-limited-support-staff-can-change-addresses

### Changes proposed in this pull request

- Add change link to school address if third line role
- Add page with form to update the school address
- Page has status if the address has been picked up by CC or not based off `school#computacenter_change`
- Added `role` column to `User` table

### Screenshots

![image](https://user-images.githubusercontent.com/92580/106599661-48055f00-6551-11eb-87a1-1c5930f48871.png)

![image](https://user-images.githubusercontent.com/92580/106599819-81d66580-6551-11eb-825c-19af05c39944.png)

![image](https://user-images.githubusercontent.com/92580/106599710-5ce1f280-6551-11eb-949b-57aeff167e4e.png)

### Guidance to review

- Login as support user
- View a school
- Cannot see link to edit school address
- Or access page to edit school address
- Set user `role` to `third_line`
- Can see link to edit school address
- If school `computacenter_change` is `none`
- see status `ACTIVE` that CC has the current address
- update address and submit form
- click `Change` address again
- Should not see address status as `pending` as CC is yet to pickup address changes