### PR TITLE
anonymize IPs in Google Analytics

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -5,5 +5,5 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', "<%= Settings.google.analytics.tracking_id %>");
+  gtag('config', "<%= Settings.google.analytics.tracking_id %>", { 'anonymize_ip': true });
 <% end %>

--- a/spec/features/google_analytics_behaviour_spec.rb
+++ b/spec/features/google_analytics_behaviour_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Google Analytics behaviour' do
   let(:consent) { nil }
   let(:tracking_id) { nil }
   let(:google_tag) { /<script [^>]*src="https:\/\/www.googletagmanager.com\/gtag\/js\?id=#{tracking_id}"/ }
+  let(:anonymize_ip_config) { /gtag\(\'config',[^\)]+'anonymize_ip': true[^\)]*\)/ }
 
   before do
     allow(Settings.google.analytics).to receive(:tracking_id).and_return(tracking_id)
@@ -19,6 +20,10 @@ RSpec.feature 'Google Analytics behaviour' do
 
       it 'renders the GA tag code' do
         expect(page.source).to match(google_tag)
+      end
+
+      it 'explicitly sets anonymize_ip to true' do
+        expect(page.source).to match(anonymize_ip_config)
       end
     end
 


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/5GWA2q1W/1505-anonymise-ips-in-google-analytics) - IP addresses are considered Personally-Identifying Information. [Google Analytics supports an IP anonymisation setting](https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization) which avoids individual IPs being recorded. We should be using that setting. 

### Changes proposed in this pull request

* add the `'anonymize_ip': true` setting to GA config

### Guidance to review

