### PR TITLE
Fix issue with finding RBs with mapped names

### DIFF
--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -12,7 +12,7 @@ class SchoolUpdateService
   end
 
   def create_school!(staged_school)
-    responsible_body_exists!(staged_school.responsible_body_name)
+    responsible_body_exists!(staged_school)
 
     school = School.create!(staged_school.staged_attributes)
     setup_preorder_information(school)
@@ -93,8 +93,8 @@ private
     predecessor.user_schools.destroy_all
   end
 
-  def responsible_body_exists!(responsible_body_name)
-    raise DataStage::Error, "Cannot find responsible body '#{responsible_body_name}'" unless ResponsibleBody.find_by(name: responsible_body_name)
+  def responsible_body_exists!(staged_school)
+    raise DataStage::Error, "Cannot find responsible body '#{staged_school.responsible_body_name}'" if staged_school.responsible_body.blank?
   end
 
   def update_school(staged_school)

--- a/spec/services/school_update_service_spec.rb
+++ b/spec/services/school_update_service_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe SchoolUpdateService, type: :model do
       }.to change(School, :count).by(1)
     end
 
+    context 'when the responsible body name has to be mapped' do
+      let!(:mapped_la) { create(:local_authority, name: 'City of Bristol') }
+
+      before do
+        staged_school.update!(responsible_body_name: 'Bristol, City of')
+      end
+
+      it 'looks up the name to find the correct responsible body' do
+        school = service.create_school!(staged_school)
+        expect(school.responsible_body).to eq(mapped_la)
+      end
+    end
+
     context 'when the responsible body has decided who will order' do
       before do
         local_authority.update!(who_will_order_devices: 'schools')


### PR DESCRIPTION
### Context
Problem was seen when rebuilding dev database that the `SchoolUpdateService` was not correctly looking up / mapping the `responsible_body_name` from the school to create and this was causing errors to be raised.

### Changes proposed in this pull request
Use the `DataStage::School#responsible_body` method to correctly map the `responsible_body_name`

### Guidance to review

