### PR TITLE
Add missing breadcrumb from Daily Mail opted in page

### DIFF
--- a/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
@@ -4,10 +4,12 @@
 %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => responsible_body_home_path },
-                  'Donated devices',
-                 ]) %>
-<%- end %>
+  <% breadcrumbs([
+    { 'Home' => responsible_body_home_path },
+    { "#{t('page_titles.responsible_body_devices_home')}" => responsible_body_devices_path },
+    'Donated devices',
+  ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
For RBs the opted in confirmation page is one level deeper, coming off the "Get laptops" page

![Screen Shot 2021-03-03 at 15 49 48](https://user-images.githubusercontent.com/319055/109832258-19ee6a00-7c38-11eb-9a97-6b4d73a2533f.png)