### PR TITLE
[1478] fix edge case allowing duplicating ExtraMobileDataRequests

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -2,7 +2,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   has_paper_trail
 
   after_initialize :set_defaults
-  before_save :normalise_device_phone_number
+  before_validation :normalise_device_phone_number
 
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network, optional: true # set to optional as we already validate on the presence of mobile_network_id and we don't want duplicate validation errors

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
       end
 
       it 'is invalid' do
-        expect(model.valid?).to eql(false)
+        expect(model.valid?).to be_falsey
       end
 
       it 'detects the existing record with the normalised phone number' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -128,6 +128,27 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
         expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
       end
     end
+
+    context 'when the device_phone_number is not normalised' do
+      let(:existing_request) do
+        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456789', school: school)
+      end
+
+      subject(:model) { build(:extra_mobile_data_request, school: existing_request.school, mobile_network_id: existing_request.mobile_network_id, account_holder_name: existing_request.account_holder_name, responsible_body: nil, device_phone_number: '07123 456 789') }
+
+      before do
+        model.mobile_network_id = existing_request.mobile_network_id
+      end
+
+      it 'is invalid' do
+        expect(model.valid?).to eql(false)
+      end
+
+      it 'detects the existing record with the normalised phone number' do
+        model.valid?
+        expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
+      end
+    end
   end
 
   describe 'validating device_phone_number' do


### PR DESCRIPTION
### Context

[Trello card 1478](https://trello.com/c/k6UsEZa6/1478-mno-prevent-duplicate-requests-part-2) - Despite there being code to look for the existence of `ExtraMobileDataRequests` for the same name & number (within the scope of school, RB, mobile network etc) we're still seeing a lot of duplicates making it through to the MNOs. This is causing them wasted time & frustration.

On a closer look, the code that normalises the phone number was running `before_save`, which is called _after_ validation. So if a user submits a phone number with spaces in, the first will be normalised on save, then the second will still pass validation as it's only looking for the exact phone number as entered, not the normalised version.
 
### Changes proposed in this pull request

Change the normalising hook to `before_validation`
Add a spec for this behaviour

### Guidance to review

