### PR TITLE
[1588] remove forcing of Windows-1252 character encoding in imported CSV files

### DIFF
--- a/app/models/csv_data_file.rb
+++ b/app/models/csv_data_file.rb
@@ -37,7 +37,7 @@ private
 
   def read_file
     csv = download_to_temp_file_if_needed(@csv_uri)
-    CSV.foreach(csv, headers: true, encoding: 'CP1252') do |row|
+    CSV.foreach(csv, headers: true) do |row|
       next if skip?(row)
 
       yield row

--- a/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
@@ -29,6 +29,20 @@ describe Mno::ExtraMobileDataRequestsCsvUpdateController, type: :controller do
       post :create, params: { mno_csv_status_update_form: { upload: upload } }
       expect(response).to render_template(:summary)
     end
+
+    it 'accepts a valid CSV file in UTF8 character encoding' do
+      upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/extra-mobile-data-request-utf8.csv'), 'text/csv')
+
+      post :create, params: { mno_csv_status_update_form: { upload: upload } }
+      expect(response).to render_template(:summary)
+    end
+
+    it 'accepts a valid CSV file in Windows-1252 character encoding' do
+      upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/extra-mobile-data-request-utf8.csv'), 'application/vnd.ms-excel')
+
+      post :create, params: { mno_csv_status_update_form: { upload: upload } }
+      expect(response).to render_template(:summary)
+    end
   end
 
   def requests_to_attrs

--- a/spec/fixtures/files/extra-mobile-data-request-utf8.csv
+++ b/spec/fixtures/files/extra-mobile-data-request-utf8.csv
@@ -1,0 +1,2 @@
+ID,Account holder name,Device phone number,Requested,Last updated,Mobile network ID,Status,Contract type
+1,Paul Katkēvičš,07123001003,2021-01-13 09:53:23 +0000,2021-02-03 10:50:27 +0000,59,complete,pay_as_you_go_payg

--- a/spec/fixtures/files/extra-mobile-data-request-windows-1252.csv
+++ b/spec/fixtures/files/extra-mobile-data-request-windows-1252.csv
@@ -1,0 +1,2 @@
+ID,Account holder name,Device phone number,Requested,Last updated,Mobile network ID,Status,Contract type
+1,Paul Parker,07123001000,2021-01-13 09:53:23 +0000,2021-02-03 10:50:27 +0000,59,complete,pay_as_you_go_payg


### PR DESCRIPTION
### Context

Three reported issues uploading CSV files of ExtraMobileDataRequest status updates. After quite a lot of investigation (see [Trello card 1588 - Three having issues uploading CSV](https://trello.com/c/2qAlEv4C/1588-three-having-issues-uploading-csv) ) it looks like a character encoding problem.

Full details are in the Trello card, but the TL;DR version - the CsvDataFile class assumes all CSV files are in windows-1252 character encoding. This normally just works and transcodes automatically, but Three's existing requests contain a particular record with a name containing several accented characters. These characters are correctly encoded on our database and in the generated CSV file in UTF-8, but have no valid representation in windows-1252. 

So if you try to download Three's data file and re-upload it _without making any changes_ it throws an error: `<Encoding::UndefinedConversionError: "\x81" to UTF-8 in conversion from Windows-1252 to UTF-8>`

_NOTE: In discussion with @tonyheadford he thinks the assumption of Windows-1252 was put in to handle import from GIAS downloads, they seem to work locally with that assumption removed, but it's difficult to say conclusively without re-importing into a blank database and looking at all the Trust names._ 

### Changes proposed in this pull request

Remove the assumption of Windows-1252 encoding 
Add a test that files in both encodings can be uploaded correctly

### Guidance to review

I've verified that if I delete the particular Trust that was causing issues on import (companies_house_number: 07606026), the name gets re-imported correctly ("FIERTÉ MULTI-ACADEMY TRUST") when you do `'rake import:trusts`, but you might want to do the same for yourself