### PR TITLE
[1430] Add PaperTrail versionning for ExtraMobileDataRequests

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -1,6 +1,6 @@
 class ExtraMobileDataRequest < ApplicationRecord
   has_paper_trail
-  
+
   after_initialize :set_defaults
   before_save :normalise_device_phone_number
 

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -1,4 +1,6 @@
 class ExtraMobileDataRequest < ApplicationRecord
+  has_paper_trail
+  
   after_initialize :set_defaults
   before_save :normalise_device_phone_number
 

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ExtraMobileDataRequest, type: :model do
+  it { is_expected.to be_versioned }
   it { is_expected.to validate_presence_of(:mobile_network_id) }
 
   it 'fails validation when the network is missing' do


### PR DESCRIPTION
### Context

[Trello card 1430](https://trello.com/c/A3xFg0VU/1430-update-unavailable-statuses-for-mno-requests-to-participating-networks) Many (several hundred) requests currently have status 'unavailable', even though their corresponding mobile network is `'participating_in_pilot'`. There are 2 possibilities - either the network was not participating at the time the request was submitted, and has since joined, or the network operators have not had a clear understanding of what 'unavailable' means (it was intended to indicate 'the offer is not available on this network') and have used it to mean that the offer is not being made available for this request for some other reason.

### Changes proposed in this pull request

* Add PaperTrail auditing to `ExtraMobileDataRequest` so that for each request in future we can see what was changed, when, and by whom 

### Guidance to review

