### PR TITLE
Remove TechSource maintenance notice

### DIFF
--- a/app/views/shared/_half_term_delivery_suspension.html.erb
+++ b/app/views/shared/_half_term_delivery_suspension.html.erb
@@ -3,8 +3,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      All deliveries are paused during half term. You can still order if you’re invited to, but delivery will happen from <span class="app-no-wrap">Monday 22 February</span> onwards.<br><br>
-      TechSource will be unavailable on <span class="app-no-wrap">Saturday 13 February</span>.
+      All deliveries are paused during half term. You can still order if you’re invited to, but delivery will happen from <span class="app-no-wrap">Monday 22 February</span> onwards.
     </strong>
   </div>
 <% end %>


### PR DESCRIPTION
### Context

The maintenance has passed so we can safely remove this message.
