### PR TITLE
[1634] add duplicate status for ExtraMobileDataRequests

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.rb
+++ b/app/components/extra_mobile_data_request_status_component.rb
@@ -11,7 +11,7 @@ class ExtraMobileDataRequestStatusComponent < ViewComponent::Base
     when :new then 'blue'
     when :in_progress then 'yellow'
     when :complete then 'green'
-    when :problem_incorrect_phone_number, :problem_no_match_for_number, :problem_no_match_for_account_name, :problem_not_eligible, :problem_no_longer_on_network, :problem_other then 'red'
+    when /problem_/ then 'red'
     when :cancelled, :unavailable then 'grey'
     end
   end

--- a/app/components/extra_mobile_data_request_status_details_component.html.erb
+++ b/app/components/extra_mobile_data_request_status_details_component.html.erb
@@ -49,6 +49,17 @@
         <%= govuk_link_to('Make new request', responsible_body_internet_mobile_extra_data_requests_type_path) %>
       <%- end %>
     </div>
+    <%- elsif @extra_mobile_data_request.problem_duplicate_status? %>
+      <div class="govuk-inset-text">
+        <h2 class="govuk-heading-m"><%= @extra_mobile_data_request.mobile_network.brand %> told us this is a duplicate request</h2>
+
+        <p class="govuk-body">Check the following:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the correct account holder was given</li>
+          <li>the number was typed correctly</li>
+          <li>the correct mobile network was provided</li>
+        </ul>
+      </div>
   <%- elsif @extra_mobile_data_request.problem_other_status? %>
     <div class="govuk-inset-text">
       <h2 class="govuk-heading-m"><%= @extra_mobile_data_request.mobile_network.brand %> couldn’t process this request</h2>

--- a/app/components/extra_mobile_data_request_status_details_component.html.erb
+++ b/app/components/extra_mobile_data_request_status_details_component.html.erb
@@ -62,7 +62,7 @@
       </div>
   <%- elsif @extra_mobile_data_request.problem_other_status? %>
     <div class="govuk-inset-text">
-      <h2 class="govuk-heading-m"><%= @extra_mobile_data_request.mobile_network.brand %> couldn’t process this request</h2>
+      <h2 class="govuk-heading-m"><%= @extra_mobile_data_request.mobile_network.brand %> could not process this request</h2>
 
       <p class="govuk-body">They did not give a reason why.</p>
       <p class="govuk-body">You can still:</p>

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -32,6 +32,7 @@ class ExtraMobileDataRequest < ApplicationRecord
     problem_incorrect_phone_number: 'problem_incorrect_phone_number',
     problem_no_match_for_account_name: 'problem_no_match_for_account_name',
     problem_no_longer_on_network: 'problem_no_longer_on_network',
+    problem_duplicate: 'problem_duplicate',
     problem_other: 'problem_other',
   }, _suffix: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,7 +211,7 @@ en:
             title: Which of these device types would you accept?
             hint: Select all devices types that you would use.
           how_many_devices:
-            title: How many devices does each school or college want?      
+            title: How many devices does each school or college want?
           address:
             title: How your details will be shared and associated with each delivery
           disclaimer:
@@ -226,7 +226,7 @@ en:
     school_details: Check your organisation’s details
     school_edit_chromebooks: Will you need to order Chromebooks?
     school_users: Manage users
-    school_before_can_order: Before you can order, we need more information  
+    school_before_can_order: Before you can order, we need more information
     order_devices:
       title: Order devices
       you_cannot_order_yet: You cannot order devices yet
@@ -649,6 +649,11 @@ en:
             dropdown_label: Problem – Not on network
             mno_user_description: This account is no longer on our network
             school_or_rb_user_description: The network reported this account was now with a different network
+          problem_duplicate:
+            tag_label: Duplicate request
+            dropdown_label: Problem – Duplicate request
+            mno_user_description: This is a duplicate of another request
+            school_or_rb_user_description: The network reported this was a duplicate request
           problem_other:
             tag_label: Other problem
             dropdown_label: Problem – Other

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -627,7 +627,7 @@ en:
           problem_no_match_for_number:
             tag_label: Unknown number
             dropdown_label: Problem – No account with this number
-            mno_user_description: We couldn’t find an account with this number
+            mno_user_description: We could not find an account with this number
             school_or_rb_user_description: No account was found with number given
           problem_not_eligible:
             tag_label: Not eligible
@@ -642,7 +642,7 @@ en:
           problem_no_match_for_account_name:
             tag_label: Unknown name
             dropdown_label: Problem – No account with this name
-            mno_user_description: We couldn’t find an account with this name
+            mno_user_description: We could not find an account with this name
             school_or_rb_user_description: No account was found with name given
           problem_no_longer_on_network:
             tag_label: Not on network

--- a/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_controller_spec.rb
@@ -25,6 +25,7 @@ describe Mno::ExtraMobileDataRequestsController, type: :controller do
         'problem_no_match_for_account_name',
         'problem_no_match_for_number',
         'problem_not_eligible',
+        'problem_duplicate',
         'problem_other',
       )
     end

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -212,6 +212,21 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
         end
       end
 
+      context 'when the request is problem_duplicate' do
+        let(:status) { 'problem_duplicate' }
+
+        it 'shows status duplicate' do
+          expect(page).to have_css('#request-status', text: 'Duplicate request')
+        end
+
+        it 'shows a panel with more info about the problem' do
+          expect(page).to have_content("#{request.mobile_network.brand} told us this is a duplicate request")
+          expect(page).to have_content('the correct account holder was given')
+          expect(page).to have_content('the number was typed correctly')
+          expect(page).to have_content('the correct mobile network was provided')
+        end
+      end
+
       context 'when the request is problem_other' do
         let(:status) { 'problem_other' }
 

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -235,7 +235,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
         end
 
         it 'shows a panel with more info about the problem' do
-          expect(page).to have_content("#{request.mobile_network.brand} couldn’t process this request")
+          expect(page).to have_content("#{request.mobile_network.brand} could not process this request")
           expect(page).to have_content('They did not give a reason why')
           expect(page).to have_link('4G wireless router instead')
         end

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -238,6 +238,21 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
         end
       end
 
+      context 'when the request is problem_duplicate' do
+        let(:status) { 'problem_duplicate' }
+
+        it 'shows status duplicate' do
+          expect(page).to have_css('#request-status', text: 'Duplicate request')
+        end
+
+        it 'shows a panel with more info about the problem' do
+          expect(page).to have_content("#{request.mobile_network.brand} told us this is a duplicate request")
+          expect(page).to have_content('the correct account holder was given')
+          expect(page).to have_content('the number was typed correctly')
+          expect(page).to have_content('the correct mobile network was provided')
+        end
+      end
+
       context 'when the request is problem_other' do
         let(:status) { 'problem_other' }
 

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -261,7 +261,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
         end
 
         it 'shows a panel with more info about the problem' do
-          expect(page).to have_content("#{request.mobile_network.brand} couldn’t process this request")
+          expect(page).to have_content("#{request.mobile_network.brand} could not process this request")
           expect(page).to have_content('They did not give a reason why')
           expect(page).to have_link('4G wireless router instead')
         end


### PR DESCRIPTION
### Context

[Trello card 1634](https://trello.com/c/why6PX23/1634-add-a-new-status-for-extramobiledatarequest-problemduplicate) - We've had a lot of duplicate requests in the system, due at least in part to a bug fixed in #1329. I've removed most of the duplicate requests where it was clear which ones should be kept and which deleted, but there will still be some (around a couple of hundred) where it was not clear. 

MNOs have been using various statuses for the duplicates - some `problem_no_match_for_number`, some `problem_ineligible`, some `problem_other`, etc - but it would be much clearer for everyone involved if they had an explicit `duplicate` status to use for them.

### Changes proposed in this pull request

Add `problem_duplicate` status to `ExtraMobileDataRequests`

### Guidance to review

Needs content review from @Lloyd-K or @emmajhf 

Screenshots:

![Screenshot from 2021-02-27 17-04-51](https://user-images.githubusercontent.com/134501/109394382-a1796780-791e-11eb-95da-43c0c3db019d.png)
![Screenshot from 2021-03-01 17-36-11](https://user-images.githubusercontent.com/134501/109535621-aff98780-7ab4-11eb-8d44-a92e86cbf914.png)
![Screenshot from 2021-02-27 17-09-00](https://user-images.githubusercontent.com/134501/109394392-b2c27400-791e-11eb-991f-25200e5105f2.png)
