### PR TITLE
1571 iterate support console for mno requests

### DIFF
--- a/app/components/support/extra_mobile_data_request_component.rb
+++ b/app/components/support/extra_mobile_data_request_component.rb
@@ -1,0 +1,15 @@
+class Support::ExtraMobileDataRequestComponent < ViewComponent::Base
+  attr_accessor :request
+
+  def initialize(request)
+    @request = request
+  end
+
+  def link_to_requester
+    if request.school_id.present?
+      govuk_link_to "#{request.school.name} (#{request.school.urn})", support_school_path(urn: request.school.urn)
+    else
+      govuk_link_to request.responsible_body.name, support_responsible_body_path(request.responsible_body_id)
+    end
+  end
+end

--- a/app/controllers/support/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/support/extra_mobile_data_requests_controller.rb
@@ -11,8 +11,8 @@ class Support::ExtraMobileDataRequestsController < Support::BaseController
 private
 
   def search_params
-    params.fetch(:search_form, {})
-          .permit(:request_id, :school_id, :rb_id, :mno_id, :status)
+    params.fetch(:emdr_search, {})
+          .permit(:request_id, :school_id, :urn_or_ukprn, :rb_id, :mno_id, :status)
   end
 
   def statuses_with_descriptions

--- a/app/controllers/support/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/support/extra_mobile_data_requests_controller.rb
@@ -1,0 +1,31 @@
+class Support::ExtraMobileDataRequestsController < Support::BaseController
+  before_action { authorize ExtraMobileDataRequest }
+
+  def index
+    @form = Support::ExtraMobileDataRequestSearchForm.new(search_params)
+    @pagination, @requests = pagy(@form.requests(current_user).order(:created_at))
+
+    @statuses_with_descriptions = statuses_with_descriptions
+  end
+
+private
+
+  def search_params
+    params.fetch(:search_form, {})
+          .permit(:request_id, :school_id, :rb_id, :mno_id, :status)
+  end
+
+  def statuses_with_descriptions
+    ExtraMobileDataRequest
+      .statuses.keys
+      .collect do |status|
+        [
+          status,
+          I18n.t!(
+            "#{status}.school_or_rb_user_description",
+            scope: %i[activerecord attributes extra_mobile_data_request status],
+          ),
+        ]
+      end
+  end
+end

--- a/app/form_objects/support/extra_mobile_data_request_search_form.rb
+++ b/app/form_objects/support/extra_mobile_data_request_search_form.rb
@@ -16,6 +16,7 @@ class Support::ExtraMobileDataRequestSearchForm
   def requests(current_user)
     requests = ExtraMobileDataRequestPolicy::Scope.new(current_user, ExtraMobileDataRequest).resolve
     requests = requests.includes(:school).includes(:responsible_body).includes(:mobile_network)
+    requests = requests.where(id: @request_id) if @request_id.present?
     requests = requests.where(school_id: @school_id) if @school_id.present?
     requests = requests.joins(:school).where('schools.urn = ? OR schools.ukprn = ?', @urn_or_ukprn, @urn_or_ukprn) if @urn_or_ukprn.present?
     requests = requests.where(responsible_body_id: @rb_id) if @rb_id.present?

--- a/app/form_objects/support/extra_mobile_data_request_search_form.rb
+++ b/app/form_objects/support/extra_mobile_data_request_search_form.rb
@@ -31,15 +31,15 @@ class Support::ExtraMobileDataRequestSearchForm
   end
 
   def mobile_network_options
-    MobileNetwork.where(id: ExtraMobileDataRequest.distinct(:mobile_network_id).pluck(:mobile_network_id)).map do |mno|
+    MobileNetwork.where(id: ExtraMobileDataRequest.distinct(:mobile_network_id).pluck(:mobile_network_id)).map { |mno|
       OpenStruct.new(value: mno.id, label: mno.brand)
-    end.prepend(OpenStruct.new(value: nil, label: '(all)'))
+    }.prepend(OpenStruct.new(value: nil, label: '(all)'))
   end
 
   def status_options
     ExtraMobileDataRequest.statuses
                           .keys
-                          .map { |k| OpenStruct.new(value: k, label: I18n.t(:dropdown_label, scope: [:activerecord, :attributes, :extra_mobile_data_request, :status, k]))}
+                          .map { |k| OpenStruct.new(value: k, label: I18n.t(:dropdown_label, scope: [:activerecord, :attributes, :extra_mobile_data_request, :status, k])) }
                           .prepend(OpenStruct.new(value: nil, label: '(all)'))
   end
 end

--- a/app/form_objects/support/extra_mobile_data_request_search_form.rb
+++ b/app/form_objects/support/extra_mobile_data_request_search_form.rb
@@ -1,0 +1,24 @@
+class Support::ExtraMobileDataRequestSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :request_id, :school_id, :rb_id, :mno_id, :status
+
+  def initialize(params = {})
+    @request_id = params[:request_id]
+    @school_id = params[:school_id]
+    @rb_id = params[:rb_id]
+    @mno_id = params[:mno_id]
+    @status = params[:status]
+  end
+
+  def requests(current_user)
+    requests = ExtraMobileDataRequestPolicy::Scope.new(current_user, ExtraMobileDataRequest).resolve
+    requests = requests.includes(:school).includes(:responsible_body).includes(:mobile_network)
+    requests = requests.where(school_id: @school_id) if @school_id.present?
+    requests = requests.where(responsible_body_id: @rb_id) if @rb_id.present?
+    requests = requests.where(mobile_network_id: @mno_id) if @mno_id.present?
+    requests = requests.where(status: @status) if @status.present?
+    requests
+  end
+end

--- a/app/form_objects/support/extra_mobile_data_request_search_form.rb
+++ b/app/form_objects/support/extra_mobile_data_request_search_form.rb
@@ -2,11 +2,12 @@ class Support::ExtraMobileDataRequestSearchForm
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :request_id, :school_id, :rb_id, :mno_id, :status
+  attr_accessor :request_id, :school_id, :urn_or_ukprn, :rb_id, :mno_id, :status
 
   def initialize(params = {})
     @request_id = params[:request_id]
     @school_id = params[:school_id]
+    @urn_or_ukprn = params[:urn_or_ukprn]
     @rb_id = params[:rb_id]
     @mno_id = params[:mno_id]
     @status = params[:status]
@@ -16,9 +17,29 @@ class Support::ExtraMobileDataRequestSearchForm
     requests = ExtraMobileDataRequestPolicy::Scope.new(current_user, ExtraMobileDataRequest).resolve
     requests = requests.includes(:school).includes(:responsible_body).includes(:mobile_network)
     requests = requests.where(school_id: @school_id) if @school_id.present?
+    requests = requests.joins(:school).where('schools.urn = ? OR schools.ukprn = ?', @urn_or_ukprn, @urn_or_ukprn) if @urn_or_ukprn.present?
     requests = requests.where(responsible_body_id: @rb_id) if @rb_id.present?
     requests = requests.where(mobile_network_id: @mno_id) if @mno_id.present?
     requests = requests.where(status: @status) if @status.present?
     requests
+  end
+
+  def select_responsible_body_options
+    ResponsibleBody.order(:name).pluck(:id, :name).map { |id, name|
+      OpenStruct.new(id: id, name: name)
+    }.prepend(OpenStruct.new(id: nil, name: '(all)'))
+  end
+
+  def mobile_network_options
+    MobileNetwork.where(id: ExtraMobileDataRequest.distinct(:mobile_network_id).pluck(:mobile_network_id)).map do |mno|
+      OpenStruct.new(value: mno.id, label: mno.brand)
+    end.prepend(OpenStruct.new(value: nil, label: '(all)'))
+  end
+
+  def status_options
+    ExtraMobileDataRequest.statuses
+                          .keys
+                          .map { |k| OpenStruct.new(value: k, label: I18n.t(:dropdown_label, scope: [:activerecord, :attributes, :extra_mobile_data_request, :status, k]))}
+                          .prepend(OpenStruct.new(value: nil, label: '(all)'))
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,8 @@
+require 'string_utils'
+
 module ViewHelper
+  include StringUtils
+
   def ghwt_contact_mailto(subject: nil, label: 'COVID.TECHNOLOGY@education.gov.uk')
     mail_to_url = [
       'mailto:COVID.TECHNOLOGY@education.gov.uk',

--- a/app/policies/extra_mobile_data_request_policy.rb
+++ b/app/policies/extra_mobile_data_request_policy.rb
@@ -1,0 +1,28 @@
+class ExtraMobileDataRequestPolicy < SupportPolicy
+  class Scope < Scope
+    def resolve
+      if user.is_support? && !user.is_computacenter?
+        scope.all
+      else
+        raise 'Unexpected user type in extra_mobile_data_request policy scope'
+      end
+    end
+  end
+
+  def readable?
+    user.is_support? && !user.is_computacenter?
+  end
+
+  def editable?
+    false
+  end
+
+  alias_method :index?, :readable?
+  alias_method :show?, :readable?
+
+  alias_method :new?, :editable?
+  alias_method :create?, :editable?
+  alias_method :edit?, :editable?
+  alias_method :update?, :editable?
+  alias_method :destroy?, :editable?
+end

--- a/app/views/support/extra_mobile_data_requests/_search_form.html.erb
+++ b/app/views/support/extra_mobile_data_requests/_search_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_error_summary %>
   <p class="govuk-body">Search by 1 or more piece of information.</p>
   <%= f.govuk_text_field :request_id, label: {text: 'Request ID'}, size: 'm', width: 'one-quarter' %>
-  <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'School URN or UKPRN'}, size: 'm', width: 'one-quarter' %>
+  <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'URN or UKPRN'}, size: 'm', width: 'one-quarter' %>
   <%= f.govuk_collection_select   :rb_id,
                                   @form.select_responsible_body_options,
                                   :id,

--- a/app/views/support/extra_mobile_data_requests/_search_form.html.erb
+++ b/app/views/support/extra_mobile_data_requests/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for @form, method: :get, url: support_extra_mobile_data_requests_path, as: 'emdr_search' do |f| %>
   <%= f.govuk_error_summary %>
-  <p class="govuk-body">All fields are optional - you can fill in as many or as few as you like.</p>
+  <p class="govuk-body">Search by 1 or more piece of information.</p>
   <%= f.govuk_text_field :request_id, label: {text: 'Request ID'}, size: 'm', width: 'one-quarter' %>
   <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'School URN or UKPRN'}, size: 'm', width: 'one-quarter' %>
   <%= f.govuk_collection_select   :rb_id,

--- a/app/views/support/extra_mobile_data_requests/_search_form.html.erb
+++ b/app/views/support/extra_mobile_data_requests/_search_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for @form, method: :get, url: support_extra_mobile_data_requests_path, as: 'emdr_search' do |f| %>
+  <%= f.govuk_error_summary %>
+  <p class="govuk-body">All fields are optional - you can fill in as many or as few as you like.</p>
+  <%= f.govuk_text_field :request_id, label: {text: 'Request ID'}, size: 'm', width: 'one-quarter' %>
+  <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'School URN or UKPRN'}, size: 'm', width: 'one-quarter' %>
+  <%= f.govuk_collection_select   :rb_id,
+                                  @form.select_responsible_body_options,
+                                  :id,
+                                  :name,
+                                  label: { text: 'Responsible body' } %>
+  <%= f.govuk_collection_select   :mno_id,
+                                  @form.mobile_network_options,
+                                  :value,
+                                  :label,
+                                  label: { text: 'Mobile network' } %>
+  <%= f.govuk_collection_select   :status,
+                                  @form.status_options,
+                                  :value,
+                                  :label,
+                                  label: { text: 'Status' } %>
+  <%= f.govuk_submit 'Search' %>
+<%- end %>

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -1,0 +1,58 @@
+<%- title = t('page_titles.support_extra_mobile_data_requests') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([
+                   { "Home" => support_home_path },
+                   title
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <% if @requests.any? %>
+      <%= render partial: 'shared/internet/help_with_statuses', locals: { statuses_with_descriptions: @statuses_with_descriptions } %>
+    <% end %>
+  </div>
+</div>
+
+<% if @requests.any? %>
+  <p class="govuk-body">Showing <%= 'request'.pluralize(@requests.count) %> <%= @pagination.from %> - <%= @pagination.to %> of <%= @pagination.count %></p>
+  <table class="govuk-table requests">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Request ID</th>
+        <th class="govuk-table__header">Account holder</th>
+        <th class="govuk-table__header">Mobile number</th>
+        <th class="govuk-table__header">Requested</th>
+        <th class="govuk-table__header">Mobile Network</th>
+        <th class="govuk-table__header">Status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <%- for emd_request in @requests do %>
+        <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
+          <td class="govuk-table__cell"><%= emd_request.id %></td>
+          <td class="govuk-table__cell"><%= redact(emd_request.account_holder_name, first: 1) %></td>
+          <td class="govuk-table__cell"><%= redact( emd_request.device_phone_number, last: 4 ) %></td>
+          <td class="govuk-table__cell">
+            <%= emd_request.created_at.to_date.to_s(:long_ordinal) %>
+            by
+            <%- if emd_request.school.present? %>
+              <%= govuk_link_to "#{emd_request.school.name} (#{emd_request.school.urn})", support_school_path(urn: emd_request.school.urn) %>
+            <%- else %>
+              <%= govuk_link_to emd_request.responsible_body.name, support_responsible_body_path(emd_request.responsible_body_id) %>
+            <%- end %>
+          <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
+          <td class="govuk-table__cell">
+            <%= render ExtraMobileDataRequestStatusComponent.new(status: emd_request.status) %>
+          </td>
+        </tr>
+      <%- end %>
+    </tbody>
+  </table>
+  <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
+<% end %>

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -14,28 +14,7 @@
     </h1>
 
     <%= govuk_details(summary: 'Search for requests') do %>
-
-      <%= form_for @form, method: :get, url: support_extra_mobile_data_requests_path, as: 'emdr_search' do |f| %>
-        <%= f.govuk_error_summary %>
-
-        <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'School URN or UKPRN'}, size: 'm' %>
-        <%= f.govuk_collection_select   :rb_id,
-                                        @form.select_responsible_body_options,
-                                        :id,
-                                        :name,
-                                        label: { text: 'Responsible body' } %>
-        <%= f.govuk_collection_select   :mno_id,
-                                        @form.mobile_network_options,
-                                        :value,
-                                        :label,
-                                        label: { text: 'Mobile network' } %>
-        <%= f.govuk_collection_select   :status,
-                                        @form.status_options,
-                                        :value,
-                                        :label,
-                                        label: { text: 'Status' } %>
-        <%= f.govuk_submit 'Search' %>
-      <%- end %>
+      <%= render partial: 'support/extra_mobile_data_requests/search_form' %>
     <%- end %>
 
     <% if @requests.any? %>
@@ -61,7 +40,7 @@
       <%- for emd_request in @requests do %>
         <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
           <td class="govuk-table__cell"><%= emd_request.id %></td>
-          <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
+          <td class="govuk-table__cell brand"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell"><%= redact(emd_request.account_holder_name, first: 1, last: 1) %></td>
           <td class="govuk-table__cell"><%= redact(emd_request.device_phone_number, first: 2, last: 4) %></td>
           <td class="govuk-table__cell">

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -65,7 +65,7 @@
           <td class="govuk-table__cell"><%= redact( emd_request.device_phone_number, last: 4 ) %></td>
           <td class="govuk-table__cell">
             <%= emd_request.created_at.to_date.to_s(:long_ordinal) %>
-            by
+            <br />by
             <%- if emd_request.school.present? %>
               <%= govuk_link_to "#{emd_request.school.name} (#{emd_request.school.urn})", support_school_path(urn: emd_request.school.urn) %>
             <%- else %>

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -50,10 +50,10 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Request ID</th>
+        <th class="govuk-table__header">Mobile Network</th>
         <th class="govuk-table__header">Account holder</th>
         <th class="govuk-table__header">Mobile number</th>
         <th class="govuk-table__header">Requested</th>
-        <th class="govuk-table__header">Mobile Network</th>
         <th class="govuk-table__header">Status</th>
       </tr>
     </thead>
@@ -61,8 +61,9 @@
       <%- for emd_request in @requests do %>
         <tr class="govuk-table__row" id="request-<%= emd_request.id %>">
           <td class="govuk-table__cell"><%= emd_request.id %></td>
-          <td class="govuk-table__cell"><%= redact(emd_request.account_holder_name, first: 1) %></td>
-          <td class="govuk-table__cell"><%= redact( emd_request.device_phone_number, last: 4 ) %></td>
+          <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
+          <td class="govuk-table__cell"><%= redact(emd_request.account_holder_name, first: 1, last: 1) %></td>
+          <td class="govuk-table__cell"><%= redact(emd_request.device_phone_number, first: 2, last: 4) %></td>
           <td class="govuk-table__cell">
             <%= emd_request.created_at.to_date.to_s(:long_ordinal) %>
             <br />by
@@ -71,7 +72,6 @@
             <%- else %>
               <%= govuk_link_to emd_request.responsible_body.name, support_responsible_body_path(emd_request.responsible_body_id) %>
             <%- end %>
-          <td class="govuk-table__cell"><%= emd_request.mobile_network.try(:brand) %></td>
           <td class="govuk-table__cell">
             <%= render ExtraMobileDataRequestStatusComponent.new(status: emd_request.status) %>
           </td>

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -44,7 +44,7 @@
           <td class="govuk-table__cell"><%= redact(emd_request.account_holder_name, first: 1, last: 1) %></td>
           <td class="govuk-table__cell"><%= redact(emd_request.device_phone_number, first: 2, last: 4) %></td>
           <td class="govuk-table__cell">
-            <%= emd_request.created_at.to_date.to_s(:long_ordinal) %>
+            <%= emd_request.created_at.to_date.to_s(:govuk) %>
             <br />by
             <%- if emd_request.school.present? %>
               <%= govuk_link_to "#{emd_request.school.name} (#{emd_request.school.urn})", support_school_path(urn: emd_request.school.urn) %>

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -13,6 +13,31 @@
       <%= title %>
     </h1>
 
+    <%= govuk_details(summary: 'Search for requests') do %>
+
+      <%= form_for @form, method: :get, url: support_extra_mobile_data_requests_path, as: 'emdr_search' do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_text_field :urn_or_ukprn, label: {text: 'School URN or UKPRN'}, size: 'm' %>
+        <%= f.govuk_collection_select   :rb_id,
+                                        @form.select_responsible_body_options,
+                                        :id,
+                                        :name,
+                                        label: { text: 'Responsible body' } %>
+        <%= f.govuk_collection_select   :mno_id,
+                                        @form.mobile_network_options,
+                                        :value,
+                                        :label,
+                                        label: { text: 'Mobile network' } %>
+        <%= f.govuk_collection_select   :status,
+                                        @form.status_options,
+                                        :value,
+                                        :label,
+                                        label: { text: 'Status' } %>
+        <%= f.govuk_submit 'Search' %>
+      <%- end %>
+    <%- end %>
+
     <% if @requests.any? %>
       <%= render partial: 'shared/internet/help_with_statuses', locals: { statuses_with_descriptions: @statuses_with_descriptions } %>
     <% end %>
@@ -55,4 +80,6 @@
     </tbody>
   </table>
   <%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>
+<%- else %>
+  <p class="govuk-body">No requests to display</p>
 <% end %>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -39,6 +39,20 @@
       <p class="govuk-body">Use this section to search for schools, colleges and FE institutions.</p>
     <% end %>
 
+    <% if policy(ExtraMobileDataRequest).index? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Find requests for extra mobile data', support_extra_mobile_data_requests_path %>
+      </h2>
+
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>search for requests for extra mobile data</li>
+        <li>view overall numbers of requests for extra mobile data</li>
+      </ul>
+    <%- else %>
+      <h2>FAIL</h2>
+    <% end %>
+
     <% if policy(Support::ServicePerformance).index? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to 'Service performance', support_service_performance_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,7 @@ en:
         adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE institutions
       addresses:
         edit: Update address
+    support_extra_mobile_data_requests: Requests for extra mobile data
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact
     support_devices: Devices

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,7 @@ Rails.application.routes.draw do
       patch 'schools', to: 'users/schools#update_schools', as: :update_schools
       resource :responsible_body, only: %i[edit update], controller: 'users/responsible_body', path: 'responsible-body'
     end
+    resources :extra_mobile_data_requests, only: %i[index show], path: 'extra-mobile-data-requests'
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin
   end
 

--- a/lib/string_utils.rb
+++ b/lib/string_utils.rb
@@ -8,4 +8,8 @@ module StringUtils
     end
     [words1.join(' '), (words2.join(' ')[0...limit])]
   end
+
+  def redact(string, first: 0, last: 0, redaction: '...')
+    [string.first(first), string.last(last)].join(redaction)
+  end
 end

--- a/lib/string_utils.rb
+++ b/lib/string_utils.rb
@@ -9,7 +9,7 @@ module StringUtils
     [words1.join(' '), (words2.join(' ')[0...limit])]
   end
 
-  def redact(string, first: 0, last: 0, redaction: '...')
+  def redact(string, first: 0, last: 0, redaction: '…')
     [string.first(first), string.last(last)].join(redaction)
   end
 end

--- a/spec/features/support/finding_extra_mobile_data_requests_spec.rb
+++ b/spec/features/support/finding_extra_mobile_data_requests_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Finding ExtraMobileDataRequests in support' do
+  let(:support_user) { create(:support_user) }
+  let(:computacenter_user) { create(:computacenter_user) }
+  let(:index_page) { PageObjects::Support::ExtraMobileDataRequests::IndexPage.new }
+
+  context 'as a support_user' do
+    before do
+      sign_in_as support_user
+    end
+
+    context 'when I visit support home' do
+      before do
+        visit support_home_path
+      end
+
+      it 'shows me a link for Extra mobile data requests' do
+        expect(page).to have_link 'Find requests for extra mobile data'
+      end
+
+      context 'clicking on the link' do
+        before do
+          click_on 'Find requests for extra mobile data'
+        end
+
+        it 'shows me the requests list' do
+          expect(index_page).to be_displayed
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/finding_extra_mobile_data_requests_spec.rb
+++ b/spec/features/support/finding_extra_mobile_data_requests_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Finding ExtraMobileDataRequests in support' do
   let(:support_user) { create(:support_user) }
   let(:computacenter_user) { create(:computacenter_user) }
   let(:index_page) { PageObjects::Support::ExtraMobileDataRequests::IndexPage.new }
+  let!(:requests) { create_list(:extra_mobile_data_request, 10) }
 
   context 'as a support_user' do
     before do
@@ -26,6 +27,58 @@ RSpec.describe 'Finding ExtraMobileDataRequests in support' do
 
         it 'shows me the requests list' do
           expect(index_page).to be_displayed
+        end
+
+        it 'only shows the first and last characters of account holder names' do
+          requests.each do |r|
+            expect(index_page).not_to have_content(r.account_holder_name)
+            expect(index_page).to have_content([r.account_holder_name.first, r.account_holder_name.last].join('…'))
+          end
+        end
+
+        it 'only shows the first 2 and last 4 characters of the mobile numbers' do
+          requests.each do |r|
+            expect(index_page).not_to have_content(r.device_phone_number)
+            expect(index_page).to have_content([r.device_phone_number.first(2), r.device_phone_number.last(4)].join('…'))
+          end
+        end
+
+        it 'shows me the search form' do
+          expect(index_page).to have_content 'Search for requests'
+        end
+      end
+    end
+
+    context 'when I click to Search for requests' do
+      before do
+        visit support_extra_mobile_data_requests_path
+        index_page.search_for_requests.click
+      end
+
+      context 'and I search by request ID' do
+        let(:request) { requests.last }
+
+        before do
+          fill_in 'Request ID', with: request.id
+          click_on 'Search'
+        end
+
+        it 'shows me only that request' do
+          expect(index_page.request_rows.size).to eq(1)
+          expect(index_page.row_for(request)).to have_content(request.id)
+        end
+      end
+
+      context 'when I search by mobile network' do
+        let(:request) { requests.sample }
+
+        before do
+          select(request.mobile_network.brand, from: 'Mobile network')
+          click_on 'Search'
+        end
+
+        it 'shows me only requests with that brand' do
+          expect(index_page.request_brands.map(&:text).uniq).to eql(Array(request.mobile_network.brand))
         end
       end
     end

--- a/spec/lib/string_utils_spec.rb
+++ b/spec/lib/string_utils_spec.rb
@@ -20,4 +20,43 @@ describe StringUtils do
       expect(result).to eq(['banana pineapple strawberry', ''])
     end
   end
+
+  describe '#redact' do
+    context 'given a string' do
+      it 'returns an ellipsis' do
+        expect(test_class.redact('a long string')).to eq('...')
+      end
+
+      context 'and a redaction' do
+        it 'returns the redaction' do
+          expect(test_class.redact('a long string', redaction: '___XXX___')).to eq('___XXX___')
+        end
+      end
+
+      context 'and a first: N param' do
+        it 'returns the first N characters plus an ellipsis' do
+          expect(test_class.redact('a long string', first: 3)).to eq('a l...')
+        end
+
+        context 'and a last: M param' do
+          it 'returns the first N characters plus an ellipsis plus the last M characters' do
+            expect(test_class.redact('a long string', first: 1, last: 2)).to eq('a...ng')
+          end
+
+          context 'and a redaction' do
+            it 'returns the first N characters plus the redaction plus the last M characters' do
+              expect(test_class.redact('a long string', first: 1, last: 2, redaction: '-REDACTED-')).to eq('a-REDACTED-ng')
+            end
+          end
+        end
+      end
+
+      context 'and a last: N param' do
+        it 'returns an ellipsis plus the last N characters' do
+          expect(test_class.redact('a long string', last: 3)).to eq('...ing')
+        end
+      end
+
+    end
+  end
 end

--- a/spec/lib/string_utils_spec.rb
+++ b/spec/lib/string_utils_spec.rb
@@ -42,12 +42,6 @@ describe StringUtils do
           it 'returns the first N characters plus an ellipsis plus the last M characters' do
             expect(test_class.redact('a long string', first: 1, last: 2)).to eq('a…ng')
           end
-
-          context 'and a redaction' do
-            it 'returns the first N characters plus the redaction plus the last M characters' do
-              expect(test_class.redact('a long string', first: 1, last: 2, redaction: '-REDACTED-')).to eq('a-REDACTED-ng')
-            end
-          end
         end
       end
 
@@ -57,6 +51,11 @@ describe StringUtils do
         end
       end
 
+      context 'with first N and last M params and a redaction' do
+        it 'returns the first N characters plus the redaction plus the last M characters' do
+          expect(test_class.redact('a long string', first: 1, last: 2, redaction: '-REDACTED-')).to eq('a-REDACTED-ng')
+        end
+      end
     end
   end
 end

--- a/spec/lib/string_utils_spec.rb
+++ b/spec/lib/string_utils_spec.rb
@@ -24,7 +24,7 @@ describe StringUtils do
   describe '#redact' do
     context 'given a string' do
       it 'returns an ellipsis' do
-        expect(test_class.redact('a long string')).to eq('...')
+        expect(test_class.redact('a long string')).to eq('…')
       end
 
       context 'and a redaction' do
@@ -35,12 +35,12 @@ describe StringUtils do
 
       context 'and a first: N param' do
         it 'returns the first N characters plus an ellipsis' do
-          expect(test_class.redact('a long string', first: 3)).to eq('a l...')
+          expect(test_class.redact('a long string', first: 3)).to eq('a l…')
         end
 
         context 'and a last: M param' do
           it 'returns the first N characters plus an ellipsis plus the last M characters' do
-            expect(test_class.redact('a long string', first: 1, last: 2)).to eq('a...ng')
+            expect(test_class.redact('a long string', first: 1, last: 2)).to eq('a…ng')
           end
 
           context 'and a redaction' do
@@ -53,7 +53,7 @@ describe StringUtils do
 
       context 'and a last: N param' do
         it 'returns an ellipsis plus the last N characters' do
-          expect(test_class.redact('a long string', last: 3)).to eq('...ing')
+          expect(test_class.redact('a long string', last: 3)).to eq('…ing')
         end
       end
 

--- a/spec/page_objects/support/extra_mobile_data_requests/index_page.rb
+++ b/spec/page_objects/support/extra_mobile_data_requests/index_page.rb
@@ -6,9 +6,19 @@ module PageObjects
 
         elements :search_form, 'form#extra_mobile_data_requests_search_form'
         element :requests_table, '.requests'
+        elements :request_rows, 'table.requests tbody tr'
+        elements :request_brands, 'table.requests tbody td.brand'
+        element :request_id_field, '#emdr-search-request-id-field'
+        element :mobile_network_field, '#emdr-search-mno-id-field'
+        element :responsible_body_field, '#emdr-search-rb-id-field'
+        element :urn_or_ukprn_field, '#emdr-search-urn-or-ukprn-field'
 
         def row_for(request)
           requests_table.find("tr#request-#{request.id}")
+        end
+
+        def search_for_requests
+          find('span', text: 'Search for requests')
         end
       end
     end

--- a/spec/page_objects/support/extra_mobile_data_requests/index_page.rb
+++ b/spec/page_objects/support/extra_mobile_data_requests/index_page.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module Support
+    module ExtraMobileDataRequests
+      class IndexPage < PageObjects::BasePage
+        set_url '/support/extra-mobile-data-requests'
+
+        elements :search_form, 'form#extra_mobile_data_requests_search_form'
+        element :requests_table, '.requests'
+
+        def row_for(request)
+          requests_table.find("tr#request-#{request.id}")
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/extra_mobile_data_request_policy_spec.rb
+++ b/spec/policies/extra_mobile_data_request_policy_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe ExtraMobileDataRequestPolicy do
+  subject(:policy) { described_class }
+  let(:object) { build(:extra_mobile_data_request) }
+
+  permissions :new?, :create?, :edit?, :update?, :destroy? do
+    it 'blocks access to support users' do
+      expect(policy).not_to permit(build(:support_user), object)
+    end
+
+    it 'blocks access to Computacenter users' do
+      expect(policy).not_to permit(build(:computacenter_user), object)
+    end
+  end
+
+  permissions :index?, :show? do
+    it 'grants access to support users' do
+      expect(policy).to permit(build(:support_user), object)
+    end
+
+    it 'blocks access to Computacenter users' do
+      expect(policy).not_to permit(build(:computacenter_user), object)
+    end
+  end
+end

--- a/spec/policies/extra_mobile_data_request_policy_spec.rb
+++ b/spec/policies/extra_mobile_data_request_policy_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe ExtraMobileDataRequestPolicy do
   subject(:policy) { described_class }
+
   let(:object) { build(:extra_mobile_data_request) }
 
   permissions :new?, :create?, :edit?, :update?, :destroy? do


### PR DESCRIPTION
### Context

[Trello card 1571](https://trello.com/c/3SK2pEbr/1571-iterate-support-console-for-mno-requests) - We need a way for support users to be able to find individual mobile data requests that they have been contacted about by the users, whilst not exposing personally-identifying information if it is at all possible to avoid doing so.

In discussion with @fofr we agreed to try a limited redaction that would just expose (say) the first character of account holder name, and the last 4 digits of the mobile number.  

### Changes proposed in this pull request

* add a new top-level support section to find & list mobile data requests
* add a basic search form to allow filtering of the list
* add a policy to only allow support users to view this list - explicitly _excluding_ any Computacenter users who may also have read-only access to support

I chose to do this as a top-level section so that later, we can link directly into it from a school or RB page in the support UI, passing the relevant search params to show specific subsets of requests

### Guidance to review

I've included all points of design feedback, and added the 'Request ID' search field, so that users can go straight a particular request ID. The specs are now completed and clean, so I think this is ready to go. Un-drafted.

Screenshots:
![Screenshot from 2021-02-22 10-57-05](https://user-images.githubusercontent.com/134501/108699333-ff601680-74fc-11eb-8676-d8b7c7fc8b66.png)


