### PR TITLE
updates banner with half-term dates and techsource downtime message

### DIFF
--- a/app/views/shared/_half_term_delivery_suspension.html.erb
+++ b/app/views/shared/_half_term_delivery_suspension.html.erb
@@ -3,7 +3,9 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      All deliveries are paused during half term, but you can still order devices. Deliveries will resume on Monday 22 February.
+      All deliveries are paused during half term. You can still order if you’re invited to, but delivery will happen from <span class="app-no-wrap">Monday 22 February</span> onwards.<br><br>
+      TechSource will be unavailable on <span class="app-no-wrap">Saturday 13 February</span>.
     </strong>
   </div>
 <% end %>
+


### PR DESCRIPTION
### Context

TechSource will stop deliveries over half-term
TechSource will have downtime Saturday 13 February

### Changes proposed in this pull request

Update half-term banner content to let users know

### Guidance to review

half_term_delivery_suspension flag needs to be active
