### PR TITLE
remove debug output

### DIFF
--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -49,8 +49,6 @@
         <li>search for requests for extra mobile data</li>
         <li>view overall numbers of requests for extra mobile data</li>
       </ul>
-    <%- else %>
-      <h2>FAIL</h2>
     <% end %>
 
     <% if policy(Support::ServicePerformance).index? %>

--- a/spec/features/support/finding_extra_mobile_data_requests_spec.rb
+++ b/spec/features/support/finding_extra_mobile_data_requests_spec.rb
@@ -83,4 +83,20 @@ RSpec.describe 'Finding ExtraMobileDataRequests in support' do
       end
     end
   end
+
+  context 'as a computacenter_user' do
+    before do
+      sign_in_as computacenter_user
+    end
+
+    context 'when I visit support home' do
+      before do
+        visit support_home_path
+      end
+
+      it 'does not show me a link for Extra mobile data requests' do
+        expect(page).not_to have_link 'Find requests for extra mobile data'
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

When a user has permission to access support, but not to see `ExtraMobileDataRequests`, the support home page is showing a debug output statement.

### Changes proposed in this pull request

Remove the output statement
Add a case to the feature spec to test the permissions

### Guidance to review

