### PR TITLE
[1433] Session expiry based on expires_at field

### DIFF
--- a/app/jobs/delete_old_sessions_job.rb
+++ b/app/jobs/delete_old_sessions_job.rb
@@ -1,11 +1,9 @@
 class DeleteOldSessionsJob < ApplicationJob
   queue_as :default
 
-  def perform(args = {})
-    older_than = args[:older_than] || Time.zone.now.utc - Settings.session_ttl_seconds * 4
-    # We'll play safe & only delete sessions that are 4 times older than the ttl
-    sessions = Session.where('updated_at < ?', older_than)
-    logger.info "deleting #{sessions.count} sessions older than #{older_than.iso8601}"
+  def perform
+    sessions = Session.where('expires_at < ?', Time.zone.now.utc - 2.hours)
+    logger.info "deleting #{sessions.count} sessions expired by 2 hours"
     sessions.delete_all
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,14 +1,5 @@
 class Session < ApplicationRecord
   def expired?
-    updated_at.nil? \
-    || (updated_at.utc + ttl.seconds) < Time.zone.now.utc
-  end
-
-  # def expired?
-  #   expires_at < Time.zone.now.utc
-  # end
-
-  def ttl
-    Settings.session_ttl_seconds
+    expires_at < Time.zone.now.utc
   end
 end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -5,6 +5,7 @@ class SessionService
 
   DEFAULT_USER_TTL = 3600.seconds.freeze
   SUPPORT_USER_TTL = 7200.seconds.freeze
+  TTLS = [DEFAULT_USER_TTL, SUPPORT_USER_TTL].freeze
 
   def self.send_magic_link_email!(email_address)
     if (user = find_user_by_lowercase_email(email_address))

--- a/app/views/cookie_preferences/new.html.erb
+++ b/app/views/cookie_preferences/new.html.erb
@@ -25,7 +25,7 @@
         <tr>
           <td class="govuk-table__cell">_session_id</td>
           <td class="govuk-table__cell">Stores encrypted session data</td>
-          <td class="govuk-table__cell">When you close your browser, or don't visit any page for <%= humanized_seconds(Settings.session_ttl_seconds) %></td>
+          <td class="govuk-table__cell">When you close your browser, or don't visit any page for <%= humanized_seconds(SessionService::TTLS.max) %></td>
         </tr>
         <tr>
           <td class="govuk-table__cell">_consented-to-cookies</td>

--- a/config/initializers/session_storage.rb
+++ b/config/initializers/session_storage.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cookie_store, expire_after: Settings.session_ttl_seconds.seconds
+Rails.application.config.session_store :cookie_store, expire_after: SessionService::TTLS.max

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,7 +68,6 @@ sentry:
   dsn:
 
 service_name_suffix: 
-session_ttl_seconds: 3600
 
 # Sign-in tokens will expire after this many seconds
 sign_in_token_ttl_seconds: 1800

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Session behaviour', type: :feature do
         fill_in_valid_application_form(mobile_network_name: participating_mobile_network.brand)
         click_on 'Continue'
 
-        Timecop.travel(Time.zone.now + Settings.session_ttl_seconds + 1) do
+        Timecop.travel(Time.zone.now + SessionService::DEFAULT_USER_TTL + 1) do
           click_on 'Back'
           expect(page).to have_text('Sign in')
         end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Session do
+  describe '#expired?' do
+    context 'when expires_at in the past' do
+      subject(:model) { described_class.new(expires_at: 10.minutes.ago) }
+
+      it 'return true' do
+        expect(model.expired?).to be_truthy
+      end
+    end
+
+    context 'when expires_at in the future' do
+      subject(:model) { described_class.new(expires_at: 10.minutes.from_now) }
+
+      it 'return false' do
+        expect(model.expired?).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/MgxnyGhN/1433-support-improvement-increase-log-in-time-for-support-agents

### Changes proposed in this pull request

- Whether or not a session has expired is based of the `expires_at` value
- `DeleteOldSessionsJob` now uses `expires_at` column to determine what records to delete
- Cookie expiration now set to max possible configurable TTL
- This now closes the loop and allows the support users to have longer session lengths

### Guidance to review

- Login as normal user
- Cookie expiration should be in 2 hours time
- DB session expiration in 1 hours time
- Login as support user
- Cookie expiration should be in 2 hours time
- DB session expiration in 2 hours time