### PR TITLE
[1638] Refactor out hard coded FE mobile networks

### DIFF
--- a/app/models/mobile_network.rb
+++ b/app/models/mobile_network.rb
@@ -14,8 +14,8 @@ class MobileNetwork < ApplicationRecord
     participating
   end
 
-  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2]) }
-  scope :fe_networks, -> { participating.where.not(id: excluded_fe_networks.pluck(:id)) }
+  scope :excluded_fe_networks, -> { where(excluded_fe_network: true) }
+  scope :fe_networks, -> { participating.where(excluded_fe_network: false) }
 
   def pathsafe_brand
     brand.to_s

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
   context 'school.hide_mno is true' do
     before do
       school.update!(hide_mno: true)
-      create(:mobile_network, brand: 'giffgaff')
+      create(:mobile_network, brand: 'giffgaff', excluded_fe_network: true)
     end
 
     scenario 'do not show FE excluded MNOs' do

--- a/spec/services/extra_data_request_spreadsheet_importer_spec.rb
+++ b/spec/services/extra_data_request_spreadsheet_importer_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe ExtraDataRequestSpreadsheetImporter, type: :model do
       ].map { |hash| ExtraMobileDataRequestRow.new(hash).build_request }
     end
 
+    before do
+      MobileNetwork.all.sample.update(excluded_fe_network: true)
+    end
+
     it 'errors on excluded FE networks' do
       importer.import!(extra_fields: { school: school })
       expect(importer.summary.successful.size).to be(1)


### PR DESCRIPTION
### Context

- https://trello.com/c/aaURe4i9/1638-tidy-up-mno-fe-only-providers-to-user-db-flag

### Changes proposed in this pull request

- Refactor hard coded FE mobile networks
- Instead use a flag from the database which has already been put in place

### Guidance to review

- There should be no behavioural change of the app
