### PR TITLE
[1597] Add test personas for heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT
+worker: bundle exec sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -p $PORT
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "get-help-with-tech",
   "scripts": {
-    "postdeploy": "RAILS_ENV=production bundle exec rake db:schema:load db:seed"
+    "postdeploy": "RAILS_ENV=production bundle exec rake db:schema:load db:seed db:personas"
   },
   "env": {
     "LANG": {

--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
     }
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "heroku-redis"
   ],
   "buildpacks": [
     {

--- a/app.json
+++ b/app.json
@@ -23,6 +23,9 @@
   "formation": {
     "web": {
       "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
     }
   },
   "addons": [

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -46,7 +46,7 @@ class SignInTokensController < ApplicationController
     if @sign_in_token_form.email_is_user?
       token = SessionService.send_magic_link_email!(@sign_in_token_form.email_address)
 
-      if ENV['HEROKU'] == 'heroku'
+      if FeatureFlag.active?(:display_sign_in_token_links)
         user = User.find_by(email_address: @sign_in_token_form.email_address)
         identifier = user.sign_in_identifier(user.sign_in_token)
         flash[:success] = validate_sign_in_token_url(token: token, identifier: identifier)

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -45,6 +45,13 @@ class SignInTokensController < ApplicationController
 
     if @sign_in_token_form.email_is_user?
       token = SessionService.send_magic_link_email!(@sign_in_token_form.email_address)
+
+      if ENV['HEROKU'] == 'heroku'
+        user = User.find_by(email_address: @sign_in_token_form.email_address)
+        identifier = user.sign_in_identifier(user.sign_in_token)
+        flash[:success] = validate_sign_in_token_url(token: token, identifier: identifier)
+      end
+
       redirect_to sent_token_path(token: token)
     else
       redirect_to email_not_recognised_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,7 @@
 class FeatureFlag
   PERMANENT_SETTINGS = %i[
     rate_limiting
+    display_sign_in_token_links
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/services/personas/support_user.rb
+++ b/app/services/personas/support_user.rb
@@ -1,0 +1,14 @@
+class Personas::SupportUser
+  def call
+    support_user
+  end
+
+private
+
+  def support_user
+    @support_user ||= User.find_or_create_by!(email_address: 'support.user.1@example.com') do |u|
+      u.full_name = 'Bill Gates'
+      u.is_support = true
+    end
+  end
+end

--- a/app/services/personas/trust_with_schools.rb
+++ b/app/services/personas/trust_with_schools.rb
@@ -1,0 +1,50 @@
+class Personas::TrustWithSchools
+  def call
+    trust
+    trust_user
+    school_one
+    school_one_user
+  end
+
+private
+
+  def school_one
+    @school_one ||= trust.schools.find_or_create_by!(name: 'George School') do |s|
+      s.urn = School.maximum(:urn) + 1
+      s.address_1 = '27 Northumberland Street'
+      s.town = 'Newcastle'
+      s.county = 'Tyne and Wear'
+      s.postcode = 'NE1 7DE'
+    end
+
+    @school_one.preorder_information || @school_one.build_preorder_information(who_will_order_devices: 'school').save!
+
+    @school_one
+  end
+
+  def school_one_user
+    @school_one_user ||= school_one.users.find_or_create_by!(email_address: 'school.user.1@example.com') do |u|
+      u.full_name = 'Jane Doe'
+      u.orders_devices = true
+    end
+  end
+
+  def trust
+    @trust ||= Trust.find_or_create_by!(name: 'Elizabeth Trust') do |rb|
+      rb.organisation_type = 'Multi-academy trust'
+      rb.in_connectivity_pilot = true
+      rb.who_will_order_devices = 'school'
+      rb.address_1 = '1 Grey Street'
+      rb.town = 'Newcastle'
+      rb.county = 'Tyne and Wear'
+      rb.postcode = 'NE1 6EE'
+    end
+  end
+
+  def trust_user
+    @trust_user ||= trust.users.find_or_create_by!(email_address: 'trust.user.1@example.com') do |u|
+      u.full_name = 'John Doe'
+      u.orders_devices = true
+    end
+  end
+end

--- a/app/services/personas/trust_with_schools.rb
+++ b/app/services/personas/trust_with_schools.rb
@@ -10,7 +10,7 @@ private
 
   def school_one
     @school_one ||= trust.schools.find_or_create_by!(name: 'George School') do |s|
-      s.urn = (School.maximum(:urn) || 0) + 1
+      s.urn = (School.maximum(:urn) || 99_999) + 1
       s.address_1 = '27 Northumberland Street'
       s.town = 'Newcastle'
       s.county = 'Tyne and Wear'

--- a/app/services/personas/trust_with_schools.rb
+++ b/app/services/personas/trust_with_schools.rb
@@ -10,7 +10,7 @@ private
 
   def school_one
     @school_one ||= trust.schools.find_or_create_by!(name: 'George School') do |s|
-      s.urn = School.maximum(:urn) + 1
+      s.urn = (School.maximum(:urn) || 0) + 1
       s.address_1 = '27 Northumberland Street'
       s.town = 'Newcastle'
       s.county = 'Tyne and Wear'

--- a/lib/tasks/personas.rake
+++ b/lib/tasks/personas.rake
@@ -1,0 +1,7 @@
+namespace :db do
+  desc 'Add tests personas to database'
+  task personas: :environment do
+    Personas::SupportUser.new.call
+    Personas::TrustWithSchools.new.call
+  end
+end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -45,6 +45,14 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     click_on 'Continue'
     expect(page).to have_content 'Check your email'
     expect(page).not_to have_content('Sign out')
+    expect(page).not_to have_content('/token/validate?identifier=')
+  end
+
+  scenario 'when feature display_sign_in_token_links is active', with_feature_flags: { display_sign_in_token_links: 'active' } do
+    visit sign_in_path
+    fill_in('Email address', with: user.email_address)
+    click_on 'Continue'
+    expect(page).to have_content('/token/validate?identifier=')
   end
 
   context 'as a user who belongs to a responsible body' do


### PR DESCRIPTION
### Context

-  https://trello.com/c/cNeHTPti/1597-add-personas-to-heroku-environments-for-user-testing

### Changes proposed in this pull request

- Modify heroku setup to start sidekiq worker. Since I added the flash messaging afterwards this change isn't actually needed but I decided to leave it as it maybe useful in the future.
- Heroku nows loads test personas into the database
- Users can then login as these personas in the heroku review apps
- Sign in links are then presented back as flash messages

### Guidance to review

- View the review app of this PR https://dfe-ghwt-pr-1313.herokuapp.com/
- Sign in as the different 3 personas `support.user.1@example.com`, `school.user.1@example.com`, `trust.user.1@example.com`