### PR TITLE
[1337] Allocation uplift feature flagged warning

### DIFF
--- a/app/views/school/devices/cannot_order_as_cap_reached.html.erb
+++ b/app/views/school/devices/cannot_order_as_cap_reached.html.erb
@@ -14,10 +14,12 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
+    <%= render partial: 'shared/upcoming_allocation_increase_banner', locals: { school: @school } %>
+
     <p class="govuk-body">We’ll contact you if you can place more orders.</p>
 
     <% if @current_user.orders_devices? && @current_user.techsource_account_confirmed? %>
-      <p class="govuk-body"><%= link_to 'View your order history on TechSource', techsource_start_path %></p>
+      <p class="govuk-body"><%= govuk_link_to 'View your order history on TechSource', techsource_start_path %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_upcoming_allocation_increase_banner.html.erb
+++ b/app/views/shared/_upcoming_allocation_increase_banner.html.erb
@@ -3,7 +3,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      Your school has been allocated extra laptops and tablets. You’ll be able to see the number of devices available to you when we invite you to order. This will happen soon.
+      Your school will soon be able to order more laptops. We’ll let you know when your allocation has been increased. You’ll then see the new number of devices available.
     </strong>
   </div>
 <% end %>

--- a/app/views/shared/_upcoming_allocation_increase_banner.html.erb
+++ b/app/views/shared/_upcoming_allocation_increase_banner.html.erb
@@ -1,0 +1,9 @@
+<% if school.group_a_feature_flag? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      Your school has been allocated extra laptops and tablets. You’ll be able to see the number of devices available to you when we invite you to order. This will happen soon.
+    </strong>
+  </div>
+<% end %>

--- a/db/migrate/20210217114408_group_a_feature_flag.rb
+++ b/db/migrate/20210217114408_group_a_feature_flag.rb
@@ -1,0 +1,5 @@
+class GroupAFeatureFlag < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :group_a_feature_flag, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_163619) do
+ActiveRecord::Schema.define(version: 2021_02_17_114408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_163619) do
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
     t.text "fe_type"
+    t.boolean "group_a_feature_flag", default: false, null: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/views/school/devices/cannot_order_as_cap_reached.html.erb_spec.rb
+++ b/spec/views/school/devices/cannot_order_as_cap_reached.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'school/devices/cannot_order_as_cap_reached.html.erb' do
+  let(:school) { user.school }
+  let(:user) { build(:school_user) }
+
+  before do
+    assign(:school, school)
+    assign(:current_user, user)
+  end
+
+  it 'does not show allocation uplift warning' do
+    render
+    expect(rendered).not_to include('Warning')
+  end
+
+  context 'school.group_a_feature_flag enabled' do
+    before do
+      school.update(group_a_feature_flag: true)
+    end
+
+    it 'shows allocation uplift warning' do
+      render
+      expect(rendered).to include('Warning')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/HF7CM3Kg

### Changes proposed in this pull request

- Adds a feature flag to school table. defaults to false
- Adds partial if school has reached cap but will soon receive an uplift

### Screenshots

![image](https://user-images.githubusercontent.com/92580/108206931-f77c2d00-711e-11eb-8233-5c26f1536ef4.png)

### Guidance to review

- Login as school user
- Set school as can order but have 0 caps/allocations
- Attempt to order
- Should not see warning
- Enable feature flag for school
- Should now see warning