### PR TITLE
[1434] Add missing timeline translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,8 +426,10 @@ en:
       field:
         std_device_cap: Device cap
         std_device_allocation: Device allocation
+        std_device_devices_ordered: Devices ordered
         coms_device_cap: Router cap
         coms_device_allocation: Router allocation
+        coms_device_devices_ordered: Routers ordered
         School_status: School status
         School_order_state: School order state
   activemodel:


### PR DESCRIPTION
### Context

- https://trello.com/c/XaACO5uV/1434-support-improvement-recent-history-for-each-school

### Changes proposed in this pull request

- Add missing translations for school timeline, otherwise shows raw enum values which aren't very user firendly

### Guidance to review

- Make a school order some devices
- Log in as support user
- View the timeline of the school
- Should see translations in use