### PR TITLE
Fix prevent double click submits

### DIFF
--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -21,7 +21,7 @@
                                     label: {text: 'Academy trust name', size: 's'},
                                     options: { include_blank: true }%>
 
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next' %>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -74,7 +74,7 @@
 
     <div class="govuk-form-group">
       <%= form_for @form, url: support_ticket_check_your_request_path do |f| %>
-        <%= f.govuk_submit 'Submit', prevent_double_click: false %>
+        <%= f.govuk_submit 'Submit'%>
       <% end %>
     </div>
   </div>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -22,7 +22,7 @@
                              label: {text: 'College UKPRN', size: 's'},
                              hint: { text: 'This 8-digit number helps us to locate your college. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">UKPRN</a>.'.html_safe },
                              width: 5 %>
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next'%>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/contact_details.html.erb
+++ b/app/views/support_tickets/contact_details.html.erb
@@ -25,7 +25,7 @@
                              label: {size: 's', text: 'Telephone number (Optional)'},
                              hint: {text: "It will help our support team if they need to call you to resolve your query."} %>
 
-      <%= f.govuk_submit "Next", prevent_double_click: false %>
+      <%= f.govuk_submit "Next" %>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/describe_yourself.html.erb
+++ b/app/views/support_tickets/describe_yourself.html.erb
@@ -22,7 +22,7 @@
 
 
 
-      <%= f.govuk_submit "Next", prevent_double_click: false%>
+      <%= f.govuk_submit "Next"%>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -21,7 +21,7 @@
                                     label: {text: 'Local authority name', size: 's'},
                                     options: { include_blank: true } %>
 
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next'%>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -22,7 +22,7 @@
                              label: {text: 'School URN', size: 's'},
                              hint: { text: 'This 6-digit number helps us to locate your school. Find your <a href="https://get-information-schools.service.gov.uk/" target="_blank" rel="noopener noreferrer">URN</a>.'.html_safe },
                              width: 5 %>
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next'%>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/support_details.html.erb
+++ b/app/views/support_tickets/support_details.html.erb
@@ -17,7 +17,7 @@
                             label: { text: 'How can we help you?', size: 'l',  tag:'h1'},
                             hint: { text: "Please provide us with as much detail as possible", size: 'l'} %>
 
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next'%>
     <% end %>
   </div>
 </div>

--- a/app/views/support_tickets/support_needs.html.erb
+++ b/app/views/support_tickets/support_needs.html.erb
@@ -23,7 +23,7 @@
 
 
 
-      <%= f.govuk_submit 'Next', prevent_double_click: false %>
+      <%= f.govuk_submit 'Next'%>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context
Firstly when this change went in the documentation was misinterupted
and the option should have been set to false. According to the
documentation now prevent double click submits are enabled by default (top of page).

https://govuk-form-builder.netlify.app/form-elements/submit/
https://govuk-form-builder.netlify.app/form-elements/submit/#input-erb-generating-a-submit-button-without-double-click-prevention

Thank you @asmega for picking up on this bug. 👍 

### Changes proposed in this pull request

### Guidance to review

