### PR TITLE
[1503] Show routers ordered in summary list

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -17,8 +17,9 @@ class ResponsibleBody::SchoolDetailsSummaryListComponent < ViewComponent::Base
     array << preorder_status_row
     array << who_will_order_row
     array << device_allocation_row
-    array << router_allocation_row if display_router_allocation_row?
     array << devices_ordered_row if display_devices_ordered_row?
+    array << router_allocation_row if display_router_allocation_row?
+    array << routers_ordered_row if display_routers_ordered_row?
     array << order_status_row
     array << school_type_row
 
@@ -91,8 +92,19 @@ private
     }
   end
 
+  def routers_ordered_row
+    {
+      key: 'Routers ordered',
+      value: pluralize(@school.coms_device_allocation&.devices_ordered.to_i, 'router'),
+    }
+  end
+
   def display_devices_ordered_row?
     (!@school.responsible_body.has_virtual_cap_feature_flags? || !@school.in_virtual_cap_pool?) && @school.std_device_allocation&.devices_ordered.to_i.positive?
+  end
+
+  def display_routers_ordered_row?
+    (!@school.responsible_body.has_virtual_cap_feature_flags? || !@school.in_virtual_cap_pool?) && @school.coms_device_allocation&.devices_ordered.to_i.positive?
   end
 
   def display_router_allocation_row?

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -210,6 +210,54 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
     end
   end
 
+  describe 'routers ordered count' do
+    context 'when no routers ordered' do
+      it 'does not show routers ordered row' do
+        expect(result.text).not_to include('Routers ordered')
+      end
+    end
+
+    context 'when routers_ordered > 0' do
+      before do
+        alloc = school.build_coms_device_allocation(devices_ordered: 3, cap: 100, allocation: 100)
+        alloc.save!
+      end
+
+      context 'when the school is not in a virtual_cap_pool' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(false)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(false)
+        end
+
+        it 'shows routers ordered row with count' do
+          expect(value_for_row(result, 'Routers ordered').text).to include('3 routers')
+        end
+      end
+
+      context 'when the responsible body is not in the virtual cap' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(true)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(false)
+        end
+
+        it 'shows routers ordered row with count' do
+          expect(value_for_row(result, 'Routers ordered').text).to include('3 routers')
+        end
+      end
+
+      context 'when the school is in a virtual_cap_pool' do
+        before do
+          allow(school).to receive(:in_virtual_cap_pool?).and_return(true)
+          allow(school.responsible_body).to receive(:has_virtual_cap_feature_flags?).and_return(true)
+        end
+
+        it 'does not show routers ordered row' do
+          expect(result.text).not_to include('Routers ordered')
+        end
+      end
+    end
+  end
+
   describe 'when school cannot_order_as_reopened' do
     let(:school) { build(:school, order_state: :cannot_order_as_reopened) }
 


### PR DESCRIPTION
### Context

- Routers ordered is missing from summary list

### Changes proposed in this pull request

- Add routers ordered to summary list
- Also tweaks ordering of these rows so devices and routers are grouped together

### Screenshots

![image](https://user-images.githubusercontent.com/92580/107973856-a6006080-6fad-11eb-9865-30a1ab253ad2.png)

### Guidance to review

- login as support agent
- view a school
- make it have caps and devices orders for both devices and routers
- summary list should reflect numbers given