### PR TITLE
add task to create users for pentest

### DIFF
--- a/app/services/personas/pentest_users.rb
+++ b/app/services/personas/pentest_users.rb
@@ -1,0 +1,65 @@
+class Personas::PentestUsers
+  attr_accessor :email_address, :school, :responsible_body, :mobile_network, :users
+
+  def initialize(email_address:, name:, school: nil, responsible_body: nil, mobile_network: nil)
+    @email_address = email_address
+    @name = name
+    raise ArgumentError, 'name and email_address are required' if @name.blank? || @email_address.blank?
+
+    @email_address_parts = email_address.split('@')
+    @responsible_body = responsible_body || find_responsible_body
+    @school = school || find_school
+    @mobile_network = mobile_network || find_mobile_network
+    @users = []
+  end
+
+  def create!
+    validate!
+    @users << User.create!(full_name: @name + ' (school)', email_address: email_with_suffix('school'), orders_devices: true, schools: [@school])
+    @users << User.create!(full_name: @name + ' (responsible_body)', email_address: email_with_suffix('rb'), orders_devices: true, responsible_body_id: @responsible_body.id)
+    @users << User.create!(full_name: @name + ' (mobile_network)', email_address: email_with_suffix('mno'), orders_devices: false, mobile_network_id: @mobile_network.id)
+    @users << User.create!(full_name: @name + ' (computacenter)', email_address: email_with_suffix('computacenter'), orders_devices: false, is_computacenter: true)
+    @users << User.create!(full_name: @name + ' (support)', email_address: email_with_suffix('support'), orders_devices: false, is_support: true)
+    @users.map(&:email_address)
+  end
+
+private
+
+  def email_with_suffix(suffix)
+    @email_address_parts.join("+#{suffix}@")
+  end
+
+  def validate!
+    raise "Couldn't find an RB that's in_connectivity_pilot and has schools, and has said who will order" if @responsible_body.blank?
+    raise "Couldn't find a school in #{@responsible_body.name} that can order but has not completed the welcome wizard" if @school.blank?
+    raise "Couldn't find a mobile network with more than one ExtraMobileDataRequest" if @mobile_network.blank?
+  end
+
+  def find_mobile_network
+    # choose the network with the most requests
+    MobileNetwork.select('mobile_networks.id, brand, COUNT(*) AS req_count')
+                 .joins(:extra_mobile_data_requests)
+                 .group('mobile_networks.id, brand')
+                 .having('count(*) > 1')
+                 .order('req_count DESC')
+                 .first
+  end
+
+  def find_responsible_body
+    # we want a responsible_body that has schools, and is in_connectivity_pilot
+    # and has specified who will order
+    ResponsibleBody.where.not(who_will_order_devices: nil)
+                   .where(in_connectivity_pilot: true)
+                   .where('exists(SELECT schools.id from schools inner join preorder_information ON preorder_information.school_id = schools.id where responsible_body_id = responsible_bodies.id)')
+                   .first
+  end
+
+  def find_school
+    # we want a school on the current responsible_body who can order
+    # but has not completed the school welcome wizard
+    School.where(responsible_body_id: @responsible_body&.id)
+          .that_can_order_now
+          .joins(:preorder_information)
+          .first
+  end
+end

--- a/app/services/personas/pentest_users.rb
+++ b/app/services/personas/pentest_users.rb
@@ -48,16 +48,18 @@ private
   def find_responsible_body
     # we want a responsible_body that has schools, and is in_connectivity_pilot
     # and has specified who will order
-    ResponsibleBody.where.not(who_will_order_devices: nil)
+    ResponsibleBody.joins(:schools).joins(schools: [:preorder_information])
+                   .where.not(who_will_order_devices: nil)
                    .where(in_connectivity_pilot: true)
-                   .where('exists(SELECT schools.id from schools inner join preorder_information ON preorder_information.school_id = schools.id where responsible_body_id = responsible_bodies.id)')
+                   .where(schools: { status: 'open' })
                    .first
   end
 
   def find_school
-    # we want a school on the current responsible_body who can order
+    # we want an open school on the current responsible_body who can order
     # but has not completed the school welcome wizard
-    School.where(responsible_body_id: @responsible_body&.id)
+    School.gias_status_open
+          .where(responsible_body_id: @responsible_body&.id)
           .that_can_order_now
           .joins(:preorder_information)
           .first

--- a/lib/tasks/pentest_users.rake
+++ b/lib/tasks/pentest_users.rake
@@ -1,0 +1,8 @@
+namespace :db do
+  desc 'Create school, RB, MNO, CC and support users with +suffixes from given NAME and EMAIL_ADDRESS'
+  task create_pentest_users: :environment do
+    email_addresses = Personas::PentestUsers.new(name: ENV['NAME'], email_address: ENV['EMAIL_ADDRESS']).create!
+    puts "#{email_addresses.size} users created with the following email addresses:"
+    puts email_addresses
+  end
+end

--- a/spec/services/personas/pentest_users_spec.rb
+++ b/spec/services/personas/pentest_users_spec.rb
@@ -18,17 +18,25 @@ RSpec.describe Personas::PentestUsers do
   end
 
   describe '#find_responsible_body' do
-    let!(:responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
+    let!(:responsible_body_with_closed_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
+    let!(:responsible_body_with_open_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
 
     before do
       create(:local_authority)
       create(:local_authority, :with_schools, in_connectivity_pilot: false)
       create(:local_authority, :with_schools, :in_connectivity_pilot, who_will_order_devices: nil)
-      responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order.schools.each { |school| school.create_preorder_information!(who_will_order_devices: 'responsible_body') }
+      responsible_body_with_closed_schools_and_in_pilot_and_has_said_who_will_order.schools.each do |school|
+        school.create_preorder_information!(who_will_order_devices: 'responsible_body')
+        school.update!(status: 'closed')
+      end
+      responsible_body_with_open_schools_and_in_pilot_and_has_said_who_will_order.schools.each do |school|
+        school.create_preorder_information!(who_will_order_devices: 'responsible_body')
+        school.update!(status: 'open')
+      end
     end
 
-    it 'finds a responsible_body that has schools, is in the connectivity pilot, and has said who will order' do
-      expect(personas.send(:find_responsible_body)).to eq(responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order)
+    it 'finds a responsible_body that has an open school, is in the connectivity pilot, and has said who will order' do
+      expect(personas.send(:find_responsible_body)).to eq(responsible_body_with_open_schools_and_in_pilot_and_has_said_who_will_order)
     end
   end
 
@@ -38,11 +46,14 @@ RSpec.describe Personas::PentestUsers do
     before do
       create(:school, :with_preorder_information, :in_lockdown, responsible_body: other_responsible_body)
       personas.responsible_body = create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally)
-      personas.responsible_body.schools.last.update!(order_state: 'can_order')
-      personas.responsible_body.schools.last.create_preorder_information!(who_will_order_devices: 'responsible_body')
+      personas.responsible_body.schools.last(2).each do  |school|
+        school.update!(order_state: 'can_order', status: 'closed')
+        school.create_preorder_information!(who_will_order_devices: 'responsible_body')
+      end
+      personas.responsible_body.schools.last.update!(status: 'open')
     end
 
-    it 'finds a school at the given responsible_body that can order now and has a preorder_information' do
+    it 'finds an open school at the given responsible_body that can order now and has a preorder_information' do
       expect(personas.send(:find_school)).to eq(personas.responsible_body.schools.last)
     end
   end

--- a/spec/services/personas/pentest_users_spec.rb
+++ b/spec/services/personas/pentest_users_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Personas::PentestUsers do
+  subject(:personas) { described_class.new(name: 'Anna Purna', email_address: 'anna.purna@example.com') }
+
+  describe '#find_mobile_network' do
+    let(:mobile_network_with_1_request) { create(:mobile_network, brand: 'test mobile network with 1 request') }
+    let(:mobile_network_with_2_requests) { create(:mobile_network, brand: 'test mobile network with 2 requests') }
+
+    before do
+      create_list(:extra_mobile_data_request, 1, mobile_network: mobile_network_with_1_request)
+      create_list(:extra_mobile_data_request, 2, mobile_network: mobile_network_with_2_requests)
+    end
+
+    it 'returns the MobileNetwork with the most requests' do
+      expect(personas.send(:find_mobile_network)).to eq(mobile_network_with_2_requests)
+    end
+  end
+
+  describe '#find_responsible_body' do
+    let!(:responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
+
+    before do
+      create(:local_authority)
+      create(:local_authority, :with_schools, in_connectivity_pilot: false)
+      create(:local_authority, :with_schools, :in_connectivity_pilot, who_will_order_devices: nil)
+      responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order.schools.each { |school| school.create_preorder_information!(who_will_order_devices: 'responsible_body') }
+    end
+
+    it 'finds a responsible_body that has schools, is in the connectivity pilot, and has said who will order' do
+      expect(personas.send(:find_responsible_body)).to eq(responsible_body_with_schools_and_in_pilot_and_has_said_who_will_order)
+    end
+  end
+
+  describe 'find school' do
+    let!(:other_responsible_body) { create(:local_authority, :with_schools) }
+
+    before do
+      create(:school, :with_preorder_information, :in_lockdown, responsible_body: other_responsible_body)
+      personas.responsible_body = create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally)
+      personas.responsible_body.schools.last.update!(order_state: 'can_order')
+      personas.responsible_body.schools.last.create_preorder_information!(who_will_order_devices: 'responsible_body')
+    end
+
+    it 'finds a school at the given responsible_body that can order now and has a preorder_information' do
+      expect(personas.send(:find_school)).to eq(personas.responsible_body.schools.last)
+    end
+  end
+
+  describe '#email_with_suffix' do
+    it 'appends the given suffix to the local part of @email_address, using the + format' do
+      expect(personas.send(:email_with_suffix, 'mno')).to eq('anna.purna+mno@example.com')
+    end
+  end
+
+  describe '#create!' do
+    before do
+      personas.school = create(:school)
+      personas.responsible_body = create(:local_authority)
+      personas.mobile_network = create(:mobile_network)
+    end
+
+    it 'creates a mobile_network user with the right suffix' do
+      expect { personas.create! }.to change { personas.mobile_network.users.count }.by(1)
+      expect(personas.mobile_network.users.last.email_address).to eq('anna.purna+mno@example.com')
+    end
+
+    it 'creates a school user with the right suffix' do
+      expect { personas.create! }.to change { personas.school.users.count }.by(1)
+      expect(personas.school.users.last.email_address).to eq('anna.purna+school@example.com')
+    end
+
+    it 'creates a responsible_body user with the right suffix' do
+      expect { personas.create! }.to change { personas.responsible_body.users.count }.by(1)
+      expect(personas.responsible_body.users.last.email_address).to eq('anna.purna+rb@example.com')
+    end
+
+    it 'creates a support user with the right suffix' do
+      expect { personas.create! }.to change { User.where(is_support: true).count }.by(1)
+      expect(User.where(is_support: true).last.email_address).to eq('anna.purna+support@example.com')
+    end
+
+    it 'creates a computacenter user with the right suffix' do
+      expect { personas.create! }.to change { User.where(is_computacenter: true).count }.by(1)
+      expect(User.where(is_computacenter: true).last.email_address).to eq('anna.purna+computacenter@example.com')
+    end
+  end
+end


### PR DESCRIPTION
### Context

We last had a pentest 6 months ago, at which point I created users manually. We're setting up for the next test, and the work involved in identifying appropriate organisations to link the users to has been fiddly enough that I don't want to do this manually every time.   

### Changes proposed in this pull request

Add a rake task to create users of all required flavours given a name and email address.
 
### Guidance to review

`rake db:create_pentest_users NAME="Jane Doe" EMAIL_ADDRESS=jane.doe@example.com`

It will create users with suffixes of `+school`, `+responsible_body` etc, and return their suffixed email addresses.
If it can't find suitable schools or responsible bodies to link them to, it will raise an error and create nothing.
