### PR TITLE
[1667] Add three and smarty as FE mno

### DIFF
--- a/app/models/mobile_network.rb
+++ b/app/models/mobile_network.rb
@@ -14,7 +14,7 @@ class MobileNetwork < ApplicationRecord
     participating
   end
 
-  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2 Three SMARTY]) }
+  scope :excluded_fe_networks, -> { where(brand: %w[giffgaff O2]) }
   scope :fe_networks, -> { participating.where.not(id: excluded_fe_networks.pluck(:id)) }
 
   def pathsafe_brand

--- a/app/views/shared/mno_offer_details/_smarty.html.erb
+++ b/app/views/shared/mno_offer_details/_smarty.html.erb
@@ -1,11 +1,6 @@
-<% brand = 'SMARTY' %>
-
 <ul class="govuk-list govuk-list--bullet">
   <li>The recipient will get unlimited data until 31 July 2021.</li>
   <li>The offer is available to both Pay Monthly and active Pay-as-you-go customers.</li>
   <li>A text message will be sent to the nominated device once the additional data has been added to the account.</li>
   <li>SMARTY will aim to process the request within 14 days.</li>
-  <% if MobileNetwork.excluded_fe_networks.where(brand: brand).exists? %>
-    <li><% brand %> will not accept requests for students over the age of 16.</li>
-  <% end %>
 </ul>

--- a/app/views/shared/mno_offer_details/_three.html.erb
+++ b/app/views/shared/mno_offer_details/_three.html.erb
@@ -1,11 +1,6 @@
-<% brand = 'Three' %>
-
 <ul class="govuk-list govuk-list--bullet">
   <li>The recipient will get unlimited data until 31 July 2021.</li>
   <li>The offer is available to both Pay Monthly and active Pay-as-you-go customers.</li>
   <li>A text message will be sent to the nominated device once the additional data has been added to the account.</li>
   <li>Three will aim to process the request within 14 days.</li>
-  <% if MobileNetwork.excluded_fe_networks.where(brand: brand).exists? %>
-    <li><% brand %> will not accept requests for students over the age of 16.</li>
-  <% end %>
 </ul>


### PR DESCRIPTION
### Context

- https://trello.com/c/vvjcnuzc/1667-add-three-and-smarty-to-fe-extension-for-mno-offer

### Changes proposed in this pull request

- Copy changes to enable Three and SMARTY as FE mnos
- No longer exclude Three and SMARTY as FE mnos

### Guidance to review

- Guidance should now list Three and SMARTY as FE mnos
