### PR TITLE
[1669] Disable worker in Heroku review apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma -p $PORT
-worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app.json
+++ b/app.json
@@ -23,9 +23,6 @@
   "formation": {
     "web": {
       "quantity": 1
-    },
-    "worker": {
-      "quantity": 1
     }
   },
   "addons": [

--- a/app.json
+++ b/app.json
@@ -27,7 +27,6 @@
   },
   "addons": [
     "heroku-postgresql",
-    "heroku-redis"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
### Context

[Trello card 1669](https://trello.com/c/iYPafQTH/1669-remove-the-worker-from-heroku-which-runs-overnight-jobs-to-import-school-data-from-gias) When a Heroku review app lives for more than a few hours, it can
trigger the overnight GIAS updates. This brings in up to 70k rows
to the DB, and triggers warnings from Heroku about the database
size exceeding the maximum available on the free plan.

Since we are now flashing login token links to the user on Heroku,
there's no reason that we can think of for actually keeping the
worker process for review apps.

### Changes proposed in this pull request

Remove the worker process.

### Guidance to review

Click around the review app for this PR, make sure it works
