### PR TITLE
[1434] Support viewing school nav tabs

### DIFF
--- a/app/components/support/email_audit_list_component.html.erb
+++ b/app/components/support/email_audit_list_component.html.erb
@@ -5,10 +5,11 @@
       <th scope="col" class="govuk-table__header">Email</th>
     </tr>
   </thead>
+
   <tbody class="govuk-table__body">
     <% email_audits.each do |email_audit| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= email_audit.created_at.to_s(:govuk_date_and_time) %></td>
+        <td class="govuk-table__cell govuk-!-width-one-quarter"><%= email_audit.created_at.to_s(:govuk_date_and_time) %></td>
         <td class="govuk-table__cell govuk-!-padding-top-0">
           <%= govuk_summary_list do |component| %>
             <%= component.slot(

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -34,6 +34,7 @@ class Support::SchoolsController < Support::BaseController
     @school = School.where_urn_or_ukprn(params[:urn]).first!
     @users = policy_scope(@school.users).not_deleted
     @email_audits = @school.email_audits.order(created_at: :desc)
+    @timeline = Timeline::School.new(school: @school)
   end
 
   def confirm_invitation

--- a/app/services/timeline/changeset.rb
+++ b/app/services/timeline/changeset.rb
@@ -1,0 +1,28 @@
+module Timeline
+  class Changeset
+    attr_reader :item, :changeset
+
+    def initialize(item:, changeset:)
+      @item = item
+      @changeset = changeset
+    end
+
+    def updated_at
+      changeset[:updated_at][1]
+    end
+
+    def changes
+      @changes ||= changeset.except(:updated_at, :id, :created_at, :school_id, :device_type)
+    end
+
+    delegate :size, to: :changes
+
+    def item_type
+      if item.respond_to?(:device_type)
+        item.device_type
+      else
+        item.class.base_class
+      end
+    end
+  end
+end

--- a/app/services/timeline/school.rb
+++ b/app/services/timeline/school.rb
@@ -1,0 +1,19 @@
+module Timeline
+  class School
+    FIELDS = %i[order_state status cap allocation devices_ordered].freeze
+
+    attr_reader :school
+
+    def initialize(school:)
+      @school = school
+    end
+
+    def changesets
+      @changesets ||= PaperTrail::Version
+        .includes(:item)
+        .where(item: [school, school.device_allocations])
+        .filter { |version| (version.changeset.symbolize_keys.keys & FIELDS).size.positive? }
+        .map { |v| Changeset.new(item: v.item, changeset: v.changeset) }
+    end
+  end
+end

--- a/app/views/support/schools/_history.html.erb
+++ b/app/views/support/schools/_history.html.erb
@@ -1,8 +1,8 @@
 <% if object %>
   <% Array(object).each do |obj| %>
-    <h2 class="govuk-heading-m"><%= obj.created_at.to_s(:govuk_date_and_time) %></h2>
+    <h2 class="govuk-heading-m">Current state</h2>
     <div class="govuk-grid-row govuk-!-margin-top-4">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-full">
         <table class="govuk-table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
@@ -28,7 +28,7 @@
   <% if object.respond_to?(:versions) && object.versions.any? %>
     <h2 class="govuk-heading-m">History</h2>
     <div class="govuk-grid-row govuk-!-margin-top-4">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-full">
         <table class="govuk-table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
@@ -39,24 +39,28 @@
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-            <% object.versions.each do |v| %>
-                  <% v.changeset.except(:updated_at, :created_at).each do |(field, changes)| %>
-                    <tr class="govuk-table__row">
-                      <td class="govuk-table__cell"><%= v.created_at.to_s(:govuk_date_and_time) %></td>
-                      <td class="govuk-table__cell"><%= field %></td>
-                      <% changes.each do |change| %>
-                        <td class="govuk-table__cell">
-                          <span class="govuk-tag govuk-tag--<%= cycle('grey', 'green') %>">
-                            <% if change.present? %>
-                              <%= change %>
-                            <% else %>
-                              Blank
-                            <% end %>
-                          </span>
-                        </td>
-                      <% end %>
-                    </tr>
+            <% (changesets = object.versions.map(&:changeset)).each do |original_changeset| %>
+              <% (changeset = original_changeset.except(:updated_at, :created_at)).each_with_index do |(field, changes), index| %>
+                <tr class="govuk-table__row">
+                  <% if index.zero? %>
+                    <td class="govuk-table__cell" rowspan="<%= changeset.size %>"><%= original_changeset[:updated_at][1].to_s(:govuk_date_and_time) %></td>
                   <% end %>
+
+                  <td class="govuk-table__cell"><%= field %></td>
+
+                  <% changes.each do |change| %>
+                    <td class="govuk-table__cell">
+                      <span class="govuk-tag govuk-tag--<%= cycle('grey', 'green') %>">
+                        <% if change.present? %>
+                          <%= change %>
+                        <% else %>
+                          Blank
+                        <% end %>
+                      </span>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>

--- a/app/views/support/schools/history.html.erb
+++ b/app/views/support/schools/history.html.erb
@@ -32,14 +32,14 @@
           selected: @view_mode == 'std_device')
         %>
         <%= render TabComponent.new(
-          label: 'Dev. Caps',
-          path: support_school_history_path(view: 'caps'),
-          selected: @view_mode == 'caps')
-        %>
-        <%= render TabComponent.new(
           label: 'Routers',
           path: support_school_history_path(view: 'coms_device'),
           selected: @view_mode == 'coms_device')
+        %>
+        <%= render TabComponent.new(
+          label: 'Cap',
+          path: support_school_history_path(view: 'caps'),
+          selected: @view_mode == 'caps')
         %>
         <%= render TabComponent.new(
           label: 'Devices (v-cap)',

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -29,38 +29,65 @@
   </div>
 <% end %>
 
-<%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
 
-<%- if @school.show_mno? && @school.extra_mobile_data_requests.present? %>
-  <h2 class="govuk-heading-l govuk-!-margin-top-9">Mobile data requests</h2>
-  <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @school.extra_mobile_data_requests) %>
-<%- end %>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <a class="govuk-tabs__tab" href="#overview">
+        Overview
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#users">
+        Users
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#notifications">
+        Notifications
+      </a>
+    </li>
+  </ul>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
+  <div class="govuk-tabs__panel" id="overview">
+    <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
 
-<% if policy(User).new? && @school.can_invite_users? %>
-  <%= govuk_button_link_to 'Invite a new user', new_support_school_user_path(school_urn: @school.urn) %>
-<% end %>
+    <%- if @school.show_mno? && @school.extra_mobile_data_requests.present? %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-9">Mobile data requests</h2>
+      <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @school.extra_mobile_data_requests) %>
+    <%- end %>
+  </div>
 
-<% if @users.present? %>
-  <% @users.each do |user| %>
-    <div class="user">
-      <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
-        <%= govuk_link_to user.full_name, support_user_path(user) %>
-      </h3>
-      <p class="govuk-body">
-        <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_user_path(user) %>
-      </p>
-      <%= render Support::UserPreviewSummaryListComponent.new(user: user) %>
-    </div>
-  <% end %>
-<% else %>
-  <p class="govuk-body">None</p>
-<% end %>
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">
+    <% if policy(User).new? && @school.can_invite_users? %>
+      <%= govuk_button_link_to 'Invite a new user', new_support_school_user_path(school_urn: @school.urn) %>
+    <% end %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Notifications sent</h2>
-<% if @email_audits.present? %>
-  <%= render Support::EmailAuditListComponent.new(@email_audits) %>
-<% else %>
-  <p class="govuk-body">None</p>
-<% end %>
+    <% if @users.present? %>
+      <% @users.each do |user| %>
+        <div class="user">
+          <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
+            <%= govuk_link_to user.full_name, support_user_path(user) %>
+          </h3>
+          <p class="govuk-body">
+            <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_user_path(user) %>
+          </p>
+          <%= render Support::UserPreviewSummaryListComponent.new(user: user) %>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="govuk-body">None</p>
+    <% end %>
+  </div>
+
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="notifications">
+    <% if @email_audits.present? %>
+      <%= render Support::EmailAuditListComponent.new(@email_audits) %>
+    <% else %>
+      <p class="govuk-body">None</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -50,9 +50,16 @@
         Notifications
       </a>
     </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#timeline">
+        Timeline
+      </a>
+    </li>
   </ul>
 
   <div class="govuk-tabs__panel" id="overview">
+    <h2 class="govuk-heading-l">Overview</h2>
+
     <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
 
     <%- if @school.show_mno? && @school.extra_mobile_data_requests.present? %>
@@ -62,6 +69,8 @@
   </div>
 
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">
+    <h2 class="govuk-heading-l">Users</h2>
+
     <% if policy(User).new? && @school.can_invite_users? %>
       <%= govuk_button_link_to 'Invite a new user', new_support_school_user_path(school_urn: @school.urn) %>
     <% end %>
@@ -84,10 +93,53 @@
   </div>
 
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="notifications">
+    <h2 class="govuk-heading-l">Notifications</h2>
+
     <% if @email_audits.present? %>
       <%= render Support::EmailAuditListComponent.new(@email_audits) %>
     <% else %>
       <p class="govuk-body">None</p>
     <% end %>
+  </div>
+
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="timeline">
+    <h2 class="govuk-heading-l">Timeline</h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Time</th>
+          <th scope="col" class="govuk-table__header">Field</th>
+          <th scope="col" class="govuk-table__header">From</th>
+          <th scope="col" class="govuk-table__header">To</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @timeline.changesets.each do |changeset| %>
+          <% changeset.changes.each_with_index do |(field, diffs), index| %>
+            <tr class="govuk-table__row">
+              <% if index.zero? %>
+                <td class="govuk-table__cell" rowspan="<%= changeset.size %>"><%= changeset.updated_at.to_s(:govuk_date_and_time) %></td>
+              <% end %>
+
+              <td class="govuk-table__cell"><%= t("#{changeset.item_type}_#{field}", scope: [:components, :timeline, :field]) %></td>
+
+              <% diffs.each do |diff| %>
+                <td class="govuk-table__cell">
+                  <span>
+                    <% if diff.present? %>
+                      <%= diff %>
+                    <% else %>
+                      Blank
+                    <% end %>
+                  </span>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,14 @@ en:
             rb_can_order: Responsible body can order
             school_can_order: School can order
             ordered: Responsible body has ordered
+    timeline:
+      field:
+        std_device_cap: Device cap
+        std_device_allocation: Device allocation
+        coms_device_cap: Router cap
+        coms_device_allocation: Router allocation
+        School_status: School status
+        School_order_state: School order state
   activemodel:
     errors:
       models:

--- a/spec/services/timeline/school_spec.rb
+++ b/spec/services/timeline/school_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Timeline::School, versioning: true do
+  let(:school) { create(:school) }
+
+  describe '#changesets' do
+    subject(:timeline) { described_class.new(school: school) }
+
+    context 'when there are no changes' do
+      it 'returns empty collection' do
+        expect(timeline.changesets).to be_empty
+      end
+    end
+
+    context 'when there are no relevant changes' do
+      before do
+        school.update!(address_1: 'new address line 1')
+      end
+
+      it 'returns empty collection' do
+        expect(timeline.changesets).to be_empty
+      end
+    end
+
+    context 'when there are relevant changes' do
+      before do
+        school.update!(status: 'closed')
+      end
+
+      it 'returns changesets' do
+        expect(timeline.changesets).not_to be_empty
+      end
+
+      it 'returns Changeset populated correctly' do
+        changeset = timeline.changesets.first
+
+        expect(changeset).to be_a(Timeline::Changeset)
+        expect(changeset.item).to eql(school)
+        expect(changeset.updated_at).to eql(school.updated_at)
+      end
+    end
+  end
+end

--- a/spec/views/support/schools/show.html.erb_spec.rb
+++ b/spec/views/support/schools/show.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'support/schools/show.html.erb' do
     enable_pundit(view, support_user)
     assign(:school, school)
     assign(:current_user, support_user)
+    assign(:timeline, Timeline::School.new(school: school))
   end
 
   describe 'banners' do


### PR DESCRIPTION
### Context

- https://trello.com/c/XaACO5uV/1434-support-improvement-recent-history-for-each-school

### Changes proposed in this pull request

- Add tabs to support viewing a school
- Add new `Timeline` tab/concept
- Timeline is chronological timeline (maybe it should be reverse chronological order?) of certain changesets at the moment. This can be expanded out to other changes or refined to show fewer changes useful for support
- `/history` has been changes so items in the same changeset share the same date with one table cell with rowspan set

### Screenshots

![image](https://user-images.githubusercontent.com/92580/107217865-b68d6580-6a06-11eb-8390-fd22968c1a93.png)

![image](https://user-images.githubusercontent.com/92580/107217893-c311be00-6a06-11eb-87fb-10aa9ca4bda7.png)

![image](https://user-images.githubusercontent.com/92580/107217925-d1f87080-6a06-11eb-9583-3dfbf5f5e5ef.png)

![image](https://user-images.githubusercontent.com/92580/107359950-367e0300-6acd-11eb-9d7c-e0bbbfda14ce.png)

### Guidance to review

- n/a