### PR TITLE
add who_will_order_devices to schools performance data API

### DIFF
--- a/app/controllers/support/performance_data/schools_controller.rb
+++ b/app/controllers/support/performance_data/schools_controller.rb
@@ -30,7 +30,8 @@ private
               coms_device_allocation.allocation AS coms_allocation,
               coms_device_allocation.cap AS coms_cap,
               coms_device_allocation.devices_ordered AS coms_devices_ordered,
-              preorder_information.status AS preorder_info_status
+              preorder_information.status AS preorder_info_status,
+              COALESCE( preorder_information.who_will_order_devices, responsible_bodies.who_will_order_devices ) AS who_will_order_devices
 
       FROM    schools   INNER JOIN responsible_bodies
                                 ON responsible_bodies.id = schools.responsible_body_id

--- a/spec/controllers/support/performance_data/schools_controller_spec.rb
+++ b/spec/controllers/support/performance_data/schools_controller_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Support::PerformanceData::SchoolsController, type: :controller do
       'coms_devices_ordered' => school.coms_device_allocation.devices_ordered,
       'preorder_info_status' => school.preorder_information.status,
       'school_order_state' => school.order_state,
+      'who_will_order_devices' => school.who_will_order_devices,
     }
   end
 


### PR DESCRIPTION
### Context

[Trello card 1519](https://trello.com/c/WDUEYvUl/1519-add-whowillorder-to-performancedata-schools-api). When a ResponsibleBody orders centrally on behalf of their schools, they often ship devices to a single IT hub for subsequent redistribution, rather than directly to the individual schools. This can cause issues for the analysts, who are reliant on shipTo information from Computacenter for responding to FOI requests & Parliamentary questions concerning numbers of devices shipped to particular locations / areas / etc. 

In a private Slack discussion, we agreed that while we're not able to accurately determine per-school numbers when the ordering pattern is like this, we can at least add the `who_will_order_devices` field to the performance data API, which will allow the analysts to determine which Responsible Bodies _could_ do this (i.e those who are ordering centrally). 

### Changes proposed in this pull request

* add the `who_will_order_devices` field to the performance data API

### Guidance to review

