### PR TITLE
Allow support agents to export zendesk macro data

### DIFF
--- a/app/controllers/support/zendesk_statistics_controller.rb
+++ b/app/controllers/support/zendesk_statistics_controller.rb
@@ -5,8 +5,15 @@ class Support::ZendeskStatisticsController < Support::BaseController
 
   def macros
     service = ZendeskMacroExportService.new
-    respond_to do |format|
-      format.csv { send_data service.csv_generator, filename: service.filename }
+    service.csv_generator
+
+    if service.valid?
+      respond_to do |format|
+        format.csv { send_data service.data, filename: service.filename }
+      end
+    else
+      flash[:warning] = service.message
+      redirect_to support_zendesk_statistics_path
     end
   end
 end

--- a/app/controllers/support/zendesk_statistics_controller.rb
+++ b/app/controllers/support/zendesk_statistics_controller.rb
@@ -1,0 +1,12 @@
+class Support::ZendeskStatisticsController < Support::BaseController
+  before_action { authorize :support }
+
+  def index; end
+
+  def macros
+    service = ZendeskMacroExportService.new
+    respond_to do |format|
+      format.csv { send_data service.csv_generator, filename: service.filename }
+    end
+  end
+end

--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -12,6 +12,7 @@ class SupportPolicy < ApplicationPolicy
   alias_method :schools?, :readable?
   alias_method :technical_support?, :editable?
   alias_method :feature_flags?, :editable?
+  alias_method :macros?, :readable?
 
   alias_method :new?, :editable?
   alias_method :create?, :editable?

--- a/app/services/zendesk_macro_export_service.rb
+++ b/app/services/zendesk_macro_export_service.rb
@@ -1,0 +1,81 @@
+require 'csv'
+
+class ZendeskMacroExportService
+  class << self
+    delegate :send!, to: :new
+  end
+
+  def csv_generator
+    CSV.generate(headers: true) do |csv|
+      csv << ['Category',
+              'Title',
+              'Description',
+              'Content',
+              'Usage 1hr',
+              'Usage 24hr',
+              'Usage 7d',
+              'Usage 30d',
+              'Created',
+              'Last updated',
+              'Set tags',
+              'Add tags',
+              'Remove tags']
+
+      macro_collection.all! do |macro|
+        if macro.active
+          csv << [
+            format_category(macro.title),
+            format_title(macro.title),
+            macro.description,
+            macro.actions.select { |action| action.field == 'comment_value_html' }.first.value,
+            macro.usage_1h,
+            macro.usage_24h,
+            macro.usage_7d,
+            macro.usage_30d,
+            macro.created_at.strftime('%d/%m/%Y %H:%M'),
+            macro.updated_at.strftime('%d/%m/%Y %H:%M'),
+            tags(macro.actions, 'set_tags'),
+            tags(macro.actions, 'current_tags'),
+            tags(macro.actions, 'remove_tags'),
+          ]
+        end
+      end
+    end
+  end
+
+  def filename
+    "zendesk-macros-#{Time.zone.now.strftime('%Y%m%d_%H%M')}.csv"
+  end
+
+  def macro_collection
+    # Returns ZendeskAPI::Collection (https://www.rubydoc.info/gems/zendesk_api/0.0.9/ZendeskAPI/Collection)
+    # Lazily loaded, resources aren't actually fetched until explicitly needed
+    @macro_collection ||= client.macros.include(:usage_1h).include(:usage_24h).include(:usage_7d).include(:usage_30d)
+  end
+
+  def client
+    @client ||= ZendeskAPI::Client.new do |config|
+      config.url = 'https://get-help-with-tech-education.zendesk.com/api/v2'
+      config.username = Settings.zendesk.username
+      config.token = Settings.zendesk.token
+      config.retry = true
+    end
+  end
+
+private
+
+  def format_category(title)
+    title[1, title.index(']::') - 1].strip
+  end
+
+  def format_title(title)
+    title[title.index(']::') + 3, title.length].strip
+  end
+
+  def tags(actions, tag)
+    return if actions.blank? || actions.select { |action| action[:field] == tag }.blank?
+
+    tags = actions.select { |action| action[:field] == tag }.first.value
+    "[#{tags.split.join('], [')}]"
+  end
+end

--- a/app/services/zendesk_macro_export_service.rb
+++ b/app/services/zendesk_macro_export_service.rb
@@ -55,7 +55,7 @@ class ZendeskMacroExportService
 
   def client
     @client ||= ZendeskAPI::Client.new do |config|
-      config.url = 'https://get-help-with-tech-education.zendesk.com/api/v2'
+      config.url = Settings.zendesk.url
       config.username = Settings.zendesk.username
       config.token = Settings.zendesk.token
       config.retry = true

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -41,7 +41,7 @@ private
 
   def client
     @client ||= ZendeskAPI::Client.new do |config|
-      config.url = 'https://get-help-with-tech-education.zendesk.com/api/v2'
+      config.url = Settings.zendesk.url
       config.username = Settings.zendesk.username
       config.token = Settings.zendesk.token
       config.retry = true

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -78,5 +78,12 @@
         <li>close schools</li>
       </ul>
     <% end %>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Zendesk statistics', support_zendesk_statistics_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to export Zendesk data.</p>
+
   </div>
 </div>

--- a/app/views/support/zendesk_statistics/_macros.html.erb
+++ b/app/views/support/zendesk_statistics/_macros.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to( 'Get information about macros', support_zendesk_macros_path(format: "csv"))%>
+    </h2>
+
+    <p class="govuk-body">
+      Export this information in CSV format which can be imported into Google Sheets or some other third-party application for further analysis.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>List of all active macros</li>
+      <li>Usage information broken down into the last 1 hour, 24hours, 7 days & 30 days.</li>
+      <li>Created/updated timestamps</li>
+      <li>Which tags are set/removed and completed replaced when a specific macro is used</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/support/zendesk_statistics/index.html.erb
+++ b/app/views/support/zendesk_statistics/index.html.erb
@@ -1,0 +1,14 @@
+<%- title = t('page_titles.support.zendesk_statistics') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Support home' => support_home_path },
+                   title,
+                 ]) %>
+<% end %>
+
+
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>
+
+<%= render partial: 'macros' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
       schools: Schools, colleges and FE institutions
       technical_support: Technical support
       feature_flags: Feature flags
+      zendesk_statistics: Zendesk statistics
       devices:
         schools:
           search: Search for schools, colleges and FE institutions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,8 @@ Rails.application.routes.draw do
       resources :schools_to_add, only: %i[index show update], param: :urn, path: '/schools-to-add'
       resources :schools_to_close, only: %i[index show update], param: :urn, path: '/schools-to-close'
     end
+    get '/zendesk-statistics', to: 'zendesk_statistics#index', as: :zendesk_statistics
+    get '/zendesk-statistics/macros', to: 'zendesk_statistics#macros', as: :zendesk_macros
     resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies' do
       resources :users, only: %i[new create], controller: 'users'
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,7 +67,7 @@ hostname_for_urls: http://localhost:3000
 sentry:
   dsn:
 
-service_name_suffix: 
+service_name_suffix:
 
 # Sign-in tokens will expire after this many seconds
 sign_in_token_ttl_seconds: 1800
@@ -98,5 +98,6 @@ support:
   performance_data_access_token: # bearer token for support performance data
 
 zendesk:
+  url: 'https://get-help-with-tech-education.zendesk.com/api/v2'
   username:  # Zendesk user account details
   token: # API Token generated from zendesk

--- a/spec/controllers/support/zendesk_statistics_controller_spec.rb
+++ b/spec/controllers/support/zendesk_statistics_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Support::ZendeskStatisticsController, type: :controller do
+  let(:support_user) { create(:support_user) }
+
+  describe '#macros' do
+    describe 'when ZendeskMacroExportService is successful' do
+      before do
+        allow(ZendeskMacroExportService).to receive(:new)
+                                              .and_return(instance_double(
+                                                            'ZendeskMacroExportService',
+                                                            csv_generator: 'Col1,Col2,Col3',
+                                                            data: 'Col1,Col2,Col3',
+                                                            filename: 'test.csv',
+                                                            valid?: true,
+                                                          ))
+        sign_in_as support_user
+        get :macros, format: :csv
+      end
+
+      it 'returns a csv file' do
+        expect(response.header['Content-Type']).to include 'text/csv'
+        expect(response.body).to include('Col1,Col2,Col3')
+      end
+    end
+
+    describe 'when ZendeskMacroExportService fails ' do
+      before do
+        allow(ZendeskMacroExportService).to receive(:new)
+                                              .and_return(instance_double(
+                                                            'ZendeskMacroExportService',
+                                                            csv_generator: nil,
+                                                            message: 'Something failed',
+                                                            valid?: false,
+                                                          ))
+        sign_in_as support_user
+        get :macros, format: :csv
+      end
+
+      it 'sets flash message' do
+        expect(request.flash[:warning]).to eq('Something failed')
+      end
+
+      it 'redirects the user back to the page' do
+        expect(response).to redirect_to(support_zendesk_statistics_path)
+      end
+    end
+  end
+end

--- a/spec/services/zendesk_macro_export_service_spec.rb
+++ b/spec/services/zendesk_macro_export_service_spec.rb
@@ -24,31 +24,32 @@ RSpec.describe ZendeskMacroExportService, type: :model do
   end
 
   describe '#csv_generator' do
-    it 'generates csv file contents' do
-      created_time = Time.zone.now - 10.minutes
-      updated_time = Time.zone.now
-
-      allow(service.macro_collection).to receive(:all!).and_yield(
-        OpenStruct.new(
-          {
-            active: true,
-            title: '[CATEGORY 1]:: Title name',
-            description: 'This is a macro',
-            usage_1h: 1,
-            usage_24h: 2,
-            usage_7d: 3,
-            usage_30d: 4,
-            created_at: created_time,
-            updated_at: updated_time,
-            actions: [
-              OpenStruct.new({ field: 'set_tags', value: 'set_tag1 set_tag2' }),
-              OpenStruct.new({ field: 'current_tags', value: 'current_tag1 current_tag2' }),
-              OpenStruct.new({ field: 'remove_tags', value: 'remove_tag1 remove_tag2' }),
-              OpenStruct.new({ field: 'comment_value_html', value: 'Dear customer' }),
-            ],
-          },
-        ),
+    let(:created_time) { Time.zone.now - 10.minutes }
+    let(:updated_time) { Time.zone.now }
+    let(:mocked_data) do
+      OpenStruct.new(
+        {
+          active: true,
+          title: '[CATEGORY 1]:: Title name',
+          description: 'This is a macro',
+          usage_1h: 1,
+          usage_24h: 2,
+          usage_7d: 3,
+          usage_30d: 4,
+          created_at: created_time,
+          updated_at: updated_time,
+          actions: [
+            OpenStruct.new({ field: 'set_tags', value: 'set_tag1 set_tag2' }),
+            OpenStruct.new({ field: 'current_tags', value: 'current_tag1 current_tag2' }),
+            OpenStruct.new({ field: 'remove_tags', value: 'remove_tag1 remove_tag2' }),
+            OpenStruct.new({ field: 'comment_value_html', value: 'Dear customer' }),
+          ],
+        },
       )
+    end
+
+    it 'generates csv file contents' do
+      allow(service.macro_collection).to receive(:all!).and_yield(mocked_data)
 
       stub_request(:get, 'https://get-help-with-tech-education.zendesk.com/api/v2/macros?include=usage_1h,usage_24h,usage_7d,usage_30d')
         .with(
@@ -60,8 +61,31 @@ RSpec.describe ZendeskMacroExportService, type: :model do
           },
         )
         .to_return(status: 200, body: '', headers: {})
+      service.csv_generator
+      expect(service.data).to eq("Category,Title,Description,Content,Usage 1hr,Usage 24hr,Usage 7d,Usage 30d,Created,Last updated,Set tags,Add tags,Remove tags\nCATEGORY 1,Title name,This is a macro,Dear customer,1,2,3,4,#{created_time.strftime('%d/%m/%Y %H:%M')},#{updated_time.strftime('%d/%m/%Y %H:%M')},\"[set_tag1], [set_tag2]\",\"[current_tag1], [current_tag2]\",\"[remove_tag1], [remove_tag2]\"\n")
+    end
 
-      expect(service.csv_generator).to eq("Category,Title,Description,Content,Usage 1hr,Usage 24hr,Usage 7d,Usage 30d,Created,Last updated,Set tags,Add tags,Remove tags\nCATEGORY 1,Title name,This is a macro,Dear customer,1,2,3,4,#{created_time.strftime('%d/%m/%Y %H:%M')},#{updated_time.strftime('%d/%m/%Y %H:%M')},\"[set_tag1], [set_tag2]\",\"[current_tag1], [current_tag2]\",\"[remove_tag1], [remove_tag2]\"\n")
+    describe 'unhappy paths' do
+      describe 'when macro titles not in the correct format' do
+        it 'sets valid to false' do
+          mocked_data.title = '[CATEGORY 1]: Title name'
+
+          allow(service.macro_collection).to receive(:all!).and_yield(mocked_data)
+
+          stub_request(:get, 'https://get-help-with-tech-education.zendesk.com/api/v2/macros?include=usage_1h,usage_24h,usage_7d,usage_30d')
+            .with(
+              headers: {
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'Authorization' => 'Basic Og==',
+                'User-Agent' => 'ZendeskAPI Ruby 1.28.0',
+              },
+            )
+            .to_return(status: 200, body: '', headers: {})
+          service.csv_generator
+          expect(service.valid?).to eq(false)
+        end
+      end
     end
   end
 end

--- a/spec/services/zendesk_macro_export_service_spec.rb
+++ b/spec/services/zendesk_macro_export_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe ZendeskMacroExportService, type: :model do
+  subject(:service) { ZendeskMacroExportService.new }
+
+  let(:ticket) do
+    {
+      'full_name' => 'Joe Blogg',
+      'email_address' => 'joe@bloggs.com',
+      'user_type' => 'parent',
+      'telephone_number' => '0207 333 4444',
+      'subject' => 'My query',
+      'message' => 'This is my query',
+      'support_topics' => %w[hello world],
+    }
+  end
+
+  describe '#filename' do
+    it 'returns a formatted string which will be used for the csv file' do
+      @time_now = Time.zone.now
+      allow(Time.zone).to receive(:now).and_return(@time_now)
+      expect(service.filename).to eq("zendesk-macros-#{@time_now.strftime('%Y%m%d_%H%M')}.csv")
+    end
+  end
+
+  describe '#csv_generator' do
+    it 'generates csv file contents' do
+      created_time = Time.zone.now - 10.minutes
+      updated_time = Time.zone.now
+
+      allow(service.macro_collection).to receive(:all!).and_yield(
+        OpenStruct.new(
+          {
+            active: true,
+            title: '[CATEGORY 1]:: Title name',
+            description: 'This is a macro',
+            usage_1h: 1,
+            usage_24h: 2,
+            usage_7d: 3,
+            usage_30d: 4,
+            created_at: created_time,
+            updated_at: updated_time,
+            actions: [
+              OpenStruct.new({ field: 'set_tags', value: 'set_tag1 set_tag2' }),
+              OpenStruct.new({ field: 'current_tags', value: 'current_tag1 current_tag2' }),
+              OpenStruct.new({ field: 'remove_tags', value: 'remove_tag1 remove_tag2' }),
+              OpenStruct.new({ field: 'comment_value_html', value: 'Dear customer' }),
+            ],
+          },
+        ),
+      )
+
+      stub_request(:get, 'https://get-help-with-tech-education.zendesk.com/api/v2/macros?include=usage_1h,usage_24h,usage_7d,usage_30d')
+        .with(
+          headers: {
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic Og==',
+            'User-Agent' => 'ZendeskAPI Ruby 1.28.0',
+          },
+        )
+        .to_return(status: 200, body: '', headers: {})
+
+      expect(service.csv_generator).to eq("Category,Title,Description,Content,Usage 1hr,Usage 24hr,Usage 7d,Usage 30d,Created,Last updated,Set tags,Add tags,Remove tags\nCATEGORY 1,Title name,This is a macro,Dear customer,1,2,3,4,#{created_time.strftime('%d/%m/%Y %H:%M')},#{updated_time.strftime('%d/%m/%Y %H:%M')},\"[set_tag1], [set_tag2]\",\"[current_tag1], [current_tag2]\",\"[remove_tag1], [remove_tag2]\"\n")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Originally this feature was developed using the nodejs API client but seeing as more people are requesting this information and finding it useful, it seems like a good feature to include in the service itself so that any support agents could export this live data from Zendesk without asking me to run it for them.

### Changes proposed in this pull request
- Add a new section at the bottom of the support agent home page
![image](https://user-images.githubusercontent.com/3441519/107033509-5059d600-67ad-11eb-864b-4c5a01b4aa8a.png)

- Clicking the heading fetches and downloads the latest macro data
![image](https://user-images.githubusercontent.com/3441519/107033522-594aa780-67ad-11eb-8646-1248164de641.png)

### Guidance to review

