### PR TITLE
[1548] FE MNO

### DIFF
--- a/app/controllers/school/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/bulk_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::BulkRequestsController < School::BaseController
-  before_action { not_found if @school.hide_mno? }
-
   def new
     @upload_form = BulkUploadForm.new
   end

--- a/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/extra_data_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::ExtraDataRequestsController < School::BaseController
-  before_action { not_found if @school.hide_mno? }
-
   def index
     @pagination, @extra_mobile_data_requests = pagy(@school.extra_mobile_data_requests.order(:created_at))
     @statuses_with_descriptions = statuses_with_descriptions

--- a/app/controllers/school/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/manual_requests_controller.rb
@@ -1,6 +1,4 @@
 class School::Internet::Mobile::ManualRequestsController < School::BaseController
-  before_action { not_found if @school.hide_mno? }
-
   def index
     @extra_mobile_data_requests = @current_user.extra_mobile_data_requests
   end
@@ -48,7 +46,7 @@ class School::Internet::Mobile::ManualRequestsController < School::BaseControlle
 private
 
   def get_participating_mobile_networks
-    @participating_mobile_networks = MobileNetwork.participating_in_pilot.order('LOWER(brand)')
+    @mobile_networks_for_school = @school.available_mobile_networks.order('LOWER(brand)')
   end
 
   def extra_mobile_data_request_params

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -19,6 +19,7 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   validate :validate_school_or_rb_present
   validate :validate_request_uniqueness, on: :create
+  validate :validate_network_permits_fe
 
   enum status: {
     new: 'new',
@@ -108,6 +109,12 @@ class ExtraMobileDataRequest < ApplicationRecord
   end
 
 private
+
+  def validate_network_permits_fe
+    if school&.hide_mno? && MobileNetwork.excluded_fe_networks.include?(mobile_network)
+      errors.add(:mobile_network, "#{mobile_network.brand} do not accept requests for students over the age of 16")
+    end
+  end
 
   def validate_school_or_rb_present
     if school_id.blank? && responsible_body_id.blank?

--- a/app/models/mobile_network.rb
+++ b/app/models/mobile_network.rb
@@ -14,7 +14,7 @@ class MobileNetwork < ApplicationRecord
     participating
   end
 
-  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2]) }
+  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2 Three SMARTY]) }
   scope :fe_networks, -> { participating.where.not(id: excluded_fe_networks.pluck(:id)) }
 
   def pathsafe_brand

--- a/app/models/mobile_network.rb
+++ b/app/models/mobile_network.rb
@@ -14,6 +14,9 @@ class MobileNetwork < ApplicationRecord
     participating
   end
 
+  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2]) }
+  scope :fe_networks, -> { participating.where.not(id: excluded_fe_networks.pluck(:id)) }
+
   def pathsafe_brand
     brand.to_s
          .downcase

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -74,6 +74,18 @@ class School < ApplicationRecord
     type == 'FurtherEducationSchool'
   end
 
+  def available_mobile_networks
+    if hide_networks_not_supporting_fe?
+      MobileNetwork.fe_networks
+    else
+      MobileNetwork.participating
+    end
+  end
+
+  def hide_networks_not_supporting_fe?
+    hide_mno?
+  end
+
   def has_ordered?
     device_allocations.to_a.any? { |alloc| alloc.devices_ordered.positive? }
   end
@@ -169,10 +181,6 @@ class School < ApplicationRecord
 
   def chromebook_domain
     preorder_information&.school_or_rb_domain if preorder_information&.will_need_chromebooks?
-  end
-
-  def show_mno?
-    !hide_mno?
   end
 
   def can_invite_users?

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -28,10 +28,8 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <% if @school.show_mno? %>
-        <li>request extra data for mobile devices</li>
-        <li>check the status of your data requests</li>
-      <% end %>
+      <li>request extra data for mobile devices</li>
+      <li>check the status of your data requests</li>
       <li>request 4G wireless routers</li>
     </ul>
 

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -12,18 +12,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @school.show_mno? %>
-      <h2 class="govuk-heading-l govuk-!-font-size-27">
-        Extra data for mobile devices
-      </h2>
-      <%= render partial: 'shared/internet/mno_information' %>
-      <p class="govuk-body">
-        <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
-        </p>
-      <p class="govuk-body">
-        <%= govuk_link_to 'Check your requests', extra_data_requests_internet_mobile_school_path(@school) %>
-       </p>
-    <% end %>
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      Extra data for mobile devices
+    </h2>
+    <%= render partial: 'shared/internet/mno_information' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Request extra data for mobile devices', extra_data_guidance_internet_mobile_school_path(@school) %>
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Check your requests', extra_data_requests_internet_mobile_school_path(@school) %>
+    </p>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27 govuk-!-margin-top-6">
       4G wireless routers

--- a/app/views/school/internet/mobile/bulk_requests/new.html.erb
+++ b/app/views/school/internet/mobile/bulk_requests/new.html.erb
@@ -28,6 +28,15 @@
       label: { text: 'Pick a spreadsheet file', size: 'm' },
       accept: Mime::Type.lookup_by_extension(:xlsx)
     %>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= MobileNetwork.excluded_fe_networks.pluck(:brand).to_sentence(last_word_connector: ' and ') %> will not accept requests for students over the age of 16
+      </strong>
+    </div>
+
     <%= f.govuk_submit 'Upload requests' %>
   <%- end %>
 </div>

--- a/app/views/school/internet/mobile/manual_requests/new.html.erb
+++ b/app/views/school/internet/mobile/manual_requests/new.html.erb
@@ -15,8 +15,8 @@
       <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint: { text: 'The account holder for a pay monthly contract must be over 18. There’s no minimum age for Pay-as-you-go customers.' } %>
       <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint: { text: 'This should start with 07 and have 11 digits' } %>
 
-      <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint: { text: 'Only networks participating in the service are listed' }) do %>
-        <%- for mobile_network in @participating_mobile_networks do %>
+      <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint: { text: "Only networks participating in the service are listed.<br />#{MobileNetwork.excluded_fe_networks.pluck(:brand).to_sentence(last_word_connector: ' and ')} will not accept requests for students over the age of 16.".html_safe }) do %>
+        <%- @mobile_networks_for_school.each do |mobile_network| %>
           <%= f.govuk_radio_button :mobile_network_id,
                                    mobile_network.id,
                                    label: { text: mobile_network.brand } %>

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -12,9 +12,7 @@
       <p class="govuk-body">You can continue to use this service to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
         <li>check how many devices you can order</li>
-        <% if @school.show_mno? %>
-          <li>request extra data for mobile devices</li>
-        <% end %>
+        <li>request extra data for mobile devices</li>
         <li>request 4G wireless routers</li>
         <li>add more users</li>
         <li>change your Chromebook settings</li>

--- a/app/views/shared/internet/_mno_guidance.html.erb
+++ b/app/views/shared/internet/_mno_guidance.html.erb
@@ -9,9 +9,12 @@
   <li>cannot afford additional data</li>
 </ul>
 
+<p class="govuk-body"><%= MobileNetwork.excluded_fe_networks.pluck(:brand).to_sentence(last_word_connector: ' and ') %> will not accept requests for students over the age of 16.</p>
+
 <p class="govuk-body">One of the following must also apply. They are children:</p>
+
 <ul class="govuk-list govuk-list--bullet">
-  <li>in years 3 to 11 and whose face-to-face education is disrupted</li>
+  <li>in years 3 to 13 and whose face-to-face education is disrupted</li>
   <li>who are <%= govuk_link_to 'clinically extremely vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19', target: '_blank', rel: 'noopener noreferrer' %> and need to shield on current official advice (this could be from a doctor or hospital consultant)</li>
   <li>who live in a household that’s been advised to shield because a family member is clinically extremely vulnerable</li>
   <li>who cannot attend school – even though theirs is open – because restrictions prevent it</li>

--- a/app/views/shared/internet/_mno_information.html.erb
+++ b/app/views/shared/internet/_mno_information.html.erb
@@ -1,1 +1,1 @@
-<p class="govuk-body">Temporarily increase data allowances on certain mobile networks so children in years 3 to 11 can continue their remote education without incurring extra data charges.</p>
+<p class="govuk-body">Temporarily increase data allowances on certain mobile networks so children in years 3 to 13 can continue their remote education without incurring extra data charges.</p>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -62,7 +62,7 @@
 
     <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
 
-    <%- if @school.show_mno? && @school.extra_mobile_data_requests.present? %>
+    <%- if @school.extra_mobile_data_requests.present? %>
       <h2 class="govuk-heading-l govuk-!-margin-top-9">Mobile data requests</h2>
       <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @school.extra_mobile_data_requests) %>
     <%- end %>

--- a/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/bulk_requests_controller_spec.rb
@@ -9,18 +9,6 @@ RSpec.describe School::Internet::Mobile::BulkRequestsController, type: :controll
       sign_in_as user
     end
 
-    describe '#new' do
-      context 'when school.hide_mno?' do
-        let(:school) { create(:school, hide_mno: true) }
-        let(:user) { create(:school_user, schools: [school]) }
-
-        it 'returns 404' do
-          get :new, params: { urn: school.urn }
-          expect(response).to be_not_found
-        end
-      end
-    end
-
     describe '#create' do
       let(:upload) { Rack::Test::UploadedFile.new(file_fixture('extra-mobile-data-requests.xlsx'), Mime[:xlsx]) }
       let(:request_data) { { urn: school.urn, bulk_upload_form: { upload: upload } } }

--- a/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/extra_data_requests_controller_spec.rb
@@ -15,16 +15,6 @@ RSpec.describe School::Internet::Mobile::ExtraDataRequestsController, type: :con
         expect(controller).to render_template(:index)
         expect(response).to have_http_status(:ok)
       end
-
-      context 'when school.hide_mno?' do
-        let(:school) { create(:school, hide_mno: true) }
-        let(:user) { create(:school_user, schools: [school]) }
-
-        it 'returns 404' do
-          get :new, params: { urn: school.urn }
-          expect(response).to be_not_found
-        end
-      end
     end
 
     describe '#guidance' do

--- a/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe School::Internet::Mobile::ManualRequestsController, type: :contro
       let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
       let(:request_data) { { urn: school.urn, extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
 
-      context 'when school.hide_mno?' do
-        let(:school) { create(:school, hide_mno: true) }
-        let(:user) { create(:school_user, schools: [school]) }
-
-        it 'returns 404' do
-          post :create, params: request_data
-          expect(response).to be_not_found
-        end
-      end
-
       it 'sends an SMS to the account holder of the request' do
         expect {
           post :create, params: request_data

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -22,6 +22,22 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     expect(page).to have_css('h1', text: 'Who needs the extra mobile data?')
   end
 
+  context 'school.hide_mno is true' do
+    before do
+      school.update!(hide_mno: true)
+      create(:mobile_network, brand: 'giffgaff')
+    end
+
+    scenario 'do not show FE excluded MNOs' do
+      click_on 'Get internet access'
+      click_on 'Request extra data for mobile devices'
+      click_on 'New request'
+      choose 'One at a time, using a form'
+      click_on 'Continue'
+      expect(page).not_to have_selector 'label', text: 'giffgaff'
+    end
+  end
+
   scenario 'the user can navigate to the bulk upload form from the home page' do
     click_on 'Get internet access'
     click_on 'Request extra data for mobile devices'


### PR DESCRIPTION
### Context

- https://trello.com/c/LlvyVpmg/1548-mno-rollout-to-fe-by-weds-17th

### Changes proposed in this pull request

- Adds MNO to FEs
- `School#hide_mno?` has now been re-purposed. Previously these schools could not see the MNO, they now can. Instead the flag is used to determine if only a subset of mobile networks are permitted
- On manual requests remove excluded networks for FE
- On bulk upload show errors if user attempt to upload FE excluded network. we should be rejected and not persisted 

### Screenshots

![image](https://user-images.githubusercontent.com/92580/108519518-9b9dd980-72c1-11eb-95bd-2b951b197897.png)

### Guidance to review

- Probably want to side by side compare current school journey vs FE journey
- For FE flag is `hide_mno` set to true. as there are some FE with `hide_mno` false as they have under 16s
- Perform manual request
- School journey should see all available networks
- FE journey should see all networks minus giffgaff and o2
- Perform bulk upload
- School journey should accept all available networks
- FE should not accept giffgaff and o2 - see screenshot above
- There are also various copy changes thru the journeys