### PR TITLE
Bulk request upload should should handle non-standard xlsx MIME types

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,4 +3,4 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register 'text/csv', :csv, %w[application/vnd.ms-excel]
-Mime::Type.register 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', :xlsx
+Mime::Type.register 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', :xlsx, %w[application/octet-stream]

--- a/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/bulk_requests_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
+  let(:filename) { Rails.root.join('tmp/update_requests.xlsx') }
 
   context 'when authenticated' do
     before do
@@ -34,6 +35,20 @@ RSpec.describe ResponsibleBody::Internet::Mobile::BulkRequestsController, type: 
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(assigns[:upload_form].errors.full_messages).to eq(["'Upload' There’s a problem with that spreadsheet"])
+      end
+
+      it 'accepts the standard content-type for xlsx' do
+        upload = Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+
+        post :create, params: { bulk_upload_form: { upload: upload } }
+        expect(response).to render_template(:summary)
+      end
+
+      it 'accepts Chromebooks content-type for xlsx' do
+        upload = Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), 'application/octet-stream')
+
+        post :create, params: { bulk_upload_form: { upload: upload } }
+        expect(response).to render_template(:summary)
       end
     end
   end

--- a/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe School::Internet::Mobile::BulkRequestsController, type: :controll
         expect(response).to have_http_status(:unprocessable_entity)
         expect(assigns[:upload_form].errors.full_messages).to eq(["'Upload' There’s a problem with that spreadsheet"])
       end
+
+      context 'with a standard content-type xls' do
+        let(:upload) { Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') }
+
+        it 'accepts the standard content-type for xlsx' do
+          post :create, params: request_data
+          expect(response).to render_template(:summary)
+        end
+      end
+
+      context 'with a Chromebook content-type xls' do
+        let(:upload) { Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), 'application/octet-stream') }
+
+        it 'accepts Chromebooks content-type for xlsx' do
+          post :create, params: request_data
+          expect(response).to render_template(:summary)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Sometimes Chromebook will upload xlsx files as `application/octet-stream` instead of the default `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.

This PR allows for uploads of that type.

Example request: https://kibana.logit.io/app/kibana#/discover/doc/8ac115c0-aac1-11e8-88ea-0383c11b333c/logstash-2021.02.02?id=FX6bY3cB_UZj64kqjsc9
