### PR TITLE
[1229] Support can impersonate users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,21 @@ private
     @current_user ||= (SessionService.identify_user!(session) || User.new)
   end
 
+  def impersonated_user
+    @impersonated_user = if session[:impersonated_user_id].blank?
+                           nil
+                         else
+                           User.find_by(id: session[:impersonated_user_id])
+                         end
+  end
+  helper_method :impersonated_user
+
   attr_reader :current_user
   helper_method :current_user
+
+  def impersonated_or_current_user
+    impersonated_user || current_user
+  end
 
   def save_user_to_session!(user = @current_user)
     # prevent duplicate key errors if they're already signed_in

--- a/app/controllers/privacy_notice_controller.rb
+++ b/app/controllers/privacy_notice_controller.rb
@@ -4,7 +4,9 @@ class PrivacyNoticeController < ApplicationController
   def show; end
 
   def seen
-    @current_user.seen_privacy_notice!
-    redirect_to root_url_for(@current_user)
+    authorize impersonated_or_current_user, policy_class: PrivacyNoticePolicy
+
+    impersonated_or_current_user.seen_privacy_notice!
+    redirect_to root_url_for(impersonated_or_current_user)
   end
 end

--- a/app/controllers/responsible_body/base_controller.rb
+++ b/app/controllers/responsible_body/base_controller.rb
@@ -11,16 +11,16 @@ private
   end
 
   def deny_single_academy_trust_user!
-    render 'errors/forbidden', status: :forbidden if @current_user.is_a_single_school_user?
+    render 'errors/forbidden', status: :forbidden if impersonated_or_current_user.is_a_single_school_user?
   end
 
   def require_rb_user!
-    unless @current_user.is_responsible_body_user?
+    unless impersonated_or_current_user.is_responsible_body_user?
       render 'errors/forbidden', status: :forbidden
     end
   end
 
   def set_responsible_body
-    @responsible_body = @current_user.responsible_body
+    @responsible_body = impersonated_or_current_user.responsible_body
   end
 end

--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -8,6 +8,8 @@ class ResponsibleBody::Devices::ChangeWhoWillOrderController < ResponsibleBody::
   end
 
   def update
+    authorize ResponsibleBody::Devices::WhoWillOrderForm, policy_class: ResponsibleBody::BasePolicy
+
     @form = ResponsibleBody::Devices::WhoWillOrderForm.new(who_will_order_params)
     if @form.valid?
       @school.preorder_information.change_who_will_order_devices!(@form.who_will_order)
@@ -32,7 +34,7 @@ private
     @school.preorder_information.who_will_order_devices
   end
 
-  def who_will_order_params(opts = params)
-    opts.require(:responsible_body_devices_who_will_order_form).permit(:who_will_order)
+  def who_will_order_params
+    params.require(:responsible_body_devices_who_will_order_form).permit(:who_will_order)
   end
 end

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -12,6 +12,8 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
   end
 
   def update
+    authorize ChromebookInformationForm.new, policy_class: ResponsibleBody::BasePolicy
+
     @preorder_info = @school.preorder_information
     @chromebook_information_form = ChromebookInformationForm.new(
       { school: @school }.merge(chromebook_params),

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -7,6 +7,8 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::BaseCo
   end
 
   def create
+    authorize ResponsibleBody::Devices::WhoToContactForm, policy_class: ResponsibleBody::BasePolicy
+
     create_or_update
   end
 
@@ -17,6 +19,8 @@ class ResponsibleBody::Devices::WhoToContactController < ResponsibleBody::BaseCo
   end
 
   def update
+    authorize ResponsibleBody::Devices::WhoToContactForm, policy_class: ResponsibleBody::BasePolicy
+
     create_or_update
   end
 

--- a/app/controllers/responsible_body/devices/who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/who_will_order_controller.rb
@@ -6,6 +6,8 @@ class ResponsibleBody::Devices::WhoWillOrderController < ResponsibleBody::BaseCo
   end
 
   def update
+    authorize ResponsibleBody::Devices::WhoWillOrderForm, policy_class: ResponsibleBody::BasePolicy
+
     @form = ResponsibleBody::Devices::WhoWillOrderForm.new(who_will_order_params)
     if @form.valid?
       ResponsibleBody.transaction do
@@ -28,7 +30,7 @@ class ResponsibleBody::Devices::WhoWillOrderController < ResponsibleBody::BaseCo
 
 private
 
-  def who_will_order_params(opts = params)
-    opts.require(:responsible_body_devices_who_will_order_form).permit(:who_will_order)
+  def who_will_order_params
+    params.require(:responsible_body_devices_who_will_order_form).permit(:who_will_order)
   end
 end

--- a/app/controllers/responsible_body/donated_devices/interest_controller.rb
+++ b/app/controllers/responsible_body/donated_devices/interest_controller.rb
@@ -9,6 +9,8 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
   def create
     @form = DonatedDeviceInterestForm.new(device_interest_params)
 
+    authorize @form, policy_class: ResponsibleBody::DonatedDevicePolicy
+
     if @form.valid?
       if @form.interested?
         redirect_to responsible_body_donated_devices_about_devices_path(@school)
@@ -26,7 +28,10 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def interest_confirmation
     @form = DonatedDeviceInterestForm.new(device_interest_params)
+
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
+
       if @form.valid?
         if @form.interested?
           redirect_to responsible_body_donated_devices_all_or_some_schools_path
@@ -41,7 +46,10 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def all_or_some_schools
     @request = find_or_build_request
+
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
+
       if request_valid_for_status?(status: 'opt_in_step')
         if @request.opt_in_all_schools?
           @request.schools = all_centrally_managed_schools_ids
@@ -60,6 +68,8 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def select_schools
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
+
       if request_valid_for_status?(status: 'schools_step', request_params: get_params_with_chosen_schools)
         if @request.schools_that_have_not_already_been_selected.count.zero?
           @request.opt_in_choice = 'all_schools'
@@ -76,6 +86,8 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def device_types
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
+
       if request_valid_for_status?(status: 'devices_step')
         @request.save!
         redirect_to responsible_body_donated_devices_how_many_devices_path
@@ -87,6 +99,8 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def how_many_devices
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
+
       if request_valid_for_status?(status: 'units_step')
         @request.save!
         redirect_to responsible_body_donated_devices_address_path
@@ -102,6 +116,7 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
 
   def check_answers
     if request.post?
+      authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
       @request.complete!
       redirect_to responsible_body_donated_devices_opted_in_path
     end

--- a/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/bulk_requests_controller.rb
@@ -4,6 +4,8 @@ class ResponsibleBody::Internet::Mobile::BulkRequestsController < ResponsibleBod
   end
 
   def create
+    authorize BulkUploadForm, policy_class: ResponsibleBody::BasePolicy
+
     @upload_form = BulkUploadForm.new(upload_form_params)
 
     if @upload_form.valid?

--- a/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/responsible_body/internet/mobile/manual_requests_controller.rb
@@ -17,6 +17,8 @@ class ResponsibleBody::Internet::Mobile::ManualRequestsController < ResponsibleB
                                              responsible_body: @current_user.responsible_body),
     )
 
+    authorize @extra_mobile_data_request, policy_class: ResponsibleBody::BasePolicy
+
     if @extra_mobile_data_request.valid?
       if params[:confirm]
         # clear the stashed params once the user has confirmed them

--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -10,6 +10,8 @@ class ResponsibleBody::UsersController < ResponsibleBody::BaseController
   end
 
   def create
+    authorize CreateUserService, policy_class: ResponsibleBody::BasePolicy
+
     @rb_user = CreateUserService.invite_responsible_body_user(
       user_params.merge(responsible_body_id: @responsible_body.id),
     )
@@ -30,6 +32,9 @@ class ResponsibleBody::UsersController < ResponsibleBody::BaseController
 
   def update
     @rb_user = @responsible_body.users.find(params[:id])
+
+    authorize @rb_user, policy_class: ResponsibleBody::BasePolicy
+
     if @rb_user.update(user_params)
       redirect_to responsible_body_users_path
     else

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -5,18 +5,18 @@ private
 
   def require_school_user!
     if SessionService.is_signed_in?(session)
-      render 'errors/forbidden', status: :forbidden unless @current_user.is_school_user?
+      render 'errors/forbidden', status: :forbidden unless impersonated_or_current_user.is_school_user?
     else
       redirect_to_sign_in
     end
   end
 
   def set_school
-    @school = @current_user.schools.where_urn_or_ukprn(params[:urn].to_i).first!
+    @school = impersonated_or_current_user.schools.where_urn_or_ukprn(params[:urn].to_i).first!
   end
 
   def require_completed_welcome_wizard!
-    unless @current_user.welcome_wizard_for(@school)&.complete? || params[:controller] == 'school/welcome_wizard'
+    unless impersonated_or_current_user.welcome_wizard_for(@school)&.complete? || params[:controller] == 'school/welcome_wizard'
       redirect_to welcome_wizard_allocation_school_path(@school)
     end
   end

--- a/app/controllers/school/chromebooks_controller.rb
+++ b/app/controllers/school/chromebooks_controller.rb
@@ -13,6 +13,9 @@ class School::ChromebooksController < School::BaseController
     @chromebook_information_form = ChromebookInformationForm.new(
       { school: @school }.merge(chromebook_params),
     )
+
+    authorize @chromebook_information_form, policy_class: School::BasePolicy
+
     if @chromebook_information_form.valid?
       @preorder_info.update_chromebook_information_and_status!(chromebook_params)
       flash[:success] = t(:success, scope: %w[school chromebooks])

--- a/app/controllers/school/donated_devices/interest_controller.rb
+++ b/app/controllers/school/donated_devices/interest_controller.rb
@@ -9,6 +9,8 @@ class School::DonatedDevices::InterestController < School::BaseController
   def create
     @form = DonatedDeviceInterestForm.new(device_interest_params)
 
+    authorize DonatedDeviceInterestForm, policy_class: School::DonatedDevicePolicy
+
     if @form.valid?
       if @form.interested?
         redirect_to about_devices_donated_devices_school_path(@school)
@@ -26,7 +28,10 @@ class School::DonatedDevices::InterestController < School::BaseController
 
   def interest_confirmation
     @form = DonatedDeviceInterestForm.new(device_interest_params)
+
     if request.post?
+      authorize @form, policy_class: School::DonatedDevicePolicy
+
       if @form.valid?
         if @form.interested?
           redirect_to what_devices_do_you_want_donated_devices_school_path(@school)
@@ -43,6 +48,8 @@ class School::DonatedDevices::InterestController < School::BaseController
     find_or_build_request
 
     if request.post?
+      authorize @request, policy_class: School::DonatedDevicePolicy
+
       @request.assign_attributes(donated_device_params)
       if @request.valid?
         @request.save!
@@ -55,6 +62,7 @@ class School::DonatedDevices::InterestController < School::BaseController
 
   def how_many_devices
     if request.post?
+      authorize @request, policy_class: School::DonatedDevicePolicy
       last_status = @request.status
       @request.assign_attributes(donated_device_params.merge(status: 'units_step'))
       if @request.valid?
@@ -73,6 +81,7 @@ class School::DonatedDevices::InterestController < School::BaseController
 
   def check_answers
     if request.post?
+      authorize @request, policy_class: School::DonatedDevicePolicy
       @request.complete!
       redirect_to opted_in_donated_devices_school_path(@school)
     end

--- a/app/controllers/school/internet/mobile/bulk_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/bulk_requests_controller.rb
@@ -4,6 +4,8 @@ class School::Internet::Mobile::BulkRequestsController < School::BaseController
   end
 
   def create
+    authorize ExtraMobileDataRequest, policy_class: School::BasePolicy
+
     @upload_form = BulkUploadForm.new(upload_form_params)
 
     if @upload_form.valid?

--- a/app/controllers/school/internet/mobile/manual_requests_controller.rb
+++ b/app/controllers/school/internet/mobile/manual_requests_controller.rb
@@ -16,6 +16,8 @@ class School::Internet::Mobile::ManualRequestsController < School::BaseControlle
       extra_mobile_data_request_params.merge(created_by_user: @current_user),
     )
 
+    authorize @extra_mobile_data_request, policy_class: School::BasePolicy
+
     if @extra_mobile_data_request.valid?
       if params[:confirm]
         # clear the stashed params once the user has confirmed them

--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -8,7 +8,10 @@ class School::UsersController < School::BaseController
   end
 
   def create
+    authorize User, policy_class: School::BasePolicy
+
     @user = CreateUserService.invite_school_user(user_params.merge(school_id: @school.id, orders_devices: true))
+
     if @user.persisted?
       redirect_to school_users_path(@school)
     else
@@ -23,6 +26,8 @@ class School::UsersController < School::BaseController
 
   def update
     @user = @school.users.find(params[:id])
+
+    authorize @user, policy_class: School::BasePolicy
 
     if @user.update(user_params)
       flash[:success] = t(:success, scope: %w[school users])

--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -5,6 +5,8 @@ class School::WelcomeWizardController < School::BaseController
   def next_step
     current_step = params.fetch(:step, @wizard.step)
 
+    authorize @wizard, policy_class: School::WelcomeWizardPolicy
+
     # clear_user_sign_in_token!
     if @wizard.update_step!(wizard_params, current_step)
       redirect_to next_step_path

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -2,10 +2,11 @@ class SchoolsController < ApplicationController
   before_action :require_sign_in!
 
   def index
-    @schools = @current_user.schools
-    if @current_user.schools.size == 1 && \
-        (@current_user.is_a_single_school_user? || !@current_user.is_responsible_body_user?)
-      redirect_to home_school_path(@current_user.schools.first)
+    @schools = impersonated_or_current_user.schools
+
+    if impersonated_or_current_user.schools.size == 1 && \
+        (impersonated_or_current_user.is_a_single_school_user? || !impersonated_or_current_user.is_responsible_body_user?)
+      redirect_to home_school_path(impersonated_or_current_user.schools.first)
     end
   end
 end

--- a/app/controllers/support/impersonates_controller.rb
+++ b/app/controllers/support/impersonates_controller.rb
@@ -34,7 +34,7 @@ private
 
   def check_computacenter_user_impersonation
     if User.find(params[:impersonated_user_id]).is_computacenter?
-      flash[:warning] = 'You cannot impersonate a computacenter user'
+      flash[:warning] = 'You cannot impersonate a Computacenter user'
       redirect_to(root_url_for(current_user))
     end
   end

--- a/app/controllers/support/impersonates_controller.rb
+++ b/app/controllers/support/impersonates_controller.rb
@@ -1,0 +1,41 @@
+class Support::ImpersonatesController < Support::BaseController
+  before_action { authorize User, policy_class: ImpersonationPolicy }
+  before_action :check_self_impersonation, only: [:create]
+  before_action :check_support_user_impersonation, only: [:create]
+  before_action :check_computacenter_user_impersonation, only: [:create]
+
+  def create
+    session[:impersonated_user_id] = params[:impersonated_user_id]
+
+    redirect_to root_url_for(impersonated_user)
+  end
+
+  def destroy
+    session.delete(:impersonated_user_id)
+
+    redirect_to root_url_for(current_user)
+  end
+
+private
+
+  def check_self_impersonation
+    if params[:impersonated_user_id] == current_user.id.to_s
+      flash[:warning] = 'You cannot impersonate yourself'
+      redirect_to(root_url_for(current_user))
+    end
+  end
+
+  def check_support_user_impersonation
+    if User.find(params[:impersonated_user_id]).is_support?
+      flash[:warning] = 'You cannot impersonate another support user'
+      redirect_to(root_url_for(current_user))
+    end
+  end
+
+  def check_computacenter_user_impersonation
+    if User.find(params[:impersonated_user_id]).is_computacenter?
+      flash[:warning] = 'You cannot impersonate a computacenter user'
+      redirect_to(root_url_for(current_user))
+    end
+  end
+end

--- a/app/policies/impersonation_policy.rb
+++ b/app/policies/impersonation_policy.rb
@@ -1,0 +1,9 @@
+class ImpersonationPolicy < ApplicationPolicy
+  def create?
+    user.third_line_role?
+  end
+
+  def destroy?
+    user.third_line_role?
+  end
+end

--- a/app/policies/privacy_notice_policy.rb
+++ b/app/policies/privacy_notice_policy.rb
@@ -1,0 +1,5 @@
+class PrivacyNoticePolicy < ApplicationPolicy
+  def seen?
+    user == record # can only accept your own privacy notice
+  end
+end

--- a/app/policies/responsible_body/base_policy.rb
+++ b/app/policies/responsible_body/base_policy.rb
@@ -1,0 +1,17 @@
+class ResponsibleBody::BasePolicy < ApplicationPolicy
+  def create?
+    if user.is_support? || user.is_computacenter?
+      false
+    else
+      true
+    end
+  end
+
+  def update?
+    if user.is_support? || user.is_computacenter?
+      false
+    else
+      true
+    end
+  end
+end

--- a/app/policies/responsible_body/donated_device_policy.rb
+++ b/app/policies/responsible_body/donated_device_policy.rb
@@ -1,0 +1,8 @@
+class ResponsibleBody::DonatedDevicePolicy < ResponsibleBody::BasePolicy
+  alias_method :interest_confirmation?, :create?
+  alias_method :all_or_some_schools?, :create?
+  alias_method :select_schools?, :create?
+  alias_method :device_types?, :create?
+  alias_method :how_many_devices?, :create?
+  alias_method :check_answers?, :create?
+end

--- a/app/policies/school/base_policy.rb
+++ b/app/policies/school/base_policy.rb
@@ -1,0 +1,17 @@
+class School::BasePolicy < ApplicationPolicy
+  def create?
+    if user.is_support? || user.is_computacenter?
+      false
+    else
+      true
+    end
+  end
+
+  def update?
+    if user.is_support? || user.is_computacenter?
+      false
+    else
+      true
+    end
+  end
+end

--- a/app/policies/school/donated_device_policy.rb
+++ b/app/policies/school/donated_device_policy.rb
@@ -1,0 +1,6 @@
+class School::DonatedDevicePolicy < School::BasePolicy
+  alias_method :interest_confirmation?, :create?
+  alias_method :device_types?, :create?
+  alias_method :how_many_devices?, :create?
+  alias_method :check_answers?, :create?
+end

--- a/app/policies/school/welcome_wizard_policy.rb
+++ b/app/policies/school/welcome_wizard_policy.rb
@@ -1,0 +1,3 @@
+class School::WelcomeWizardPolicy < School::BasePolicy
+  alias_method :next_step?, :create?
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,20 @@
             "This is a new service – your #{ghwt_contact_mailto(label: "feedback", subject: "Feedback")} will help us to improve it.".html_safe
           end
         end %>
+
+        <% if impersonated_user %>
+          <%= render NotificationBanner.new(title: 'Important', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-1') do |banner| %>
+            <p class="govuk-notification-banner__heading">
+              You are impersonating <%= link_to impersonated_user.full_name, support_user_path(impersonated_user) %> (<%= impersonated_user.email_address %>)
+            </p>
+
+            <%= govuk_button_to('Stop impersonating',
+                                support_impersonate_path,
+                                method: :delete,
+                                class: 'govuk-!-margin-bottom-1') %>
+          <% end %>
+        <% end %>
+
         <%= content_for(:before_content) %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,6 @@
     </header>
     <div class="app-phase-banner">
       <div class="govuk-width-container">
-
         <%= render GovukComponent::PhaseBanner.new(phase: 'Alpha') do
           if SessionService.is_signed_in?(session) && (current_user.is_responsible_body_user? || current_user.is_school_user?)
             "#{t('user_feedback')} – #{user_feedback_link}".html_safe
@@ -70,8 +69,14 @@
           end
         end %>
 
+        <%= content_for(:before_content) %>
+      </div>
+    </div>
+    <main class="govuk-main-wrapper " id="main-content" role="main">
+      <%= yield :start_page_banner %>
+      <div class="govuk-width-container">
         <% if impersonated_user %>
-          <%= render NotificationBanner.new(title: 'Important', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-1') do |banner| %>
+          <%= render NotificationBanner.new(title: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5') do |banner| %>
             <p class="govuk-notification-banner__heading">
               You are impersonating <%= link_to impersonated_user.full_name, support_user_path(impersonated_user) %> (<%= impersonated_user.email_address %>)
             </p>
@@ -83,12 +88,6 @@
           <% end %>
         <% end %>
 
-        <%= content_for(:before_content) %>
-      </div>
-    </div>
-    <main class="govuk-main-wrapper " id="main-content" role="main">
-      <%= yield :start_page_banner %>
-      <div class="govuk-width-container">
         <%= render partial: "shared/banners/global_notice_banner" if @show_parent_carer_pupil_banner %>
         <%= render partial: 'shared/flash_message' %>
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -14,8 +14,17 @@
 
     <%= render Support::UserSummaryListComponent.new(user: @user, viewer: @current_user) %>
 
+    <% if ImpersonationPolicy.new(current_user, @user).create? %>
+      <%= govuk_button_to('Impersonate user',
+                          support_impersonate_path,
+                          params: {
+                            impersonated_user_id: @user.id,
+                          },
+                          method: :post)  %>
+    <% end %>
+
     <p class="govuk-body">
-      <% if policy(@user).destroy? %>
+      <% if UserPolicy.new(current_user, @user).destroy? %>
         <%= govuk_link_to 'Delete this user', confirm_deletion_support_user_path(@user) %>
       <% end %>
     </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,7 @@ Rails.application.routes.draw do
     get '/feature-flags', to: 'home#feature_flags', as: :feature_flags
     get '/performance', to: 'service_performance#index', as: :service_performance
     get '/performance/mno-requests', to: 'service_performance#mno_requests', format: :csv
+    resource :impersonate, only: %i[create destroy]
     namespace :gias do
       get '/updates', to: 'home#index', as: :home
       resources :schools_to_add, only: %i[index show update], param: :urn, path: '/schools-to-add'

--- a/spec/controllers/privacy_notice_controller_spec.rb
+++ b/spec/controllers/privacy_notice_controller_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe PrivacyNoticeController do
       it 'does not add timestamp to privacy_notice_seen_at of impersonated user' do
         expect {
           post :seen
-        }.not_to change { school_user.reload.privacy_notice_seen_at }
+        }.not_to(change { school_user.reload.privacy_notice_seen_at })
       end
 
       it 'does not change their own privacy_notice_seen_at' do
         expect {
           post :seen
-        }.not_to change { support_user.reload.privacy_notice_seen_at }
+        }.not_to(change { support_user.reload.privacy_notice_seen_at })
       end
 
       it 'returns forbidden' do

--- a/spec/controllers/privacy_notice_controller_spec.rb
+++ b/spec/controllers/privacy_notice_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe PrivacyNoticeController do
+  let(:support_user) { create(:support_user) }
+  let(:school_user) { create(:school_user, :has_not_seen_privacy_notice) }
+
+  describe '#seen' do
+    context 'signed in as school user' do
+      before do
+        sign_in_as school_user
+      end
+
+      it 'adds timestamp to privacy_notice_seen_at' do
+        post :seen
+        expect(school_user.reload.privacy_notice_seen_at).to be_present
+      end
+    end
+
+    context 'support impersonating school user' do
+      before do
+        sign_in_as support_user
+        impersonate school_user
+      end
+
+      it 'does not add timestamp to privacy_notice_seen_at of impersonated user' do
+        expect {
+          post :seen
+        }.not_to change { school_user.reload.privacy_notice_seen_at }
+      end
+
+      it 'does not change their own privacy_notice_seen_at' do
+        expect {
+          post :seen
+        }.not_to change { support_user.reload.privacy_notice_seen_at }
+      end
+
+      it 'returns forbidden' do
+        post :seen
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/responsible_body/devices/change_who_will_order_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/change_who_will_order_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::ChangeWhoWillOrderController do
+  let(:support_user) { create(:support_user) }
+  let(:rb_user) { create(:trust_user) }
+  let(:rb) { rb_user.responsible_body }
+  let(:school) { create(:school, responsible_body: rb) }
+
+  describe '#update' do
+    context 'when support user impersonating' do
+      before do
+        sign_in_as support_user
+        impersonate rb_user
+      end
+
+      it 'returns forbidden' do
+        put :update, params: { school_urn: school.urn, responsible_body_devices_who_will_order_form: { who_will_order: 'school' } }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/responsible_body/devices/chromebook_information_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/chromebook_information_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::ChromebookInformationController do
+  describe '#update' do
+    context 'when support user impersonating user' do
+      let(:support_user) { create(:support_user) }
+      let(:rb_user) { create(:trust_user) }
+      let(:rb) { rb_user.responsible_body }
+      let(:school) { rb.schools.first }
+
+      before do
+        create(:school, :with_preorder_information, responsible_body: rb)
+        sign_in_as support_user
+        impersonate rb_user
+      end
+
+      it 'denys the update' do
+        put :update, params: { school_urn: school.urn, chromebook_information_form: { will_need_chromebooks: 'no' } }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/responsible_body/devices/who_will_order_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/who_will_order_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::Devices::WhoWillOrderController do
+  let(:support_user) { create(:support_user) }
+  let(:rb_user) { create(:trust_user) }
+
+  describe '#update' do
+    context 'when support user impersonating' do
+      before do
+        sign_in_as support_user
+        impersonate rb_user
+      end
+
+      it 'returns forbidden' do
+        put :update, params: { responsible_body_devices_who_will_order_form: { who_will_order: 'school' } }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/responsible_body/donated_devices/interest_controller_spec.rb
+++ b/spec/controllers/responsible_body/donated_devices/interest_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ResponsibleBody::DonatedDevices::InterestController do
+  let(:support_user) { create(:support_user) }
+  let(:rb_user) { create(:trust_user) }
+  let(:rb) { rb_user.responsible_body }
+
+  actions = %w[
+    create
+    interest_confirmation
+    all_or_some_schools
+    select_schools
+    device_types
+    how_many_devices
+    check_answers
+  ]
+
+  actions.each do |action|
+    describe "##{action}" do
+      context 'when support user impersonating' do
+        before do
+          create(:donated_device_request, responsible_body: rb)
+          sign_in_as support_user
+          impersonate rb_user
+        end
+
+        it 'returns forbidden' do
+          post action, params: {
+            donated_device_interest_form: { device_interest: 'asd' },
+          }
+
+          expect(response).to be_forbidden
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/manual_requests_controller_spec.rb
@@ -3,20 +3,34 @@ require 'rails_helper'
 RSpec.describe ResponsibleBody::Internet::Mobile::ManualRequestsController, type: :controller do
   let(:local_authority_user) { create(:local_authority_user) }
 
-  context 'when authenticated' do
-    before do
-      sign_in_as local_authority_user
-    end
+  describe '#create' do
+    let(:mno) { create(:mobile_network) }
+    let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
+    let(:request_data) { { extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
 
-    describe 'create' do
-      let(:mno) { create(:mobile_network) }
-      let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
-      let(:request_data) { { extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
+    context 'when authenticated' do
+      before do
+        sign_in_as local_authority_user
+      end
 
       it 'sends an SMS to the account holder of the request' do
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob).once
+      end
+    end
+
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate local_authority_user
+      end
+
+      it 'returns forbidden' do
+        post :create, params: request_data
+        expect(response).to be_forbidden
       end
     end
   end

--- a/spec/controllers/school/chromebooks_controller_spec.rb
+++ b/spec/controllers/school/chromebooks_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe School::ChromebooksController do
+  let(:school_user) { create(:school_user) }
+  let(:school) { school_user.school }
+
+  describe '#update' do
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate school_user
+      end
+
+      it 'returns forbidden' do
+        put :update, params: { urn: school.urn, chromebook_information_form: { will_need_chromebooks: 'no' } }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/school/donated_devices/interest_controller_spec.rb
+++ b/spec/controllers/school/donated_devices/interest_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe School::DonatedDevices::InterestController do
+  let(:support_user) { create(:support_user) }
+  let(:school_user) { create(:school_user) }
+  let(:school) { school_user.school }
+
+  actions = %w[
+    create
+    interest_confirmation
+    device_types
+    how_many_devices
+    check_answers
+  ]
+
+  actions.each do |action|
+    describe "##{action}" do
+      context 'when support user impersonating' do
+        before do
+          create(:donated_device_request, device_types: [:windows], schools: [school.id])
+          sign_in_as support_user
+          impersonate school_user
+        end
+
+        it 'returns forbidden' do
+          post action, params: {
+            urn: school.urn,
+            donated_device_interest_form: { device_interest: 'asd' },
+          }
+
+          expect(response).to be_forbidden
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
+++ b/spec/controllers/school/internet/mobile/manual_requests_controller_spec.rb
@@ -3,21 +3,34 @@ require 'rails_helper'
 RSpec.describe School::Internet::Mobile::ManualRequestsController, type: :controller do
   let(:user) { create(:school_user) }
   let(:school) { user.school }
+  let(:mno) { create(:mobile_network) }
+  let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
+  let(:request_data) { { urn: school.urn, extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
 
-  context 'when authenticated' do
-    before do
-      sign_in_as user
-    end
-
-    describe '#create' do
-      let(:mno) { create(:mobile_network) }
-      let(:form_attrs) { attributes_for(:extra_mobile_data_request, mobile_network_id: mno.id) }
-      let(:request_data) { { urn: school.urn, extra_mobile_data_request: form_attrs, confirm: 'confirm' } }
+  describe '#create' do
+    context 'when authenticated' do
+      before do
+        sign_in_as user
+      end
 
       it 'sends an SMS to the account holder of the request' do
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(NotifyExtraMobileDataRequestAccountHolderJob).once
+      end
+    end
+
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate user
+      end
+
+      it 'returns forbidden' do
+        post :create, params: request_data
+        expect(response).to be_forbidden
       end
     end
   end

--- a/spec/controllers/school/users_controller_spec.rb
+++ b/spec/controllers/school/users_controller_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 
 RSpec.describe School::UsersController, type: :controller do
   let(:school_user) { create(:school_user) }
-  let(:new_user) { build(:school_user, school: school_user.school) }
+  let(:school) { school_user.school }
+  let(:new_user) { build(:school_user, school: school) }
+  let(:request_data) do
+    { urn: school.urn, user: { full_name: new_user.full_name, email_address: new_user.email_address, orders_devices: false } }
+  end
 
-  context 'when authenticated' do
-    before do
-      sign_in_as school_user
-    end
-
-    describe 'create' do
-      let(:request_data) do
-        { urn: school_user.school.urn, user: { full_name: new_user.full_name, email_address: new_user.email_address, orders_devices: false } }
+  describe '#create' do
+    context 'when authenticated' do
+      before do
+        sign_in_as school_user
       end
 
       it 'adds the new user to the school' do
@@ -24,6 +24,36 @@ RSpec.describe School::UsersController, type: :controller do
         expect {
           post :create, params: request_data
         }.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
+      end
+    end
+
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate school_user
+      end
+
+      it 'returns forbidden' do
+        post :create, params: request_data
+        expect(response).to be_forbidden
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate school_user
+      end
+
+      it 'returns forbidden' do
+        put :update, params: { urn: school.urn, id: school_user.id, user: { full_name: 'new name' } }
+        expect(response).to be_forbidden
       end
     end
   end

--- a/spec/controllers/school/welcome_wizard_controller_spec.rb
+++ b/spec/controllers/school/welcome_wizard_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe School::WelcomeWizardController do
+  let(:school_user) { create(:school_user) }
+  let(:school) { school_user.school }
+
+  describe '#next_step' do
+    context 'when support user impersonating' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+        impersonate school_user
+      end
+
+      it 'returns forbidden' do
+        patch :next_step, params: { urn: school.urn }
+        expect(response).to be_forbidden
+      end
+    end
+  end
+end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe SchoolsController do
+  let(:support_user) { create(:support_user, role: 'third_line') }
+  let(:single_school_user) { create(:school_user) }
+  let(:multi_school_user) { create(:school_user, schools: [create(:school), create(:school)]) }
+
+  describe '#index' do
+    context 'school user has one school' do
+      before do
+        sign_in_as single_school_user
+      end
+
+      it 'redirects to school' do
+        get :index
+        school = single_school_user.schools.first
+        expect(response).to redirect_to("/schools/#{school.urn}")
+      end
+    end
+
+    context 'school user has multiple schools' do
+      before do
+        sign_in_as multi_school_user
+      end
+
+      it 'shows list of schools' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:schools)).to eq(multi_school_user.schools)
+      end
+    end
+
+    context 'support user impersonating school user with one school' do
+      before do
+        sign_in_as support_user
+        impersonate single_school_user
+      end
+
+      it 'shows list of schools' do
+        get :index
+        school = single_school_user.schools.first
+        expect(response).to redirect_to("/schools/#{school.urn}")
+      end
+    end
+
+    context 'support user impersonating school user multiple schools' do
+      before do
+        sign_in_as support_user
+        impersonate multi_school_user
+      end
+
+      it 'shows list of schools' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:schools)).to eq(multi_school_user.schools)
+      end
+    end
+  end
+end

--- a/spec/controllers/support/impersonates_controller_spec.rb
+++ b/spec/controllers/support/impersonates_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Support::ImpersonatesController do
+  let(:support_user) { create(:support_user, role: 'third_line') }
+  let(:other_support_user) { create(:support_user) }
+  let(:computacenter_user) { create(:computacenter_user) }
+  let(:impersonated_user) { create(:school_user) }
+
+  before do
+    sign_in_as support_user
+  end
+
+  describe '#create' do
+    it 'sets session[:impersonated_user_id] of impersonated user' do
+      post :create, params: { impersonated_user_id: impersonated_user.id }
+      expect(session[:impersonated_user_id]).to eql(impersonated_user.id.to_s)
+    end
+
+    it 'redirects to impersonated user start page' do
+      post :create, params: { impersonated_user_id: impersonated_user.id }
+      expect(response).to redirect_to("/schools/#{impersonated_user.school.urn}")
+    end
+
+    it 'cannot impersonate yourself' do
+      post :create, params: { impersonated_user_id: support_user.id }
+      expect(session[:impersonated_user_id]).not_to eql(support_user.id.to_s)
+    end
+
+    it 'cannot impersonate another support user' do
+      post :create, params: { impersonated_user_id: other_support_user.id }
+      expect(session[:impersonated_user_id]).not_to eql(other_support_user.id.to_s)
+    end
+
+    it 'cannot impersonate a computacenter user' do
+      post :create, params: { impersonated_user_id: computacenter_user.id }
+      expect(session[:impersonated_user_id]).not_to eql(computacenter_user.id.to_s)
+    end
+  end
+
+  describe '#destroy' do
+    it 'clears session[:impersonated_user_id]' do
+      session[:impersonated_user_id] = impersonated_user.id
+      delete :destroy
+      expect(session[:impersonated_user_id]).to be_blank
+    end
+
+    it 'redirects to support user start page' do
+      delete :destroy
+      expect(response).to redirect_to('/support')
+    end
+  end
+end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -8,6 +8,10 @@ module ControllerHelper
     create_session_id!
     controller.send(:save_user_to_session!, user)
   end
+
+  def impersonate(user)
+    session[:impersonated_user_id] = user.id
+  end
 end
 
 RSpec.configure do |c|

--- a/spec/views/support/users/show.html.erb_spec.rb
+++ b/spec/views/support/users/show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'support/users/show.html.erb' do
+  let(:support_user) { create(:support_user) }
+  let(:third_line_support_user) { create(:support_user, role: 'third_line') }
+  let(:user) { create(:school_user) }
+
+  around do |example|
+    without_partial_double_verification { example.run }
+  end
+
+  context 'when support user' do
+    before do
+      allow(view).to receive(:current_user).and_return(support_user)
+      assign(:current_user, support_user)
+      assign(:user, user)
+    end
+
+    it 'does not show impersonate button' do
+      render
+      expect(rendered).not_to have_button('Impersonate user')
+    end
+  end
+
+  context 'when third line support user' do
+    before do
+      allow(view).to receive(:current_user).and_return(third_line_support_user)
+      assign(:current_user, third_line_support_user)
+      assign(:user, user)
+    end
+
+    it 'shows impersonate button' do
+      render
+      expect(rendered).to have_button('Impersonate user')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/U0VcWDUR/1229-support-improvement-impersonate-an-rb-or-school-god-user

### Changes proposed in this pull request

- Third line support staff can impersonate other users excluding other support users, computacenter users and themselves
- This feature is found on the viewing a user typically from user search results
- Whilst impersonating actions should be readonly to prevent quirky audits
- Actions whilst impersonating will therefore return forbidden and prevent the action from happening
- Users can only accept their own privacy policy, this prevents impersonation from accepting someone elses privacy policy on their behalf
- Whilst impersonating, adds a notification banner near the top of the page to show they are currently impersonating someone and who that someone is
- The banner has a button to end the impersonation

### Screenshots

Support viewing a user to kickoff impersonation session
![image](https://user-images.githubusercontent.com/92580/110666436-3ef75580-81c1-11eb-84cd-99c42d986a1d.png)

Impersonating a user
![image](https://user-images.githubusercontent.com/92580/110796467-e3d06c00-826f-11eb-878c-17e581f90386.png)

### Guidance to review

- Login as third line support
- Find different users to impersonate - school user, rb user, single school user vs multi school user, user that has not accepted privacy policy
- Ensure view a of the viewing user
- Should see notification banner of current impersonation
- Should not be able to perform any actions when impersonating ie make modifications eg. invite user, change who orders etc
- Stop impersonation
- Everything should return to normal
- Should not be able to impersonate yourself just incase there are any quirks
- Should not be able to impersonate another support user so there is no privilege escalation or affecting of audits
- Should not be able to impersonate a computacenter user for the same above reason 