### PR TITLE
[1617] add upload & download Makefile tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,13 +124,14 @@ setup_scp_params: set_cf_target
 	$(eval export sshpass = $(shell (cf ssh-code)))
 	$(eval export app_guid = $(shell (cf app $(APP_NAME)-$(env_stub) --guid)))
 	$(eval export process_guid=$(shell (cf curl /v3/apps/$(app_guid)/processes | jq -r '.resources | map(select(.type == "$(PROCESS)") | .guid)[$(INSTANCE)]')))
+	@echo "\n\n*** Enter ${sshpass} at the password prompt (this is a one-time-only password) ***\n"
 
 download: setup_scp_params
 	@test ${REMOTE_PATH} || (echo ">> REMOTE_PATH is not set (${REMOTE_PATH})- please use make (env) download REMOTE_PATH=(some path to download from) LOCAL_PATH=(path to download to) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
 	@test ${LOCAL_PATH} || (echo ">> FROM is not set (${FROM})- please use make (env) download REMOTE_PATH=(some path to download from) LOCAL_PATH=(path to download to) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
-	sshpass -p '${sshpass}' scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 ssh.london.cloud.service.gov.uk:$(REMOTE_PATH) $(LOCAL_PATH)
+	scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 ssh.london.cloud.service.gov.uk:$(REMOTE_PATH) $(LOCAL_PATH)
 
 upload: setup_scp_params
 	@test ${REMOTE_PATH} || (echo ">> REMOTE_PATH is not set (${REMOTE_PATH})- please use make (env) upload REMOTE_PATH=(remote path to upload to) LOCAL_PATH=(local path to upload from) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
 	@test ${LOCAL_PATH} || (echo ">> FROM is not set (${FROM})- please use make (env) upload REMOTE_PATH=(remote path to upload to) LOCAL_PATH=(local path to upload from) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
-	sshpass -p '${sshpass}' scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 $(LOCAL_PATH) ssh.london.cloud.service.gov.uk:$(REMOTE_PATH)
+	scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 $(LOCAL_PATH) ssh.london.cloud.service.gov.uk:$(REMOTE_PATH)

--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,20 @@ logs: set_cf_target
 
 logs-recent: set_cf_target
 	cf logs --recent $(APP_NAME)-$(env_stub)
+
+setup_scp_params: set_cf_target
+	$(eval export PROCESS ?= 'sidekiq')
+	$(eval export INSTANCE ?= '0')
+	$(eval export sshpass = $(shell (cf ssh-code)))
+	$(eval export app_guid = $(shell (cf app $(APP_NAME)-$(env_stub) --guid)))
+	$(eval export process_guid=$(shell (cf curl /v3/apps/$(app_guid)/processes | jq -r '.resources | map(select(.type == "$(PROCESS)") | .guid)[$(INSTANCE)]')))
+
+download: setup_scp_params
+	@test ${REMOTE_PATH} || (echo ">> REMOTE_PATH is not set (${REMOTE_PATH})- please use make (env) download REMOTE_PATH=(some path to download from) LOCAL_PATH=(path to download to) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
+	@test ${LOCAL_PATH} || (echo ">> FROM is not set (${FROM})- please use make (env) download REMOTE_PATH=(some path to download from) LOCAL_PATH=(path to download to) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
+	sshpass -p '${sshpass}' scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 ssh.london.cloud.service.gov.uk:$(REMOTE_PATH) $(LOCAL_PATH)
+
+upload: setup_scp_params
+	@test ${REMOTE_PATH} || (echo ">> REMOTE_PATH is not set (${REMOTE_PATH})- please use make (env) upload REMOTE_PATH=(remote path to upload to) LOCAL_PATH=(local path to upload from) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
+	@test ${LOCAL_PATH} || (echo ">> FROM is not set (${FROM})- please use make (env) upload REMOTE_PATH=(remote path to upload to) LOCAL_PATH=(local path to upload from) PROCESS=(process name - defaults to sidekiq) INSTANCE=(instance number - defaults to 0)"; exit 1)
+	sshpass -p '${sshpass}' scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:${process_guid}/0 $(LOCAL_PATH) ssh.london.cloud.service.gov.uk:$(REMOTE_PATH)


### PR DESCRIPTION
### Context

[Trello card 1617](https://trello.com/c/A4R5tPm1/1617-provide-an-easier-way-to-scp-files-from-instances) - it's currently awkward transferring files to and from server instances (e.g. for exported data dumps). This can lead to insecure workarounds which are best avoided. 

### Changes proposed in this pull request

Add `upload` and `download` Makefile tasks, which use `scp` to transfer files to & from named container instances

### Guidance to review

```
# upload to the first sidekiq instance:
make dev upload LOCAL_PATH=/some/local/file REMOTE_PATH=/tmp/

# download from the first sidekiq instance:
make dev download LOCAL_PATH=/tmp/ REMOTE_PATH=/some/remote/filepath

# download from the 3rd web instance in prod:
make prod download  LOCAL_PATH=/tmp/ REMOTE_PATH=/some/remote/filepath INSTANCE=2 PROCESS=web
```
