### PR TITLE
[1631] Remove references to closures and self-isolating groups

### DIFF
--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -9,7 +9,7 @@
 
     <%= render partial: 'shared/techsource_unavailable_banner' %>
 
-    <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order. You cannot order a school’s full allocation yet because no school closures or groups of self-isolating children have been reported.</p>
+    <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order.</p>
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
   </div>

--- a/app/views/school/devices/cannot_order_as_reopened.html.erb
+++ b/app/views/school/devices/cannot_order_as_reopened.html.erb
@@ -23,14 +23,8 @@
       <p class="govuk-body"><%= link_to 'View your order history on TechSource', techsource_start_path %></p>
     <% end %>
 
-    <h2 class="govuk-heading-m">When you can order again</h2>
-
     <p class="govuk-body">
-      You can only place orders when you report further closures or groups of self-isolating children.
-    </p>
-
-    <p class="govuk-body">
-      We’ll contact you as soon as you’re able to place orders.
+      We’ll contact you as soon as you’re able to place orders again.
     </p>
   </div>
 </div>


### PR DESCRIPTION
These pages shouldn't be seen by schools, but just in case – remove references to reporting closures.