### PR TITLE
Prevent allocation change during gias update when in virtual cap pool

### DIFF
--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -70,20 +70,23 @@ private
   end
 
   def move_remaining_allocations(school, predecessor)
-    predecessor.device_allocations.each do |allocation|
-      alloc = allocation.raw_allocation
-      ordered = allocation.raw_devices_ordered
-      spare_allocation = alloc - ordered
+    rb = predecessor.responsible_body
+    unless rb.has_virtual_cap_feature_flags? && rb.has_school_in_virtual_cap_pools?(predecessor)
+      predecessor.device_allocations.each do |allocation|
+        alloc = allocation.raw_allocation
+        ordered = allocation.raw_devices_ordered
+        spare_allocation = alloc - ordered
 
-      next unless spare_allocation.positive?
+        next unless spare_allocation.positive?
 
-      SchoolDeviceAllocation.transaction do
-        school.device_allocations
-          .send(allocation.device_type).first
-          .update!(allocation: spare_allocation,
-                   cap: spare_allocation)
+        SchoolDeviceAllocation.transaction do
+          school.device_allocations
+            .send(allocation.device_type).first
+            .update!(allocation: spare_allocation,
+                     cap: spare_allocation)
 
-        allocation.update!(allocation: ordered, cap: ordered)
+          allocation.update!(allocation: ordered, cap: ordered)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/CVq8JC4o/1569-prevent-gias-updates-from-add-closing-schools-where-virtual-caps-are-involved)
We haven't worked out how to deal with removing schools from virtual cap pools so prevent the GIAS updates from moving allocation from predecessor school when adding a successor school if predecessor is in a virtual cap pool.

### Changes proposed in this pull request
Prevents moving any remaining allocation from school being closed to new school in `SchoolUpdateService`

### Guidance to review
Some setup needed:

* A new school to be added in DataStage
* A predecessor in the DataStage that should be closed
* The corresponding active (predecessor) school with a some remaining allocation in a virtual pool

Adding the new school via `SchoolUpdateService#create_school!` should not move any of the predecessor school's remaining allocation to the new school school.
