### PR TITLE
Guidance for people who don't have access to or cant use our service

### DIFF
--- a/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
+++ b/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, t('page_titles.how_to_access_the_get_help_with_technology_service') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+                  t('page_titles.how_to_access_the_get_help_with_technology_service'),
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.how_to_access_the_get_help_with_technology_service') %>
+    </h1>
+    <p class="govuk-body">
+      You need to be invited to use this service by DfE, or someone from your <span class="app-no-wrap">state-funded</span> school, college, FE institution, trust or local authority education team who has access.
+    </p>
+    <p class="govuk-body">
+      People with access to the service can invite colleagues to use it by <span class="app-no-wrap"><%= govuk_link_to 'signing in', sign_in_path %></span> and selecting ‘Manage users’.
+    </p>
+    <p class="govuk-body">
+      If you’re not sure which colleagues can give you access, <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk?subject=Access to get help with tehcnology">contact us</a>.
+    </p>
+    <p class="govuk-body">
+      You cannot access this service with your DfE Sign-in account.
+    </p>
+  </div>
+</div>
+

--- a/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
+++ b/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
@@ -1,0 +1,129 @@
+<% content_for :title, t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+                  t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe'),
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe') %>
+    </h1>
+
+    <p class="govuk-body">
+      The Get help with technology programme provides support for disadvantaged pupils and students in years 3 to 13, or 16 to 19 education, in England. It can only be accessed by:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>state-funded schools</li>
+      <li>colleges and other further education institutions</li>
+      <li>academy trusts</li>
+      <li>local authority education teams</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Get help for:</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to 'parents, carers, pupils and students', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'parents-carers-pupils-students') %>
+      </li>
+      <li>
+        <%= govuk_link_to 'social care workers', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'social-care-workers') %>
+      </li>
+      <li>
+        <%= govuk_link_to 'nurseries and infant schools', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'nurseries-and-infant-schools') %>
+      </li>
+      <li>
+        <%= govuk_link_to 'independent schools', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'independent-schools') %>
+      </li>
+      <li>
+        <%= govuk_link_to 'schools, colleges and further education institutions in Northern Ireland, Scotland and Wales', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'schools-colleges-and-further-education-institutions-in-northern-ireland-scotland-and-wales') %>
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+    <h2 class="govuk-heading-l" id="parents-carers-pupils-students">
+      Parents, carers, pupils and students
+    </h2>
+    <p class="govuk-body">
+      You cannot apply for laptops, tablets or internet access through this scheme yourself.
+    </p>
+    <p class="govuk-body">
+      Contact your school, college or further education institution to discuss your options for accessing remote education.
+    </p>
+    <p class="govuk-body">
+      The <%= govuk_link_to 'Family Fund', 'https://www.familyfund.org.uk/' %> may be able to provide grants for devices and other support to children or young people who are disabled or seriously ill.
+    </p>
+    <p class="govuk-body">
+      If you’ve been given a DfE laptop, tablet or 4G wireless router and need some help with it, these guides may be useful:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to 'Getting started with your Microsoft Windows device ', devices_guidance_subpage_path('getting-started-with-your-microsoft-windows-device') %>
+      </li>
+      <li>
+        <%= govuk_link_to 'Getting started with your Google Chromebook', devices_guidance_subpage_path('getting-started-with-your-google-chromebook')  %>
+      </li>
+      <li>
+        <%= govuk_link_to 'How to get started with your 4G wireless router', devices_guidance_subpage_path('4g-user-guidance')  %>
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      If you need more help, contact the person who gave you your device.
+    </p>
+
+    <h2 class="govuk-heading-l" id="social-care-workers">
+      Social care workers
+    </h2>
+    <p class="govuk-body">
+      You cannot request laptops, tablets or internet access for children and young people in social care.
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Find out which disadvantaged pupils and students are eligible for devices', 'https://get-help-with-tech.education.gov.uk/devices/about-the-offer#ordering-devices-for-schools-colleges-academy-trusts-and-local-authorities-from-september-2020' %> from their school, college or FE institution. 
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Read about devices provided for social care in the 2020 summer term', 'https://www.gov.uk/guidance/laptops-tablets-and-4g-wireless-routers-provided-during-coronavirus-covid-19' %>.
+    </p>
+    <p class="govuk-body">
+      If you need help with a device you received from DfE, <%= govuk_link_to 'find out how to get technical support', 'https://get-help-with-tech.education.gov.uk/devices/support-and-maintenance' %>.
+    </p>
+
+    <h2 class="govuk-heading-l" id="nurseries-and-infant-schools">
+      Nurseries and infant schools
+    </h2>
+    <p class="govuk-body">
+      Schools and nurseries can request a device or internet access for a disadvantaged child in any year group (including reception) if:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>they’ve been <%= govuk_link_to 'advised to shield', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19' %> because they (or someone they live with) are <%= govuk_link_to 'clinically extremely vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#cev' %></li>
+      <li>they’re attending a hospital school</li>
+    </ul>
+    <p class="govuk-body">
+      <%= govuk_link_to "Contact us to make a request", support_ticket_path %>. Do not submit any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask you to resend it.
+    </p>
+
+    <h2 class="govuk-heading-l" id="independent-schools">
+      Independent schools
+    </h2>
+    <p class="govuk-body">
+      Independent schools (including independent special schools) are currently not able to access the Get help with technology programme.
+    </p>
+    <p class="govuk-body">
+      Parents or carers of pupils attending independent schools may be able to apply to the <%= govuk_link_to 'Family Fund', 'https://www.familyfund.org.uk/' %>, which provides some grants for devices and other support for children or young people who are disabled or seriously ill.
+    </p>
+    <h2 class="govuk-heading-l" id="schools-colleges-and-further-education-institutions-in-northern-ireland-scotland-and-wales">
+      Schools, colleges and further education institutions in <span class="app-no-wrap">Northern Ireland</span>, Scotland and Wales
+    </h2>
+    <p class="govuk-body">
+      The Get help with technology programme is only available in England. Contact your devolved administration to find out about similar support programmes. These may include: 
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= govuk_link_to 'Northern Ireland – Education Restart', 'https://www.education-ni.gov.uk/landing-pages/education-restart' %></li>
+      <li><%= govuk_link_to 'Scotland – Support for continuity in learning', 'https://www.gov.scot/publications/coronavirus-covid-19-support-for-continuity-in-learning/pages/related-guidance/' %>
+      <li><%= govuk_link_to 'Wales – Guidance for supporting vulnerable and disadvantaged learners', 'https://gov.wales/guidance-supporting-vulnerable-and-disadvantaged-learners' %></li>
+    </ul>
+
+  </div>
+</div>
+

--- a/app/views/sign_in_tokens/email_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/email_not_recognised.html.erb
@@ -6,19 +6,20 @@
       <%= t('page_titles.email_not_recognised') %>
     </h1>
     <p class="govuk-body">
-      We did not recognise the email address you entered.
-      You may have mistyped it, or you may not have access.
+      If you mistyped your email address, <%= govuk_link_to 'try to sign in again', sign_in_path %>.
     </p>
-    <p class="govuk-body">
-      <%= govuk_button_link_to 'Try again', sign_in_path %>
-    </p>
-    <p class="govuk-body">
-      If you think your email address is correct and you should have access,
-      you can <%= govuk_link_to "contact our support team", support_ticket_path %>.
+
+    <h2 class="govuk-heading-m">
+      How to access this service to order laptops, tablets and internet connectivity
+    </h2>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      This service is for schools, colleges, <span class="app-no-wrap">FE institutions</span>, trusts and local authority education teams only. If you work for one of these institutions, <%= govuk_link_to 'find out how to get access', how_to_access_the_get_help_with_technology_service_path %>.
     </p>
     <h2 class="govuk-heading-m">
-      Parents, carers, pupils and students
+      Help for parents, pupils, social care workers, independent schools, and schools outside of England
     </h2>
-    <p class="govuk-body">Parents, carers, pupils and students do not have access to this service. You should contact your school, college or further education institution for help accessing remote education.</p>
+    <p class="govuk-body">
+      You cannot use this service to request support. <%= govuk_link_to 'Find out what to do if you cannot get laptops, tablets or internet access from DfE.', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path %>
+    </p>
   </div>
 </div>

--- a/app/views/sign_in_tokens/sign_in_only.html.erb
+++ b/app/views/sign_in_tokens/sign_in_only.html.erb
@@ -9,12 +9,12 @@
         <%= t('page_titles.sign_in') %>
       </h1>
 
-      <%= render partial: 'shared/banners/parents_carers_pupils' %>
+      <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter your email address, and if you have an account, we’ll send you a link to sign in.' } %>
 
-      <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter your email address, and we’ll send you a link to sign in.' } %>
-
-      <%= render GovukComponent::Details.new(summary: 'Change email address') do %>
-        <p>Contact <%= ghwt_contact_mailto(subject: 'Request access for another email address') %> to request access for a different email address.</p>
+      <%= render GovukComponent::Details.new(summary: 'Change email address for your account') do %>
+        <p>
+          A colleague with access to the service can update your email address for you. If a colleague cannot do this, you can <%= ghwt_contact_mailto(label: "contact us", subject: "Change my email address") %> to change it instead.
+        </p>
       <%- end %>
 
       <%= f.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,9 +61,8 @@ en:
     privacy: Privacy
     dfe_windows_privacy_notice: How we look after personal information using the mobile device management on Microsoft Windows laptops and tablets
     general_privacy_notice: How we look after personal information as part of the Get help with technology programme
-    gias_updates: GIAS updates
-    gias_schools_to_add: Schools to be added
-    gias_schools_to_close: Schools to be closed
+    what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe: What to do if you cannot get laptops, tablets or internet access from DfE
+    how_to_access_the_get_help_with_technology_service: How to access the Get help with technology service
 
     support:
       home: Support
@@ -101,6 +100,9 @@ en:
     support_edit_chromebook_details: Will the school need to order Chromebooks?
     support_bulk_allocation: Allow schools, colleges and FE institutions to order their full allocation
     support_bulk_allocation_result: Bulk allocation summary
+    gias_updates: GIAS updates
+    gias_schools_to_add: Schools to be added
+    gias_schools_to_close: Schools to be closed
     upload_key_contacts_file: Upload a CSV file of key contacts
     weve_processed_your_file: We’ve processed your file
     computacenter:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
   get '/request-a-change', to: 'pages#request_a_change'
   get '/how-to-request-4g-wireless-routers', to: 'pages#how_request_4g_routers'
   get '/choosing-help-with-internet-access', to: 'pages#choosing_help_with_internet_access'
+  get '/what-to-do-if-you-cannot-get-laptops-tablets-or-internet-access-from-dfe', to: 'pages#what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe'
+  get '/how-to-access-the-get-help-with-technology-service', to: 'pages#how_to_access_the_get_help_with_technology_service'
 
   # redirects for moved guidance pages
   get '/pages/guidance', to: redirect('/')


### PR DESCRIPTION
### Context

[Trelllo card](https://trello.com/c/YGRbFY6Q/1405-support-users-who-cannot-sign-in-to-the-service)

The support team have data on high volumes of request coming from users who can't access the service.

### Changes proposed in this pull request

Improve content to give clarity to the existing sign-in flow.
Adds a page to give guidance for users who could have an account but don't
Adds a page for users who can't access the service.

### Guidance to review

Sign in using an email address that the service doesn't recognise.

![localhost_3000_sign-in (2)](https://user-images.githubusercontent.com/8417288/108865825-87bce500-75eb-11eb-82a2-83c96f198588.png)

![localhost_3000_token_email-not-recognised (3)](https://user-images.githubusercontent.com/8417288/108868750-6f01fe80-75ee-11eb-810e-c13f89351a89.png)

![localhost_3000_how-to-access-the-get-help-with-technology-service (3)](https://user-images.githubusercontent.com/8417288/108865811-84c1f480-75eb-11eb-87a6-6bd7134c32ac.png)

![localhost_3000_what-to-do-if-you-cannot-get-laptops-tablets-or-internet-access-from-dfe (3)](https://user-images.githubusercontent.com/8417288/108865784-7c69b980-75eb-11eb-9434-56d0284881db.png)
