### PR TITLE
[1434] Support viewing user tweaks

### DIFF
--- a/app/components/support/user_preview_summary_list_component.rb
+++ b/app/components/support/user_preview_summary_list_component.rb
@@ -16,6 +16,10 @@ class Support::UserPreviewSummaryListComponent < ViewComponent::Base
         value: @user.telephone,
       },
       {
+        key: 'Privacy notice seen',
+        value: @user.privacy_notice_seen_at ? l(@user.privacy_notice_seen_at, format: :short) : 'No',
+      },
+      {
         key: 'Last sign in',
         value: @user.last_signed_in_at ? l(@user.last_signed_in_at, format: :short) : 'Never',
       },
@@ -34,7 +38,7 @@ private
 
   def can_order_devices_label
     if @user.relevant_to_computacenter? && @user.techsource_account_confirmed?
-      'Yes, TechSource account confirmed'
+      "Yes, TechSource account confirmed at #{l(@user.techsource_account_confirmed_at, format: :short)}"
     elsif @user.relevant_to_computacenter?
       'No, waiting for TechSource account'
     elsif @user.orders_devices? && !@user.seen_privacy_notice?

--- a/spec/components/support/user_preview_summary_list_component_spec.rb
+++ b/spec/components/support/user_preview_summary_list_component_spec.rb
@@ -4,7 +4,7 @@ describe Support::UserPreviewSummaryListComponent do
   subject(:result) { render_inline(described_class.new(user: user)) }
 
   let(:user) do
-    build(:school_user, telephone: '12345')
+    build(:school_user, :has_seen_privacy_notice, telephone: '12345')
   end
 
   it 'displays the email address' do
@@ -15,13 +15,27 @@ describe Support::UserPreviewSummaryListComponent do
     expect(result.css('.govuk-summary-list__row')[1].text).to include('12345')
   end
 
+  it 'displays when privacy notice was seen' do
+    expect(result.css('.govuk-summary-list__row')[2].text).to include(user.privacy_notice_seen_at.strftime('%d'))
+  end
+
+  context 'when privacy notice has not been seen' do
+    let(:user) do
+      build(:school_user, :has_not_seen_privacy_notice, telephone: '12345')
+    end
+
+    it 'displays privacy notice as not seen' do
+      expect(result.css('.govuk-summary-list__row')[2].text).to include('No')
+    end
+  end
+
   context 'for a user who cannot order devices' do
     let(:user) do
       build(:school_user, telephone: '12345', orders_devices: false)
     end
 
     it 'displays the user as unable to order devices' do
-      expect(result.css('.govuk-summary-list__row')[4].text).to include('No')
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('No')
     end
   end
 
@@ -31,7 +45,7 @@ describe Support::UserPreviewSummaryListComponent do
     end
 
     it 'displays the user as able to order devices once they sign in' do
-      expect(result.css('.govuk-summary-list__row')[4].text).to include('No, will get a TechSource account once they sign in')
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('No, will get a TechSource account once they sign in')
     end
   end
 
@@ -45,7 +59,7 @@ describe Support::UserPreviewSummaryListComponent do
     end
 
     it "displays the user as able to order devices once it's confirmed that they have a TechSource account" do
-      expect(result.css('.govuk-summary-list__row')[4].text).to include('No, waiting for TechSource account')
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('No, waiting for TechSource account')
     end
   end
 
@@ -59,7 +73,11 @@ describe Support::UserPreviewSummaryListComponent do
     end
 
     it 'displays the user as able to order devices' do
-      expect(result.css('.govuk-summary-list__row')[4].text).to include('Yes')
+      expect(result.css('.govuk-summary-list__row')[5].text).to include('Yes')
+    end
+
+    it 'displays the when the TechSource account was confirmed' do
+      expect(result.css('.govuk-summary-list__row')[5].text).to include(user.techsource_account_confirmed_at.strftime('%d'))
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/XaACO5uV/1434-support-improvement-recent-history-for-each-school

### Changes proposed in this pull request

- Show when user saw privacy notice
- Show when TechSource was confirmed

### Sreenshots

![image](https://user-images.githubusercontent.com/92580/107507149-0d29a980-6b97-11eb-9c46-35f084727b2a.png)

### Guidance to review

- Login as support user and view a user
- Change whether not user has seen privacy notice
- View should update accordingly
- Change whether or not TechSource account confirmed
- Timestamp of confirmation should show or disappear