### PR TITLE
[1661] Reject example mobile number

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -20,6 +20,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   validate :validate_school_or_rb_present
   validate :validate_request_uniqueness, on: :create
   validate :validate_network_permits_fe
+  validate :validate_not_example_number
 
   enum status: {
     new: 'new',
@@ -111,6 +112,12 @@ class ExtraMobileDataRequest < ApplicationRecord
   end
 
 private
+
+  def validate_not_example_number
+    if device_phone_number == '07123456789'
+      errors.add(:device_phone_number, '07123456789 is the example number and will not be added')
+    end
+  end
 
   def validate_network_permits_fe
     if school&.hide_mno? && MobileNetwork.excluded_fe_networks.include?(mobile_network)

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
 
         expect(page.status_code).to eq(200)
         expect(page).to have_text('Anne Account-Holder')
-        expect(page).to have_text('07123456789')
+        expect(page).to have_text('07123456780')
         expect(page).to have_text(mobile_network.brand)
         expect(page).to have_text('Pay as you go (PAYG)')
         expect(page).to have_text('Check your answers')
@@ -88,7 +88,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
       end
 
       expect(find_field('Account holder name').value).to eq('My new account holder name')
-      expect(find_field('Mobile phone number').value).to eq('07123456789')
+      expect(find_field('Mobile phone number').value).to eq('07123456780')
       expect(page).to have_checked_field(mobile_network.brand)
       expect(page).to have_checked_field('Pay as you go (PAYG)')
       expect(page).to have_checked_field('Yes, the privacy statement has been shared')

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
   end
 
+  describe 'validates example number' do
+    subject(:model) { described_class.new(device_phone_number: '07123456789') }
+
+    it 'is not valid' do
+      expect(model.valid?).to be_falsey
+      expect(model.errors[:device_phone_number]).to be_present
+    end
+  end
+
   describe 'validate RB or school must be present' do
     let(:school) { create(:school) }
     let(:rb) { create(:trust) }
@@ -106,7 +115,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
     context 'when school present' do
       let(:existing_request) do
-        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456789', school: school)
+        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456780', school: school)
       end
 
       subject(:model) { build(:extra_mobile_data_request, school: existing_request.school, responsible_body: nil) }
@@ -119,7 +128,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
         model.valid?
         expect(model.errors[:device_phone_number]).to be_blank
 
-        model.device_phone_number = '07123456789'
+        model.device_phone_number = '07123456780'
         model.valid?
         expect(model.errors[:device_phone_number]).to be_blank
 
@@ -131,10 +140,10 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
     context 'when the device_phone_number is not normalised' do
       let(:existing_request) do
-        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456789', school: school)
+        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456780', school: school)
       end
 
-      subject(:model) { build(:extra_mobile_data_request, school: existing_request.school, mobile_network_id: existing_request.mobile_network_id, account_holder_name: existing_request.account_holder_name, responsible_body: nil, device_phone_number: '07123 456 789') }
+      subject(:model) { build(:extra_mobile_data_request, school: existing_request.school, mobile_network_id: existing_request.mobile_network_id, account_holder_name: existing_request.account_holder_name, responsible_body: nil, device_phone_number: '07123 456 780') }
 
       before do
         model.mobile_network_id = existing_request.mobile_network_id
@@ -197,13 +206,13 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
   end
 
   it 'normalises phone numbers to the national format without spaces' do
-    expect(mno_request_for_number('07 123 456 789').device_phone_number).to eq('07123456789')
-    expect(mno_request_for_number('0712345 6789').device_phone_number).to eq('07123456789')
+    expect(mno_request_for_number('07 123 456 780').device_phone_number).to eq('07123456780')
+    expect(mno_request_for_number('0712345 6780').device_phone_number).to eq('07123456780')
     expect(mno_request_for_number('+44 7712345678').device_phone_number).to eq('07712345678')
   end
 
   it 'normalises phone numbers without the leading zero to the national format without spaces' do
-    expect(mno_request_for_number('7123456789').device_phone_number).to eq('07123456789')
+    expect(mno_request_for_number('7123456780').device_phone_number).to eq('07123456780')
   end
 
   describe 'validating contract_type' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
   end
 
-  describe 'validates example number' do
+  describe 'validates device_phone_number is not the example number' do
     subject(:model) { described_class.new(device_phone_number: '07123456789') }
 
     it 'is not valid' do

--- a/spec/services/extra_data_request_spreadsheet_importer_spec.rb
+++ b/spec/services/extra_data_request_spreadsheet_importer_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe ExtraDataRequestSpreadsheetImporter, type: :model do
       [
         {
           account_holder_name: 'John Doe',
-          mobile_phone_number: '07123456789',
+          mobile_phone_number: '07123456780',
           mobile_network: MobileNetwork.fe_networks.sample.brand,
           pay_monthly_or_payg: 'pay_monthly',
           has_someone_shared_the_privacy_statement_with_the_account_holder: 'TRUE',
         },
         {
           account_holder_name: 'John Doe',
-          mobile_phone_number: '07123456789',
+          mobile_phone_number: '07123456781',
           mobile_network: MobileNetwork.excluded_fe_networks.sample.brand,
           pay_monthly_or_payg: 'pay_monthly',
           has_someone_shared_the_privacy_statement_with_the_account_holder: 'TRUE',

--- a/spec/shared/filling_in_forms.rb
+++ b/spec/shared/filling_in_forms.rb
@@ -1,6 +1,6 @@
 def fill_in_valid_application_form(mobile_network_name: 'Participating mobile network', contract_type: 'Pay as you go (PAYG)')
   fill_in 'Account holder name', with: 'Anne Account-Holder'
-  fill_in 'Mobile phone number', with: '07123456789'
+  fill_in 'Mobile phone number', with: '07123456780'
 
   choose mobile_network_name
   choose contract_type


### PR DESCRIPTION
### Context

- https://trello.com/c/AGdMGI1F/1661-investigate-sample-spreadsheet-rows-present-as-extramobiledatarequests

### Changes proposed in this pull request

- Spreadsheet uploads with example number are rejected
- Validations added so users can see the problem to rectify

### Screenshots

![image](https://user-images.githubusercontent.com/92580/110315256-eb3e0e00-8000-11eb-924c-1b59bed2485f.png)

### Guidance to review

- Sign in as school or RB
- Download the MNO template spreadsheet
- Change the name of the example user in the template spreadsheet and upload
- Should see validation error message about example number
