### PR TITLE
[1668] Enable tracking of notify emails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,14 @@ RSpec/PredicateMatcher:
 RSpec/DescribeClass:
   Enabled: false
 
+RSpec/VariableDefinition:
+  Exclude:
+    - spec/mailers/log_email_delivery_observer_spec.rb
+
+RSpec/VariableName:
+  Exclude:
+    - spec/mailers/log_email_delivery_observer_spec.rb
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/system/support_interface/daily_report_spec.rb'

--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -1,0 +1,44 @@
+class NotifyCallbacksController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+  before_action :check_bearer_token
+
+  def create
+    return unless callback_notification_type_is_email?
+    return unless user
+
+    if existing_audit
+      existing_audit.update!(govuk_notify_status: callback_params[:status])
+    else
+      EmailAudit.create!(
+        user: user,
+        govuk_notify_id: callback_params[:id],
+        govuk_notify_status: callback_params[:status],
+        message_type: 'other',
+      )
+    end
+  end
+
+private
+
+  def check_bearer_token
+    authenticate_or_request_with_http_token do |token, _options|
+      Digest::SHA256.hexdigest(token) == Settings.govuk_notify.callback_bearer_token
+    end
+  end
+
+  def existing_audit
+    @existing_audit ||= EmailAudit.find_by(govuk_notify_id: callback_params[:id])
+  end
+
+  def user
+    @user ||= User.find_by(email_address: callback_params[:to])
+  end
+
+  def callback_params
+    params.permit(:id, :reference, :status, :notification_type, :to)
+  end
+
+  def callback_notification_type_is_email?
+    params[:notification_type] == 'email'
+  end
+end

--- a/app/controllers/support/email_audits_controller.rb
+++ b/app/controllers/support/email_audits_controller.rb
@@ -1,0 +1,7 @@
+class Support::EmailAuditsController < Support::BaseController
+  before_action { authorize EmailAudit }
+
+  def index
+    @email_audits = EmailAudit.order(id: :desc).limit(300)
+  end
+end

--- a/app/mailers/can_order_devices_mailer.rb
+++ b/app/mailers/can_order_devices_mailer.rb
@@ -100,13 +100,13 @@ class CanOrderDevicesMailer < ApplicationMailer
 private
 
   def tracked_template_mail(message_type, template_id, mail_params = {})
-    EmailAudit.create!(message_type: message_type,
-                       template: template_id,
-                       email_address: @user.email_address,
-                       user: @user,
-                       school: @school)
+    audit = EmailAudit.create!(message_type: message_type,
+                               template: template_id,
+                               email_address: @user.email_address,
+                               user: @user,
+                               school: @school)
 
-    template_mail(template_id, mail_params)
+    template_mail(template_id, mail_params.merge(reference: audit.id))
   end
 
   def personalisation

--- a/app/mailers/log_email_delivery_observer.rb
+++ b/app/mailers/log_email_delivery_observer.rb
@@ -1,9 +1,29 @@
 class LogEmailDeliveryObserver
   def self.delivered_email(message)
+    log_to_debugger(message)
+    link_message_with_audit(message)
+  end
+
+  def self.log_to_debugger(message)
     Rails.logger.debug <<~END_LOG_MSG
       To: #{message.to}
 
       #{message.preview.try(:body)}
     END_LOG_MSG
+  end
+
+  def self.link_message_with_audit(message)
+    if message.delivery_method.is_a?(Mail::Notify::DeliveryMethod)
+      govuk_notify_id = message.delivery_method.response.id
+      audit_id = message.delivery_method.response.reference
+      audit = EmailAudit.find_by(id: audit_id)
+
+      if audit
+        audit.update!(govuk_notify_id: govuk_notify_id)
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.warn(e)
+    Rails.logger.warn(e.message)
   end
 end

--- a/app/models/email_audit.rb
+++ b/app/models/email_audit.rb
@@ -3,7 +3,8 @@ class EmailAudit < ApplicationRecord
   belongs_to :school, optional: true
 
   validates :message_type, presence: true
-  validates :template, presence: true
 
   scope :sent_to, ->(email_address) { where(email_address: email_address) }
+
+  scope :problematic, -> { where(govuk_notify_status: %w[permanent-failure temporary-failure technical-failure]) }
 end

--- a/app/policies/email_audit_policy.rb
+++ b/app/policies/email_audit_policy.rb
@@ -1,0 +1,5 @@
+class EmailAuditPolicy < SupportPolicy
+  def index?
+    user.is_support?
+  end
+end

--- a/app/views/support/email_audits/index.html.erb
+++ b/app/views/support/email_audits/index.html.erb
@@ -1,0 +1,33 @@
+<%- title = t('page_titles.support.email_audits.index') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_link_to('Back', support_home_path, class: 'govuk-back-link') %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Recipient</th>
+          <th scope="col" class="govuk-table__header">Message type</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @email_audits.each do |audit| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= audit.email_address %></th>
+            <th scope="row" class="govuk-table__header"><%= audit.message_type %></th>
+            <td class="govuk-table__cell"><%= audit.govuk_notify_status %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -63,6 +63,15 @@
       </ul>
     <% end %>
 
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to 'Email audits', support_email_audits_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>view emails the service has recently sent</li>
+    </ul>
+
     <% if policy(:support).technical_support? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to 'Technical support', support_technical_support_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
         adjust_allocations_for_many_schools: Adjust allocations for many schools, colleges and FE institutions
       addresses:
         edit: Update address
+      email_audits:
+        index: Email audits
     support_extra_mobile_data_requests: Requests for extra mobile data
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   get '/start', to: 'pages#start'
 
+  resource :notify_callbacks, only: [:create]
+
   get '/digital-platforms', to: 'landing_pages#digital_platforms', as: :digital_platforms_landing_page
   get '/EdTech-demonstrator-programme', to: 'landing_pages#edtech_demonstrator_programme', as: :edtech_demonstrator_programme_landing_page
 
@@ -277,6 +279,7 @@ Rails.application.routes.draw do
       resource :responsible_body, only: %i[edit update], controller: 'users/responsible_body', path: 'responsible-body'
     end
     resources :extra_mobile_data_requests, only: %i[index show], path: 'extra-mobile-data-requests'
+    resources :email_audits, only: [:index], path: 'email-audits'
     mount Sidekiq::Web => '/sidekiq', constraints: RequireSupportUserConstraint.new, as: :sidekiq_admin
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,6 +33,7 @@ govuk_notify:
   # API key for the GOV.UK Notify service, used for sending emails
   api_key:
   service_id: 71eea423-f9c5-4b7f-aac9-c88a4ca4dea2
+  callback_bearer_token:
 
   templates:
     # ID of the template in GOV.UK Notify used for mailing sign-in tokens

--- a/db/migrate/20210304153213_add_gov_notify_id_to_email_audits.rb
+++ b/db/migrate/20210304153213_add_gov_notify_id_to_email_audits.rb
@@ -1,0 +1,10 @@
+class AddGovNotifyIdToEmailAudits < ActiveRecord::Migration[6.1]
+  def change
+    add_column :email_audits, :govuk_notify_id, :text, null: true
+    add_column :email_audits, :govuk_notify_status, :text, null: true
+
+    change_column_null :email_audits, :template, true
+
+    add_index :email_audits, :govuk_notify_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,12 +139,15 @@ ActiveRecord::Schema.define(version: 2021_03_15_133757) do
 
   create_table "email_audits", force: :cascade do |t|
     t.string "message_type", null: false
-    t.string "template", null: false
+    t.string "template"
     t.string "email_address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.bigint "school_id"
+    t.text "govuk_notify_id"
+    t.text "govuk_notify_status"
+    t.index ["govuk_notify_id"], name: "index_email_audits_on_govuk_notify_id"
     t.index ["message_type"], name: "index_email_audits_on_message_type"
     t.index ["school_id"], name: "index_email_audits_on_school_id"
     t.index ["user_id"], name: "index_email_audits_on_user_id"

--- a/spec/controllers/notify_callbacks_controller_spec.rb
+++ b/spec/controllers/notify_callbacks_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe NotifyCallbacksController do
+  let(:user) { create(:user) }
+  let(:audit) { create(:email_audit, user: user, govuk_notify_id: SecureRandom.uuid) }
+
+  let(:payload) do
+    {
+      id: SecureRandom.uuid,
+      reference: nil,
+      to: user.email_address,
+      status: 'delivered', # delivered, permanent-failure, temporary-failure or technical-failure
+      created_at: '2017-05-14T12:15:30.000000Z',
+      completed_at:	'2017-05-14T12:15:30.000000Z', # or null
+      sent_at: '2017-05-14T12:15:30.000000Z', # or null
+      notification_type: 'email',
+    }
+  end
+
+  let(:govuk_notify_settings) { OpenStruct.new(callback_bearer_token: Digest::SHA256.hexdigest('password')) }
+
+  before do
+    allow(Settings).to receive(:govuk_notify).and_return(govuk_notify_settings)
+  end
+
+  describe '#create' do
+    context 'without auth' do
+      it 'returns a 401' do
+        post :create, params: payload, format: :json
+        expect(response).to be_unauthorized
+      end
+
+      it 'does not create an email audit' do
+        expect {
+          post :create, params: payload, format: :json
+        }.not_to(change { EmailAudit.count })
+      end
+    end
+
+    context 'with auth' do
+      before do
+        request.headers['Authorization'] = 'Bearer password'
+      end
+
+      it 'creates an email audit' do
+        expect {
+          post :create, params: payload, format: :json
+        }.to change { EmailAudit.count }.by(1)
+      end
+
+      context 'when we do not have the email address' do
+        let(:payload) do
+          {
+            id: SecureRandom.uuid,
+            reference: nil,
+            to: 'do.not.exist@example.com',
+            status: 'delivered', # delivered, permanent-failure, temporary-failure or technical-failure
+            created_at: '2017-05-14T12:15:30.000000Z',
+            completed_at:	'2017-05-14T12:15:30.000000Z', # or null
+            sent_at: '2017-05-14T12:15:30.000000Z', # or null
+            notification_type: 'email',
+          }
+        end
+
+        it 'does not store the audit' do
+          expect {
+            post :create, params: payload, format: :json
+          }.not_to(change { EmailAudit.count })
+        end
+      end
+
+      context 'when we have associated audit thru govuk_notify_id' do
+        let(:payload) do
+          {
+            id: audit.govuk_notify_id,
+            reference: nil,
+            to: user.email_address,
+            status: 'delivered', # delivered, permanent-failure, temporary-failure or technical-failure
+            created_at: '2017-05-14T12:15:30.000000Z',
+            completed_at:	'2017-05-14T12:15:30.000000Z', # or null
+            sent_at: '2017-05-14T12:15:30.000000Z', # or null
+            notification_type: 'email',
+          }
+        end
+
+        it 'updates the audit' do
+          expect {
+            post :create, params: payload, format: :json
+          }.to change { audit.reload.govuk_notify_status }.from(nil).to('delivered')
+        end
+      end
+
+      context 'when an sms callback' do
+        let(:payload) do
+          {
+            id: SecureRandom.uuid,
+            reference: nil,
+            to: user.email_address,
+            status: 'delivered', # delivered, permanent-failure, temporary-failure or technical-failure
+            created_at: '2017-05-14T12:15:30.000000Z',
+            completed_at:	'2017-05-14T12:15:30.000000Z', # or null
+            sent_at: '2017-05-14T12:15:30.000000Z', # or null
+            notification_type: 'sms',
+          }
+        end
+
+        it 'is ignored' do
+          expect {
+            post :create, params: payload, format: :json
+          }.not_to(change { EmailAudit.count })
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/can_order_devices_mailer_spec.rb
+++ b/spec/mailers/can_order_devices_mailer_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe CanOrderDevicesMailer, type: :mailer do
       }.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
 
+    it 'passes email_audit id as reference to notify' do
+      described_class.with(user: user, school: school).user_can_order.deliver_now
+
+      audit = EmailAudit.last
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.header['reference'].value).to eql(audit.id.to_s)
+    end
+
     context 'when user is deleted' do
       let(:user) { create(:school_user, deleted_at: 1.second.ago) }
 

--- a/spec/mailers/log_email_delivery_observer_spec.rb
+++ b/spec/mailers/log_email_delivery_observer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe LogEmailDeliveryObserver do
+  let(:message) do
+    Mail.new do
+      from    'sender@example.com'
+      to      'recipient@example.com'
+      subject 'This is a test email'
+      body    'hello world'
+    end
+  end
+
+  let(:delivery_method) { OpenStruct.new(response: response) }
+  let(:response) { OpenStruct.new(reference: audit.id, id: '456') }
+  let(:audit) { create(:email_audit) }
+
+  before do
+    allow(message).to receive(:delivery_method).and_return(delivery_method)
+    allow(delivery_method).to receive(:is_a?).with(Mail::Notify::DeliveryMethod).and_return(true)
+  end
+
+  describe '::delivered_email' do
+    let(:logger) { instance_double(Rails.logger.class, debug: nil) }
+
+    before do
+      audit
+    end
+
+    it 'logs email sent a debugger level' do
+      allow(Rails).to receive(:logger).and_return(logger)
+      described_class.delivered_email(message)
+      expect(logger).to have_received(:debug)
+    end
+
+    it 'links message with audit' do
+      described_class.delivered_email(message)
+      audit.reload
+      expect(audit.govuk_notify_id).to eql('456')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/w2iRzC2P/1668-spike-store-status-of-email-notifications-sent

### Changes proposed in this pull request

- When sending emails via notify we attach attach a reference on the api call which is the `id` of the `EmailAudit`
- When notify sends back the callback sometime in the future it includes the above reference
- We then link the above reference to an existing `EmailAudit` and update the status
- Some emails we send do not create an `EmailAudit`
- In these cases when notify hits the callback endpoint we will create a new `EmailAudit`
- NOTE: Notify will also send us callbacks for emails sent via there web interface so any failed batched jobs will now be recorded by our app 

### TODO

- [x] before merging. add api keys via env vars
- [ ] after deployment configure endpoint in notify to start using the now available endpoint

### Screenshots

![image](https://user-images.githubusercontent.com/92580/110976332-ad225080-8358-11eb-931c-5262e678eed0.png)

### Guidance to review

- Sign in as support user
- Find a school with users and make them able to order, this should send an email
- Check `EmailAudit` table, should have new row with `govuk_notify_id` set with a guid by notify
- Fake notify callback with the following:

```
curl --header "Content-Type: application/json" \
  --header "Authorization: Bearer password" \
  --request POST \
  --data '{"id":"GUID","reference":"EMAIL_AUDIT_ID","to":"EMAIL_ADDRESS","status":"delivered","notification_type":"email"}' \
  http://localhost:3000/notify_callbacks
```

- `EmailAudit` status should now be updated