### PR TITLE
[1686] store & detect duplication of normalised name for ExtraMobileDataRequests

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -2,7 +2,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   has_paper_trail
 
   after_initialize :set_defaults
-  before_validation :normalise_device_phone_number
+  before_validation :normalise_device_phone_number, :normalise_name
 
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network, optional: true # set to optional as we already validate on the presence of mobile_network_id and we don't want duplicate validation errors
@@ -95,7 +95,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   def has_already_been_made?(extra_conditions = {})
     self.class.exists?(
       {
-        account_holder_name: account_holder_name,
+        normalised_name: normalised_name,
         device_phone_number: device_phone_number,
         mobile_network_id: mobile_network_id,
         contract_type: contract_type,
@@ -109,6 +109,10 @@ class ExtraMobileDataRequest < ApplicationRecord
 
   def in_a_problem_state?
     status.start_with?('problem')
+  end
+
+  def normalise_name
+    self.normalised_name = account_holder_name.to_s.downcase.gsub(/[\s[[:punct:]]]/, '')
   end
 
 private

--- a/db/migrate/20210315133435_add_normalised_name_to_extra_mobile_data_requests.rb
+++ b/db/migrate/20210315133435_add_normalised_name_to_extra_mobile_data_requests.rb
@@ -1,0 +1,6 @@
+class AddNormalisedNameToExtraMobileDataRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :extra_mobile_data_requests, :normalised_name, :string, null: true
+    add_index :extra_mobile_data_requests, :normalised_name
+  end
+end

--- a/db/migrate/20210315133757_populate_extra_mobile_data_requests_normalised_name.rb
+++ b/db/migrate/20210315133757_populate_extra_mobile_data_requests_normalised_name.rb
@@ -1,0 +1,7 @@
+class PopulateExtraMobileDataRequestsNormalisedName < ActiveRecord::Migration[6.1]
+  def change
+    ExtraMobileDataRequest.find_each do |record|
+      record.update!(normalised_name: record.normalise_name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_150630) do
+ActiveRecord::Schema.define(version: 2021_03_15_133757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,7 +162,9 @@ ActiveRecord::Schema.define(version: 2021_03_02_150630) do
     t.integer "responsible_body_id"
     t.string "contract_type"
     t.bigint "school_id"
+    t.string "normalised_name"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
+    t.index ["normalised_name"], name: "index_extra_mobile_data_requests_on_normalised_name"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"
     t.index ["school_id"], name: "index_extra_mobile_data_requests_on_school_id"
     t.index ["status"], name: "index_extra_mobile_data_requests_on_status"
@@ -218,8 +220,8 @@ ActiveRecord::Schema.define(version: 2021_03_02_150630) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.string "computacenter_change", default: "none", null: false
     t.boolean "vcap_feature_flag", default: false
+    t.string "computacenter_change", default: "none", null: false
     t.boolean "new_fe_wave", default: false
     t.index ["computacenter_change"], name: "index_responsible_bodies_on_computacenter_change"
     t.index ["computacenter_reference"], name: "index_responsible_bodies_on_computacenter_reference"
@@ -438,8 +440,8 @@ ActiveRecord::Schema.define(version: 2021_03_02_150630) do
     t.boolean "orders_devices"
     t.datetime "techsource_account_confirmed_at"
     t.datetime "deleted_at"
-    t.boolean "rb_level_access", default: false, null: false
     t.text "role", default: "no", null: false
+    t.boolean "rb_level_access", default: false, null: false
     t.index "lower((email_address)::text)", name: "index_users_on_lower_email_address_unique", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -268,13 +268,12 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
 
     context 'given a name with non-ASCII characters' do
-      let(:account_holder_name) { 'MĀREK Buzkēvičš'}
+      let(:account_holder_name) { 'MĀREK Buzkēvičš' }
 
       it 'retains and correctly downcases all non-ASCII characters' do
         expect(request.normalised_name).to eq('mārekbuzkēvičš')
       end
     end
-
   end
 
   describe 'validating contract_type' do

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -236,6 +236,47 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     expect(mno_request_for_number('7123456780').device_phone_number).to eq('07123456780')
   end
 
+  describe 'normalising account_holder_name' do
+    subject(:request) { described_class.new(account_holder_name: account_holder_name) }
+
+    before do
+      request.normalise_name
+    end
+
+    context 'given a name with spaces' do
+      let(:account_holder_name) { '  A NNA P urna ' }
+
+      it 'removes all the spaces' do
+        expect(request.normalised_name).to eq('annapurna')
+      end
+    end
+
+    context 'given an account_holder_name with mixed case' do
+      let(:account_holder_name) { 'ANNA NG' }
+
+      it 'normalises to all lower case' do
+        expect(request.normalised_name).to eq('annang')
+      end
+    end
+
+    context 'given a name with punctuation' do
+      let(:account_holder_name) { 'Mr. Miles Cholmondley-Warner Esq.' }
+
+      it 'removes all the spaces' do
+        expect(request.normalised_name).to eq('mrmilescholmondleywarneresq')
+      end
+    end
+
+    context 'given a name with non-ASCII characters' do
+      let(:account_holder_name) { 'MĀREK Buzkēvičš'}
+
+      it 'retains and correctly downcases all non-ASCII characters' do
+        expect(request.normalised_name).to eq('mārekbuzkēvičš')
+      end
+    end
+
+  end
+
   describe 'validating contract_type' do
     context 'when a new record' do
       let(:request) { subject }

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -159,6 +159,27 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
       end
     end
 
+    context 'when the account_holder_name is different but the normalised name exists' do
+      let(:existing_request) do
+        create(:extra_mobile_data_request, account_holder_name: 'Person 2', device_phone_number: '07123456780', school: school)
+      end
+
+      subject(:model) { existing_request.dup }
+
+      before do
+        model.account_holder_name = ' person  2'
+      end
+
+      it 'is invalid' do
+        expect(model.valid?).to be_falsey
+      end
+
+      it 'detects the existing record with the normalised name' do
+        model.valid?
+        expect(model.errors[:device_phone_number]).to include 'A request with these details has already been made'
+      end
+    end
+
     context 'when there is an existing request with everything the same except contract_type' do
       let(:existing_request) do
         create(:extra_mobile_data_request, account_holder_name: 'Person', device_phone_number: '07123456788', responsible_body: rb, contract_type: 'pay_as_you_go_payg')


### PR DESCRIPTION
### Context

[Trello card 1686](https://trello.com/c/y6UnyaGS/1686-store-and-detect-duplication-of-normalised-accountholdername-on-extramobiledatarequest) -  we're currently only looking for _exact_ matches of account_holder_name exactly as it was entered. In analysis for the first official publication of our success metrics, we found lots of closely-related names in the dataset - some all in upper or lower case vs mixed case, some with a middle name or title, or a dot after 'Mr.' vs not, etcetc . 

We should be able to help the situation by running a simple normalisation process.

### Changes proposed in this pull request

* Migration to add the field `normalised_name` to `ExtraMobileDataRequest`
* Add a method to normalise the name on validation
* Change the current check for existing `account_holder_name` to instead check `normalised_name`
* Add a separate migration to populate the field

### Guidance to review

