### PR TITLE
Allow ssh-ing to a specific PROCESS & INSTANCE from make

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,7 @@ cf unset-env get-help-with-tech-prod FEATURES_rate_limiting
 
 ## Operations
 
-Some service steps can only be carried out using the Rails console. To get to the console on GOV.UK PaaS:
-
-### Running the Rails console
+### Connecting to the deployed containers
 
 Log on to the first instance of the sidekiq container with:
 
@@ -216,6 +214,9 @@ Both parameters are optional.
 PROCESS defaults to sidekiq, to prevent any possibility of using too much memory in the console and accidentally getting the web container restarted by the hosts' monitoring.
 INSTANCE defaults to 0.
 
+### Running the Rails console
+
+Some service steps can only be carried out using the Rails console. To get to the console on GOV.UK PaaS, first `ssh` as above.
 Once you have a prompt on the container, you'll be in a subshell with the Rails app's environment variables, and in the app's root directory:
 In this subshell, you can then launch the console in the normal way:
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The output just above the prompt will tell you what the password is for this ses
 ```
 Connecting to 'sidekiq' instance '0'
 
-*** Enter iWonl545qf at the password prompt (this is a one-time-only password) ***
+*** Enter (some hex string) at the password prompt (this is a one-time-only password) ***
 
 scp -P 2222 -o StrictHostKeyChecking=no -o User=cf:(...) ssh.london.cloud.service.gov.uk:/tmp/test.txt /tmp/
 cf:(....)@ssh.london.cloud.service.gov.uk's password:


### PR DESCRIPTION
### Context

For a while now, we've had the convenient command `make (env) ssh` for sshing to the first web process, but if you want to connect to a different instance and/or process, you have to run the more verbose `make (env) set_cf_target  && cf ssh (fully-scoped app name) --process (process) -i (instance)`.

Recently I added the `make (env) upload|download` tasks which support `PROCESS`and `INSTANCE` parameters - we should add the same support to the ssh command.

### Changes proposed in this pull request

* support the same `PROCESS` and `INSTANCE` parameters that we allow in `make (env) upload|download`
* explicitly tell you which instance and process you're connecting to, to prevent confusion
* document the new parameters in  /README.md and remove some now-redundant lines
* also add documentation for the `make (env) upload|download` tasks, which it appears I did not get time to do when adding the functionality (whoops)

### Guidance to review

Read the updated docs on the `ssh`, `upload` and `download` tasks
Try and follow them
