### PR TITLE
Fix inconsistencies between school and RB MNO form

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -68,24 +68,6 @@ module ViewHelper
     end
   end
 
-  def participation_description(mobile_network)
-    [
-      mobile_network.translated_enum_value(:participation_in_pilot),
-      # TODO: uncomment this when we've added the supports_payg field
-      # mobile_network.supports_payg? ? '' : 'Does not support Pay-as-you-go customers.'
-    ].join('. ')
-  end
-
-  def mobile_network_options(mobile_networks)
-    mobile_networks.map do |network|
-      OpenStruct.new(
-        id: network.id,
-        label: network.brand,
-        description: participation_description(network),
-      )
-    end
-  end
-
   def humanized_seconds(seconds)
     ActiveSupport::Duration.build(seconds).inspect
   end

--- a/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
@@ -15,12 +15,11 @@
       <%= f.govuk_text_field :account_holder_name, label: {size: 'm', text: 'Account holder name'}, hint: { text: 'The account holder for a pay monthly contract must be over 18. There’s no minimum age for Pay-as-you-go customers.' } %>
       <%= f.govuk_text_field :device_phone_number, label: {size: 'm', text: 'Mobile phone number'}, hint: { text: 'This should start with 07 and have 11 digits' } %>
 
-      <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint: { text: 'Only networks participating in the service are listed' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:mobile_network_id, legend: {size: 'm', text: 'Mobile network'}, hint: { text: "Only networks participating in the service are listed.<br />#{MobileNetwork.excluded_fe_networks.pluck(:brand).to_sentence(last_word_connector: ' and ')} will not accept requests for students over the age of 16.".html_safe }) do %>
         <%- for mobile_network in @participating_mobile_networks do %>
           <%= f.govuk_radio_button :mobile_network_id,
                                    mobile_network.id,
-                                   label: { text: mobile_network.brand },
-                                   hint: { text: participation_description(mobile_network) } %>
+                                   label: { text: mobile_network.brand } %>
         <%- end %>
       <%- end %>
 


### PR DESCRIPTION
These have come about from having two templates for pages that are otherwise essentially the same.

- Add missing note about FE to the RB form
- Remove hint text from list of networks from the RB form

### Changes proposed in this pull request

| Before | After |
|--|--|
|![Screen Shot 2021-03-03 at 15 13 25](https://user-images.githubusercontent.com/319055/109826972-3f2ca980-7c33-11eb-8fc1-54364e2d4140.png)|![Screen Shot 2021-03-03 at 15 13 36](https://user-images.githubusercontent.com/319055/109826968-3dfb7c80-7c33-11eb-9c90-5eefc11884be.png)|
