### PR TITLE
Fix build issue with libffi on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ on:
 
 jobs:
   build_and_test:
-    # TODO: put this back to ubuntu-latest once we have a fix for issue with
-    # LoadError on 2.7/ffi_c
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Service containers to run with `container-job`
     services:
@@ -47,6 +45,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Setup Gemfile.lock cache
         uses: actions/cache@v2
         with:
@@ -81,6 +80,15 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+
+      # Workaround issue with parallel_tests requiring libffi6, with is not
+      # available on ubuntu-latest (20.04 only provides libffi7)
+      - name: pretend we have libffi6
+        run: |
+          cd /usr/lib/x86_64-linux-gnu/ &&
+          sudo ln -s ./libffi.so.7 ./libffi.so.6 &&
+          cd -
+
       - name: Install Node.js packages with yarn
         run: yarn --frozen-lockfile
 


### PR DESCRIPTION
### Context

Yesterday, [Github updated their `ubuntu-latest` image from 18.04 to 20.04](https://github.com/actions/virtual-environments/issues/1816)

20.04 only provides version 7 of `libffi`, which Ruby uses to provide native extensions facilities to gems. That causes problems for `rake parallel:setup`, which we use to setup test databases in CI  - [example failed build](https://github.com/DFE-Digital/get-help-with-tech/runs/1880926452?check_suite_focus=true) - and appears to have been built against libffi version 6

The error we see looks like this:

```
rake aborted!
LoadError: libffi.so.6: cannot open shared object file: No such file or directory - /home/runner/work/get-help-with-tech/get-help-with-tech/vendor/bundle/ruby/2.7.0/gems/ffi-1.14.2/lib/ffi_c.so
```

I temporarily worked around the problem by version-locking it to `ubuntu-18.04`, but that won't be available and supported forever, so we need to fix it properly ( [Trello card](https://trello.com/c/1Xj1VMy0/1547-fix-issue-with-ffi-on-ubuntu-latest-in-github) )

### Changes proposed in this pull request

* Use the symlink hack from [this page on Ubuntu launchpad](https://answers.launchpad.net/ubuntu/+question/690445) to load `libffo.so.7` when `libffo.so.6` is requested

This is also something of a workaround, but preferable to the previous one (locking Ubuntu to 18.04) as it should become automatically redundant once the issue is fixed in future releases of the upstream gems.
 
### Guidance to review

If this build goes green, it's good.