### PR TITLE
[1430] Update all unavailable requests to new, where the MNO is participating

### DIFF
--- a/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
+++ b/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
@@ -2,7 +2,7 @@ class SetAllUnavailableEmdrsToNewForParticipatingNetworks < ActiveRecord::Migrat
   def up
     reqs = ExtraMobileDataRequest.joins(:mobile_network)
                                  .where(status: 'unavailable')
-                                 .where(mobile_network: {participation_in_pilot: 'participating'})
+                                 .where(mobile_network: { participation_in_pilot: 'participating' })
     # we're updating each one individually rather than in bulk,
     # so that we get a PaperTrail record for each
     reqs.each do |req|

--- a/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
+++ b/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
@@ -1,6 +1,7 @@
 class SetAllUnavailableEmdrsToNewForParticipatingNetworks < ActiveRecord::Migration[6.1]
   def up
     reqs = ExtraMobileDataRequest.joins(:mobile_network)
+                                 .where.not(mobile_network: { brand: 'Three' })
                                  .where(status: 'unavailable')
                                  .where(mobile_network: { participation_in_pilot: 'participating' })
     # we're updating each one individually rather than in bulk,

--- a/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
+++ b/db/migrate/20210208113843_set_all_unavailable_emdrs_to_new_for_participating_networks.rb
@@ -1,0 +1,16 @@
+class SetAllUnavailableEmdrsToNewForParticipatingNetworks < ActiveRecord::Migration[6.1]
+  def up
+    reqs = ExtraMobileDataRequest.joins(:mobile_network)
+                                 .where(status: 'unavailable')
+                                 .where(mobile_network: {participation_in_pilot: 'participating'})
+    # we're updating each one individually rather than in bulk,
+    # so that we get a PaperTrail record for each
+    reqs.each do |req|
+      req.update(status: 'new')
+    end
+  end
+
+  def down
+    # no-op
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_02_111622) do
+ActiveRecord::Schema.define(version: 2021_02_08_113843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,10 +291,10 @@ ActiveRecord::Schema.define(version: 2021_02_02_111622) do
     t.boolean "increased_allocations_feature_flag", default: false
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
-    t.boolean "hide_mno", default: false
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
     t.text "fe_type"
+    t.boolean "hide_mno", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"


### PR DESCRIPTION
### Context

[Trello card 1430](https://trello.com/c/A3xFg0VU/1430-update-unavailable-statuses-for-mno-requests-to-participating-networks) - Many (several hundred) requests currently have status 'unavailable', even though their corresponding mobile network is 'participating_in_pilot'. These should be updated to `new` so that they can now be processed - except for Three, whom we will contact directly to discuss.

_NOTE_ although it's not essential, it would be good to merge this after #1263 so that we get a `PaperTrail::Version` for each updated record.

### Changes proposed in this pull request

* Add a migration to set status to 'new' for all `ExtraMobileDataRequest`s which belong to a network that is `participating_in_pilot`

### Guidance to review

