### PR TITLE
fix issue pre-rendering 429.html in production build

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
     </header>
     <div class="govuk-width-container">
       <%= render GovukComponent::PhaseBanner.new(phase: 'Alpha') do
-        if current_user.persisted? && (current_user.is_responsible_body_user? || current_user.is_school_user?)
+        if SessionService.is_signed_in?(session) && (current_user.is_responsible_body_user? || current_user.is_school_user?)
           "#{t('user_feedback')} – #{user_feedback_link}".html_safe
         else
           "This is a new service – your #{ghwt_contact_mailto(label: "feedback", subject: "Feedback")} will help us to improve it.".html_safe


### PR DESCRIPTION
### Context

A recent change has resulted in a [build failure on `main`](https://github.com/DFE-Digital/get-help-with-tech/runs/2032233362?check_suite_focus=true) with this error:

```
rake aborted!
ActionView::Template::Error: undefined method `persisted?' for nil:NilClass
/var/www/get-help-with-tech/app/views/layouts/application.html.erb:63
```

On investigation, it's because the current_user is nil when running the rake task to pre-render the 429 error page to a flat file, and new code in application.html does not account for this.

### Changes proposed in this pull request

Add a check to `layouts/application.html` for whether there is a signed in user

### Guidance to review

```
$ bundle exec rake release:render_429_to_file
```
You should see something like:
```
Rendered 9889 bytes to (...)/public/429.html
```
...and not an error
```
