### PR TITLE
[1460] Note that deliveries are paused over half term

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,6 +8,7 @@ class FeatureFlag
     secondary_mass_testing_banner
     ipad_stock_message
     schools_closed_for_national_lockdown
+    half_term_delivery_suspension
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -7,6 +7,7 @@
     </h1>
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render partial: 'shared/half_term_delivery_suspension' %>
   </div>
 </div>
 

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -9,6 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render partial: 'shared/half_term_delivery_suspension' %>
 
     <%= render DeviceCountComponent.new(school: @school) %>
 

--- a/app/views/shared/_half_term_delivery_suspension.html.erb
+++ b/app/views/shared/_half_term_delivery_suspension.html.erb
@@ -3,7 +3,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      All deliveries are paused during half term. You can still order devices and deliveries will resume from Monday 22 February.
+      All deliveries are paused during half term, but you can still order devices. Deliveries will resume on Monday 22 February.
     </strong>
   </div>
 <% end %>

--- a/app/views/shared/_half_term_delivery_suspension.html.erb
+++ b/app/views/shared/_half_term_delivery_suspension.html.erb
@@ -1,0 +1,9 @@
+<% if FeatureFlag.active?(:half_term_delivery_suspension) %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      All deliveries are paused during half term. You can still order devices and deliveries will resume from Monday 22 February.
+    </strong>
+  </div>
+<% end %>


### PR DESCRIPTION
Users can continue to order throughout half term, but deliveries will not resume until Feb 22.

![Screen Shot 2021-02-04 at 18 01 11](https://user-images.githubusercontent.com/319055/106935220-fa385480-6712-11eb-9ee0-7b9e367a9257.png)

https://trello.com/c/jH7QlXDk/1460-prepare-the-service-for-pausing-deliveries-over-half-term
