### PR TITLE
remove body of migration that blocks releases

### DIFF
--- a/db/migrate/20210315133757_populate_extra_mobile_data_requests_normalised_name.rb
+++ b/db/migrate/20210315133757_populate_extra_mobile_data_requests_normalised_name.rb
@@ -1,7 +1,6 @@
 class PopulateExtraMobileDataRequestsNormalisedName < ActiveRecord::Migration[6.1]
   def change
-    ExtraMobileDataRequest.find_each do |record|
-      record.update!(normalised_name: record.normalise_name)
-    end
+    # make this migration a no-op as it times out in production. I'll
+    # just have to populate the field from the console
   end
 end


### PR DESCRIPTION
### Context

The migration to populate `ExtraMobileDataRequest.normalised_name` is taking too long to run on prod, and this makes releases fail. 

### Changes proposed in this pull request

Make the migration a no-op - I'll run the one-of operations from the console

### Guidance to review

