### PR TITLE
[1019] Fix headteacher key in summary list

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -75,7 +75,7 @@ private
 
   def headteacher_row
     {
-      key: headteacher.title.present? ? headteacher.title.upcase_first : 'Headteacher',
+      key: 'Headteacher',
       value: headteacher_lines.map { |line| h(line) }.join('<br>').html_safe,
     }
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/U8kj33G3/1019-school-summary-list-contact-key-incorrect

### Changes proposed in this pull request

- Do not use contact title for headteacher simply use `Headteacher`

### Screenshots

![image](https://user-images.githubusercontent.com/92580/109838974-9126fc80-7c3e-11eb-9387-c60d04c2803c.png)

### Guidance to review

- View a school with headteacher contact with a custom title
- Should show `Headteacher` not custom title
