### PR TITLE
[1720] Hide 0 allocation on device count component

### DIFF
--- a/app/components/device_count_component.html.erb
+++ b/app/components/device_count_component.html.erb
@@ -3,9 +3,11 @@
     <%= availability_string.html_safe -%>
   </h2>
 
-  <div class="govuk-panel__body govuk-!-font-size-24">
-    <%= ordered_string -%>
-  </div>
+  <% if non_zero_allocations.any? %>
+    <div class="govuk-panel__body govuk-!-font-size-24">
+      <%= ordered_string -%>
+    </div>
+  <% end %>
 
   <% if show_action && action.present? %>
     <%= govuk_button_link_to action.first[0], action.first[1], class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-1' %>

--- a/app/components/device_count_component.rb
+++ b/app/components/device_count_component.rb
@@ -49,10 +49,6 @@ private
     end
   end
 
-  def allocations
-    school.device_allocations
-  end
-
   def non_zero_allocations
     school.device_allocations.reject { |alloc| alloc.cap.zero? }
   end

--- a/app/components/device_count_component.rb
+++ b/app/components/device_count_component.rb
@@ -12,7 +12,7 @@ class DeviceCountComponent < ViewComponent::Base
 
   def availability_string
     if school.has_devices_available_to_order?
-      allocations.map { |allocation|
+      non_zero_allocations.map { |allocation|
         "#{allocation.available_devices_count} #{allocation.device_type_name.pluralize(allocation.available_devices_count)}"
       }.join(' and <br/>') + ' available' + availability_suffix
     else
@@ -24,7 +24,7 @@ class DeviceCountComponent < ViewComponent::Base
     if school.can_order_for_specific_circumstances? && school.has_ordered?
       'You cannot order your full allocation yet'
     else
-      state_prefix + allocations.map { |allocation|
+      state_prefix + non_zero_allocations.map { |allocation|
         "#{allocation.devices_ordered} of #{allocation.cap} #{allocation.device_type_name.pluralize(allocation.cap)}"
       }.join(' and ')
     end
@@ -51,5 +51,9 @@ private
 
   def allocations
     school.device_allocations
+  end
+
+  def non_zero_allocations
+    school.device_allocations.reject { |alloc| alloc.cap.zero? }
   end
 end

--- a/spec/components/device_count_component_spec.rb
+++ b/spec/components/device_count_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe DeviceCountComponent, type: :component do
   context 'when no devices available' do
     let(:school) { School.new(device_allocations: [allocation]) }
-    let(:allocation) { SchoolDeviceAllocation.new(devices_ordered: 0, cap: 0) }
+    let(:allocation) { SchoolDeviceAllocation.new(devices_ordered: 1, cap: 1) }
 
     subject(:component) { described_class.new(school: school) }
 
@@ -16,7 +16,28 @@ RSpec.describe DeviceCountComponent, type: :component do
     it 'renders state' do
       html = render_inline(component).to_html
 
-      expect(html).to include 'ordered 0 of 0 devices'
+      expect(html).to include 'ordered 1 of 1 device'
+    end
+  end
+
+  context 'when zero allocation present' do
+    let(:school) { School.new(device_allocations: [allocation1, allocation2]) }
+    let(:allocation1) { SchoolDeviceAllocation.new(devices_ordered: 0, cap: 0) }
+    let(:allocation2) { SchoolDeviceAllocation.new(devices_ordered: 0, cap: 1) }
+
+    subject(:component) { described_class.new(school: school) }
+
+    it 'renders availability' do
+      html = render_inline(component).to_html
+
+      expect(html).not_to include '0 devices'
+      expect(html).to include '1 device available'
+    end
+
+    it 'does not render zero allocation' do
+      html = render_inline(component).to_html
+
+      expect(html).not_to include 'ordered 0 of 0 device'
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/szUJw8JR/1720-do-not-show-0-of-0-routers-or-0-routers-available-when-the-org-has-no-router-allocation

### Changes proposed in this pull request

- Do not show any zero allocations for the device count component

### Screenshots

before
![image](https://user-images.githubusercontent.com/92580/111334601-9be48700-866b-11eb-95c9-b8be2ef1701d.png)

after
![image](https://user-images.githubusercontent.com/92580/111334614-9edf7780-866b-11eb-8760-ce7555137c52.png)

### Guidance to review

- Login as school user that can order
- Give them a zero device allocation
- Should not see `0 of 0`
- Give then a non zero router allocation
- Should continue to not see `0 of 0`
