### PR TITLE
[1634] add contract_type to the check for ExtraMobileDataRequest uniqueness

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -97,6 +97,7 @@ class ExtraMobileDataRequest < ApplicationRecord
         account_holder_name: account_holder_name,
         device_phone_number: device_phone_number,
         mobile_network_id: mobile_network_id,
+        contract_type: contract_type,
       }.merge(extra_conditions),
     )
   end

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -149,6 +149,24 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
         expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
       end
     end
+
+    context 'when there is an existing request with everything the same except contract_type' do
+      let(:existing_request) do
+        create(:extra_mobile_data_request, account_holder_name: 'Person', device_phone_number: '07123456788', responsible_body: rb, contract_type: 'pay_as_you_go_payg')
+      end
+
+      subject(:model) do
+        build(:extra_mobile_data_request, device_phone_number: existing_request.device_phone_number,
+                                          account_holder_name: existing_request.account_holder_name,
+                                          mobile_network_id: existing_request.mobile_network_id,
+                                          responsible_body: existing_request.responsible_body,
+                                          contract_type: 'pay_monthly')
+      end
+
+      it 'is valid' do
+        expect(model.valid?).to be_truthy
+      end
+    end
   end
 
   describe 'validating device_phone_number' do


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/DVJGycEu/1643-link-account-type-status-into-duplicate-requests-for-data-increase) - currently, when a user is entering an `ExtraMobileDataRequest` (or several), the `contract_type` is not taken into account. This means that if a user initially put in the wrong contract_type, the system will not let them resubmit with the correct contract_type
.
### Changes proposed in this pull request

Include `contract_type` in the check for whether an ExtraMobileDataRequest has already been made.

### Guidance to review

