### PR TITLE
[1684] Build view of unclaimed devices count per day

### DIFF
--- a/app/controllers/support/remaining_device_counts_controller.rb
+++ b/app/controllers/support/remaining_device_counts_controller.rb
@@ -1,0 +1,21 @@
+class Support::RemainingDeviceCountsController < Support::BaseController
+  before_action { authorize Support::ServicePerformance }
+
+  def index
+    respond_to do |format|
+      format.csv do
+        send_data RemainingDeviceCount.to_csv, filename: "remaining_device_counts-#{file_date}.csv"
+      end
+    end
+  end
+
+private
+
+  def file_date
+    RemainingDeviceCount.most_recent.date_of_count.strftime('%Y%m%d')
+  end
+
+  def service
+    @service ||= RemainingDevicesCalculator.new
+  end
+end

--- a/app/controllers/support/remaining_device_counts_controller.rb
+++ b/app/controllers/support/remaining_device_counts_controller.rb
@@ -12,7 +12,7 @@ class Support::RemainingDeviceCountsController < Support::BaseController
 private
 
   def file_date
-    RemainingDeviceCount.most_recent.date_of_count.strftime('%Y%m%d')
+    (RemainingDeviceCount.most_recent&.date_of_count || Time.zone.now).strftime('%Y%m%d')
   end
 
   def service

--- a/app/jobs/update_remaining_devices_job.rb
+++ b/app/jobs/update_remaining_devices_job.rb
@@ -1,0 +1,5 @@
+class UpdateRemainingDevicesJob < ApplicationJob
+  def perform
+    RemainingDevicesCalculator.new.current_unclaimed_totals.save!
+  end
+end

--- a/app/models/remaining_device_count.rb
+++ b/app/models/remaining_device_count.rb
@@ -14,9 +14,13 @@ class RemainingDeviceCount < ApplicationRecord
     }
   end
 
+  def self.most_recent
+    find_by(date_of_count: select('max(date_of_count)'))
+  end
+
 private
-  
+
   def calculate_total
-    self.total_remaining = remaining_from_devolved_schools + remaining_from_managed_schools
+    self.total_remaining = (remaining_from_devolved_schools || 0) + (remaining_from_managed_schools || 0)
   end
 end

--- a/app/models/remaining_device_count.rb
+++ b/app/models/remaining_device_count.rb
@@ -1,0 +1,11 @@
+class RemainingDeviceCount < ApplicationRecord
+  validates :date_of_count, :remaining_from_devolved_schools, :remaining_from_managed_schools, :total_remaining, presence: true
+
+  before_validation :calculate_total
+
+private
+
+  def calculate_total
+    self.total_remaining = remaining_from_devolved_schools + remaining_from_managed_schools
+  end
+end

--- a/app/models/remaining_device_count.rb
+++ b/app/models/remaining_device_count.rb
@@ -1,10 +1,21 @@
 class RemainingDeviceCount < ApplicationRecord
+  include ExportableAsCsv
+
   validates :date_of_count, :remaining_from_devolved_schools, :remaining_from_managed_schools, :total_remaining, presence: true
 
   before_validation :calculate_total
 
-private
+  def self.exportable_attributes
+    {
+      date_of_count: 'Date',
+      total_remaining: 'Total remaining',
+      remaining_from_devolved_schools: 'Remaining from devolved schools',
+      remaining_from_managed_schools: 'Remaining from managed schools',
+    }
+  end
 
+private
+  
   def calculate_total
     self.total_remaining = remaining_from_devolved_schools + remaining_from_managed_schools
   end

--- a/app/services/remaining_devices_calculator.rb
+++ b/app/services/remaining_devices_calculator.rb
@@ -1,0 +1,28 @@
+class RemainingDevicesCalculator
+  def current_unclaimed_totals
+    RemainingDeviceCount.new(
+      date_of_count: Time.zone.now,
+      remaining_from_devolved_schools: remaining_from_devolved_schools,
+      remaining_from_managed_schools: remaining_from_managed_schools,
+    ).tap(&:valid?)
+  end
+
+  def remaining_from_devolved_schools
+    remaining_amount_for(School.that_will_order_devices)
+  end
+
+  def remaining_from_managed_schools
+    remaining_amount_for(School.that_are_centrally_managed)
+  end
+
+private
+
+  def remaining_amount_for(school_ordering_type)
+    SchoolDeviceAllocation
+      .std_device
+      .joins(:school)
+      .merge(school_ordering_type)
+      .where('devices_ordered < cap')
+      .sum('cap - devices_ordered')
+  end
+end

--- a/app/services/remaining_devices_calculator.rb
+++ b/app/services/remaining_devices_calculator.rb
@@ -8,7 +8,7 @@ class RemainingDevicesCalculator
   end
 
   def remaining_from_devolved_schools
-    remaining_amount_for(School.that_will_order_devices)
+    remaining_amount_for(School.gias_status_open.that_will_order_devices)
   end
 
   def remaining_from_managed_schools

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
     get '/feature-flags', to: 'home#feature_flags', as: :feature_flags
     get '/performance', to: 'service_performance#index', as: :service_performance
     get '/performance/mno-requests', to: 'service_performance#mno_requests', format: :csv
+    get '/performance/remaining-device-counts', to: 'remaining_device_counts#index', format: :csv
     resource :impersonate, only: %i[create destroy]
     namespace :gias do
       get '/updates', to: 'home#index', as: :home
@@ -261,9 +262,11 @@ Rails.application.routes.draw do
       get '/devices/chromebooks/edit', to: 'schools/devices/chromebooks#edit'
       patch '/devices/chromebooks', to: 'schools/devices/chromebooks#update'
     end
+
     namespace :performance_data, path: 'performance-data' do
       resources :schools, only: :index
     end
+
     resources :users, only: %i[show edit update destroy] do
       collection do
         get 'search'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,10 @@
   - mailers
   - scheduler
 :schedule:
+  UpdateRemainingDevicesJob:
+    cron: '55 23 * * * Europe/London'  # every day at 11:55pm
+    queue: scheduler
+    description: Store daily total for remaining devices
   StageGiasDataJob:
     cron: '15 5 * * * Europe/London'  # every day at 5:15am
     queue: scheduler

--- a/db/migrate/20210312133156_create_remaining_device_counts.rb
+++ b/db/migrate/20210312133156_create_remaining_device_counts.rb
@@ -1,0 +1,11 @@
+class CreateRemainingDeviceCounts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :remaining_device_counts do |t|
+      t.datetime :date_of_count, null: false, index: true
+      t.integer :remaining_from_devolved_schools, null: false
+      t.integer :remaining_from_managed_schools, null: false
+      t.integer :total_remaining, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -198,6 +198,16 @@ ActiveRecord::Schema.define(version: 2021_03_15_133757) do
     t.index ["status"], name: "index_preorder_information_on_status"
   end
 
+  create_table "remaining_device_counts", force: :cascade do |t|
+    t.datetime "date_of_count", null: false
+    t.integer "remaining_from_devolved_schools", null: false
+    t.integer "remaining_from_managed_schools", null: false
+    t.integer "total_remaining", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["date_of_count"], name: "index_remaining_device_counts_on_date_of_count"
+  end
+
   create_table "responsible_bodies", force: :cascade do |t|
     t.string "type", null: false
     t.string "name", null: false

--- a/spec/factories/remaining_device_counts.rb
+++ b/spec/factories/remaining_device_counts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :remaining_device_count do
+    date_of_count { Faker::Date.between(from: 9.months.ago, to: 1.day.ago) }
+    remaining_from_devolved_schools { Faker::Number.within(range: 100..2000) }
+    remaining_from_managed_schools { Faker::Number.within(range: 100..2000) }
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -22,6 +22,14 @@ FactoryBot.define do
       preorder_information { association :preorder_information, school: instance }
     end
 
+    trait :manages_orders do
+      association :preorder_information, :school_will_order
+    end
+
+    trait :centrally_managed do
+      association :preorder_information, :rb_will_order
+    end
+
     trait :with_headteacher_contact do
       after :create do |school|
         school.contacts << create(:school_contact, :headteacher)

--- a/spec/models/remaining_device_count_spec.rb
+++ b/spec/models/remaining_device_count_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe RemainingDeviceCount, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:date_of_count) }
+    it { is_expected.to validate_presence_of(:remaining_from_devolved_schools) }
+    it { is_expected.to validate_presence_of(:remaining_from_managed_schools) }
+
+    it 'populates the total remaining before validation' do
+      rdc = build(:remaining_device_count)
+      expect(rdc.total_remaining).to be_nil
+      expect(rdc.valid?).to be true
+      expect(rdc.total_remaining).to eq(rdc.remaining_from_devolved_schools + rdc.remaining_from_managed_schools)
+    end
+  end
+end

--- a/spec/services/remaining_devices_calculator_spec.rb
+++ b/spec/services/remaining_devices_calculator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe RemainingDevicesCalculator, type: :model do
+  subject(:service) { described_class.new }
+
+  let(:devolved_schools) { create_list(:school, 3, :manages_orders, :with_std_device_allocation) }
+  let(:managed_schools) { create_list(:school, 3, :centrally_managed, :with_std_device_allocation) }
+
+  describe '#current_unclaimed_totals' do
+    before do
+      devolved_schools[0].std_device_allocation.update!(allocation: 20, cap: 20, devices_ordered: 10)
+      devolved_schools[1].std_device_allocation.update!(allocation: 30, cap: 30, devices_ordered: 30)
+      devolved_schools[2].std_device_allocation.update!(allocation: 40, cap: 20, devices_ordered: 5)
+      managed_schools[0].std_device_allocation.update!(allocation: 50, cap: 50, devices_ordered: 10)
+      managed_schools[1].std_device_allocation.update!(allocation: 60, cap: 60, devices_ordered: 60)
+      managed_schools[2].std_device_allocation.update!(allocation: 70, cap: 40, devices_ordered: 15)
+    end
+
+    it 'returns a RemainingDeviceCount object with the current totals remaining' do
+      rdc = service.current_unclaimed_totals
+      expect(rdc.remaining_from_devolved_schools).to eq(70 - 45) #  = 25
+      expect(rdc.remaining_from_managed_schools).to eq(150 - 85) #  = 65
+      expect(rdc.total_remaining).to eq(25 + 65)
+    end
+
+    it 'returns a RemainingDeviceCount object for the current datetime' do
+      rdc = service.current_unclaimed_totals
+      expect(rdc.date_of_count).to be_within(2.seconds).of(Time.zone.now)
+    end
+
+    it 'returns a RemainingDeviceCount object that has not been persisted' do
+      rdc = service.current_unclaimed_totals
+      expect(rdc.persisted?).to be false
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/NBVc0nsi/1684-build-view-on-unclaimed-devices-count-per-day)
Record and display daily totals of unclaimed devices.
__NOTE__: the view of the unclaimed devices is not included in this PR, it will be done as part of the updates to the performance dashboard

### Changes proposed in this pull request
Adds a new table/model `RemainingDeviceCount` to record daily totals
Adds `RemainingDevicesCalculator` service to calculate the totals
Adds `UpdateRemainingDevicesJob` which is scheduled to record the daily total at 11:55pm
Adds ability to download a CSV of all `RemainingDeviceCount` records

### Guidance to review
The current unclaimed totals can be retrieved via `RemainingDevicesCalculator.new.current_unclaimed_totals`. This returns a `RemainingDeviceCount` instance that has not been persisted.
There are no safe guards to prevent multiple `RemainingDeviceCount` records being generated for the same day, however the only place they _should_ actually be persisted is from the `UpdateRemainingDevicesJob`.
This enables us to always have a dynamic current view of the unclaimed devices during the day while only recording the value at the end of each day.
CSV can be downloaded from `/support/performance/remaining-device-counts.csv`