### PR TITLE
Add missing page titles to two second level pages

### DIFF
--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, @title  %>
+
 <%- content_for :before_content do %>
   <div class="govuk-breadcrumbs ">
     <ol class="govuk-breadcrumbs__list">

--- a/spec/features/start_journey_spec.rb
+++ b/spec/features/start_journey_spec.rb
@@ -10,12 +10,14 @@ RSpec.feature 'View pages', type: :feature do
     when_i_visit_the_home_page
     and_i_click_on_free_training_and_free_support_link
     then_i_should_see_the_edtech_programme_page
+    and_the_page_title_should_be_set(@edtech_landing_page, 'Get free training and support to set up and use technology effectively')
   end
 
   scenario 'user would like to find out hot to get a digital platform setup' do
     when_i_visit_the_home_page
     and_i_click_on_get_funding_to_setup_platforms_link
     then_i_should_see_the_digital_platforms_page
+    and_the_page_title_should_be_set(@digital_platforms_page, 'Get funding and support to set up a digital education platform')
   end
 
 private
@@ -45,5 +47,10 @@ private
   def then_i_should_see_the_digital_platforms_page
     @digital_platforms_page ||= PageObjects::LandingPages::DigitalPlatformsPage.new
     expect(@digital_platforms_page).to be_displayed
+  end
+
+  def and_the_page_title_should_be_set(current_page, title)
+    expect(current_page)
+      .to have_title "#{title} - Get help with technology - GOV.UK"
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/WFtlnHwp/1611-check-metadata-on-platforms-and-edtech-guidance-pages

Two of our second level pages had missing page titles which is why they were only displaying the service name in the tab.
### Changes proposed in this pull request

### Guidance to review

Visit the following links and the browser tab copy should mirror the h1 copy
- https://dfe-ghwt-pr-1353.herokuapp.com/digital-platforms
- https://dfe-ghwt-pr-1353.herokuapp.com/EdTech-demonstrator-programme