### PR TITLE
Revert remove redis from heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
     }
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "heroku-redis"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
### Context

- Deploying to heroku without redis causes the app to raise errors when it attempts to write to redis which is not present

### Changes proposed in this pull request

This reverts commit 9818facafdbe910eaa8253a45130542b0a080dd5.

- Heroku redis is needed so jobs can be written to storage
- The app expects redis to be present so jobs can be written otherwise errors occur
- The worker itself will not run so none of these jobs will be executed

### Guidance to review

- Able to sign into review app successfully
- Prior to this change it throws an error