### PR TITLE
1410 rb access flag for cc part 1

### DIFF
--- a/db/migrate/20210201135621_add_rb_level_access_to_users.rb
+++ b/db/migrate/20210201135621_add_rb_level_access_to_users.rb
@@ -1,0 +1,5 @@
+class AddRbLevelAccessToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :rb_level_access, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,8 +201,8 @@ ActiveRecord::Schema.define(version: 2021_02_08_113843) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
     t.string "computacenter_change", default: "none", null: false
+    t.boolean "vcap_feature_flag", default: false
     t.boolean "new_fe_wave", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 2021_02_08_113843) do
     t.boolean "orders_devices"
     t.datetime "techsource_account_confirmed_at"
     t.datetime "deleted_at"
+    t.boolean "rb_level_access", default: false, null: false
     t.text "role", default: "no", null: false
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/EWxSCmOl/1410-investigate-putting-an-rb-access-flag-on-all-sat-users)
Pass a flag to CC to indicate which users should have 'RB level' access at their end. This is the extra functionality granted to RB users which needs to be extended to SAT users.  This PR is the first part of the process to add a boolean `rb_level_access` flag to the `User` model.  This can then be populated before we wire up the attribute to the CC api.

### Changes proposed in this pull request
Adds `rb_level_access` boolean attribute to the `User` model

### Guidance to review

