### PR TITLE
Changes 'further education provider' to 'further education institution'

### DIFF
--- a/app/components/support/user_search_result_component.rb
+++ b/app/components/support/user_search_result_component.rb
@@ -27,7 +27,7 @@ class Support::UserSearchResultComponent < ViewComponent::Base
 private
 
   def no_organisations
-    'No responsible bodies, schools, colleges or FE providers'
+    'No responsible bodies, schools, colleges or FE institutions'
   end
 
   def organisation_link_or_text(organisation)

--- a/app/views/devices_guidance/about_the_offer.md
+++ b/app/views/devices_guidance/about_the_offer.md
@@ -9,11 +9,11 @@ Examples of this include disadvantaged children:
 * with a single device in their household that’s being shared with more than one other family member
 * who do not have access to the internet at home
 
-This offer applies to maintained schools, pupil referral units, academy trusts and hospital schools, as well as sixth-form colleges and further education providers which have enrolled 14 to 16-year-olds. They’ll receive an allocation of laptops and tablets to be used to support disadvantaged children if they do not have access to a digital device through other means.
+This offer applies to maintained schools, pupil referral units, academy trusts and hospital schools, as well as sixth-form colleges and further education institutions which have enrolled 14 to 16-year-olds. They’ll receive an allocation of laptops and tablets to be used to support disadvantaged children if they do not have access to a digital device through other means.
 
 They may also be eligible to get internet access for disadvantaged children through [increased mobile phone data allowances](/about-increasing-mobile-data) or [4G wireless routers](/how-to-request-4g-wireless-routers).
 
-Laptops and tablets will be available for further education providers to order in the 2021 spring term. We’ll contact these providers with more information during the term.
+Laptops and tablets will be available for further education institutions to order in the 2021 spring term. We’ll contact these institutions with more information during the term.
 
 Devices are currently available for:
 

--- a/app/views/devices_guidance/device_allocations.md
+++ b/app/views/devices_guidance/device_allocations.md
@@ -2,13 +2,13 @@
 
 In February 2021, we allocated 300,000 more devices to support the pupils and students most in need.
 
-The number of devices we’ve made available for you to order through the service reflects the number of laptops and tablets we estimate are needed by your school, college or further education provider.
+The number of devices we’ve made available for you to order through the service reflects the number of laptops and tablets we estimate are needed by your school, college or further education institution.
 
 This calculation is based on:
 
 * free school meals data
-* free meals data for further education providers
-* an estimate of the number of devices a school or further education provider already has
+* free meals data for further education institutions
+* an estimate of the number of devices a school or further education institution already has
 
 ## Providing internet connectivity
 
@@ -31,17 +31,17 @@ You’ll need to provide anonymised evidence that confirms:
 * the ages of the pupils and students for whom you are requesting additional devices
 * how you’ve identified that these pupils and students are disadvantaged (such as whether they get free meals)
 * how you know that the pupils and students do not have access to a private device (for example, through phone calls to families or a survey you’ve conducted about device ownership)
-* that all the devices your school or further education provider has already, have been distributed
+* that all the devices your school or further education institution has already, have been distributed
 
 ### If you’re applying for a local authority or academy trust, you need to tell us:
 
 * the LAESTAB number for a hospital school
 * the name of the school your query is for and the number of additional devices required. If you’re requesting additional devices for more than one school, you’ll need to provide the number of additional devices required for each school
 
-### If you’re applying for a school, college or further education provider, you need to tell us:
+### If you’re applying for a school, college or further education institution, you need to tell us:
 
 * your unique reference number (URN), which is normally 6 digits. If you’re applying for a further education college, this will be your 8-digit UKPRN. If you don’t know your URN or UKPRN, you can find these on the [Get Information about Schools](https://get-information-schools.service.gov.uk/) site
-* the name of your school, college or further education provider
+* the name of your school, college or further education institution
 * the number of additional devices required
 
 We’ll review your query and respond with a decision as soon as possible.

--- a/app/views/devices_guidance/device_distribution_and_ownership.md
+++ b/app/views/devices_guidance/device_distribution_and_ownership.md
@@ -1,18 +1,18 @@
 ## Who owns the devices
 
-Ownership of devices is transferred from the Department for Education (DfE) to the local authorities (LAs), academy trusts, schools, colleges and further education (FE) providers who receive them at the point of delivery.
+Ownership of devices is transferred from the Department for Education (DfE) to the local authorities (LAs), academy trusts, schools, colleges and further education (FE) institutions who receive them at the point of delivery.
 
-### Devices for education: children and young people in schools and FE providers
+### Devices for education: children and young people in schools and FE institutions
 
 <div class="govuk-inset-text">
   <p class="govuk-body">This guidance is about laptops, tablets and 4G wireless routers given to LAs and academy trusts for disadvantaged:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>year 10s in the 2020 summer term and those given to LAs, academy trusts, schools, colleges and further education providers</li>
+    <li>year 10s in the 2020 summer term and those given to LAs, academy trusts, schools, colleges and further education institutions</li>
     <li>children and students after September 2020</li>
   </ul>
 </div>
 
-The school, college, further education provider, trust or LA should retain ownership and lend the devices to those children and young people who need them. This gives them the ability to re-allocate the devices where required, for example, when different groups of pupils or students are required to <span class="app-no-wrap">self-isolate</span> at different times.
+The school, college, further education institution, trust or LA should retain ownership and lend the devices to those children and young people who need them. This gives them the ability to re-allocate the devices where required, for example, when different groups of pupils or students are required to <span class="app-no-wrap">self-isolate</span> at different times.
 
 LAs and trusts may choose to transfer ownership to schools and colleges.
 
@@ -64,25 +64,25 @@ LAs may also have valid reasons for retaining a pool of devices. For example, th
 
 ## Distributing devices
 
-Laptops, tablets and 4G wireless routers ordered from September 2020 will be delivered directly to schools, colleges, further education providers or LAs named in the order. Read guidance on [how to order laptops and tablets](/devices/how-to-order) or [4G wireless routers](/how-to-request-4g-wireless-routers) for more information on the delivery process. 
+Laptops, tablets and 4G wireless routers ordered from September 2020 will be delivered directly to schools, colleges, further education institutions or LAs named in the order. Read guidance on [how to order laptops and tablets](/devices/how-to-order) or [4G wireless routers](/how-to-request-4g-wireless-routers) for more information on the delivery process. 
 
 Organisations are responsible for deciding how they deliver devices. For example, they can:
 
 * arrange for them to be collected
 * organise for them to be delivered to the homes of pupils, students and care leavers
-* arrange for schools, colleges and further education providers to deliver them
+* arrange for schools, colleges and further education institutions to deliver them
 * use local organisations, such as those supporting care leavers
 
 All distribution and return of lent devices should be done in accordance with [social distancing guidelines relevant to your local area](https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19).
 
 ### Redistributing unused 4G wireless routers
 
-LAs, academy trusts, schools, colleges and further education providers can use the [Support Portal](https://computacenterprod.service-now.com/dfe) to see how much data is being used by each router they are responsible for. If you identify routers that are not being used, you may wish to collect them and lend them to other children and young people who may have greater need.
+LAs, academy trusts, schools, colleges and further education institutions can use the [Support Portal](https://computacenterprod.service-now.com/dfe) to see how much data is being used by each router they are responsible for. If you identify routers that are not being used, you may wish to collect them and lend them to other children and young people who may have greater need.
 
 
 ## Loan agreements
 
-LAs, academy trusts, schools, colleges and further education providers could consider using loan agreements when they choose to lend devices to children and young people. This agreement could set out the terms and conditions, including who is responsible for what.
+LAs, academy trusts, schools, colleges and further education institutions could consider using loan agreements when they choose to lend devices to children and young people. This agreement could set out the terms and conditions, including who is responsible for what.
 
 [The Key for School Leaders](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/make-tech-work-you/loaning-it-equipment-pupils-and-staff/#section-1) has templates and examples of how to set these up.
 
@@ -92,7 +92,7 @@ LAs, academy trusts, schools, colleges and further education providers could con
 
 ## Labelling or tagging devices
 
-Laptops, tablets and 4G wireless routers will not be tagged or labelled when they are delivered. Schools, colleges, further education providers, LAs and trusts are responsible for implementing their own security and tracking methods. 
+Laptops, tablets and 4G wireless routers will not be tagged or labelled when they are delivered. Schools, colleges, further education institutions, LAs and trusts are responsible for implementing their own security and tracking methods. 
 
 You will invalidate the warranty on your device if you use any permanent method of labelling or tagging the laptop or tablet.
 
@@ -100,6 +100,6 @@ See the [guidance on preparing devices](/devices/preparing-chromebooks) for info
 
 ## Lost, stolen or sold devices
 
-The LA, trust, school or further education provider should make clear to recipients of devices that it is unlawful for any lent device to be sold by a student or their family. If a lent device is lost, stolen or sold, or where recall is not possible, organisations should follow any existing protocol they may have for lost, stolen or missing devices.
+The LA, trust, school or further education institution should make clear to recipients of devices that it is unlawful for any lent device to be sold by a student or their family. If a lent device is lost, stolen or sold, or where recall is not possible, organisations should follow any existing protocol they may have for lost, stolen or missing devices.
 
 Where an LA, trust, school, college or further education provide has a safeguarding concern relating to a device that they suspect has been lost, stolen or sold they should [contact us](/get-support).

--- a/app/views/devices_guidance/device_specification.md
+++ b/app/views/devices_guidance/device_specification.md
@@ -1,4 +1,4 @@
-When [placing an order](/start), schools, colleges, further education providers, academy trusts and local authorities (LAs) can choose (depending on availability) from:
+When [placing an order](/start), schools, colleges, further education institutions, academy trusts and local authorities (LAs) can choose (depending on availability) from:
 
 * Microsoft Windows laptops
 * Microsoft Windows tablets (with or without keyboards)

--- a/app/views/devices_guidance/getting_started_with_your_google_chromebook.md
+++ b/app/views/devices_guidance/getting_started_with_your_google_chromebook.md
@@ -13,7 +13,7 @@ If you’re using your own Wi-Fi to access the internet,  then connect using the
 
 You can start using your Chromebook once you’re connected to a Wi-Fi network. 
 
-For pupils and students, your school, college or further education provider will let you know which resources you should use. For care leavers, and children and families with a social worker, your local authority will let you know how you can use your Chromebook to get the services you need.
+For pupils and students, your school, college or further education institution will let you know which resources you should use. For care leavers, and children and families with a social worker, your local authority will let you know how you can use your Chromebook to get the services you need.
 
 ## Staying safe online
 

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -50,7 +50,7 @@
             </ul>
 
             <p class="app-step-nav__paragraph">
-              Further education providers can place their own orders.
+              Further education institutions can place their own orders.
             </p>
 
             <p class="app-step-nav__paragraph">
@@ -112,7 +112,7 @@
                   Not having DfE settings installed
                 </h4>
                 <p class="app-step-nav__paragraph">
-                  These ‘DfE Standard’ devices are provided with factory settings. Schools, colleges, further education providers, trusts or LAs should configure them at their own cost before lending them to students. This means installing preferred safeguarding measures and bringing them into an existing device management framework.
+                  These ‘DfE Standard’ devices are provided with factory settings. Schools, colleges, further education institutions, trusts or LAs should configure them at their own cost before lending them to students. This means installing preferred safeguarding measures and bringing them into an existing device management framework.
                 </p>
               </li>
               <li>
@@ -137,8 +137,8 @@
              You need to sign in to the <a class="govuk-link" href="/start">Get help with technology service</a> and provide the following information before you can order Google Chromebooks:
             </p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>the school, college or further education provider’s Google domain for G Suite for Education</li>
-              <li>a recovery email address, which must be on a different domain to the school, college or further education provider’s domain</li>
+              <li>the school, college or further education institution’s Google domain for G Suite for Education</li>
+              <li>a recovery email address, which must be on a different domain to the school, college or further education institution’s domain</li>
             </ul>
 
             <p class="app-step-nav__paragraph">
@@ -202,11 +202,7 @@
 
           <div class="app-step-nav__panel" id="step-panel-prepare-to-place-an-order-3">
             <p class="app-step-nav__paragraph">
-              All primary and secondary schools in England have been invited to order through the <a class="govuk-link" href="/start">Get help with technology service</a>.
-            </p>
-
-            <p class="app-step-nav__paragraph">
-              The majority of further education providers will have been invited to order by the end of January 2021.
+              All schools, colleges and eligible further education institutions in England have been invited to order through the <a class="govuk-link" href="/start">Get help with technology service</a>.
             </p>
 
             <h3 class="govuk-heading-s">
@@ -264,11 +260,15 @@
             </p>
 
             <p class="app-step-nav__paragraph">
-              All devices will be <a class="govuk-link" href="/devices/device-distribution-and-ownership">owned by the schools, colleges, further education providers or or academy trusts</a> that receive them. It is their responsibility to lend the devices to those who need them.
+              All devices will be owned by the schools, colleges, further education institutions or or academy trusts that receive them. It is their responsibility to lend the devices to those who need them.
             </p>
 
             <p class="app-step-nav__paragraph">
-              After receiving devices and preparing them for use by pupils and students, schools, colleges and further education providers can:
+              <%= govuk_link_to "Read more about who owns devices and how to distribute them" , devices_distributing_devices_path %>
+            </p>
+
+            <p class="app-step-nav__paragraph">
+              After receiving devices and preparing them for use by pupils and students, schools, colleges and further education institutions can:
             </p>
 
             <ul class="govuk-list govuk-list--bullet">

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -12,9 +12,9 @@
       <%= t('landing_pages.get_support_guides.title' ) %>
     </h1>
 
-    <p class="govuk-body">Many vulnerable and disadvantaged children and young people in England do not have access to a laptop, tablet or internet connection. The Department for Education (DfE) is offering support to help children, young people and families access remote education and social care during coronavirus <span class="app-no-wrap">(COVID-19)</span>.</p>
+    <p class="govuk-body">Many vulnerable and disadvantaged children and young people in England do not have access to a laptop, tablet or internet connection. The Department for Education (DfE) is offering support to help children, young people and families access remote education and social care during the pandemic.</p>
 
-    <p class="govuk-body">The DfE is working with delivery partners to supply local authorities, academy trusts, further education providers and schools with <%= govuk_link_to 'laptops, tablets and connectivity packages', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.</p>
+    <p class="govuk-body">The DfE is working with delivery partners to supply local authorities, academy trusts, schools and further education institutions with <%= govuk_link_to 'laptops, tablets and connectivity packages', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.</p>
 
     <%= render partial: 'page_link_and_description', collection: @responsible_body_pages, as: :page %>
 

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -21,7 +21,7 @@
       <li>4G wireless routers (available for children in years 3 to 11 and those in further education)</li>
     </ul>
 
-    <p class="govuk-body">Schools can request one type of support per child. Further education providers can request 4G routers, but not extra data for mobile devices.</p>
+    <p class="govuk-body">Schools can request one type of support per child. Further education institutions can request 4G routers, but not extra data for mobile devices.</p>
 
     <p class="govuk-body">To choose which option may be best for a particular child, use the information here to compare the two schemes.</p>
 

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -4,8 +4,8 @@
       Get help with technology
     </h1>
 
-    <p class="govuk-body-l">
-      Information for local authorities, academy trusts, schools, colleges and <span class="app-no-wrap">further education providers</span> about the devices, internet access
+    <p class="govuk-body">
+      Information for local authorities, academy trusts, schools, colleges and <span class="app-no-wrap">further education institutions</span> about the devices, internet access
       and support available to provide remote education and access to social care during
       coronavirus (COVID-19).
     </p>
@@ -72,11 +72,11 @@
       Get support
     </h2>
     <p class="govuk-body-s">
-      If you work for a local authority, academy trust, school, college or further education provider, and you need help with any of the devices or services
+      If you work for a local authority, academy trust, school, college or further education institution, and you need help with any of the devices or services
       offered by this programme, <%= govuk_link_to "contact us", support_ticket_path %>.
     </p>
     <p class="govuk-body-s">
-      If you’ve been given a laptop, tablet or 4G wireless router by your local authority or school or further education provider and need some help, contact the person or school who gave it to you.
+      If you’ve been given a laptop, tablet or 4G wireless router by your local authority or school or further education institution and need some help, contact the person or school who gave it to you.
     </p>
     <p class="govuk-body-s">
       Find out more about the Department for Education’s

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -134,7 +134,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>how you’ve identified disadvantage, such as the number of pupils and students in receipt of free meals</li>
       <li>your understanding of children, young people and families’ access to internet connectivity - this information could be from survey data, calls home, your awareness of specific family circumstances, demographic data, or questions asked to parents</li>
-      <li>disadvantaged pupils joining the school since the most recent School Workforce Census, or for further education providers, disadvantaged students joining after October 2020</li>
+      <li>disadvantaged pupils joining the school since the most recent School Workforce Census, or for further education institutions, disadvantaged students joining after October 2020</li>
     </ul>
 
     <p class="govuk-body">

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -46,7 +46,7 @@
     </h2>
 
     <p class="govuk-body">
-      Schools, colleges, further education providers, trusts and local authorities in England can request 4G wireless routers for disadvantaged pupils and students who are experiencing disruption to face-to-face education and do not have fixed broadband or access to the internet at home.
+      Schools, colleges, further education institutions, trusts and local authorities in England can request 4G wireless routers for disadvantaged pupils and students who are experiencing disruption to face-to-face education and do not have fixed broadband or access to the internet at home.
     </p>
 
     <p class="govuk-body">

--- a/app/views/school/details/show.html.erb
+++ b/app/views/school/details/show.html.erb
@@ -21,7 +21,7 @@
     </h2>
 
     <p class="govuk-body">
-      Allocations are based on an estimate of the number of devices your school, college or <span class="app-no-wrap">further education provider</span> already has and the number of:
+      Allocations are based on an estimate of the number of devices your school, college or <span class="app-no-wrap">further education institution</span> already has and the number of:
     </p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
       <li>pupils in years 3 to 11</li>

--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -9,7 +9,7 @@
         <%= title %>
       </h1>
 
-        <p class="govuk-body">Your allocation of <%= @allocation %> is based on an estimate of the number of devices your school, college or <span class="app-no-wrap">further education provider</span> already has and the number of:</p>
+        <p class="govuk-body">Your allocation of <%= @allocation %> is based on an estimate of the number of devices your school, college or <span class="app-no-wrap">further education institution</span> already has and the number of:</p>
 
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
           <li>pupils in years 3 to 11</li>

--- a/app/views/shared/_privacy_notice_text.html.erb
+++ b/app/views/shared/_privacy_notice_text.html.erb
@@ -10,7 +10,7 @@
   <li>academy trusts (trusts)</li>
   <li>schools</li>
   <li>colleges</li>
-  <li>further education providers</li>
+  <li>further education institutions</li>
 </ul>
 
 <h3 class="govuk-heading-m">How we use your personal information</h3>
@@ -50,7 +50,7 @@
 
 <h3 class="govuk-heading-m">Who we share your personal information with</h3>
 
-<p class="govuk-body">We share your personal information with other contacts in local authorities, academy trusts, schools, colleges and <span class="app-no-wrap">further education providers</span> so that they may contact you in relation to the programme, such as gaining access to technical support.</p>
+<p class="govuk-body">We share your personal information with other contacts in local authorities, academy trusts, schools, colleges and <span class="app-no-wrap">further education institutions</span> so that they may contact you in relation to the programme, such as gaining access to technical support.</p>
 
 <p class="govuk-body">We share your information with contracted third parties who work on behalf of the DfE as part of the programme:</p>
 

--- a/app/views/shared/banners/_global_notice_banner.html.erb
+++ b/app/views/shared/banners/_global_notice_banner.html.erb
@@ -3,7 +3,7 @@
     <%= render GovukComponent::NotificationBanner.new({ title: 'Important'}) do |component| %>
       <%= component.slot(:heading, text: "Parents, carers, children and young people") %>
       <p class="govuk-notification-banner__body">
-        Parents, carers, children and young people cannot apply for laptops, tablets or internet access. You should contact your school, college or further education provider for help accessing remote education.
+        Parents, carers, children and young people cannot apply for laptops, tablets or internet access. You should contact your school, college or further education institution for help accessing remote education.
       </p>
     <% end %>
   </div>

--- a/app/views/shared/banners/_parents_carers_pupils.html.erb
+++ b/app/views/shared/banners/_parents_carers_pupils.html.erb
@@ -5,6 +5,6 @@
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
       Parents, carers, pupils and students
     </h2>
-    <p class="govuk-body">Parents, carers, pupils and students cannot apply for laptops, tablets or internet access. You should contact your school, college or <span class="app-no-wrap">further education provider</span> for help accessing remote education.</p>
+    <p class="govuk-body">Parents, carers, pupils and students cannot apply for laptops, tablets or internet access. You should contact your school, college or <span class="app-no-wrap">further education institution</span> for help accessing remote education.</p>
   </strong>
 </div>

--- a/app/views/sign_in_tokens/email_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/email_not_recognised.html.erb
@@ -19,6 +19,6 @@
     <h2 class="govuk-heading-m">
       Parents, carers, pupils and students
     </h2>
-    <p class="govuk-body">Parents, carers, pupils and students do not have access to this service. You should contact your school, college or further education provider for help accessing remote education.</p>
+    <p class="govuk-body">Parents, carers, pupils and students do not have access to this service. You should contact your school, college or further education institution for help accessing remote education.</p>
   </div>
 </div>

--- a/app/views/support/home/schools.html.erb
+++ b/app/views/support/home/schools.html.erb
@@ -16,20 +16,20 @@
       <%= govuk_link_to 'Find organisations', search_support_schools_path %>
     </h2>
 
-    <p class="govuk-body">Use this section to find one or more school, college or FE provider by URN or UKPRN.</p>
+    <p class="govuk-body">Use this section to find one or more school, college or FE institution by URN or UKPRN.</p>
 
     <% if policy(School).edit? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to 'Enable orders for many organisations', devices_enable_orders_for_many_schools_support_schools_path %>
       </h2>
 
-      <p class="govuk-body">Use this section to allow schools, colleges and FE providers to order their full allocation</p>
+      <p class="govuk-body">Use this section to allow schools, colleges and FE institutions to order their full allocation</p>
 
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to 'Adjust allocations for many organisations', devices_adjust_allocations_for_many_schools_support_schools_path %>
       </h2>
 
-      <p class="govuk-body">Use this section to allow schools, colleges and FE providers to order their full allocation</p>
+      <p class="govuk-body">Use this section to allow schools, colleges and FE institutions to order their full allocation</p>
 
     <% end %>
   </div>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -22,21 +22,21 @@
 
     <% if policy(School).edit? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Find and manage schools, colleges and FE providers', support_schools_path %>
+        <%= govuk_link_to 'Find and manage schools, colleges and FE institutions', support_schools_path %>
       </h2>
 
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>search for schools, colleges and further education (FE) providers</li>
-        <li>enable orders for many schools, colleges and FE providers</li>
-        <li>adjust allocations for many schools, colleges and FE providers</li>
+        <li>search for schools, colleges and further education (FE) institutions</li>
+        <li>enable orders for many schools, colleges and FE institutions</li>
+        <li>adjust allocations for many schools, colleges and FE institutions</li>
       </ul>
     <% else %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Find schools, colleges and FE providers', support_schools_path %>
+        <%= govuk_link_to 'Find schools, colleges and FE institutions', support_schools_path %>
       </h2>
 
-      <p class="govuk-body">Use this section to search for schools, colleges and FE providers.</p>
+      <p class="govuk-body">Use this section to search for schools, colleges and FE institutions.</p>
     <% end %>
 
     <% if policy(Support::ServicePerformance).index? %>

--- a/app/views/support/schools/devices/order_status/collect_urns_to_allow_many_schools_to_order.html.erb
+++ b/app/views/support/schools/devices/order_status/collect_urns_to_allow_many_schools_to_order.html.erb
@@ -15,7 +15,7 @@
     <%= form_for @form, url: allow_ordering_for_many_schools_support_schools_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <p class="govuk-body">These schools, colleges or FE providers can place orders because they have reported a closure or a group of self-isolating pupils or students.</p>
+      <p class="govuk-body">These schools, colleges or FE institutions can place orders because they have reported a closure or a group of self-isolating pupils or students.</p>
 
       <%= f.govuk_text_area :school_urns,
                             label: { text: 'URNs', size: 'm' },

--- a/app/views/support/users/search.html.erb
+++ b/app/views/support/users/search.html.erb
@@ -14,7 +14,7 @@
     </h1>
 
     <p class="govuk-body">
-      Search for responsible body, school, college or FE provider users by their email address or name.
+      Search for responsible body, school, college or FE institution users by their email address or name.
     </p>
 
     <%= form_with model: @search_form, url: results_support_users_path do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
     internet_access: Get internet access
     who_needs_the_data: Who needs the extra mobile data?
     report_a_problem: Report a problem
-    devices_guidance_how_to_order: "How and when to order DfE laptops and tablets during coronavirus (COVID-19)"
+    devices_guidance_how_to_order: "How and when to order DfE laptops and tablets during the pandemic"
     click_to_sign_in:
       standard: You’re signed in
       related_organisation: You’re signed in as %{organisation}
@@ -66,12 +66,12 @@ en:
 
     support:
       home: Support
-      schools: Schools, colleges and FE providers
+      schools: Schools, colleges and FE institutions
       technical_support: Technical support
       feature_flags: Feature flags
       devices:
         schools:
-          search: Search for schools, colleges and FE providers
+          search: Search for schools, colleges and FE institutions
           results: School search results
       users:
         search: Find users
@@ -84,7 +84,7 @@ en:
           index: Associate with a responsible body
           edit: Update responsible body
       allocation:
-        adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE providers
+        adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE institutions
       addresses:
         edit: Update address
     support_responsible_bodies: Responsible bodies
@@ -97,7 +97,7 @@ en:
       std_device: Change device allocation
       coms_device: Change router allocation
     support_edit_chromebook_details: Will the school need to order Chromebooks?
-    support_bulk_allocation: Allow schools, colleges and FE providers to order their full allocation
+    support_bulk_allocation: Allow schools, colleges and FE institutions to order their full allocation
     support_bulk_allocation_result: Bulk allocation summary
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
@@ -238,7 +238,7 @@ en:
       audience: device_users
     preparing_chromebooks:
       title: Preparing Chromebooks
-      description: Guidance on how to enrol Google Chromebooks on your domain, how to install Cisco Umbrella content filtering, and set up instructions for local authorities, trusts, further education providers and schools.
+      description: Guidance on how to enrol Google Chromebooks on your domain, how to install Cisco Umbrella content filtering, and set up instructions for local authorities, trusts, schools and further education institutions.
       audience: responsible_body_users
     getting_started_with_your_google_chromebook:
       title: Getting started with your Google Chromebook

--- a/spec/components/support/user_search_result_component_spec.rb
+++ b/spec/components/support/user_search_result_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Support::UserSearchResultComponent do
     subject { described_class.new(user: unassociated_user, current_user: support_user) }
 
     it 'shows (no schools or responsible bodies) in the associations' do
-      expect(rendered_result_html).to include('No responsible bodies, schools, colleges or FE providers')
+      expect(rendered_result_html).to include('No responsible bodies, schools, colleges or FE institutions')
     end
   end
 

--- a/spec/features/devices_guidance/how_to_order_spec.rb
+++ b/spec/features/devices_guidance/how_to_order_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'How to order devices', type: :feature do
 
     expect(devices_guidance_how_to_order_page).to be_displayed
 
-    expect(devices_guidance_how_to_order_page.page_heading).to have_content('How and when to order DfE laptops and tablets during coronavirus (COVID-19)')
+    expect(devices_guidance_how_to_order_page.page_heading).to have_content('How and when to order DfE laptops and tablets during the pandemic')
     expect(devices_guidance_how_to_order_page.steps.length).to equal(4)
   end
 end

--- a/spec/features/support/enabling_orders_for_many_schools_spec.rb
+++ b/spec/features/support/enabling_orders_for_many_schools_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Allowing multiple schools to order their full allocation' do
   end
 
   def then_i_see_the_full_allocations_page
-    expect(page).to have_selector('h1', text: 'Allow schools, colleges and FE providers to order their full allocation')
+    expect(page).to have_selector('h1', text: 'Allow schools, colleges and FE institutions to order their full allocation')
   end
 
   def when_i_navigate_to_the_full_allocations_page


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/zZfi6hDM/1418-update-fe-content-with-approved-wording)

We've been asked to use 'further education institution' instead of 'further education provider'

### Changes proposed in this pull request

Changes all instances of
- Further education provider
- Further education providers
- FE provider
- FE providers

to

- Further education institution
- Further education institutions
- FE institution
- FE institutions
