### PR TITLE
[1628] Include routers in allocations csv export

### DIFF
--- a/app/services/allocations_exporter.rb
+++ b/app/services/allocations_exporter.rb
@@ -38,6 +38,12 @@ class AllocationsExporter
       'Pool devices allocation',
       'Pool devices cap',
       'Pool devices ordered',
+      'Routers allocation',
+      'Routers cap',
+      'Routers ordered',
+      'Pool routers allocation',
+      'Pool routers cap',
+      'Pool routers ordered',
     ].freeze
   end
 
@@ -60,6 +66,12 @@ private
         (school.in_virtual_cap_pool? ? school.std_device_allocation&.allocation : nil),
         (school.in_virtual_cap_pool? ? school.std_device_allocation&.cap : nil),
         (school.in_virtual_cap_pool? ? school.std_device_allocation&.devices_ordered : nil),
+        school.coms_device_allocation&.raw_allocation,
+        school.coms_device_allocation&.raw_cap,
+        school.coms_device_allocation&.raw_devices_ordered,
+        (school.in_virtual_cap_pool? ? school.coms_device_allocation&.allocation : nil),
+        (school.in_virtual_cap_pool? ? school.coms_device_allocation&.cap : nil),
+        (school.in_virtual_cap_pool? ? school.coms_device_allocation&.devices_ordered : nil),
       ]
     end
   end
@@ -69,6 +81,6 @@ private
   end
 
   def schools
-    School.all.includes(:responsible_body, :std_device_allocation).order(urn: :asc)
+    School.all.includes(:responsible_body, :std_device_allocation, :coms_device_allocation).order(urn: :asc)
   end
 end

--- a/spec/services/allocations_exporter_spec.rb
+++ b/spec/services/allocations_exporter_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe AllocationsExporter, type: :model do
       create(:preorder_information, :rb_will_order, school: schools.last)
       create(:school_device_allocation, device_type: 'std_device', school: schools.first, allocation: 20, cap: 20, devices_ordered: 10)
       create(:school_device_allocation, device_type: 'std_device', school: schools.last, allocation: 25, cap: 5, devices_ordered: 5)
+
+      create(:school_device_allocation, device_type: 'coms_device', school: schools.first, allocation: 21, cap: 21, devices_ordered: 11)
+      create(:school_device_allocation, device_type: 'coms_device', school: schools.last, allocation: 26, cap: 6, devices_ordered: 6)
       trust.add_school_to_virtual_cap_pools!(schools.last)
       trust.add_school_to_virtual_cap_pools!(schools.first)
     end
@@ -51,6 +54,13 @@ RSpec.describe AllocationsExporter, type: :model do
       expect(csv[0]['Pool devices allocation'].to_i).to eq(45)
       expect(csv[0]['Pool devices cap'].to_i).to eq(25)
       expect(csv[0]['Pool devices ordered'].to_i).to eq(15)
+
+      expect(csv[0]['Routers allocation'].to_i).to eq(21)
+      expect(csv[0]['Routers cap'].to_i).to eq(21)
+      expect(csv[0]['Routers ordered'].to_i).to eq(11)
+      expect(csv[0]['Pool routers allocation'].to_i).to eq(47)
+      expect(csv[0]['Pool routers cap'].to_i).to eq(27)
+      expect(csv[0]['Pool routers ordered'].to_i).to eq(17)
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/EHwrsQLG/1628-list-of-fe-providers-on-the-service

### Changes proposed in this pull request

- After a school search when exporting data to csv include router data

### Guidance to review

- Sign in as support agent
- Perform a schools search with multiple schools preferably with combination of devices and router allocations, in and out of virtual pools
- Export the data to csv
- Should see router data along with device data
