### PR TITLE
[1449] Opening schools adds related schools

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -195,6 +195,14 @@ module ViewHelper
     MobileNetwork.where(participation_in_pilot: 'participating').order(:brand)
   end
 
+  def link_to_urn_otherwise_urn(urn)
+    if School.exists?(urn: urn)
+      link_to urn, support_school_path(urn)
+    else
+      urn
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -15,6 +15,7 @@ class School < ApplicationRecord
   has_one :preorder_information, touch: true
   has_many :email_audits
   has_many :extra_mobile_data_requests
+  has_many :school_links, dependent: :destroy
   has_many :devices_ordered_updates, class_name: 'Computacenter::DevicesOrderedUpdate',
                                      primary_key: :computacenter_reference,
                                      foreign_key: :ship_to

--- a/app/models/school_link.rb
+++ b/app/models/school_link.rb
@@ -1,0 +1,3 @@
+class SchoolLink < ApplicationRecord
+  belongs_to :school
+end

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -15,106 +15,141 @@
       <%= @responsible_body.name %>
     </h1>
 
-    <%- if @responsible_body.extra_mobile_data_requests.present? %>
-      <h2 class="govuk-heading-l govuk-!-margin-top-9">Mobile data requests</h2>
-      <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @responsible_body.extra_mobile_data_requests) %>
-    <%- end %>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <h2 class="govuk-tabs__title">
+        Contents
+      </h2>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-9">Users</h2>
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#schools-colleges">
+            Schools and colleges
+          </a>
+        </li>
 
-    <% if policy(User).new? %>
-      <%= govuk_button_link_to 'Invite a new user', new_support_responsible_body_user_path(@responsible_body) %>
-    <% end %>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#users">
+            Users
+          </a>
+        </li>
 
-    <% if @users.present? %>
-      <% @users.each do |user| %>
-        <div class="user">
-          <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
-            <%= govuk_link_to user.full_name, support_user_path(user) %>
-          </h3>
-          <% if policy(user).edit? %>
-            <p class="govuk-body">
-              <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_user_path(user) %>
-            </p>
-          <% end %>
-          <%= render Support::UserPreviewSummaryListComponent.new(user: user) %>
-        </div>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">None</p>
-    <% end %>
+        <%- if @responsible_body.extra_mobile_data_requests.present? %>
+          <li class="govuk-tabs__list-item">
+            <a class="govuk-tabs__tab" href="#mobile-data-requests">
+              Mobile data requests
+            </a>
+          </li>
+        <%- end %>
+      </ul>
 
-    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
-      <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools and colleges</h2>
-            <p class="govuk-body"><%= @responsible_body.name %>:</p>
-            <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
-              <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools and colleges</li>
-              <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available to order right now</li>
-              <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %> so far</li>
-            </ul>
+      <div class="govuk-tabs__panel" id="schools-colleges">
+        <h2 class="govuk-heading-l">Schools and colleges</h2>
+
+        <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools and colleges</h2>
+              <p class="govuk-body"><%= @responsible_body.name %>:</p>
+              <ul id="responsible-body-centrally-managed-stats" class="govuk-list govuk-list--bullet">
+                <li>manages ordering for <%= centrally_managing_count_or_all_schools(responsible_body: @responsible_body) %> of its schools and colleges</li>
+                <li>has <%= what_to_order_allocation_list(allocations: @virtual_cap_pools) %> available to order right now</li>
+                <li>has ordered <%= what_to_order_state_list(allocations: @virtual_cap_pools) %> so far</li>
+              </ul>
+            </div>
           </div>
-        </div>
-    <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-9">Schools and colleges</h2>
-
-    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body">
-            For centrally managed schools and colleges, device allocations are combined. We only know how many devices <%= @responsible_body.name %> has ordered, not how many devices went to which school or college.
-          </p>
-        </div>
-      </div>
-    <% end %>
-
-    <table id="responsible-body-schools" class="govuk-table">
-      <caption class="govuk-table__caption govuk-visually-hidden">Schools and colleges</caption>
-
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
-          <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header">Devices</th>
-          <th scope="col" class="govuk-table__header">Routers</th>
-          <th scope="col" class="govuk-table__header">Who is ordering</th>
-          <th scope="col" class="govuk-table__header">Actions</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @schools.each do |school| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.human_for_school_type %></td>
-            <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
-            <%- device_allocations_data = school.std_device_allocation %>
-            <td class="govuk-table__cell">
-              <%= device_allocations_data&.raw_allocation.to_i %> allocated<br>
-              <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
-                <%= device_allocations_data&.cap || 0 %> caps<br>
-                <%= device_allocations_data&.devices_ordered || 0 %> ordered
-              <% end %>
-            </td>
-            <%- dongles_allocations_data = school.coms_device_allocation %>
-            <td class="govuk-table__cell">
-              <%= dongles_allocations_data&.raw_allocation.to_i %> allocated<br>
-              <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
-                <%= dongles_allocations_data&.cap || 0 %> caps<br>
-                <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
-              <% end %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
-            </td>
-            <td class="govuk-table__cell">
-              <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>
-                <%= govuk_link_to 'Invite', support_school_confirm_invitation_path(school_urn: school.urn) %>
-              <% end %>
-            </td>
-          </tr>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">
+                For centrally managed schools and colleges, device allocations are combined. We only know how many devices <%= @responsible_body.name %> has ordered, not how many devices went to which school or college.
+              </p>
+            </div>
+          </div>
         <% end %>
-      </tbody>
-    </table>
+
+        <table id="responsible-body-schools" class="govuk-table">
+          <caption class="govuk-table__caption govuk-visually-hidden">Schools and colleges</caption>
+
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
+              <th scope="col" class="govuk-table__header">Status</th>
+              <th scope="col" class="govuk-table__header">Devices</th>
+              <th scope="col" class="govuk-table__header">Routers</th>
+              <th scope="col" class="govuk-table__header">Who is ordering</th>
+              <th scope="col" class="govuk-table__header">Actions</th>
+            </tr>
+          </thead>
+
+          <tbody class="govuk-table__body">
+            <% @schools.each do |school| %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.human_for_school_type %></td>
+                <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
+                <%- device_allocations_data = school.std_device_allocation %>
+                <td class="govuk-table__cell">
+                  <%= device_allocations_data&.raw_allocation.to_i %> allocated<br>
+                  <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                    <%= device_allocations_data&.cap || 0 %> caps<br>
+                    <%= device_allocations_data&.devices_ordered || 0 %> ordered
+                  <% end %>
+                </td>
+                <%- dongles_allocations_data = school.coms_device_allocation %>
+                <td class="govuk-table__cell">
+                  <%= dongles_allocations_data&.raw_allocation.to_i %> allocated<br>
+                  <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                    <%= dongles_allocations_data&.cap || 0 %> caps<br>
+                    <%= dongles_allocations_data&.devices_ordered || 0 %> ordered
+                  <% end %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
+                </td>
+                <td class="govuk-table__cell">
+                  <% if policy(school).invite? && school&.preorder_information&.school_will_be_contacted? %>
+                    <%= govuk_link_to 'Invite', support_school_confirm_invitation_path(school_urn: school.urn) %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+      </div>
+
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">
+        <h2 class="govuk-heading-l">Users</h2>
+
+        <% if policy(User).new? %>
+          <%= govuk_button_link_to 'Invite a new user', new_support_responsible_body_user_path(@responsible_body) %>
+        <% end %>
+
+        <% if @users.present? %>
+          <% @users.each do |user| %>
+            <div class="user">
+              <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
+                <%= govuk_link_to user.full_name, support_user_path(user) %>
+              </h3>
+              <% if policy(user).edit? %>
+                <p class="govuk-body">
+                  <%= govuk_link_to "Edit user<span class=\"govuk-visually-hidden\"> #{user.full_name}</span>".html_safe, edit_support_user_path(user) %>
+                </p>
+              <% end %>
+              <%= render Support::UserPreviewSummaryListComponent.new(user: user) %>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="govuk-body">None</p>
+        <% end %>
+      </div>
+
+      <%- if @responsible_body.extra_mobile_data_requests.present? %>
+        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="mobile-data-requests">
+          <h2 class="govuk-heading-l">Mobile data requests</h2>
+
+          <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @responsible_body.extra_mobile_data_requests) %>
+        </div>
+      <%- end %>
+    </div>
   </div>
 </div>

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -55,6 +55,11 @@
         Timeline
       </a>
     </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#related">
+        Related schools (<%= @school.school_links.count %>)
+      </a>
+    </li>
   </ul>
 
   <div class="govuk-tabs__panel" id="overview">
@@ -141,5 +146,33 @@
         <% end %>
       </tbody>
     </table>
+  </div>
+
+  <div class="govuk-tabs__panel" id="related">
+    <h2 class="govuk-heading-l">Related schools</h2>
+
+    <% if @school.school_links.present? %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">URN</th>
+            <th scope="col" class="govuk-table__header">Relation</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @school.school_links.each do |school_link| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= link_to_urn_otherwise_urn(school_link.urn) %></td>
+              <td class="govuk-table__cell"><%= SchoolLink.translate_enum_value(:link_type, school_link.link_type) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">
+        There are no related schools
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -659,6 +659,23 @@ en:
           participating: 'Offers data now'
           not_participating: 'Not participating'
           maybe_participating: 'May offer data when the service launches'
+      school_link:
+        link_types:
+          successor: Successor
+          predecessor: Predecessor
+          sixth_form: Sixth Form Centre Link
+          predecessor_amalgamated: Predecessor - amalgamated
+          successor_amalgamated: Successor - amalgamated
+          predecessor_merged: Predecessor - merged
+          successor_merged: Successor - merged
+          result_of_amalgamation: Result of Amalgamation
+          merged_expansion_and_change_in_age_range: Merged - expansion in school capacity and changer in age range
+          merged_change_in_age_range: Merged - change in age range
+          expansion: Expansion
+          other: Other
+          merged_expansion: Merged - expansion of school capacity
+          successor_split_school: Successor - Split School
+          predecessor_split_school: Predecessor - Split School
       preorder_information:
         will_need_chromebooks:
           "yes": Yes, we will order Chromebooks

--- a/db/migrate/20210224145258_create_school_links.rb
+++ b/db/migrate/20210224145258_create_school_links.rb
@@ -1,0 +1,11 @@
+class CreateSchoolLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :school_links do |t|
+      t.references :school
+      t.text :link_type, null: false
+      t.integer :urn
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_19_145448) do
+ActiveRecord::Schema.define(version: 2021_02_25_165034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -256,6 +256,15 @@ ActiveRecord::Schema.define(version: 2021_02_19_145448) do
     t.index ["created_by_user_id"], name: "index_school_device_allocations_on_created_by_user_id"
     t.index ["last_updated_by_user_id"], name: "index_school_device_allocations_on_last_updated_by_user_id"
     t.index ["school_id"], name: "index_school_device_allocations_on_school_id"
+  end
+
+  create_table "school_links", force: :cascade do |t|
+    t.bigint "school_id"
+    t.text "link_type", null: false
+    t.integer "urn"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id"], name: "index_school_links_on_school_id"
   end
 
   create_table "school_virtual_caps", force: :cascade do |t|

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -161,4 +161,26 @@ RSpec.describe ViewHelper do
       end
     end
   end
+
+  describe '#link_to_urn_otherwise_urn' do
+    context 'when school exists' do
+      before do
+        create(:school, urn: 123_456)
+      end
+
+      it 'renders link to school' do
+        output = helper.link_to_urn_otherwise_urn(123_456)
+        doc = Nokogiri::HTML(output)
+
+        expect(doc.css('a').attribute('href').value).to eql('/support/schools/123456')
+        expect(doc.css('a').text).to eql('123456')
+      end
+    end
+
+    context 'when school does not exist' do
+      it 'renders text' do
+        expect(helper.link_to_urn_otherwise_urn(123_456)).to be(123_456)
+      end
+    end
+  end
 end

--- a/spec/views/support/schools/show.html.erb_spec.rb
+++ b/spec/views/support/schools/show.html.erb_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe 'support/schools/show.html.erb' do
       expect(rendered).not_to include('Invite a new user')
     end
   end
+
+  context 'when there are no related schools' do
+    it 'shows tab with zero related schools' do
+      render
+
+      expect(rendered).to include('Related schools (0)')
+      expect(rendered).to include('There are no related schools')
+    end
+  end
+
+  context 'when there is a related school' do
+    before do
+      SchoolLink.create!(school: school, urn: '123456', link_type: 'predecessor')
+    end
+
+    it 'shows tab with related school' do
+      render
+
+      expect(rendered).to include('Related schools (1)')
+      expect(rendered).to include('123456')
+      expect(rendered).to include('Predecessor')
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/A7CZ5t0K/1449-support-improvement-link-predecessor-and-successor-schools

### Changes proposed in this pull request

- Adds a new model `Relation` and table 'relations'
- This stores relationships between schools from GIAS
- These are added when a school is opened from the web interface which hooks into the service objects
- Added a new tab when support views a school. this shows the related schools 

### Screenshots

No related schools

![image](https://user-images.githubusercontent.com/92580/109168923-36416100-7777-11eb-80cf-10a274a9348d.png)

A closed school

![image](https://user-images.githubusercontent.com/92580/109168822-1ad65600-7777-11eb-8c8c-2a64b2cea636.png)

Opened school

![image](https://user-images.githubusercontent.com/92580/109168835-1d38b000-7777-11eb-9d95-6b378bca79c6.png)

### Guidance to review

- Open a school. best option is academisation which closes another school in the process
- View the closed school
- Should link to new school
- View new school
- Should link to old school