### PR TITLE
Fix infer_status to accommodate coms devices

### DIFF
--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -44,7 +44,7 @@ class PreorderInformation < ApplicationRecord
     elsif school_will_order_devices? && any_school_users? && chromebook_information_complete?
       if school.can_order_devices_right_now?
         'school_can_order'
-      elsif (school.std_device_allocation&.devices_ordered || 0).positive? # bug should do all device types
+      elsif school.device_allocations.map(&:devices_ordered).any?(&:positive?)
         'ordered'
       else
         'school_ready'
@@ -52,7 +52,7 @@ class PreorderInformation < ApplicationRecord
     elsif chromebook_information_complete?
       if orders_managed_centrally? && school.can_order_devices_right_now?
         'rb_can_order'
-      elsif orders_managed_centrally? && (school.std_device_allocation&.devices_ordered || 0).positive? # bug should do all device types
+      elsif orders_managed_centrally? && school.device_allocations.map(&:devices_ordered).any?(&:positive?)
         'ordered'
       else
         'ready'

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -130,7 +130,13 @@ RSpec.describe PreorderInformation, type: :model do
       end
 
       context 'when all devices have been ordered' do
-        let(:allocation) { create(:school_device_allocation, :fully_ordered) }
+        let(:allocation) { create(:school_device_allocation, :with_std_allocation, :fully_ordered) }
+
+        it { is_expected.to eq('ordered') }
+      end
+
+      context 'when some devices have been ordered' do
+        let(:allocation) { create(:school_device_allocation, :with_coms_allocation, devices_ordered: 5) }
 
         it { is_expected.to eq('ordered') }
       end
@@ -193,7 +199,6 @@ RSpec.describe PreorderInformation, type: :model do
       before do
         trust.update!(who_will_order_devices: 'school')
         preorder_info.update!(who_will_order_devices: 'school', will_need_chromebooks: nil)
-        preorder_info.refresh_status!
       end
 
       it 'responds to setting a contact' do
@@ -240,8 +245,9 @@ RSpec.describe PreorderInformation, type: :model do
         school.users << user
         preorder_info.update!(will_need_chromebooks: 'no')
         expect(preorder_info.status).to eq('school_ready')
-
         school.std_device_allocation.update!(devices_ordered: 2)
+        school.device_allocations.reload
+        preorder_info.refresh_status!
         expect(preorder_info.status).to eq('ordered')
       end
 
@@ -270,6 +276,8 @@ RSpec.describe PreorderInformation, type: :model do
       it 'responds to changing the device allocation' do
         expect(preorder_info.status).to eq('ready')
         school.std_device_allocation.update!(devices_ordered: 2)
+        school.device_allocations.reload
+        preorder_info.refresh_status!
         expect(preorder_info.status).to eq('ordered')
       end
 

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
       before do
         allocation
         router_allocation
+        school.device_allocations.reload
         responsible_body.update!(vcap_feature_flag: true)
         add_school_to_pool_without_side_affects(responsible_body, school)
         responsible_body.virtual_cap_pools.each(&:recalculate_caps!)
@@ -208,6 +209,8 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
                  allocation: 7,
                  cap: 3,
                  devices_ordered: 1)
+
+          school.device_allocations.reload
           school.can_order!
         end
 

--- a/spec/support/school_creator.rb
+++ b/spec/support/school_creator.rb
@@ -70,6 +70,7 @@ def create_schools_at_status(preorder_status:, count: 1, responsible_body: nil)
   end
   schools.each do |school|
     school.reload
+    school.preorder_information.refresh_status!
     expect(school.preorder_information.status).to eq(preorder_status)
   end
   schools.count == 1 ? schools.first : schools


### PR DESCRIPTION
### Context

This method would progress statuses of PreorderInformation when a school had ordered _some_ of its devices. This PR fixes a bug where we weren't taking into account router devices.