### PR TITLE
Spike - adding LA funding places school

### DIFF
--- a/app/concerns/school_type.rb
+++ b/app/concerns/school_type.rb
@@ -17,6 +17,7 @@ module SchoolType
       local_authority: 'local_authority',
       special: 'special',
       other_type: 'other_type',
+      la_funded_places: 'la_funded_places',
     }, _suffix: true
 
     def human_for_school_type

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -1,0 +1,5 @@
+class LaFundedPlace < CompulsorySchool
+  def institution_type
+    'funded_places'
+  end
+end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -15,4 +15,30 @@ class LocalAuthority < ResponsibleBody
   }
 
   validates :organisation_type, presence: true
+
+  def la_funded_places
+    schools.la_funded_places_establishment_type.first
+  end
+
+  def create_la_funded_places!(urn:, device_allocation: 0, router_allocation: 0, extra_args: {})
+    return unless la_funded_places.nil?
+    attrs = {
+      responsible_body: self,
+      urn: urn,
+      name: 'LA Funded Places',
+      establishment_type: 'la_funded_places',
+      address_1: address_1,
+      address_2: address_2,
+      address_3: address_3,
+      town: town,
+      county: county,
+      postcode: postcode,
+    }.reverse_merge(extra_args)
+
+    funded_places = LaFundedPlace.create!(attrs)
+    funded_places.create_preorder_information!(who_will_order_devices: 'responsible_body', will_need_chromebooks: 'no')
+    funded_places.device_allocations.std_device.create!(allocation: device_allocation)
+    funded_places.device_allocations.coms_device.create!(allocation: router_allocation)
+    funded_places
+  end
 end

--- a/app/policies/la_funded_place_policy.rb
+++ b/app/policies/la_funded_place_policy.rb
@@ -1,0 +1,2 @@
+class LaFundedPlacePolicy < SchoolPolicy
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/phfNsAcy/1607-spike-to-set-up-placeholder-school-named-la-funded-places)

__SPIKE__ to add a school to represent LA funding places - an allocation that can be used by LAs for children they support in institutions such as independent schools that are not included in the service.

### Changes proposed in this pull request
Add a school type `LaFundedPlace` based on `CompulsorySchool`, and an `establishment_type` of `la_funded_places`
Adds policy based on `CompulsorySchool`
Adds `create_la_funded_places!` method to a `LocalAuthority` to create and populate a funding places school for that RB.

### Notes / Questions
* We need to determine what we use for a URN - e.g. start at 999000?
* Would the URN scheme need agreeing with CC?
* None of the LAs in the service have any of the address fields populated
* Some content changes may be required:
  * LA Funding Places school appears in school lists for the RB along with all the other schools - that presumably would need to be communicated to the LAs
  * Should we remove the ability to change who orders devices, or whether they want Chromebooks?
 
![image](https://user-images.githubusercontent.com/333931/109024757-fb2b2900-76b5-11eb-9766-4043baab21c8.png)
![image](https://user-images.githubusercontent.com/333931/109024860-139b4380-76b6-11eb-8c3c-7cb239d8747e.png)

