### PR TITLE
Adds guidance to on checking what to do and remove 'do not delay' message

### DIFF
--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -24,6 +24,26 @@
     <% end %>
 
     <h2 class="govuk-heading-m">
+      Before you order
+    </h2>
+    <p class="govuk-body">
+      Make sure you’re certain of what devices you need, as amending or cancelling an order will cause delays.
+    </p>
+    <p class="govuk-body">
+      It may help to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %></li>
+      <li>
+        <% if @responsible_body.is_a_trust? %>
+          <%= govuk_link_to 'give someone else access so they can place orders', responsible_body_users_path %>
+        <% else %>
+          <%= govuk_link_to 'give someone else access so they can place orders', responsible_body_users_path %>
+        <% end %>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m">
       How to order
     </h2>
     <p class="govuk-body">
@@ -55,7 +75,6 @@
       </p>
     <%- end %>
 
-    <h3 class="govuk-heading-s">Using TechSource for the first time</h3>
     <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address } %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/schools/order_devices.html.erb
+++ b/app/views/responsible_body/devices/schools/order_devices.html.erb
@@ -10,6 +10,26 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
+    <h2 class="govuk-heading-m">
+      Before you order
+    </h2>
+    <p class="govuk-body">
+      Make sure you’re certain of what devices you need, as amending or cancelling an order will cause delays.
+    </p>
+    <p class="govuk-body">
+      It may help to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %></li>
+      <li>
+        <% if @responsible_body.is_a_trust? %>
+          <%= govuk_link_to 'give someone else access so they can place orders', responsible_body_users_path %>
+        <% else %>
+          <%= govuk_link_to 'give someone else access so they can place orders', responsible_body_users_path %>
+        <% end %>
+      </li>
+    </ul>
+
     <h2 class="govuk-heading-m">How to order</h2>
 
     <p class="govuk-body">You need to place your orders on a website called TechSource.</p>
@@ -23,8 +43,6 @@
     <p class="govuk-body">
       If you try to order more than <%= what_to_order_allocation_list(allocations: @school.device_allocations) %> the order will be cancelled.
     </p>
-
-    <p class="govuk-body">Order your devices now. Do not delay.</p>
 
     <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address, school_urn: @school.urn } %>
   </div>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -13,6 +13,20 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
+    <h2 class="govuk-heading-m">
+      Before you order
+    </h2>
+    <p class="govuk-body">
+      Make sure you’re certain of what devices you need, as amending or cancelling an order will cause delays.
+    </p>
+    <p class="govuk-body">
+      It may help to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %></li>
+      <li><%= govuk_link_to 'give someone else access so they can place orders', school_users_path %></li>
+    </ul>
+
     <h2 class="govuk-heading-m">How to order</h2>
 
     <p class="govuk-body">You need to place your orders on a website called TechSource.</p>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -1,7 +1,5 @@
 <h3 class="govuk-heading-s">Using TechSource for the first time</h3>
 
-<p class="govuk-body">You need to place orders on a website called TechSource.</p>
-
 <p class="govuk-body">Use these details to sign in:</p>
 <ul class="govuk-list govuk-list--bullet<% unless local_assigns[:school_urn] %> govuk-!-margin-bottom-7<% end %>">
   <li>User ID: <%= local_assigns[:email_address] %></li>


### PR DESCRIPTION
### Context

We’ve noticed that a few users are submitting their orders and then having to amend or cancel them.

### Changes proposed in this pull request

- add a few lines to help users check device specification and invite others to order
- remove the 'Do not delay' message as this may be causing users to feel its better to place and order before they're certain of what they need

