### PR TITLE
Signed in users shouldn't need to complete "Contact details" page of "Get support" journey

### DIFF
--- a/app/controllers/support_ticket/contact_details_controller.rb
+++ b/app/controllers/support_ticket/contact_details_controller.rb
@@ -2,15 +2,27 @@ class SupportTicket::ContactDetailsController < SupportTicket::BaseController
   before_action :require_support_ticket_data!, only: :new
 
   def new
-    @form ||= SupportTicket::ContactDetailsForm.new(set_params)
-    render 'support_tickets/contact_details'
+    if current_user.id.present?
+      session[:support_ticket].merge!({
+        full_name: helpers.sanitize(current_user.full_name),
+        email_address: helpers.sanitize(current_user.email_address),
+        telephone_number: helpers.sanitize(current_user.telephone),
+        user_profile_path: support_user_url(current_user.id),
+      })
+
+      redirect_to next_step
+    else
+      @form ||= SupportTicket::ContactDetailsForm.new(set_params)
+      render 'support_tickets/contact_details'
+    end
   end
 
   def save
     if form.valid?
       session[:support_ticket].merge!({ full_name: helpers.sanitize(form.full_name),
                                         email_address: helpers.sanitize(form.email_address),
-                                        telephone_number: helpers.sanitize(form.telephone_number) })
+                                        telephone_number: helpers.sanitize(form.telephone_number),
+                                        user_profile_path: nil })
       redirect_to next_step
     else
       render 'support_tickets/contact_details'

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -6,6 +6,7 @@ class ZendeskService
     user_type: '360011798678',
     support_topics: '360011519218',
     telephone_number: '360011762698',
+    user_profile_path: '360013507477',
   }.freeze
 
   class << self
@@ -31,6 +32,7 @@ class ZendeskService
         { id: CUSTOM_FIELD_IDS[:user_type], value: ticket['user_type'] },
         { id: CUSTOM_FIELD_IDS[:support_topics], value: ticket['support_topics'] },
         { id: CUSTOM_FIELD_IDS[:telephone_number], value: ticket['telephone_number'] },
+        { id: CUSTOM_FIELD_IDS[:user_profile_path], value: ticket['user_profile_path'] },
       ],
     )
   end

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -40,14 +40,15 @@
         %>
       <% end %>
 
-      <% component.slot(
-         :row,
-         key: "How can we contact you?",
-         value: "#{ @support_ticket.full_name}<br>#{ @support_ticket.email_address}<br>#{ @support_ticket.telephone_number}".html_safe ,
-         action: govuk_link_to("Change", support_ticket_contact_details_path),
-         classes: "Name".to_s.downcase.gsub(/ /, "-"),
-       ) %>
-
+      <% if current_user.id.nil? %>
+        <% component.slot(
+           :row,
+           key: "How can we contact you?",
+           value: "#{ @support_ticket.full_name}<br>#{ @support_ticket.email_address}<br>#{ @support_ticket.telephone_number}".html_safe ,
+           action: govuk_link_to("Change", support_ticket_contact_details_path),
+           classes: "Name".to_s.downcase.gsub(/ /, "-"),
+         ) %>
+      <% end %>
       <% component.slot(
          :row,
          key: "What do you need help with?",

--- a/spec/controllers/support_ticket/contact_details_controller_spec.rb
+++ b/spec/controllers/support_ticket/contact_details_controller_spec.rb
@@ -29,13 +29,34 @@ RSpec.describe SupportTicket::ContactDetailsController, type: :controller do
         expect(response).to redirect_to(support_ticket_path)
       end
     end
+
+    context 'when attempting to access the page when user is signed in' do
+      let(:user) { create(:school_user) }
+
+      before do
+        session[:support_ticket] = { user_type: '' }
+        allow(controller).to receive(:current_user).and_return(user)
+        get :new
+      end
+
+      it 'sets user profile details in the session' do
+        expect(session[:support_ticket][:full_name]).to eq(user.full_name)
+        expect(session[:support_ticket][:email_address]).to eq(user.email_address)
+        expect(session[:support_ticket][:telephone_number]).to eq(user.telephone)
+        expect(session[:support_ticket][:user_profile_path]).to eq(support_user_url(user.id))
+      end
+
+      it 'redirects the user to the next step' do
+        expect(response).to redirect_to(support_ticket_support_needs_path)
+      end
+    end
   end
 
   describe '#save' do
     it 'stores the data in session state' do
       session[:support_ticket] = {}
       post :save, params: { support_ticket_contact_details_form: { full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333' } }
-      expect(session[:support_ticket]).to eq({ full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333' })
+      expect(session[:support_ticket]).to eq({ full_name: 'Joe Blogg', email_address: 'hello@world.com', telephone_number: '0203 333 3333', user_profile_path: nil })
     end
 
     it 'redirects to support needs page' do

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ZendeskService, type: :model do
       'subject' => 'My query',
       'message' => 'This is my query',
       'support_topics' => %w[hello world],
+      'user_profile_path' => nil,
     }
   end
 
@@ -25,7 +26,7 @@ RSpec.describe ZendeskService, type: :model do
     it 'makes the expected request, with common and custom fields' do
       call_to_zendesk = stub_request(:post, 'https://get-help-with-tech-education.zendesk.com/api/v2/requests')
         .with(
-          body: '{"request":{"requester":{"email":"joe@bloggs.com","name":"Joe Blogg"},"subject":"My query","comment":{"body":"This is my query"},"custom_fields":[{"id":"360011490478","value":"contact_form"},{"id":"360011798678","value":"parent"},{"id":"360011519218","value":["hello","world"]},{"id":"360011762698","value":"0207 333 4444"}]}}',
+          body: '{"request":{"requester":{"email":"joe@bloggs.com","name":"Joe Blogg"},"subject":"My query","comment":{"body":"This is my query"},"custom_fields":[{"id":"360011490478","value":"contact_form"},{"id":"360011798678","value":"parent"},{"id":"360011519218","value":["hello","world"]},{"id":"360011762698","value":"0207 333 4444"},{"id":"360013507477","value":null}]}}',
           headers: {
             'Accept' => 'application/json',
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',


### PR DESCRIPTION
### Context
If a user is not signed in and they try to contact us using the contact form, they should not notice any changes.

If a user is signed in and they try to contact us using the contact form, they go through exactly the same journey as they would before except they will not be asked to provide their contact details.

### Changes proposed in this pull request

### Guidance to review

