### PR TITLE
[1452] 0 users found returns users on same domain

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,6 +1,4 @@
 class Support::UsersController < Support::BaseController
-  SEARCH_RESULTS_LIMIT = 100
-
   before_action :set_user, except: %i[new create search results]
   before_action { authorize User }
 
@@ -65,16 +63,11 @@ class Support::UsersController < Support::BaseController
   end
 
   def results
-    @search_form = Support::UserSearchForm.new(search_params)
+    @search_form = Support::UserSearchForm.new(search_params.merge(scope: policy_scope(User)))
     @search_term = @search_form.email_address_or_full_name
-    @results = policy_scope(User)
-      .search_by_email_address_or_full_name(@search_term)
-      .not_deleted
-      .distinct
-      .includes(:responsible_body, :schools)
-      .order(full_name: :asc)
-      .limit(SEARCH_RESULTS_LIMIT)
-    @maximum_search_result_number_reached = (@results.size == SEARCH_RESULTS_LIMIT)
+    @results = @search_form.results
+    @related_results = @search_form.related_results
+    @maximum_search_result_number_reached = @search_form.maximum_search_result_number_reached?
   end
 
   def confirm_destroy; end

--- a/app/form_objects/support/user_search_form.rb
+++ b/app/form_objects/support/user_search_form.rb
@@ -1,5 +1,42 @@
 class Support::UserSearchForm
+  SEARCH_RESULTS_LIMIT = 100
+
   include ActiveModel::Model
 
-  attr_accessor :email_address_or_full_name
+  attr_accessor :email_address_or_full_name, :scope
+
+  def results
+    @results ||= scope
+      .search_by_email_address_or_full_name(email_address_or_full_name)
+      .not_deleted
+      .distinct
+      .includes(:responsible_body, :schools)
+      .order(full_name: :asc)
+      .limit(SEARCH_RESULTS_LIMIT)
+  end
+
+  def related_results
+    @related_results ||=
+      begin
+        if results.empty?
+          suffix = "@#{Mail::Address.new(email_address_or_full_name).domain}".strip
+
+          scope
+          .where('email_address ILIKE ?', "%#{suffix}")
+          .not_deleted
+          .distinct
+          .includes(:responsible_body, :schools)
+          .order(full_name: :asc)
+          .limit(SEARCH_RESULTS_LIMIT)
+        else
+          []
+        end
+      rescue StandardError
+        []
+      end
+  end
+
+  def maximum_search_result_number_reached?
+    @maximum_search_result_number_reached ||= (results.size == SEARCH_RESULTS_LIMIT)
+  end
 end

--- a/app/views/support/users/results.html.erb
+++ b/app/views/support/users/results.html.erb
@@ -34,15 +34,44 @@
   </div>
 </div>
 
+<% if @results.present? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <ul class="govuk-list search-results">
+        <% @results.each do |user| %>
+          <li>
+            <%= render Support::UserSearchResultComponent.new(user: user, current_user: current_user) %>
+          </li>
+        <%- end %>
+      </ul>
+    </div>
+  </div>
+<%- end %>
+
+<% if @related_results.present? %>
+  <div class="govuk-grid-row govuk-!-margin-top-9">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">
+        Related users
+      </h2>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <ul class="govuk-list search-results">
+        <% @related_results.each do |user| %>
+          <li>
+            <%= render Support::UserSearchResultComponent.new(user: user, current_user: current_user) %>
+          </li>
+        <%- end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <ul class="govuk-list search-results">
-      <% @results.each do |user| %>
-        <li>
-          <%= render Support::UserSearchResultComponent.new(user: user, current_user: current_user) %>
-        </li>
-      <%- end %>
-    </ul>
     <p class="govuk-body">
       <%= govuk_link_to 'Search again', search_support_users_path %>
     </p>

--- a/spec/form_objects/support/user_search_form_spec.rb
+++ b/spec/form_objects/support/user_search_form_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Support::UserSearchForm do
+  before do
+    create(:school_user, email_address: 'user1@example.com')
+  end
+
+  describe '#results' do
+    context 'when there is a match' do
+      subject(:form) { described_class.new(email_address_or_full_name: 'user1@example.com', scope: User) }
+
+      it 'returns match' do
+        expect(form.results.size).to be(1)
+        expect(form.results.map(&:email_address)).to include('user1@example.com')
+      end
+    end
+
+    context 'when there is no match' do
+      subject(:form) { described_class.new(email_address_or_full_name: 'user2@example.com', scope: User) }
+
+      it 'returns empty' do
+        expect(form.results.size).to be(0)
+      end
+    end
+  end
+
+  describe '#related_results' do
+    context 'when there is a match' do
+      subject(:form) { described_class.new(email_address_or_full_name: 'user1@example.com', scope: User) }
+
+      it 'returns empty' do
+        expect(form.related_results.size).to be(0)
+      end
+    end
+
+    context 'when there is no match' do
+      subject(:form) { described_class.new(email_address_or_full_name: 'user2@example.com', scope: User) }
+
+      it 'returns related results' do
+        expect(form.related_results.size).to be(1)
+        expect(form.related_results.map(&:email_address)).to include('user1@example.com')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/MOZGgRVr/1452-support-improvement-return-emails-in-same-domain-if-user-doesnt-exist-on-service

### Changes proposed in this pull request

- When searching for users if there are no results search for users on the same domain
- If parsing of the search term fails ie is not an email address but a name simply return no related results

### Screenshots

![image](https://user-images.githubusercontent.com/92580/106882620-dfe08580-66d6-11eb-8573-f665389878c0.png)

### Guidance to review

- Login as support agent
- Find search for an existing user eg `user1@example.com`
- Should return user
- Search for non-existent user eg `user2@example.com`
- Should return `user1@example.com` as related user
- Searching for normal string that returns no results should not throw an error
- eg `rgioerjgierjgioerjgiejrg`