### PR TITLE
Add .rspec_parallel to even test run times

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log


### PR DESCRIPTION
### Context

- Uneven parallel test run times compared to each thread/process

### Changes proposed in this pull request

- Add `.rspec_parallel`
- Logs runtime to file so future run times should be more even

### Guidance to review

- Run the tests in parallel
- Test run times should be more even and therefore hopefully overall quicker
