### PR TITLE
fix edge case in occasional spec fail

### DIFF
--- a/spec/services/donated_device_requests_exporter_spec.rb
+++ b/spec/services/donated_device_requests_exporter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DonatedDeviceRequestsExporter, type: :model do
     it 'includes the request information in the CSV file' do
       CSV.read(filename, headers: true).each do |request|
         record = DonatedDeviceRequest.find(request['id'])
-        expect(record.school.created_at.to_s).to eq(request['created_at'])
+        expect(record.school.created_at).to be_within(1.second).of(request['created_at'].to_datetime)
         expect(record.school.urn.to_s).to eq(request['urn'])
         expect(record.school.computacenter_reference).to eq(request['shipTo'])
         expect(record.school.responsible_body.computacenter_reference).to eq(request['soldTo'])

--- a/spec/services/donated_device_requests_exporter_spec.rb
+++ b/spec/services/donated_device_requests_exporter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DonatedDeviceRequestsExporter, type: :model do
       CSV.read(filename, headers: true).each do |request|
         record = DonatedDeviceRequest.find(request['id'])
         school = School.find(record.schools.first)
-        expect(record.created_at.to_s).to be_within(1.second).of(request['created_at'].to_datetime)
+        expect(record.created_at.utc).to be_within(1.second).of(Time.zone.parse(request['created_at']).utc)
         expect(school.urn.to_s).to eq(request['urn'])
         expect(school.computacenter_reference).to eq(request['shipTo'])
         expect(school.responsible_body.computacenter_reference).to eq(request['soldTo'])


### PR DESCRIPTION
### Context

I saw an intermittent spec failure due to what looks like a time rounding issue:

```
1) DonatedDeviceRequestsExporter when given a filename includes the request information in the CSV file
     Failure/Error: expect(record.school.created_at.to_s).to eq(request['created_at'])
       expected: "2021-02-19 16:08:52 +0000"
            got: "2021-02-19 16:08:51 +0000"
```

Although the error goes away on re-run, it shouldn't be happening in the first place

### Changes proposed in this pull request

* change the comparison to use `be_within(1.second).of(...)` to allow for the very occasional rounding edge case

### Guidance to review

