### PR TITLE
Fixes malformed app.json for heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
     }
   },
   "addons": [
-    "heroku-postgresql",
+    "heroku-postgresql"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
### Context
Heroku was failing to build review apps:

![image](https://user-images.githubusercontent.com/3441519/110478193-029df980-80dc-11eb-9b1e-3a49dfa9bcce.png)

This was introduced from a recent change we made to this file to remove the worker from heroku review apps (9818facafdbe910eaa8253a45130542b0a080dd5)
### Changes proposed in this pull request

### Guidance to review

- Review apps should work (Visit https://dfe-ghwt-pr-1404.herokuapp.com/)