### PR TITLE
[1590] Re-write 'stock availability' and 'before you order' content

### DIFF
--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -29,7 +29,6 @@
       <li><%= govuk_link_to 'give someone else access so they can place orders', school_users_path %></li>
     </ul>
 
-
     <h2 class="govuk-heading-m">How to order</h2>
 
     <p class="govuk-body">You need to place your orders on a website called TechSource.</p>
@@ -61,7 +60,7 @@
       <%= @school.postcode %><br>
     </p>
 
-    <p class="govuk-body">If you need to change your delivery address, contact <a class="govuk-link" href="mailto:COVID.TECHNOLOGY@education.gov.uk">COVID.TECHNOLOGY@education.gov.uk</a>.</p>
+    <p class="govuk-body">If you need to change your delivery address, <%= govuk_link_to "contact us", support_ticket_path %>.</p>
 
     <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address, school_urn: @school.urn } %>
   </div>

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -22,12 +22,8 @@
       Make sure you’re certain of what devices you need, as amending or cancelling an order will cause delays.
     </p>
     <p class="govuk-body">
-      It may help to:
+      You can <%= govuk_link_to 'give someone else access so they can place orders', school_users_path %>.
     </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %></li>
-      <li><%= govuk_link_to 'give someone else access so they can place orders', school_users_path %></li>
-    </ul>
 
     <h2 class="govuk-heading-m">How to order</h2>
 

--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -18,7 +18,7 @@
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
 
-    <p class="govuk-body">While you’re waiting, <%= link_to_devices_guidance_subpage 'check device specifications', 'device-specification' %> to decide what you will order.</p>
+    <p class="govuk-body">While you’re waiting, <%= link_to_devices_guidance_subpage 'check which devices and specifications are available', 'device-specification' %> to decide what you’ll order.</p>
 
   </div>
 </div>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -30,16 +30,16 @@
       </ul>
 
       <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to_ed_settings_form %>.</p>
+    <% end %>
 
-      <% unless @current_user.orders_devices? %>
-        <h2 class="govuk-heading-m">
-          You won’t be able to place orders yourself
-        </h2>
+    <% unless @current_user.orders_devices? %>
+      <h2 class="govuk-heading-m">
+        You will not be able to place orders yourself
+      </h2>
 
-        <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
+      <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
 
-        <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
-      <% end %>
+      <p class="govuk-body"><%= govuk_link_to "Go to Manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -15,6 +15,6 @@
 
     <p class="govuk-body">You do not have a TechSource account. Someone else will need to place your school’s orders.</p>
 
-    <p class="govuk-body"><%= govuk_link_to "Go to manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
+    <p class="govuk-body"><%= govuk_link_to "Go to Manage users to see who can place orders, or give yourself access", school_users_path(@school) %>.</p>
   </div>
 </div>

--- a/app/views/shared/_stock_levels.html.erb
+++ b/app/views/shared/_stock_levels.html.erb
@@ -9,14 +9,8 @@
   <li>
     Google Chromebooks
   </li>
-</ul>
-
-<h3 class="govuk-heading-s">
-  Low stock
-</h3>
-<ul class="govuk-list govuk-list--bullet">
   <li>
-    Standard and DfE Restricted Windows laptops – delivery may take longer than 5 working days
+    Standard and DfE Restricted Windows laptops – low stock, delivery may take longer than 5 working days
   </li>
 </ul>
 
@@ -31,3 +25,7 @@
     Microsoft Windows tablets
   </li>
 </ul>
+
+<p class="govuk-body">
+  <%= link_to_devices_guidance_subpage 'Read more about the devices and specifications available', 'device-specification' %>
+</p>

--- a/app/views/shared/_stock_levels.html.erb
+++ b/app/views/shared/_stock_levels.html.erb
@@ -3,14 +3,11 @@
 </h2>
 
 <h3 class="govuk-heading-s">
-  Permanently out of stock
+  In stock
 </h3>
 <ul class="govuk-list govuk-list--bullet">
   <li>
-    Apple iPads
-  </li>
-  <li>
-    Microsoft Windows tablets
+    Google Chromebooks
   </li>
 </ul>
 
@@ -20,5 +17,17 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>
     Standard and DfE Restricted Windows laptops – delivery may take longer than 5 working days
+  </li>
+</ul>
+
+<h3 class="govuk-heading-s">
+  Permanently out of stock
+</h3>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    Apple iPads
+  </li>
+  <li>
+    Microsoft Windows tablets
   </li>
 </ul>


### PR DESCRIPTION
To prepare for limited stock, we need to rewrite these sections to:

- make it clear what device types are out of stock, or low on stock
- provide easy access to information about different device types (but not necessarily recommend any alternatives)
- be transparent about devices that will come back into stock
- soften language about being certain what device types are needed (as their first and second choices may be unavailable)