### PR TITLE
1410 rb access flag for cc part 2

### DIFF
--- a/app/jobs/notify_computacenter_of_latest_change_for_user_job.rb
+++ b/app/jobs/notify_computacenter_of_latest_change_for_user_job.rb
@@ -1,11 +1,6 @@
 class NotifyComputacenterOfLatestChangeForUserJob < ApplicationJob
   queue_as :default
 
-  # NOTE: we only pass the allocation_ids, not the amounts to update the caps to.
-  # This way, the new caps get read at the time the job is performed rather than
-  # when it was scheduled - so if there are several jobs queued up, it doesn't
-  # matter if the jobs get processed in the right order or not, the last job
-  # processed will always set the latest value.
   def perform(user_id)
     @latest_change = Computacenter::UserChange.latest_for_user(User.find(user_id))
     @request = construct_request

--- a/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
+++ b/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
@@ -62,6 +62,7 @@ module Computacenter
           u_telephone: user_change.telephone,
           u_timestamp_of_update: user_change.updated_at_timestamp.utc.iso8601,
           u_time_of_update: user_change.updated_at_timestamp.utc.strftime('%R %z'),
+          u_rb_user: user_change.cc_rb_user,
           u_original_email: user_change.original_email_address,
           u_original_cc_sold_to_number: user_change.original_cc_sold_to_number,
           u_original_first_name: user_change.original_first_name,
@@ -72,6 +73,7 @@ module Computacenter
           u_original_school: user_change.original_school,
           u_original_school_urn: user_change.original_school_urn,
           u_original_telephone: user_change.original_telephone,
+          u_original_rb_user: user_change.original_cc_rb_user,
         }.to_json
       end
 

--- a/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
+++ b/app/models/computacenter/service_now_user_import_api/import_user_change_request.rb
@@ -47,7 +47,7 @@ module Computacenter
       end
 
       def construct_body
-        {
+        body = {
           u_email: user_change.email_address,
           u_type_of_update: user_change.type_of_update,
           u_cc_sold_to_number: user_change.cc_sold_to_number,
@@ -62,7 +62,6 @@ module Computacenter
           u_telephone: user_change.telephone,
           u_timestamp_of_update: user_change.updated_at_timestamp.utc.iso8601,
           u_time_of_update: user_change.updated_at_timestamp.utc.strftime('%R %z'),
-          u_rb_user: user_change.cc_rb_user,
           u_original_email: user_change.original_email_address,
           u_original_cc_sold_to_number: user_change.original_cc_sold_to_number,
           u_original_first_name: user_change.original_first_name,
@@ -73,8 +72,16 @@ module Computacenter
           u_original_school: user_change.original_school,
           u_original_school_urn: user_change.original_school_urn,
           u_original_telephone: user_change.original_telephone,
-          u_original_rb_user: user_change.original_cc_rb_user,
-        }.to_json
+        }
+
+        if FeatureFlag.active?(:rb_level_access_notification)
+          body.merge!({
+            u_rb_user: user_change.cc_rb_user,
+            u_original_rb_user: user_change.original_cc_rb_user,
+          })
+        end
+
+        body.to_json
       end
 
       def setting(name)

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -13,6 +13,7 @@ module Computacenter
       school
       school_urn
       cc_ship_to_number
+      cc_rb_user
     ].freeze
 
     enum type_of_update: { New: 0, Change: 1, Remove: 2 }

--- a/app/models/computacenter/user_change.rb
+++ b/app/models/computacenter/user_change.rb
@@ -38,7 +38,11 @@ module Computacenter
     end
 
     def computacenter_attributes
-      attributes.symbolize_keys.select { |k, _| CSV_ATTRIBUTES.include?(k) }
+      cc_attrs = attributes.symbolize_keys
+
+      cc_attrs.except!(:cc_rb_user, :original_cc_rb_user) unless FeatureFlag.active?(:rb_level_access_notification)
+
+      cc_attrs.select { |k, _| CSV_ATTRIBUTES.include?(k) }
     end
 
     def add_original_fields_from(change)

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -67,7 +67,7 @@ private
   end
 
   def computacenter_attributes
-    {
+    cc_attrs = {
       first_name: user.first_name,
       last_name: user.last_name,
       email_address: user.email_address,
@@ -79,8 +79,15 @@ private
       school: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.name }.join('|')),
       school_urn: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.urn }.join('|')),
       cc_ship_to_number: cc_ship_to_number_list,
-      cc_rb_user: user.rb_level_access,
     }
+
+    if FeatureFlag.active?(:rb_level_access_notification)
+      cc_attrs.merge!({
+        cc_rb_user: user.rb_level_access,
+      })
+    end
+
+    cc_attrs
   end
 
   def cc_ship_to_number_list

--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -79,6 +79,7 @@ private
       school: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.name }.join('|')),
       school_urn: (user.is_a_single_school_user? ? '' : user.user_schools.map { |us| us.school.urn }.join('|')),
       cc_ship_to_number: cc_ship_to_number_list,
+      cc_rb_user: user.rb_level_access,
     }
   end
 

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -1,9 +1,9 @@
 class CreateUserService
   def self.invite_responsible_body_user(user_params = {})
     if user_exists?(user_params)
-      invite_existing_user_to_responsible_body!(user_params)
+      invite_existing_user_to_responsible_body!(user_params.merge({ rb_level_access: true }))
     else
-      invite_new_user_to_responsible_body!(user_params)
+      invite_new_user_to_responsible_body!(user_params.merge({ rb_level_access: true }))
     end
   end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,6 +10,7 @@ class FeatureFlag
     schools_closed_for_national_lockdown
     half_term_delivery_suspension
     donated_devices
+    rb_level_access_notification
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/db/migrate/20210211092428_add_rb_user_to_user_change.rb
+++ b/db/migrate/20210211092428_add_rb_user_to_user_change.rb
@@ -1,0 +1,6 @@
+class AddRbUserToUserChange < ActiveRecord::Migration[6.1]
+  def change
+    add_column :computacenter_user_changes, :cc_rb_user, :boolean
+    add_column :computacenter_user_changes, :original_cc_rb_user, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,6 +106,8 @@ ActiveRecord::Schema.define(version: 2021_02_19_145448) do
     t.text "original_cc_ship_to_number"
     t.datetime "cc_import_api_timestamp"
     t.string "cc_import_api_transaction_id"
+    t.boolean "cc_rb_user"
+    t.boolean "original_cc_rb_user"
     t.index ["cc_import_api_timestamp"], name: "ix_cc_user_changes_timestamp"
     t.index ["cc_import_api_transaction_id"], name: "ix_cc_user_changes_cc_tx_id"
     t.index ["updated_at_timestamp"], name: "index_computacenter_user_changes_on_updated_at_timestamp"

--- a/spec/models/computacenter/service_now_user_import_api/import_user_change_request_spec.rb
+++ b/spec/models/computacenter/service_now_user_import_api/import_user_change_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest d
       u_telephone: user_change.telephone,
       u_timestamp_of_update: user_change.updated_at_timestamp.utc.iso8601,
       u_time_of_update: user_change.updated_at_timestamp.utc.strftime('%R %z'),
+      u_rb_user: user_change.cc_rb_user,
       u_original_email: user_change.original_email_address,
       u_original_cc_sold_to_number: user_change.original_cc_sold_to_number,
       u_original_first_name: user_change.original_first_name,
@@ -52,6 +53,7 @@ RSpec.describe Computacenter::ServiceNowUserImportAPI::ImportUserChangeRequest d
       u_original_school: user_change.original_school,
       u_original_school_urn: user_change.original_school_urn,
       u_original_telephone: user_change.original_telephone,
+      u_original_rb_user: user_change.original_cc_rb_user,
     }.to_json
   end
 


### PR DESCRIPTION
## DO NOT MERGE UNTIL PART 1 DEPLOYED AND THE USERS POPULATED WITH THE CORRECT VALUES FOR RB_LEVEL_ACCESS

### Context
[Trello card](https://trello.com/c/EWxSCmOl/1410-investigate-putting-an-rb-access-flag-on-all-sat-users)
[Part 1 PR](https://github.com/DFE-Digital/get-help-with-tech/pull/1288)

Part 2 to tie in passing the `rb_level_access` flag to Computacenter to indicate that a user should have RB level access at Techsource.

There is no front-end exposure of this attribute so far. I think this might get complex as we expose and edit user info in several places so it will need design/content input. The value is also dependent on the `orders_devices` value as it will only be passed to CC when that is set and the user has a techsource account and has seen the privacy statement.

### Changes proposed in this pull request
Adds the `cc_rb_user` and `original_cc_rb_user` to the `Computacenter::UserChange` model
Passes that value to the CC API with user changes as `u_rb_user` and `u_original_rb_user`.
Sets the `User.rb_level_access` to `true` when creating a responsible body user in the `CreateUserService`
Adds `:rb_level_access_notification` feature flag around exposing the `Computacenter::UserChange` attributes to Computacenter.

### Guidance to review
Create a user that orders devices and has seen the privacy notice.
Set the `:rb_level_access_notification` feature flag
Observe that `cc_rb_user` and `original_cc_rb_user` are populated in `Computacenter::UserChange.latest_for_user(user)`
Changing the `rb_level_access` will generate new UserChanges and populate the `cc_rb_user` values accordingly

