### PR TITLE
Add feedback copy and link to survey

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -181,6 +181,10 @@ module ViewHelper
     end
   end
 
+  def user_feedback_link
+    govuk_link_to 'Complete a survey', 'https://docs.google.com/forms/d/e/1FAIpQLSd9g4jlGTXM6FLOxgfyEIoAWZuhAweL7A6kx5qhDYpwguznAg/viewform?usp=sf_link'
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,16 +60,13 @@
       </div>
     </header>
     <div class="govuk-width-container">
-      <div class="govuk-phase-banner">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">
-            alpha
-          </strong>
-          <span class="govuk-phase-banner__text">
-            This is a new service – your <%= ghwt_contact_mailto(label: "feedback", subject: "Feedback") %> will help us to improve it.
-          </span>
-        </p>
-      </div>
+      <%= render GovukComponent::PhaseBanner.new(phase: 'Alpha') do
+        if current_user.persisted? && (current_user.is_responsible_body_user? || current_user.is_school_user?)
+          "#{t('user_feedback')} – #{user_feedback_link}".html_safe
+        else
+          "This is a new service – your #{ghwt_contact_mailto(label: "feedback", subject: "Feedback")} will help us to improve it.".html_safe
+        end
+      end %>
       <%= content_for(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= render partial: "shared/banners/global_notice_banner" if @show_parent_carer_pupil_banner %>
@@ -88,6 +85,7 @@
                 <a class="govuk-footer__link" href="<%= support_ticket_path %>">
                   Contact us
                 </a>
+
               </li>
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="<%= accessibility_path %>">

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,11 +1,16 @@
 <%= render partial: 'shared/banners/responsible_body' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @responsible_body.name %></span>
       <%= t('page_titles.responsible_body_home') %>
     </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Get laptops and tablets', responsible_body_devices_path %>
@@ -46,4 +51,5 @@
       <li>set up accounts for your <%= @responsible_body.humanized_type %> to order devices</li>
     </ul>
   </div>
+  <%= render partial: 'shared/link_to_survey' %>
 </div>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -7,11 +7,15 @@
 <%= render partial: 'shared/banners/school' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>
+  </div>
+</div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.school_order_devices'), order_devices_school_path(@school) %>
     </h2>
@@ -78,4 +82,5 @@
       <li>set which accounts can use TechSource and use the <span class="app-no-wrap">Support Portal</span></li>
     </ul>
   </div>
+  <%= render partial: 'shared/link_to_survey' %>
 </div>

--- a/app/views/shared/_link_to_survey.html.erb
+++ b/app/views/shared/_link_to_survey.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-column-one-third-from-desktop govuk-grid-column-full">
+  <div class="app-survey-container">
+    <h2 class="govuk-heading-m7">
+      Give feedback
+    </h2>
+    <p class="govuk-body">
+      <%= t('user_feedback') %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-2">
+      <%= user_feedback_link %>
+    </p>
+  </div>
+</div>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full govuk-!-margin-bottom-5">
     <%=render GovukComponent::Panel.new(
       title: 'Support request sent',
       body: "Your reference number #{session[:support_ticket_number]}")
@@ -16,7 +16,7 @@
   </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
 
     <h2 class="govuk-heading-m">
       What happens next?
@@ -36,4 +36,7 @@
       <a href="https://get-help-with-tech.education.gov.uk/" rel="noreferrer noopener" target="_blank">Get help with technology</a>
     </p>
   </div>
+  <% if current_user.persisted? %>
+    <%= render partial: 'shared/link_to_survey' %>
+  <% end %>
 </div>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -72,3 +72,14 @@ $govuk-image-url-function: frontend-image-url;
 .app-no-wrap {
   white-space: nowrap;
 }
+
+.app-survey-container {
+  background-color: govuk-colour("light-grey");
+  padding: 20px;
+  margin-top: -20px;
+
+  @media (max-width: 768px) {
+    @include govuk-responsive-margin(6, "top");
+  }
+
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   service_name: Get help with technology
+  user_feedback: Help us understand the impact this programme has had on your pupils and students.
   pages:
     order_devices:
       can_order_full_allocation_when_list:

--- a/spec/views/layouts/multipage_guide.html.erb_spec.rb
+++ b/spec/views/layouts/multipage_guide.html.erb_spec.rb
@@ -1,18 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'layouts/multipage_guide.html.erb' do
-  before do
-    controller.singleton_class.class_eval do
-      def hide_nav_menu?
-        false
-      end
-      helper_method :hide_nav_menu?
-    end
-  end
-
   context 'when page has noindex set to true' do
     it 'has meta tag noindex' do
       assign(:page, OpenStruct.new(page_id: 'google_domain_for_care_leavers_and_children_with_social_worker', noindex: true))
+      stub_template 'layouts/application.html.erb' => '<%= yield(:head) %>'
       render
       expect(rendered).to include('noindex')
     end
@@ -21,6 +13,7 @@ RSpec.describe 'layouts/multipage_guide.html.erb' do
   context 'when page has noindex not set' do
     it 'has meta tag noindex' do
       assign(:page, OpenStruct.new(page_id: 'google_domain_for_care_leavers_and_children_with_social_worker'))
+      stub_template 'layouts/application.html.erb' => '<%= yield(:head) %>'
       render
       expect(rendered).not_to include('noindex')
     end


### PR DESCRIPTION
### Context
https://trello.com/c/Dupc9WB4/1646-create-access-to-evaluation-survey-in-the-account-and-at-the-end-of-the-contact-form
### Changes proposed in this pull request
- Change phase banner copy and link to survey if the user is signed in
- Display the survey link on the School/RB home page when the user signs in
- Display the survey link on the contact form thank you page if the user is signed in
### Guidance to review

- Visit https://dfe-ghwt-pr-1363.herokuapp.com/
- Login as `school.user.1@example.com`, `trust.user.1@example.com` and `support.user.1@example.com`

**As a school/trust user**
  - User home page should include a sidebar asking the user for feedback and include a link to the survey.
  - Phase banner should be updated to  use the new feedback copy and should link to the survey
  - Go to "Contact us" link in the footer and submit a query (don't worry it will not create a real support ticket)
  	- "Success page" displays a sidebar with copy asking for feedback and a link to the survey
  
**As a support user** 
  - Phase banner should display the old feedback copy with a link to the email address to provide feedback

**As a user who is not signed in**
  - Phase banner should display the old feedback copy with a link to the email address to provide   
  - Go to "Contact us" link in the footer and submit a query (don't worry it will not create a real support ticket)
  	- "Success page" displays a sidebar with copy asking for feedback and a link to the survey
