### PR TITLE
Privacy link should go to previous page (Address)

### DIFF
--- a/app/views/responsible_body/donated_devices/interest/disclaimer.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/disclaimer.html.erb
@@ -11,7 +11,8 @@
       <%= title %>
     </h1>
 
-    <%= render partial: 'shared/donated_devices_disclaimer', locals: { i18n_scope: scope } %>
+    <%= render partial: 'shared/donated_devices_disclaimer', locals: { i18n_scope: scope,
+      privacy_notice_link: responsible_body_donated_devices_address_path } %>
 
     <p class="govuk-body">
       <%= govuk_button_link_to 'Continue', responsible_body_donated_devices_check_answers_path %>

--- a/app/views/school/donated_devices/interest/disclaimer.html.erb
+++ b/app/views/school/donated_devices/interest/disclaimer.html.erb
@@ -11,7 +11,9 @@
       <%= title %>
     </h1>
 
-    <%= render partial: 'shared/donated_devices_disclaimer', locals: { i18n_scope: scope } %>
+    <%= render partial: 'shared/donated_devices_disclaimer',
+      locals: { i18n_scope: scope,
+                privacy_notice_link: address_donated_devices_school_path(@school) } %>
 
     <p class="govuk-body">
       <%= govuk_button_link_to 'Continue', check_answers_donated_devices_school_path(@school) %>

--- a/app/views/shared/_donated_devices_disclaimer.html.erb
+++ b/app/views/shared/_donated_devices_disclaimer.html.erb
@@ -6,7 +6,7 @@ Computers For Kids is an initiative run by the Mail Force charity. It’s separa
 If you have any queries relating to the Computers For Kids initiative, you should direct these to Mail Force or its third party supplier.
 </p>
 <p class="govuk-body">
-For details of how we share your information when you opt in for Computers For Kids, see our <%= govuk_link_to 'privacy notice', privacy_computers_for_kids_privacy_notice_path, target: '_blank' %>.
+For details of how we share your information when you opt in for Computers For Kids, see our <%= govuk_link_to 'privacy notice', privacy_notice_link, target: '_blank' %>.
 </p>
 <p class="govuk-body">
 School, colleges, trusts and responsible bodies must make sure that devices and/or related software are suitable for children and young people.  The DfE does not provide any guarantee or warranty for the reliability, suitability or completeness of the devices, and/or related software, or third party service. This includes the Computers For Kids initiative itself.


### PR DESCRIPTION
### Context
Link to privacy notice on disclaimer page should go to previous page ("address" page) which has the data sharing information,  not the "Computers for Kids" privacy policy

### Changes proposed in this pull request
Change link to go to correct page.

### Guidance to review
In the donated devices journey for both school and RB users, the "privacy notice" link on the "Disclaimer" page should take you to the previous page.
