### PR TITLE
changes link from mail:to to support_path

### DIFF
--- a/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
+++ b/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
@@ -17,7 +17,7 @@
       People with access to the service can invite colleagues to use it by <span class="app-no-wrap"><%= govuk_link_to 'signing in', sign_in_path %></span> and selecting ‘Manage users’.
     </p>
     <p class="govuk-body">
-      If you’re not sure which colleagues can give you access, <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk?subject=Access to get help with tehcnology">contact us</a>.
+      If you’re not sure which colleagues can give you access, <%= govuk_link_to "contact us", support_ticket_path %>.
     </p>
     <p class="govuk-body">
       You cannot access this service with your DfE Sign-in account.


### PR DESCRIPTION
### Context

Link on app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb is a mail to but the contact form is now the default way for users to contact us' – @Lloyd-K 

### Changes proposed in this pull request

Link goes to the contact form.

### Guidance to review

visit /how-to-access-the-get-help-with-technology-service


