### PR TITLE
Fix typo, add note about delivery timelines

### DIFF
--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -16,7 +16,9 @@
 
     <p class="govuk-body">We’ll email you when you can order.</p>
 
-    <p class="govuk-body">While you’re waiting, check <%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %> to decide what you will order.</p>
+    <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
+
+    <p class="govuk-body">While you’re waiting, <%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %> to decide what you will order.</p>
 
   </div>
 </div>


### PR DESCRIPTION
- Indicate to users waiting for an account how long deliveries are taking
- fix typo "check check device"

(Current delivery text: "Most devices will be delivered within 5 working days of an order being confirmed, subject to stock availability.")