### PR TITLE
Do not show order action on devolved schools page

### DIFF
--- a/app/components/device_count_component.rb
+++ b/app/components/device_count_component.rb
@@ -3,10 +3,11 @@ class DeviceCountComponent < ViewComponent::Base
 
   attr_reader :school, :action, :show_action
 
-  def initialize(school:, show_action: true, action: {})
+  def initialize(school:, show_action: true, they_ordered_prefix: false, action: {})
     @school = school
     @action = action
     @show_action = show_action
+    @they_ordered_prefix = they_ordered_prefix
   end
 
   def availablility_string
@@ -34,7 +35,9 @@ class DeviceCountComponent < ViewComponent::Base
   end
 
   def state_prefix
-    if @school.cannot_order_as_reopened?
+    if @they_ordered_prefix
+      'They have ordered '
+    elsif @school.cannot_order_as_reopened?
       'You ordered '
     else
       'You’ve ordered '

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -13,9 +13,14 @@
       <%- end %>
     <%- else %>
       <%- if @school.has_std_device_allocation? %>
+        <%
+          show_action = @school.preorder_information.orders_managed_centrally? && (@school.std_device_allocation.devices_ordered < @school.std_device_allocation.cap)
+          they_ordered_prefix = !@school.preorder_information.orders_managed_centrally?
+        %>
         <%= render DeviceCountComponent.new(
           school: @school,
-          show_action: @school.std_device_allocation.devices_ordered < @school.std_device_allocation.cap,
+          show_action: show_action,
+          they_ordered_prefix: they_ordered_prefix,
           action: { 'Order devices' => order_devices_responsible_body_devices_school_path(urn: @school.urn) }) %>
       <% else %>
         <%= render partial: 'shared/school_without_allocation' %>


### PR DESCRIPTION
Remove the "Order" button from school pages for responsible bodies that have devolved ordering to schools.

Also update the prefix to highlight that "they" ordered, rather than the RB

| Before | After |
|--|--|
|![Screen Shot 2021-03-03 at 16 43 39](https://user-images.githubusercontent.com/319055/109840506-19f26800-7c40-11eb-8800-90378bb9df63.png)|![Screen Shot 2021-03-03 at 16 43 16](https://user-images.githubusercontent.com/319055/109840501-1828a480-7c40-11eb-8d6f-1fa9f7468a38.png)|

