### PR TITLE
Adds info on current out of stock and low stock devices

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,7 +6,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %i[
     increased_allocations_banner
     secondary_mass_testing_banner
-    ipad_stock_message
     schools_closed_for_national_lockdown
     half_term_delivery_suspension
   ].freeze

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -23,6 +23,8 @@
       <% end %>
     <% end %>
 
+    <%= render partial: 'shared/stock_levels' %>
+
     <h2 class="govuk-heading-m">
       Before you order
     </h2>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -13,6 +13,8 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
+    <%= render partial: 'shared/stock_levels' %>
+
     <h2 class="govuk-heading-m">
       Before you order
     </h2>
@@ -27,6 +29,7 @@
       <li><%= govuk_link_to 'give someone else access so they can place orders', school_users_path %></li>
     </ul>
 
+
     <h2 class="govuk-heading-m">How to order</h2>
 
     <p class="govuk-body">You need to place your orders on a website called TechSource.</p>
@@ -40,8 +43,6 @@
     <p class="govuk-body">
       If you try to order more than <%= what_to_order_allocation_list(allocations: @school.device_allocations) %> the order will be cancelled.
     </p>
-
-    <p class="govuk-body">Order your devices now. Do not delay.</p>
 
     <h3 class="govuk-heading-s">Delivery address</h3>
 

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -14,6 +14,8 @@
 
     <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order. You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>
 
+    <%= render partial: 'shared/stock_levels' %>
+
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
 
     <h2 class="govuk-heading-m">Before you start</h2>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -12,17 +12,6 @@
 </p>
 <% end %>
 
-<% if FeatureFlag.active?(:ipad_stock_message) %>
-  <div class="govuk-warning-text govuk-!-margin-top-7 govuk-!-margin-bottom-4">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning</span>
-       We have no iPads in stock. Stock will be available in February, but choose other devices if you need them now.<br /><br />
-       We’ve got limited Standard Windows laptops in stock. You can order them now, but delivery may take longer than 5 working days.
-    </strong>
-  </div>
-<% end %>
-
 <%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3', target: '_blank') -%>
 
 <p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/views/shared/_stock_levels.html.erb
+++ b/app/views/shared/_stock_levels.html.erb
@@ -1,0 +1,24 @@
+<h2 class="govuk-heading-m">
+  Device availability
+</h2>
+
+<h3 class="govuk-heading-s">
+  Out of stock
+</h3>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    Apple iPads – stock will be available later in February
+  </li>
+  <li>
+    Microsoft Windows tablets
+  </li>
+</ul>
+
+<h3 class="govuk-heading-s">
+  Low stock
+</h3>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    Standard Windows laptops – delivery may take longer than 5 working days
+  </li>
+</ul>


### PR DESCRIPTION
### Context

https://trello.com/c/OUHwvuLx/1537-persona-d-stock-update-for-techsource-and-the-service-banners

There's low and out of stock devices.

### Changes proposed in this pull request

We've relied on banners in the past, but as this is fairly constant we're adding a more permanent solution to the order page.

### Guidance to review

Note — I've fixed the capitalisation of Windows on 'Microsoft Windows Tablets'

![localhost_3000_schools_130524_order-devices (1)](https://user-images.githubusercontent.com/8417288/107662524-4a1e9a80-6c82-11eb-8368-55a63a7b4ef8.png)


![localhost_3000_responsible-body_devices_order-devices (2)](https://user-images.githubusercontent.com/8417288/107662505-45f27d00-6c82-11eb-8385-979be5b9fa78.png)


