### PR TITLE
[1561] Remove schools_closed_for_national_lockdown flag

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -176,10 +176,6 @@ module ViewHelper
     end
   end
 
-  def link_to_ed_settings_form
-    govuk_link_to 'DfE educational settings status form', 'https://form.education.gov.uk/service/educational-setting-status'
-  end
-
   def chromebook_domain_label(school)
     label = Array(school.institution_type.capitalize)
     label << "or #{school.responsible_body.humanized_type}" unless school.is_further_education?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -7,7 +7,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %i[
     increased_allocations_banner
     secondary_mass_testing_banner
-    schools_closed_for_national_lockdown
     half_term_delivery_suspension
     donated_devices
     rb_level_access_notification

--- a/app/views/responsible_body/devices/home/tell_us.html.erb
+++ b/app/views/responsible_body/devices/home/tell_us.html.erb
@@ -31,24 +31,7 @@
         <li>manage who can order devices</li>
         <li>order devices themselves</li>
       </ul>
-
     <% end %>
-
-    <% unless FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <h2 class="govuk-heading-m">Help schools and colleges prepare for disruption</h2>
-
-      <p class="govuk-body">Give us contact details as soon as you can so we can help schools and colleges prepare to deliver remote education if they need to.</p>
-
-      <h2 class="govuk-heading-m">Each school and college has their own allocation</h2>
-
-      <p class="govuk-body">Every school and college has its own allocation of laptops and tablets. Allocations are based on free meal data and estimates of how many devices the school or college has already received.</p>
-
-      <h2 class="govuk-heading-m">A school’s full allocation can only be ordered when a closure is reported</h2>
-
-      <p class="govuk-body">We’ll contact people as soon as they’re able to place orders.</p>
-
-    <% end %>
-
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Continue', responsible_body_devices_who_will_order_edit_path %>
     </div>

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -2,27 +2,6 @@
   <div class="govuk-grid-column-two-thirds">
 
     <%= render ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: @responsible_body) %>
-
-    <% unless FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <% if @schools_can_order.any? && @schools_can_order_for_specific_circumstances.any? %>
-        <p class="govuk-body govuk-!-margin-bottom-1">
-          The number of devices you can order is the remaining allocation of devices for:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>approved requests for specific circumstances</li>
-          <li><%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time</li>
-        </ul>
-      <% elsif @schools_can_order.any? %>
-        <p class="govuk-body">
-          The number of devices you can order is the remaining allocation of devices for <%= govuk_link_to "schools that have reported a closure".html_safe, responsible_body_devices_schools_path %> or 15 or more pupils self-isolating at the same time.
-        </p>
-      <% elsif @schools_can_order_for_specific_circumstances.any? %>
-        <p class="govuk-body">
-          The number of devices you can order is the remaining allocation of devices where a request for specific circumstances has been approved.
-        </p>
-      <% end %>
-    <% end %>
-
     <%= render partial: 'shared/stock_levels' %>
 
     <h2 class="govuk-heading-m">

--- a/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_yet.html.erb
@@ -7,27 +7,7 @@
       <%= t('page_titles.order_devices.you_cannot_order_yet') %>
     </h1>
 
-    <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">Ordering will be opened as soon as possible.</p>
-
-      <p class="govuk-body">We’ll email you when you can place an order.</p>
-    <% else %>
-      <p class="govuk-body">You can order a school’s full allocation when:</p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <% t('pages.order_devices.can_order_full_allocation_when_list').each do |li| %>
-          <li><%= li %></li>
-        <% end %>
-      </ul>
-
-      <p class="govuk-body">We’ll contact you about placing orders if a school reports disruption through the <%= link_to_ed_settings_form %>.</p>
-
-      <% school_count = @responsible_body.schools.that_are_centrally_managed.count %>
-      <p class="govuk-body">None of the <%= govuk_link_to "#{school_count} #{'school'.pluralize(school_count)} you will be placing orders for", responsible_body_devices_schools_path %> <%= 'has'.pluralize(school_count) %> reported disruption.</p>
-
-      <% if @responsible_body.has_schools_that_can_order_devices_now? %>
-        <%= render partial: 'some_schools_can_order' %>
-      <%- end %>
-    <% end %>
+    <p class="govuk-body">Ordering will be opened as soon as possible.</p>
+    <p class="govuk-body">We’ll email you when you can place an order.</p>
   </div>
 </div>

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -12,7 +12,7 @@
 
     <%= render DeviceCountComponent.new(school: @school) %>
 
-    <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order. You cannot order your full allocation yet because no closures or groups of self-isolating children have been reported through the <%= link_to_ed_settings_form %>.</p>
+    <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order.</p>
 
     <%= render partial: 'shared/stock_levels' %>
 

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -1,9 +1,6 @@
-<% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-  <%- title = t('page_titles.national_lockdown_school_cannot_order_yet') %>
-<% else %>
-  <%- who_cannot_order = @current_user.orders_devices? ? 'school_user' : 'school' %>
-  <%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices.title") %>
-<% end %>
+<%- who_cannot_order = @current_user.orders_devices? ? 'school_user' : 'school' %>
+<%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices.title") %>
+
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <%- school_breadcrumbs items: 'Order devices', school: @school, user: @current_user %>
@@ -16,21 +13,8 @@
       <%= title %>
     </h1>
 
-    <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-      <p class="govuk-body">Ordering will be opened for your school as soon as possible.</p>
-
-      <p class="govuk-body">We’ll email you when you can place an order.</p>
-    <% else %>
-      <p class="govuk-body"><%= t("page_titles.#{who_cannot_order}_cannot_order_devices.can_order_when") %></p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <% t('pages.order_devices.can_order_full_allocation_when_list').each do |list_item| %>
-          <li><%= list_item %></li>
-        <% end %>
-      </ul>
-
-      <p class="govuk-body">We’ll contact you about placing orders if you report disruption through the <%= link_to_ed_settings_form %>.</p>
-    <% end %>
+    <p class="govuk-body">Ordering will be opened for your school as soon as possible.</p>
+    <p class="govuk-body">We’ll email you when you can place an order.</p>
 
     <% unless @current_user.orders_devices? %>
       <h2 class="govuk-heading-m">

--- a/app/views/school/welcome_wizard/order_your_own.html.erb
+++ b/app/views/school/welcome_wizard/order_your_own.html.erb
@@ -12,7 +12,7 @@
       </h1>
 
       <p class="govuk-body">
-        You’ll be able to order your current device allocation during term time if you use the <%= link_to_ed_settings_form %> to:
+        You’ll be able to order your current device allocation during term time if you:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/school/welcome_wizard/techsource_account.html.erb
+++ b/app/views/school/welcome_wizard/techsource_account.html.erb
@@ -11,11 +11,8 @@
 
       <p class="govuk-body">You will need to place orders on a website called TechSource, which is run by Computacenter.</p>
 
-      <% if FeatureFlag.active?(:schools_closed_for_national_lockdown) %>
-        <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when it is ready.</p>
-      <% else %>
-        <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when your school can place orders.</p>
-      <% end %>
+      <p class="govuk-body">We will create a TechSource account for you. You’ll get an email with instructions about your account when it is ready.</p>
+
       <%= f.govuk_submit 'Continue' %>
     <%- end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,15 +123,12 @@ en:
       school: The school will place their own orders
       responsible_body: Orders will be placed centrally
     privacy_notice: Privacy notice
-    national_lockdown_school_cannot_order_yet: Your school cannot order devices yet
     school_home: Get devices for your school
     school_can_order_devices: Your school can order devices
     school_cannot_order_devices:
-      title: Your school cannot your full allocation yet
-      can_order_when: 'Your school can order your full allocation when:'
+      title: Your school cannot order devices yet
     school_user_cannot_order_devices:
-      title: You cannot order your full allocation yet
-      can_order_when: 'You can order your full allocation when:'
+      title: You cannot order devices yet
     school:
       devices:
         cannot_order_as_cap_reached:

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -20,8 +20,8 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     then_i_see_the_cannot_order_devices_yet_page
   end
 
-  scenario 'a centrally managed school that can order for local restrictions' do
-    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+  scenario 'a centrally managed school that can order full allocation' do
+    given_a_centrally_managed_school_within_a_pool_can_order_full_allocation
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_1_school_in_local_restrictions_that_i_need_to_place_orders_for
@@ -38,8 +38,8 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
-  scenario 'centrally managed schools that can order for local restrictions and specific circumstances' do
-    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+  scenario 'centrally managed schools that can order for specific circumstances and full allocation' do
+    given_a_centrally_managed_school_within_a_pool_can_order_full_allocation
     given_a_centrally_managed_school_within_a_pool_can_order_for_specific_circumstances
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
@@ -50,7 +50,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
 
   scenario 'centrally managed schools with multiple Chromebook domains that can order' do
     given_there_are_multiple_chromebook_domains_being_managed
-    given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+    given_a_centrally_managed_school_within_a_pool_can_order_full_allocation
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_a_section_regarding_ordering_chromebooks
@@ -75,7 +75,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     schools[3].preorder_information.responsible_body_will_order_devices!
   end
 
-  def given_a_centrally_managed_school_within_a_pool_can_order_for_local_restrictions
+  def given_a_centrally_managed_school_within_a_pool_can_order_full_allocation
     schools[0].can_order!
     schools[0].std_device_allocation.update!(cap: 3, allocation: 20, devices_ordered: 1) # 2 left
     schools[0].coms_device_allocation.update!(cap: 5, allocation: 10, devices_ordered: 2) # 3 left

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -25,8 +25,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_1_school_in_local_restrictions_that_i_need_to_place_orders_for
-    and_is_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
-    and_i_see_where_my_allocation_has_come_from_for_the_1_school_in_local_restrictions
+    and_i_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
     and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
@@ -35,8 +34,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_1_school_with_specific_circumstances_that_i_need_to_place_orders_for
-    and_is_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
-    and_i_see_where_my_allocation_has_come_from_for_the_1_school_with_specific_circumstances
+    and_i_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
     and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
@@ -47,7 +45,6 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     then_i_see_the_order_now_page
     and_i_see_2_schools_that_i_need_to_place_orders_for
     and_i_see_2_schools_that_i_have_already_placed_orders_for
-    and_i_see_where_my_allocation_has_come_from_for_the_2_schools
     and_i_do_not_see_a_section_on_ordering_chromebooks
   end
 
@@ -151,7 +148,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     expect(page).to have_text('2 devices and 3 routers available to order')
   end
 
-  def and_is_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
+  def and_i_see_1_school_in_local_restrictions_that_i_have_already_placed_orders_for
     expect(page).to have_text('You ordered 1 devices and 2 routers')
   end
 
@@ -159,7 +156,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
     expect(page).to have_text('2 devices and 0 routers available to order')
   end
 
-  def and_is_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
+  def and_i_see_1_school_with_specific_circumstances_that_i_have_already_placed_orders_for
     expect(page).to have_text('You ordered 1 devices and 0 routers')
   end
 
@@ -169,20 +166,6 @@ RSpec.feature 'Ordering devices within a virtual pool' do
 
   def and_i_see_2_schools_that_i_have_already_placed_orders_for
     expect(page).to have_text('You ordered 2 devices and 2 routers')
-  end
-
-  def and_i_see_where_my_allocation_has_come_from_for_the_1_school_in_local_restrictions
-    expect(page).to have_text('remaining allocation of devices for schools that have reported a closure or')
-  end
-
-  def and_i_see_where_my_allocation_has_come_from_for_the_1_school_with_specific_circumstances
-    expect(page).to have_text('remaining allocation of devices where a request for specific circumstances')
-  end
-
-  def and_i_see_where_my_allocation_has_come_from_for_the_2_schools
-    expect(page).to have_text('remaining allocation of devices for:')
-    expect(page).to have_text('approved requests for specific circumstances')
-    expect(page).to have_text('schools that have reported a closure or 15')
   end
 
   def and_i_see_i_have_no_more_devices_to_order

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -34,15 +34,15 @@ RSpec.feature 'Ordering devices' do
     then_i_see_the_order_for_specific_circumstances_page
   end
 
-  scenario 'a centrally managed school can order for local restrictions' do
-    given_a_centrally_managed_school_can_order_for_local_restrictions
+  scenario 'a centrally managed school can order full allocation' do
+    given_a_centrally_managed_school_can_order_full_allocation
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_1_school_that_i_need_to_place_orders_for
   end
 
-  scenario 'centrally managed schools that can order for local restrictions and specific circumstances' do
-    given_a_centrally_managed_school_can_order_for_local_restrictions
+  scenario 'centrally managed schools that can order for specific circumstances and full allocation' do
+    given_a_centrally_managed_school_can_order_full_allocation
     given_a_centrally_managed_school_can_order_for_specific_circumstances
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
@@ -68,7 +68,7 @@ RSpec.feature 'Ordering devices' do
     schools[1].std_device_allocation.update!(cap: 4, allocation: 8)
   end
 
-  def given_a_centrally_managed_school_can_order_for_local_restrictions
+  def given_a_centrally_managed_school_can_order_full_allocation
     schools[2].can_order!
     schools[2].std_device_allocation.update!(cap: 7, allocation: 7)
   end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -19,15 +19,13 @@ RSpec.feature 'Ordering devices' do
     then_i_see_the_cannot_order_devices_yet_page
   end
 
-  context 'when there’s a national lockdown', with_feature_flags: { schools_closed_for_national_lockdown: 'active' } do
-    scenario 'a responsible body that cannot order devices yet' do
-      when_i_visit_the_responsible_body_home_page
-      and_i_follow_the_get_laptops_and_tablets_link
-      then_i_see_the_get_laptops_and_tablets_page
+  scenario 'a responsible body that cannot order devices yet' do
+    when_i_visit_the_responsible_body_home_page
+    and_i_follow_the_get_laptops_and_tablets_link
+    then_i_see_the_get_laptops_and_tablets_page
 
-      when_i_follow_the_order_devices_link
-      then_i_see_that_i_will_be_able_to_order_soon
-    end
+    when_i_follow_the_order_devices_link
+    then_i_see_that_i_will_be_able_to_order_soon
   end
 
   scenario 'a centrally managed school can order for specific circumstances' do
@@ -49,28 +47,6 @@ RSpec.feature 'Ordering devices' do
     when_i_visit_the_order_devices_page
     then_i_see_the_order_now_page
     and_i_see_2_schools_that_i_need_to_place_orders_for
-  end
-
-  scenario 'a school that orders can order for specific circumstances' do
-    given_a_school_that_will_order_devices_can_order_for_specific_circumstances
-    when_i_visit_the_order_devices_page
-    then_i_see_the_cannot_order_devices_yet_page
-    and_i_see_that_1_school_can_place_their_own_order_for_specific_circumstances
-  end
-
-  scenario 'a school that orders can order for local restrictions' do
-    given_a_school_that_will_order_devices_can_order_for_local_restrictions
-    when_i_visit_the_order_devices_page
-    then_i_see_the_cannot_order_devices_yet_page
-    and_i_see_that_1_school_can_place_their_own_order_for_local_restrictions
-  end
-
-  scenario 'schools that order can order for local restrictions and specific circumstances' do
-    given_a_school_that_will_order_devices_can_order_for_local_restrictions
-    given_a_school_that_will_order_devices_can_order_for_specific_circumstances
-    when_i_visit_the_order_devices_page
-    then_i_see_the_cannot_order_devices_yet_page
-    and_i_see_that_2_schools_can_place_their_own_orders
   end
 
   def given_i_am_signed_in_as_a_responsible_body_user
@@ -95,16 +71,6 @@ RSpec.feature 'Ordering devices' do
   def given_a_centrally_managed_school_can_order_for_local_restrictions
     schools[2].can_order!
     schools[2].std_device_allocation.update!(cap: 7, allocation: 7)
-  end
-
-  def given_a_school_that_will_order_devices_can_order_for_specific_circumstances
-    schools[3].can_order_for_specific_circumstances!
-    schools[3].std_device_allocation.update!(cap: 2, allocation: 23)
-  end
-
-  def given_a_school_that_will_order_devices_can_order_for_local_restrictions
-    schools[4].can_order!
-    schools[4].std_device_allocation.update!(cap: 23, allocation: 23)
   end
 
   def when_i_visit_the_responsible_body_home_page
@@ -133,22 +99,6 @@ RSpec.feature 'Ordering devices' do
 
   def then_i_see_the_cannot_order_devices_yet_page
     expect(page).to have_css('h1', text: 'You cannot order devices yet')
-  end
-
-  def and_i_see_that_1_school_can_place_their_own_order_for_specific_circumstances
-    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
-    expect(page).to have_text('1 school can order devices for specific circumstances because their request has been approved.')
-  end
-
-  def and_i_see_that_1_school_can_place_their_own_order_for_local_restrictions
-    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
-    expect(page).to have_text('1 school can order their full allocation')
-  end
-
-  def and_i_see_that_2_schools_can_place_their_own_orders
-    expect(page).to have_css('h2', text: 'Some schools can place their own orders')
-    expect(page).to have_text('1 school can order their full allocation')
-    expect(page).to have_text('1 school can order devices for specific circumstances because their request has been approved.')
   end
 
   def then_i_see_the_order_for_specific_circumstances_page

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -42,15 +42,13 @@ RSpec.feature 'Order devices' do
     then_i_see_that_i_cannot_order_devices_yet
   end
 
-  context 'when there’s a national lockdown', with_feature_flags: { schools_closed_for_national_lockdown: 'active' } do
-    scenario 'a school that cannot order devices yet' do
-      given_the_school_cannot_order_devices
-      given_i_can_order_devices
-      given_i_am_signed_in_as_a_school_user
+  scenario 'a school that cannot order devices yet' do
+    given_the_school_cannot_order_devices
+    given_i_can_order_devices
+    given_i_am_signed_in_as_a_school_user
 
-      when_i_visit_the_order_devices_page
-      then_i_see_that_i_will_be_able_to_order_soon
-    end
+    when_i_visit_the_order_devices_page
+    then_i_see_that_i_will_be_able_to_order_soon
   end
 
   scenario 'when my school cannot order devices and I cannot order devices' do
@@ -125,7 +123,7 @@ RSpec.feature 'Order devices' do
   end
 
   def then_i_see_that_i_cannot_order_devices_yet
-    expect(page).to have_content('You cannot order your full allocation yet')
+    expect(page).to have_content('You cannot order devices yet')
   end
 
   def then_i_see_that_i_cannot_order_as_school_reopened
@@ -133,7 +131,7 @@ RSpec.feature 'Order devices' do
   end
 
   def then_i_see_that_the_school_cannot_order_devices_yet
-    expect(page).to have_content('Your school cannot your full allocation yet')
+    expect(page).to have_content('Your school cannot order devices yet')
   end
 
   def then_i_see_that_i_will_be_able_to_order_soon


### PR DESCRIPTION
Make it the default, and remove older alternatives.
We will not be going back to an Education Settings approach based on partial closures.

Part of https://trello.com/c/xCvrbaea/1561-service-updates-preparing-for-school-reopening