### PR TITLE
[1613] email audits destroyed along with user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
   has_many :school_welcome_wizards, dependent: :destroy
-  has_many :email_audits
+  has_many :email_audits, dependent: :destroy
 
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_many(:email_audits).dependent(:destroy) }
+  end
+
   describe '#is_mno_user?' do
     it 'is true when the user is from an MNO participating in the pilot' do
       user = build(:user, mobile_network: build(:mobile_network))


### PR DESCRIPTION
### Context

- https://trello.com/c/SSUuQz97/1613-deleted-users-causing-referential-integrity-issues-in-email-audits

### Changes proposed in this pull request

- When a user is destroyed, also destroy their `email_audits`
- Otherwise null pointers will cause certain pages to not load

### Guidance to review

- Find or create a user with an email audit
- Destroy the user
- Their email audits should also be removed from the database