### PR TITLE
1733 remove guidance link from header

### DIFF
--- a/app/components/nav_component.rb
+++ b/app/components/nav_component.rb
@@ -72,14 +72,12 @@ private
   def responsible_body_links
     [
       NavLinkComponent.new(title: 'Home', url: responsible_body_home_path),
-      NavLinkComponent.new(title: 'Guidance', url: guidance_page_path),
     ]
   end
 
   def school_links
     [
       NavLinkComponent.new(title: 'Home', url: schools_path),
-      NavLinkComponent.new(title: 'Guidance', url: guidance_page_path),
     ]
   end
 end

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, t('page_titles.devices_guidance_how_to_order') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   "Get laptops",
                  ]) %>
 <% end %>

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :devices_service, true %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   t('landing_pages.get_support_guides.title'),
                  ]) %>
 <% end %>

--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "#{@title} – #{t('page_titles.guide_to_collecting_mobile_information')}" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   { t('page_titles.about_increasing_mobile_data_short') => about_increasing_mobile_data_path },
                   t('page_titles.guide_to_collecting_mobile_information'),

--- a/app/views/layouts/_service_link.html.erb
+++ b/app/views/layouts/_service_link.html.erb
@@ -1,3 +1,2 @@
-<% home_page_link = @current_user&.is_responsible_body_user? ? responsible_body_home_path : "/" %>
-<%= link_to t('service_name'), home_page_link, class: "govuk-header__link govuk-header__link--service-name" %>
+<%= link_to t('service_name'), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 <%= Settings.service_name_suffix %>

--- a/app/views/layouts/multipage_guide.html.erb
+++ b/app/views/layouts/multipage_guide.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },
                   @page.title,
                  ]) %>

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-breadcrumbs ">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Get help with technology", guidance_page_path, class: 'govuk-breadcrumbs__link' %>
+        <%= link_to "Get help with technology", root_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item">
         <%= @title %>

--- a/app/views/pages/about_increasing_mobile_data.html.erb
+++ b/app/views/pages/about_increasing_mobile_data.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.about_increasing_mobile_data') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.about_increasing_mobile_data_short'),
                  ]) %>

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.choosing_help_with_internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.choosing_help_with_internet_access'),
                  ]) %>

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.how_request_4g_routers') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.how_request_4g_routers'),
                  ]) %>

--- a/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
+++ b/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.how_to_access_the_get_help_with_technology_service') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   t('page_titles.how_to_access_the_get_help_with_technology_service'),
                  ]) %>
 <% end %>

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   t('page_titles.internet_access'),
                  ]) %>
 <% end %>

--- a/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
+++ b/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe'),
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which academy trust do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which academy trust do you work for?',
                  ]) %>

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Check your answers before submitting your request' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Check your answers',
                  ]) %>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which college do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which college do you work for?',
                  ]) %>

--- a/app/views/support_tickets/contact_details.html.erb
+++ b/app/views/support_tickets/contact_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we contact you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we contact you?',
                  ]) %>

--- a/app/views/support_tickets/describe_yourself.html.erb
+++ b/app/views/support_tickets/describe_yourself.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.describe_yourself')%>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   t('landing_pages.get_support.describe_yourself'),
                  ]) %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which local authority do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which local authority do you work for?',
                  ]) %>

--- a/app/views/support_tickets/parent_support.html.erb
+++ b/app/views/support_tickets/parent_support.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Contact your school, college or local authority for support' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Contact your school, college or local authority for support',
                  ]) %>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which school do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which school do you work for?',
                  ]) %>

--- a/app/views/support_tickets/start.html.erb
+++ b/app/views/support_tickets/start.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.start') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   t('landing_pages.get_support.start'),
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/support_details.html.erb
+++ b/app/views/support_tickets/support_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we help you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we help you?',
                  ]) %>

--- a/app/views/support_tickets/support_needs.html.erb
+++ b/app/views/support_tickets/support_needs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "What do you need help with?" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   "What do you need help with?",
                  ]) %>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title,  'Support request sent' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => guidance_page_path },
+  <% breadcrumbs([{ "Get help with technology" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Support request sent',
                  ]) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require Rails.root.join('lib/constraints/require_dfe_user_constraint')
 
 Rails.application.routes.draw do
-  root 'pages#home_page', as: :guidance_page
+  root 'pages#home_page'
 
   get '/start', to: 'pages#start'
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Pretty minor changes and might be easier to review per commit. Majority file changes relate to the refactoring of the `guidance_page_path` to `root_path
### Guidance to review
Visit https://dfe-ghwt-pr-1432.herokuapp.com/ and try login as 
- `support.user.1@example.com`
- `school.user.1@example.com`
- `trust.user.1@example.com`

You should not see the "Guidance" link in the header and click on the service name should take you to the service home page.
