### PR TITLE
[1473] Add anonymised mno requests csv download

### DIFF
--- a/app/controllers/support/service_performance_controller.rb
+++ b/app/controllers/support/service_performance_controller.rb
@@ -5,4 +5,14 @@ class Support::ServicePerformanceController < Support::BaseController
     skip_policy_scope
     @stats = Support::ServicePerformance.new
   end
+
+  def mno_requests
+    skip_policy_scope
+
+    exporter = Exporters::MnoRequestsCsv.new
+    exporter.call
+    now = Time.zone.now
+
+    send_file exporter.path, filename: "mno-requests-#{now.strftime('%Y')}-#{now.strftime('%m')}-#{now.strftime('%d')}.csv", type: 'text/csv'
+  end
 end

--- a/app/policies/support/service_performance_policy.rb
+++ b/app/policies/support/service_performance_policy.rb
@@ -2,4 +2,8 @@ class Support::ServicePerformancePolicy < ApplicationPolicy
   def index?
     user.is_support?
   end
+
+  def mno_requests?
+    user.is_support?
+  end
 end

--- a/app/services/exporters/mno_requests_csv.rb
+++ b/app/services/exporters/mno_requests_csv.rb
@@ -1,0 +1,60 @@
+require 'csv'
+
+class Exporters::MnoRequestsCsv
+  HEADERS = %w[
+    id
+    mobile_network_id
+    brand
+    urn
+    ukprn
+    school_name
+    responsible_body_id
+    responsible_body_name
+    status
+    contract_type
+    created_at
+    created_at_date
+    updated_at
+    updated_at_date
+  ].freeze
+
+  def call
+    CSV.open(path, 'w') do |csv|
+      csv << HEADERS
+      requests.find_each do |request|
+        csv << [
+          request.id,
+          request.mobile_network_id,
+          request.mobile_network.brand,
+          request.school&.urn,
+          request.school&.ukprn,
+          request.school&.name,
+          request.responsible_body_id,
+          request.responsible_body&.name,
+          request.status,
+          request.contract_type,
+          request.created_at,
+          request.created_at.strftime('%d/%m/%Y'),
+          request.updated_at,
+          request.updated_at.strftime('%d/%m/%Y'),
+        ]
+      end
+    end
+  end
+
+  delegate :path, to: :file
+
+  def delete_generated_csv!
+    File.unlink(path)
+  end
+
+private
+
+  def file
+    @file ||= Tempfile.new
+  end
+
+  def requests
+    @requests ||= ExtraMobileDataRequest.includes(:mobile_network, :school, :responsible_body)
+  end
+end

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -121,3 +121,7 @@
     </table>
   </div>
 </div>
+
+<h2 class="govuk-heading-l">Anonymised mobile data requests</h2>
+
+<%= link_to 'Download CSV', support_performance_mno_requests_path(format: :csv), class: 'govuk-button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
     get '/technical', to: 'home#technical_support', as: :technical_support
     get '/feature-flags', to: 'home#feature_flags', as: :feature_flags
     get '/performance', to: 'service_performance#index', as: :service_performance
+    get '/performance/mno-requests', to: 'service_performance#mno_requests', format: :csv
     namespace :gias do
       get '/updates', to: 'home#index', as: :home
       resources :schools_to_add, only: %i[index show update], param: :urn, path: '/schools-to-add'

--- a/spec/controllers/support/service_performance_controller_spec.rb
+++ b/spec/controllers/support/service_performance_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Support::ServicePerformanceController, type: :controller do
-  describe 'index' do
+  describe '#index' do
     it 'displays the service performance when authenticated as a DfE user' do
       sign_in_as create(:dfe_user)
 
@@ -22,6 +22,18 @@ RSpec.describe Support::ServicePerformanceController, type: :controller do
       get :index
 
       expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  describe '#mno_requests' do
+    it 'returns a csv' do
+      sign_in_as create(:dfe_user)
+
+      get :mno_requests, format: :csv
+
+      expect(response.headers['Content-Type']).to eql('text/csv')
+      rows = CSV.parse(response.body, headers: true)
+      expect(rows.headers).to eql(Exporters::MnoRequestsCsv::HEADERS)
     end
   end
 end

--- a/spec/services/exporters/mno_requests_csv_spec.rb
+++ b/spec/services/exporters/mno_requests_csv_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Exporters::MnoRequestsCsv do
+  let!(:first_school) { create(:school) }
+  let!(:first_request) { create(:extra_mobile_data_request, school: first_school) }
+
+  let!(:second_rb) { create(:trust) }
+  let!(:second_request) { create(:extra_mobile_data_request, responsible_body: second_rb) }
+
+  subject(:exporter) { described_class.new }
+
+  describe '#call' do
+    it 'exports correct headers' do
+      exporter.call
+
+      rows = CSV.read(exporter.path, headers: true)
+
+      expect(rows.headers).to eql(described_class::HEADERS)
+    end
+
+    it 'exports correct number of rows' do
+      exporter.call
+
+      rows = CSV.read(exporter.path, headers: true)
+
+      expect(rows.size).to be(2)
+    end
+
+    it 'exports correct data' do
+      exporter.call
+
+      rows = CSV.read(exporter.path, headers: true)
+
+      expect(rows[0]['id']).to eql(first_request.id.to_s)
+      expect(rows[0]['mobile_network_id']).to eql(first_request.mobile_network_id.to_s)
+      expect(rows[0]['brand']).to eql(first_request.mobile_network.brand)
+      expect(rows[0]['urn']).to eql(first_request.school.urn.to_s)
+      expect(rows[0]['ukprn']).to eql(first_request.school.ukprn)
+      expect(rows[0]['school_name']).to eql(first_request.school.name)
+      expect(rows[0]['responsible_body_id']).to eql(first_request.responsible_body_id.to_s)
+      expect(rows[0]['responsible_body_name']).to eql(first_request.responsible_body.name)
+      expect(rows[0]['status']).to eql(first_request.status)
+      expect(rows[0]['contract_type']).to eql(first_request.contract_type)
+      expect(rows[0]['created_at']).to eql(first_request.created_at.to_s)
+      expect(rows[0]['created_at_date']).to eql(first_request.created_at.strftime('%d/%m/%Y'))
+      expect(rows[0]['updated_at']).to eql(first_request.updated_at.to_s)
+      expect(rows[0]['updated_at_date']).to eql(first_request.updated_at.strftime('%d/%m/%Y'))
+
+      expect(rows[1]['id']).to eql(second_request.id.to_s)
+      expect(rows[1]['mobile_network_id']).to eql(second_request.mobile_network_id.to_s)
+      expect(rows[1]['brand']).to eql(second_request.mobile_network.brand)
+      expect(rows[1]['urn']).to be_nil
+      expect(rows[1]['ukprn']).to be_nil
+      expect(rows[1]['school_name']).to be_nil
+      expect(rows[1]['responsible_body_id']).to eql(second_request.responsible_body_id.to_s)
+      expect(rows[1]['responsible_body_name']).to eql(second_request.responsible_body.name)
+      expect(rows[1]['status']).to eql(second_request.status)
+      expect(rows[1]['contract_type']).to eql(second_request.contract_type)
+      expect(rows[1]['created_at']).to eql(second_request.created_at.to_s)
+      expect(rows[1]['created_at_date']).to eql(second_request.created_at.strftime('%d/%m/%Y'))
+      expect(rows[1]['updated_at']).to eql(second_request.updated_at.to_s)
+      expect(rows[1]['updated_at_date']).to eql(second_request.updated_at.strftime('%d/%m/%Y'))
+    end
+  end
+
+  describe '#path' do
+    it 'returns path to csv' do
+      expect(exporter.path).to be_present
+      expect(File.exist?(exporter.path)).to be_truthy
+    end
+  end
+
+  describe '#delete_generated_csv!' do
+    it 'deletes the generated csv file from disk' do
+      exporter.call
+      expect(File.exist?(exporter.path)).to be_truthy
+      exporter.delete_generated_csv!
+      expect(File.exist?(exporter.path)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/RyV99paX/1473-improve-mno-reporting-add-download-anonymised-request-data

### Changes proposed in this pull request

- Add button in service performance dashboard - see screenshot
- This downloads a CSV of all mno requests minus any personally identifiable info

### Screenshots

![image](https://user-images.githubusercontent.com/92580/108867536-36adf080-75ed-11eb-8c18-b3321055c3bf.png)

### Guidance to review

- Sign in as support user
- Navigate to service performance dashboard and view connectivity tab
- Download csv
- CSV should show all mno requests
- CSV should not have any personally identifiable info