### PR TITLE
Enable MNO offer for all local authorities

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ private
     end
   end
 
-  def render_404_unless_responsible_body_has_centrally_managed_schools(responsible_body)
+  def render_404_unless_responsible_body_has_connectivity_feature_flags(responsible_body)
     unless responsible_body.has_connectivity_feature_flags?
       render 'errors/not_found', status: :not_found and return
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ private
   end
 
   def render_404_unless_responsible_body_has_centrally_managed_schools(responsible_body)
-    unless responsible_body.in_connectivity_pilot_and_has_centrally_managed_schools?
+    unless responsible_body.has_connectivity_feature_flags?
       render 'errors/not_found', status: :not_found and return
     end
   end

--- a/app/controllers/responsible_body/internet/home_controller.rb
+++ b/app/controllers/responsible_body/internet/home_controller.rb
@@ -1,5 +1,5 @@
 class ResponsibleBody::Internet::HomeController < ResponsibleBody::Internet::BaseController
-  before_action { render_404_unless_responsible_body_has_centrally_managed_schools(@responsible_body) }
+  before_action { render_404_unless_responsible_body_has_connectivity_feature_flags(@responsible_body) }
 
   def show; end
 end

--- a/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/extra_data_requests_controller.rb
@@ -1,5 +1,5 @@
 class ResponsibleBody::Internet::Mobile::ExtraDataRequestsController < ResponsibleBody::BaseController
-  before_action { render_404_unless_responsible_body_has_centrally_managed_schools(@responsible_body) }
+  before_action { render_404_unless_responsible_body_has_connectivity_feature_flags(@responsible_body) }
 
   def index
     @pagination, @extra_mobile_data_requests = pagy(@responsible_body.extra_mobile_data_requests.order(:created_at))

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -112,8 +112,8 @@ class ResponsibleBody < ApplicationRecord
     has_virtual_cap_feature_flags? && has_centrally_managed_schools?
   end
 
-  def in_connectivity_pilot_and_has_centrally_managed_schools?
-    in_connectivity_pilot? && has_centrally_managed_schools?
+  def has_connectivity_feature_flags?
+    in_connectivity_pilot? && (has_centrally_managed_schools? || is_a_local_authority?)
   end
 
   def has_multiple_chromebook_domains_in_managed_schools?

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -24,7 +24,7 @@
       <li>opt in schools and colleges to the Daily Mail’s donated devices scheme</li>
     </ul>
 
-    <%- if @responsible_body.in_connectivity_pilot_and_has_centrally_managed_schools? %>
+    <%- if @responsible_body.has_connectivity_feature_flags? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to t('page_titles.responsible_body_internet_home'), responsible_body_internet_path %>
       </h2>

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -73,7 +73,9 @@ RSpec.feature ResponsibleBody do
       end
     end
 
-    context 'with a responsible body devolved to all schools' do
+    context 'with a trust devolved to all schools' do
+      let(:responsible_body) { create(:trust) }
+
       before do
         responsible_body.update!(in_connectivity_pilot: true)
       end
@@ -81,6 +83,17 @@ RSpec.feature ResponsibleBody do
       it 'does not show link to get extra data' do
         visit responsible_body_home_path
         expect(page).not_to have_link('Get internet access')
+      end
+    end
+
+    context 'with a local authority devolved to all schools' do
+      before do
+        responsible_body.update!(in_connectivity_pilot: true)
+      end
+
+      it 'shows link to get extra data' do
+        visit responsible_body_home_path
+        expect(page).to have_link('Get internet access')
       end
     end
 


### PR DESCRIPTION
LAs, even those that have devolved to all schools, must sometimes request mobile data on behalf of students not in school. For example – pupils who aren't in a mainstream school as they're awaiting an EHCP.