### PR TITLE
Split closed schools off into separate table for support RB view

### DIFF
--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -17,6 +17,12 @@ class Support::ResponsibleBodiesController < Support::BaseController
     @users = policy_scope(@responsible_body.users).not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
     @schools = @responsible_body
       .schools
+      .gias_status_open
+      .includes(:device_allocations, :preorder_information)
+      .order(name: :asc)
+    @closed_schools = @responsible_body
+      .schools
+      .gias_status_closed
       .includes(:device_allocations, :preorder_information)
       .order(name: :asc)
   end

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -24,6 +24,9 @@ class Support::ResponsibleBodiesController < Support::BaseController
       .schools
       .gias_status_closed
       .includes(:device_allocations, :preorder_information)
+      .left_outer_joins(:user_schools)
+      .select('schools.*, count(user_schools.id) AS user_count')
+      .group('schools.id')
       .order(name: :asc)
   end
 end

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -115,6 +115,66 @@
           </tbody>
         </table>
 
+        <% if @closed_schools.any? %>
+          <h2 class="govuk-heading-l govuk-!-margin-top-9">Closed schools and colleges</h2>
+          <table id="responsible-body-closed-schools" class="govuk-table">
+            <caption class="govuk-table__caption govuk-visually-hidden">Closed schools and colleges</caption>
+
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and URN</th>
+                <th scope="col" class="govuk-table__header">Virtual caps</th>
+                <th scope="col" class="govuk-table__header">Devices</th>
+                <th scope="col" class="govuk-table__header">Routers</th>
+                <th scope="col" class="govuk-table__header">Who is ordering</th>
+                <th scope="col" class="govuk-table__header">Users</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              <% @closed_schools.each do |school| %>
+                <%- school_in_virtual_pool = @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.human_for_school_type %></td>
+                  <td class="govuk-table__cell">
+                    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+                      <% if @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                        <%= govuk_tag text: 'In pool', colour: 'red' %>
+                      <%- else %>
+                        <%= govuk_tag text: 'Not in pool', colour: 'green' %>
+                      <%- end %>
+                    <%- else %>
+                      <%= govuk_tag text: 'Not applicable', colour: 'grey' %>
+                    <%- end %>
+                  </td>
+                  <%- device_allocations_data = school.std_device_allocation %>
+                  <td class="govuk-table__cell">
+                    <%= device_allocations_data&.raw_allocation.to_i %> allocated<br>
+                    <%= device_allocations_data&.raw_cap || 0 %> caps<br>
+                    <%= device_allocations_data&.raw_devices_ordered || 0 %> ordered
+                  </td>
+                  <%- dongles_allocations_data = school.coms_device_allocation %>
+                  <td class="govuk-table__cell">
+                    <%= dongles_allocations_data&.raw_allocation.to_i %> allocated<br>
+                    <%= dongles_allocations_data&.raw_cap || 0 %> caps<br>
+                    <%= dongles_allocations_data&.raw_devices_ordered || 0 %> ordered
+                  </td>
+                  <td class="govuk-table__cell">
+                    <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <%- user_count = school.users.count %>
+                    <%- if user_count.positive? %>
+                      <%= govuk_tag text: "#{user_count} #{'user'.pluralize(user_count)}", colour: 'yellow' %>
+                    <%- else %>
+                      <%= govuk_tag text: 'No users', colour: 'green' %>
+                    <%- end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <%- end %>
       </div>
 
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -163,7 +163,7 @@
                     <%= school&.preorder_information&.who_will_order_devices_label || 'Not decided' %>
                   </td>
                   <td class="govuk-table__cell">
-                    <%- user_count = school.users.count %>
+                    <%- user_count = school.user_count %>
                     <%- if user_count.positive? %>
                       <%= govuk_tag text: "#{user_count} #{'user'.pluralize(user_count)}", colour: 'yellow' %>
                     <%- else %>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -132,8 +132,6 @@
             </thead>
             <tbody class="govuk-table__body">
               <% @closed_schools.each do |school| %>
-                <%- school_in_virtual_pool = @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
-
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.human_for_school_type %></td>
                   <td class="govuk-table__cell">

--- a/spec/controllers/support/responsible_bodies_controller_spec.rb
+++ b/spec/controllers/support/responsible_bodies_controller_spec.rb
@@ -28,10 +28,14 @@ RSpec.describe Support::ResponsibleBodiesController, type: :controller do
       sign_in_as user
     end
 
-    it 'excludes closed schools' do
+    it 'includes open schools in the schools collection' do
       get :show, params: { id: rb.id }
-      expect(assigns(:schools)).to include(school)
-      expect(assigns(:schools)).to include(closed_school)
+      expect(assigns(:schools)).to match_array [school]
+    end
+
+    it 'includes closed schools in the closed_schools collection' do
+      get :show, params: { id: rb.id }
+      expect(assigns(:closed_schools)).to match_array [closed_school]
     end
   end
 end

--- a/spec/page_objects/support/responsible_body_page.rb
+++ b/spec/page_objects/support/responsible_body_page.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       elements :users, '.user'
       elements :school_rows, '#responsible-body-schools tbody tr'
+      elements :closed_school_rows, '#responsible-body-closed-schools tbody tr'
       elements :centrally_managed_stats, '#responsible-body-centrally-managed-stats li'
       element :invite_a_new_user_link, 'a[text()="Invite a new user"]'
     end

--- a/spec/views/support/responsible_bodies/show.html.erb_spec.rb
+++ b/spec/views/support/responsible_bodies/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'support/responsible_bodies/show.html.erb' do
     enable_pundit(view, support_user)
     assign(:responsible_body, responsible_body)
     assign(:schools, schools)
+    assign(:closed_schools, [])
   end
 
   describe 'banners' do


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/nbI7zpoQ/1568-do-not-show-closed-schools-in-schools-list-for-rbs-might-be-virtual-cap-related)
Do not include closed schools in the school list shown in the RB view of the support area. As an aid for support, I've moved closed schools into a separate table under the list of open schools with some additional tags to indicate whether the school is (still) in the RBs virtual cap pool or not and whether there are any users still associated with the school.

### Changes proposed in this pull request
Remove closed schools from current list of RB's schools
Add closed schools under the school list
Added indicator tags to show whether the school is still in the virtual cap pool and/or still has users still associated with it.
The Allocation, Cap and Devices Ordered are the 'raw' values not the virtual cap pool values if applicable for the closed schools.

### Guidance to review
As a support user, select a responsible body to view that has one or more (GIAS status) closed schools.
The closed schools should not be visible in the main "Schools and colleges" list
There should be a "Closed schools and colleges" table under the "Schools and colleges" table containing the closed schools.
There are tags to highlight whether the school is still in a virtual pool (or not applicable) and a count of users or "No users" in each row.

![image](https://user-images.githubusercontent.com/333931/109528211-5db46880-7aac-11eb-99c4-9ec872f01ba2.png)

![image](https://user-images.githubusercontent.com/333931/109528112-44132100-7aac-11eb-8ffa-8d80528e8716.png)
