### PR TITLE
lock github action to ubuntu 18.04 as workaround for LoadError with FFI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ on:
 
 jobs:
   build_and_test:
-
-    runs-on: ubuntu-latest
+    # TODO: put this back to ubuntu-latest once we have a fix for issue with
+    # LoadError on 2.7/ffi_c
+    runs-on: ubuntu-18.04
 
     # Service containers to run with `container-job`
     services:


### PR DESCRIPTION
### Context

We're seeing all builds fail in Github with:
```
rake aborted!
LoadError: libffi.so.6: cannot open shared object file: No such file or directory - /home/runner/work/get-help-with-tech/get-help-with-tech/vendor/bundle/ruby/2.7.0/gems/ffi-1.14.2/lib/ffi_c.so
```

Looks like it's as a result of [GitHub bumping the ubuntu-latest image to Ubuntu 20.04](https://github.com/actions/virtual-environments/issues/1816)


### Changes proposed in this pull request

* workaround the issue by reverting to ubuntu-18.04 until we have an actual fix for the issue on 20.04

### Guidance to review

If this build goes green, merge it :)
