### PR TITLE
Refactored find_requests method into the index method

### DIFF
--- a/app/views/mno/extra_mobile_data_requests/index.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/index.html.erb
@@ -20,7 +20,7 @@
   <div class="app-card govuk-!-margin-bottom-4 govuk-!-margin-top-2">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= form_for @find_requests_form, url: find_requests_mno_extra_mobile_data_requests_path, method: :post do |f| %>
+        <%= form_for @find_requests_form, as: '', url: mno_extra_mobile_data_requests_path, method: :get do |f| %>
           <%= f.govuk_error_summary %>
 
           <%= f.govuk_fieldset(legend: { text: 'Find requests by telephone number', size: 'l'}) do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,6 @@ Rails.application.routes.draw do
     resources :extra_mobile_data_requests, only: %i[index show edit update], path: '/extra-mobile-data-requests' do
       put 'bulk-update', to: 'extra_mobile_data_requests#bulk_update', on: :collection
       get 'report-a-problem', to: 'extra_mobile_data_requests#report_problem', as: :report_problem
-      post 'find-requests', to: 'extra_mobile_data_requests#find_requests', on: :collection
     end
     resources :extra_mobile_data_requests_csv_update, only: %i[new create], path: '/extra-mobile-data-requests-csv-update'
   end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/sUXFoyqW/1407-can-the-index-findrequests-method-in-mnoextramobiledatarequestcontroller-be-more-dry)
Address an issue found during a [PR review](https://github.com/DFE-Digital/get-help-with-tech/pull/1190) that we didn't have time to fix at the time.

### Changes proposed in this pull request
Refactor the `ExtraMobileDataRequestController` to make it more DRY. Incorporate the `find_requests` method into the `index` method to remove a bunch of duplication

### Guidance to review
The functionality to be able to search, view and update `ExtraMobileDataRequest`s as a MNO user should be the same.
