### PR TITLE
[1057] Third line can edit school name

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -1,9 +1,9 @@
 class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetailsSummaryListComponent
   def rows
     array = super
+    array.prepend school_name_editable_row if SchoolPolicy.new(viewer, @school).update_name?
     array << headteacher_row if headteacher.present?
     array.map { |row| remove_change_links_if_read_only(row) }
-
     array << if SchoolPolicy.new(viewer, @school).update_address?
                address_editable_row
              else
@@ -12,6 +12,15 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
   end
 
 private
+
+  def school_name_editable_row
+    {
+      key: 'Name',
+      value: @school.name,
+      action: 'Change <span class="govuk-visually-hidden">school name</span>'.html_safe,
+      action_path: edit_support_school_path(@school),
+    }
+  end
 
   def address_read_only_row
     {

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -62,6 +62,25 @@ class Support::SchoolsController < Support::BaseController
     @history_object = object_for_view_mode
   end
 
+  def edit
+    authorize School, :update_name?
+
+    @school = School.where_urn_or_ukprn(params[:urn]).first!
+  end
+
+  def update
+    authorize School, :update_name?
+
+    @school = School.where_urn_or_ukprn(params[:urn]).first!
+
+    if @school.update(school_params)
+      flash[:success] = 'School has been updated'
+      redirect_to support_school_path(@school)
+    else
+      render :edit
+    end
+  end
+
 private
 
   def view_mode
@@ -105,5 +124,9 @@ private
       :name_or_identifier,
       :identifier,
     )
+  end
+
+  def school_params
+    params.require(:school).permit(:name)
   end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -22,4 +22,8 @@ class SchoolPolicy < SupportPolicy
   def update_address?
     user.third_line_role?
   end
+
+  def update_name?
+    user.third_line_role?
+  end
 end

--- a/app/views/support/schools/edit.html.erb
+++ b/app/views/support/schools/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "#{@school.name} – Support" %>
+<%- content_for :before_content do %>
+  <%= breadcrumbs([
+    { 'Support home' => support_home_path },
+    { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
+    { @school.responsible_body.name => support_responsible_body_path(@school.responsible_body) },
+    { @school.name => support_school_path(@school) },
+    'Change name',
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.responsible_body.name %></span>
+      <%= @school.name %>
+    </h1>
+
+    <%= form_with model: @school, url: support_school_path, scope: :school do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :name, label: { text: 'Name', size: 's' } %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,7 +184,7 @@ Rails.application.routes.draw do
     resources :responsible_bodies, only: %i[index show], path: '/responsible-bodies' do
       resources :users, only: %i[new create], controller: 'users'
     end
-    resources :schools, only: %i[show], param: :urn do
+    resources :schools, only: %i[show edit update], param: :urn do
       resource :addresses, only: %i[edit update], path: 'address'
 
       collection do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -8,9 +8,26 @@ describe Support::SchoolDetailsSummaryListComponent do
            email_address: 'davy.jones@school.sch.uk',
            phone_number: '12345')
   end
+
   let(:support_user) { build(:support_user) }
 
   subject(:result) { render_inline(described_class.new(school: school, viewer: support_user)) }
+
+  it 'does not show school name' do
+    expect(row_for_key(result, 'Name')).to be_nil
+  end
+
+  context 'when third line support user' do
+    let(:support_user) { build(:support_user, :third_line) }
+
+    it 'shows school name' do
+      expect(value_for_row(result, 'Name').text).to include(school.name)
+    end
+
+    it 'shows change link for school name' do
+      expect(action_for_row(result, 'Name').text).to include('Change school name')
+    end
+  end
 
   context 'when the school will place device orders' do
     before do

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -147,4 +147,54 @@ RSpec.describe Support::SchoolsController, type: :controller do
       end
     end
   end
+
+  describe '#edit' do
+    before do
+      sign_in_as user
+    end
+
+    context 'when third_line' do
+      let(:user) { create(:support_user, :third_line) }
+
+      it 'is accessible' do
+        get :edit, params: { urn: school.urn }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when not third_line' do
+      let(:user) { create(:support_user) }
+
+      it 'is not accessible' do
+        get :edit, params: { urn: school.urn }
+        expect(response).not_to be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    before do
+      sign_in_as user
+    end
+
+    context 'when third_line' do
+      let(:user) { create(:support_user, :third_line) }
+
+      it 'update school name and redirects to school' do
+        patch :update, params: { urn: school.urn, school: { name: 'new name' } }
+        expect(school.reload.name).to eql('new name')
+        expect(response).to redirect_to(support_school_path(school))
+      end
+    end
+
+    context 'when not third_line' do
+      let(:user) { create(:support_user) }
+
+      it 'does not update school name' do
+        patch :update, params: { urn: school.urn, school: { name: 'new name' } }
+        expect(school.reload.name).not_to eql('new name')
+        expect(response).not_to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/P3pygUFZ/1057-support-functionality-to-rename-schools

### Changes proposed in this pull request

- Third line support can change school names

### Screenshots

![image](https://user-images.githubusercontent.com/92580/107537093-6e16a900-6bba-11eb-8804-a67bec82630b.png)

![image](https://user-images.githubusercontent.com/92580/107537165-7d95f200-6bba-11eb-8bfc-2b69512f7725.png)

### Guidance to review

- Login as support user
- View a school
- Cannot see school name with change link in summary list
- Login as third line support
- View a school
- Can see school name with change link in summary list
- Click change
- Can update school name