### PR TITLE
1530 donated devices download csv

### DIFF
--- a/app/controllers/computacenter/donated_device_requests_controller.rb
+++ b/app/controllers/computacenter/donated_device_requests_controller.rb
@@ -1,0 +1,9 @@
+class Computacenter::DonatedDeviceRequestsController < Computacenter::BaseController
+  def index
+    respond_to do |format|
+      format.csv do
+        send_data DonatedDeviceRequestsExporter.new.export, filename: "donated-device-requests-#{Time.zone.now.iso8601}.csv"
+      end
+    end
+  end
+end

--- a/app/models/donated_device_request.rb
+++ b/app/models/donated_device_request.rb
@@ -1,0 +1,21 @@
+class DonatedDeviceRequest < ApplicationRecord
+  DEVICE_TYPES = %w[
+    windows-laptop
+    windows-tablet
+    android-tablet
+    chromebook
+    ipad
+  ].freeze
+
+  belongs_to :user
+  belongs_to :school
+
+  validates :units, :device_types, presence: true
+  validate :validate_applicable_device_types
+
+private
+
+  def validate_applicable_device_types
+    errors.add(:device_types, 'includes an invalid device type') if device_types.all? { |d| DEVICE_TYPES.include?(d) }
+  end
+end

--- a/app/models/donated_device_request.rb
+++ b/app/models/donated_device_request.rb
@@ -16,6 +16,6 @@ class DonatedDeviceRequest < ApplicationRecord
 private
 
   def validate_applicable_device_types
-    errors.add(:device_types, 'includes an invalid device type') if device_types.all? { |d| DEVICE_TYPES.include?(d) }
+    errors.add(:device_types, 'includes an invalid device type') unless device_types.all? { |d| DEVICE_TYPES.include?(d) }
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -18,6 +18,7 @@ class School < ApplicationRecord
   has_many :devices_ordered_updates, class_name: 'Computacenter::DevicesOrderedUpdate',
                                      primary_key: :computacenter_reference,
                                      foreign_key: :ship_to
+  has_one :donated_device_request
 
   validates :name, presence: true
 

--- a/app/services/donated_device_requests_exporter.rb
+++ b/app/services/donated_device_requests_exporter.rb
@@ -1,0 +1,61 @@
+require 'csv'
+
+class DonatedDeviceRequestsExporter
+  attr_reader :filename
+
+  def initialize(filename = nil)
+    @filename = filename
+  end
+
+  def export(query = donated_device_requests)
+    if filename
+      CSV.open(filename, 'w') do |csv|
+        render(csv, query)
+      end
+      nil
+    else
+      CSV.generate(headers: true) do |csv|
+        render(csv, query)
+      end
+    end
+  end
+
+  def self.headings
+    %w[
+      id
+      created_at
+      urn
+      shipTo
+      soldTo
+      full_name
+      email_address
+      telephone_number
+      device_types
+      units
+    ].freeze
+  end
+
+private
+
+  def render(csv, query)
+    csv << self.class.headings
+    query.find_each do |request|
+      csv << [
+        request.id,
+        request.created_at,
+        request.school.urn,
+        request.school.computacenter_reference,
+        request.school.responsible_body.computacenter_reference,
+        request.user.full_name,
+        request.user.telephone,
+        request.user.email_address,
+        request.device_types.join(','),
+        request.units,
+      ]
+    end
+  end
+
+  def donated_device_requests
+    DonatedDeviceRequest.all.includes(:user, school: :responsible_body).order(:asc)
+  end
+end

--- a/app/services/donated_device_requests_exporter.rb
+++ b/app/services/donated_device_requests_exporter.rb
@@ -47,8 +47,8 @@ private
         request.school.computacenter_reference,
         request.school.responsible_body.computacenter_reference,
         request.user.full_name,
-        request.user.telephone,
         request.user.email_address,
+        request.user.telephone,
         request.device_types.join(','),
         request.units,
       ]

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -40,6 +40,12 @@
 
     <p class="govuk-body">View details of responsible bodies that manage schools with mutliple Chromebook domains.</p>
 
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'Dwonload Donated Devices', computacenter_donated_device_requests_path(format: :csv) %>
+    </h2>
+
+    <p class="govuk-body">Download opt-in requests for Mail Force donated devices.</p>
+
     <% if policy(:support).readable? %>
       <h2 class="govuk-heading-m">
         <%= govuk_link_to 'Support home', support_home_path %>

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -41,10 +41,10 @@
     <p class="govuk-body">View details of responsible bodies that manage schools with mutliple Chromebook domains.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to 'Dwonload Donated Devices', computacenter_donated_device_requests_path(format: :csv) %>
+      <%= govuk_link_to 'Download donated device requests', computacenter_donated_device_requests_path(format: :csv) %>
     </h2>
 
-    <p class="govuk-body">Download opt-in requests for Mail Force donated devices.</p>
+    <p class="govuk-body">Download a CSV file of opt-in requests for Mail Force donated devices.</p>
 
     <% if policy(:support).readable? %>
       <h2 class="govuk-heading-m">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ Rails.application.routes.draw do
     get '/', to: 'home#show', as: :home
     get '/user-ledger', to: 'user_ledger#index', as: :user_ledger
     get '/chromebooks', to: 'chromebooks#index', as: :chromebooks
+    get '/donated-device-requests', to: 'donated_device_requests#index', as: :donated_device_requests
     resources :schools, only: %i[index edit update], path: '/school-changes', as: :school_changes, controller: 'school_changes'
     resources :responsible_bodies, only: %i[index edit update], path: '/responsible-body-changes', as: :responsible_body_changes, controller: 'responsible_body_changes'
     get '/techsource', to: 'techsource#new'

--- a/db/migrate/20210211163619_create_donated_device_requests.rb
+++ b/db/migrate/20210211163619_create_donated_device_requests.rb
@@ -1,0 +1,12 @@
+class CreateDonatedDeviceRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :donated_device_requests do |t|
+      t.references :user, null: false, index: true
+      t.references :school, null: false, index: { unique: true }
+      t.text :device_types, array: true, default: []
+      t.integer :units
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_113843) do
+ActiveRecord::Schema.define(version: 2021_02_11_163619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,17 @@ ActiveRecord::Schema.define(version: 2021_02_08_113843) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_data_update_records_on_name", unique: true
+  end
+
+  create_table "donated_device_requests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "school_id", null: false
+    t.text "device_types", default: [], array: true
+    t.integer "units"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id"], name: "index_donated_device_requests_on_school_id", unique: true
+    t.index ["user_id"], name: "index_donated_device_requests_on_user_id"
   end
 
   create_table "email_audits", force: :cascade do |t|
@@ -291,10 +302,10 @@ ActiveRecord::Schema.define(version: 2021_02_08_113843) do
     t.boolean "increased_allocations_feature_flag", default: false
     t.boolean "increased_sixth_form_feature_flag", default: false
     t.boolean "increased_fe_feature_flag", default: false
+    t.boolean "hide_mno", default: false
     t.string "type", default: "CompulsorySchool", null: false
     t.integer "ukprn"
     t.text "fe_type"
-    t.boolean "hide_mno", default: false
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/factories/donated_device_requests.rb
+++ b/spec/factories/donated_device_requests.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :donated_device_request do
+    
+  end
+end

--- a/spec/factories/donated_device_requests.rb
+++ b/spec/factories/donated_device_requests.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
   factory :donated_device_request do
-    
+    user
+    school
+    units { 4 }
+
+    trait :wants_laptops do
+      device_types { %w[ windows-laptop chromebook ] }
+    end
+
+    trait :wants_tablets do
+      device_types { %w[ windows-tablet android-tablet ipad ] }
+    end
   end
 end

--- a/spec/factories/donated_device_requests.rb
+++ b/spec/factories/donated_device_requests.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     units { 4 }
 
     trait :wants_laptops do
-      device_types { %w[ windows-laptop chromebook ] }
+      device_types { %w[windows-laptop chromebook] }
     end
 
     trait :wants_tablets do
-      device_types { %w[ windows-tablet android-tablet ipad ] }
+      device_types { %w[windows-tablet android-tablet ipad] }
     end
   end
 end

--- a/spec/models/donated_device_request_spec.rb
+++ b/spec/models/donated_device_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DonatedDeviceRequest, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/donated_device_request_spec.rb
+++ b/spec/models/donated_device_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DonatedDeviceRequest, type: :model do
 
   it 'validates device_types are correct' do
     request = build(:donated_device_request)
-    request.device_types = %w[ windows-laptop windows-tablet android-tablet chromebook ipad ]
+    request.device_types = %w[windows-laptop windows-tablet android-tablet chromebook ipad]
     expect(request.valid?).to be true
     request.device_types << 'biscuit'
     expect(request.valid?).to be false

--- a/spec/models/donated_device_request_spec.rb
+++ b/spec/models/donated_device_request_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe DonatedDeviceRequest, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to validate_presence_of(:units) }
+
+  it 'validates device_types are correct' do
+    request = build(:donated_device_request)
+    request.device_types = %w[ windows-laptop windows-tablet android-tablet chromebook ipad ]
+    expect(request.valid?).to be true
+    request.device_types << 'biscuit'
+    expect(request.valid?).to be false
+    expect(request.errors[:device_types]).to be_present
+  end
 end

--- a/spec/services/donated_device_requests_exporter_spec.rb
+++ b/spec/services/donated_device_requests_exporter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe DonatedDeviceRequestsExporter, type: :model do
+  let(:laptops_request) { create(:donated_device_request, :wants_laptops) }
+  let(:tablets_request) { create(:donated_device_request, :wants_tablets) }
+  let(:filename) { Rails.root.join('tmp/donated_devices_exporter_test_data.csv') }
+
+  context 'when given a filename' do
+    subject(:exporter) { described_class.new(filename) }
+
+    before do
+      laptops_request
+      tablets_request
+      exporter.export
+    end
+
+    after do
+      remove_file(filename)
+    end
+
+    it 'creates a CSV file' do
+      expect(File.exist?(filename)).to be true
+    end
+
+    it 'includes a heading row and all of the donated device requests in the CSV file' do
+      line_count = `wc -l "#{filename}"`.split.first.to_i
+      expect(line_count).to eq(DonatedDeviceRequest.count + 1)
+    end
+
+    it 'includes the request information in the CSV file' do
+      CSV.read(filename, headers: true).each do |request|
+        record = DonatedDeviceRequest.find(request['id'])
+        expect(record.school.created_at.to_s).to eq(request['created_at'])
+        expect(record.school.urn.to_s).to eq(request['urn'])
+        expect(record.school.computacenter_reference).to eq(request['shipTo'])
+        expect(record.school.responsible_body.computacenter_reference).to eq(request['soldTo'])
+        expect(record.user.full_name).to eq(request['full_name'])
+        expect(record.user.email_address).to eq(request['email_address'])
+        expect(record.user.telephone).to eq(request['telephone_number'])
+        expect(record.device_types.join(',')).to eq(request['device_types'])
+        expect(record.units.to_s).to eq(request['units'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/sWfOU7rT/1530-donated-devices-ability-for-cc-to-download-a-export-of-opt-ins)
Provide facility for Computacenter to download donated device request opt-ins as a CSV file

### Changes proposed in this pull request
Adds the `DonatedDeviceRequest` model
Adds download link to Computacenter home page
Adds `DonatedDeviceRequestExporter` service to produce CSV
Adds controller to send CSV to requester.

### Guidance to review
Add one or more `DonatedDeviceRequest`s
As a Computacenter user, visit the homepage.
Near the bottom will be a link to "Download donated device requests".
Clicking this will download a CSV containing all the `DonatedDeviceRequest` records in the service in ascending `:id` order.
