### PR TITLE
[1655] On deleting user, orders_devices => false

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -73,7 +73,7 @@ class Support::UsersController < Support::BaseController
   def confirm_destroy; end
 
   def destroy
-    @user.update!(deleted_at: Time.zone.now)
+    @user.update!(deleted_at: Time.zone.now, orders_devices: false)
 
     flash[:success] = 'You have deleted this user'
 

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Support::UsersController do
   describe '#destroy' do
     let(:responsible_body) { create(:local_authority) }
     let(:school) { create(:school) }
-    let(:existing_user) { create(:local_authority_user) }
+    let(:existing_user) { create(:local_authority_user, orders_devices: true) }
 
     context 'for support users' do
       before do
@@ -297,6 +297,12 @@ RSpec.describe Support::UsersController do
       it 'sets user deleted_at timestamp' do
         delete :destroy, params: { id: existing_user.id }
         expect(existing_user.reload.deleted_at).to be_present
+      end
+
+      it 'marks the user as being no longer able to order' do
+        expect {
+          delete :destroy, params: { id: existing_user.id }
+        }.to change { existing_user.reload.orders_devices }.from(true).to(false)
       end
 
       it 'redirects back to the RB page when called from the responsible body area' do


### PR DESCRIPTION
### Context

- https://trello.com/c/ZYKzLXeR/1655-when-deleting-a-user-ensure-they-cannot-order

### Changes proposed in this pull request

- On soft deleting users set `orders_device` to false
- This is so they do not contribute to the count of TechSource accounts per org
- This way should they be re-instated they do not automatically go back into the pool of TechSource accounts causing too many accounts per org

### Guidance to review

- Sign in as support user
- Soft delete a user that can order devices
- Should set their `deleted_at` timestamp and toggle `orders_devices` to false
