### PR TITLE
Add log unset to ssh welcome motd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ promote:
 	make $(env_stub) push deploy
 
 ssh: set_cf_target
-	@echo "\nTo get a Rails console, run: \nbundle exec rails c\n\n" && \
+	@echo "\nTo get a Rails console, run: \nunset RAILS_LOG_TO_STDOUT\nbundle exec rails c\n\n" && \
 		cf $(CF_V3_PREFIX)ssh $(APP_NAME)-$(env_stub)
 
 logs: set_cf_target


### PR DESCRIPTION
### Context

- I got bored of typing `env | grep -i log`

### Changes proposed in this pull request

- Add variable unset to welcome/motd aff when ssh-ing into container
- This will prevent extraneous log messages from appearing in a rails console session

### Guidance to review

- Not sure if this can be tested locally?
- Will be tested in integration environments