### PR TITLE
1570 show request id to school and rb users

### DIFF
--- a/app/components/extra_mobile_data_request_summary_list_component.rb
+++ b/app/components/extra_mobile_data_request_summary_list_component.rb
@@ -8,6 +8,10 @@ class ExtraMobileDataRequestSummaryListComponent < ViewComponent::Base
   def rows
     [
       {
+        key: 'Request ID',
+        value: @extra_mobile_data_request.id,
+      },
+      {
         key: 'Requested on',
         value: @extra_mobile_data_request.created_at.to_s(:govuk_date_and_time),
       },

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -31,6 +31,7 @@
 <table class="govuk-table requests">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
+      <th class="govuk-table__header">Request ID</th>
       <th class="govuk-table__header">Account holder</th>
       <th class="govuk-table__header">Mobile number</th>
       <th class="govuk-table__header">Requested</th>
@@ -41,6 +42,7 @@
   <tbody class="govuk-table__body">
     <%- for emd_request in @extra_mobile_data_requests do %>
       <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
+        <td class="govuk-table__cell"><%= emd_request.id %></td>
         <td class="govuk-table__cell"><%= govuk_link_to(emd_request.account_holder_name, responsible_body_internet_mobile_extra_data_request_path(emd_request)) %></td>
         <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
         <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -32,6 +32,7 @@
   <table class="govuk-table requests">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
+        <th class="govuk-table__header">Request ID</th>
         <th class="govuk-table__header">Account holder</th>
         <th class="govuk-table__header">Mobile number</th>
         <th class="govuk-table__header">Requested</th>
@@ -42,6 +43,7 @@
     <tbody class="govuk-table__body">
       <%- for emd_request in @extra_mobile_data_requests do %>
         <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
+          <td class="govuk-table__cell"><%= emd_request.id %></td>
           <td class="govuk-table__cell"><%= govuk_link_to(emd_request.account_holder_name, extra_data_request_internet_mobile_school_path(@school, emd_request)) %></td>
           <td class="govuk-table__cell"><%= emd_request.device_phone_number %></td>
           <td class="govuk-table__cell"><%= emd_request.created_at.to_date.to_s(:long_ordinal) %></td>

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
       @requests.each do |request|
         request_row = my_requests_page.row_for(request)
         expect(request_row).not_to be_nil
+        expect(request_row).to have_content(request.id)
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
         expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
@@ -118,6 +119,11 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
       it 'shows the request details' do
         expect(page).to have_css 'h1', text: request.account_holder_name
         expect(page).to have_content 'Request details'
+      end
+
+      it 'shows the request ID' do
+        expect(page).to have_content 'Request ID'
+        expect(page).to have_content request.id
       end
 
       context 'when the request has a mobile network with an offer details partial template' do

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -65,6 +65,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       requests.each do |request|
         request_row = my_requests_page.row_for(request)
         expect(request_row).not_to be_nil
+        expect(request_row).to have_content(request.id)
         expect(request_row).to have_content(request.device_phone_number)
         expect(request_row).to have_content(request.account_holder_name)
         expect(request_row).to have_content(request.created_at.to_date.to_s(:long_ordinal))
@@ -128,6 +129,11 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       it 'shows the request details' do
         expect(page).to have_css 'h1', text: request.account_holder_name
         expect(page).to have_content 'Request details'
+      end
+
+      it 'shows the request ID' do
+        expect(page).to have_css 'h1', text: request.account_holder_name
+        expect(page).to have_content 'Request ID'
       end
 
       context 'when the request has a mobile network with an offer details partial template' do

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -132,8 +132,8 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
       end
 
       it 'shows the request ID' do
-        expect(page).to have_css 'h1', text: request.account_holder_name
         expect(page).to have_content 'Request ID'
+        expect(page).to have_content request.id
       end
 
       context 'when the request has a mobile network with an offer details partial template' do


### PR DESCRIPTION
### Context

[Trello card 1570](https://trello.com/c/TN7vlRt6/1570-mno-display-requestid-in-table-of-requests-for-school-trust-users) - we want to move users towards using request ID to identify requests when contacting support, and away from name + mobile number  as they often do at the moment. This will help us minimise the number of places where Personally-Identifying Information is stored. A first step towards this is actually showing them the request IDs. Please see the Trello card for full context.

### Changes proposed in this pull request

Show the request ID to school and responsible_body users when viewing `ExtraMobileDataRequest`s 

### Guidance to review

Screenshots:
![Screenshot from 2021-02-17 12-16-10](https://user-images.githubusercontent.com/134501/108203218-162bf500-711a-11eb-9376-7a9e3e62b564.png)
![Screenshot from 2021-02-17 12-16-51](https://user-images.githubusercontent.com/134501/108203223-175d2200-711a-11eb-8ef0-d93a21f42204.png)
