### PR TITLE
[1668] Email audit tweaks

### DIFF
--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -11,6 +11,7 @@ class NotifyCallbacksController < ActionController::Base
     else
       EmailAudit.create!(
         user: user,
+        email_address: callback_params[:to],
         govuk_notify_id: callback_params[:id],
         govuk_notify_status: callback_params[:status],
         message_type: 'other',

--- a/app/views/support/email_audits/index.html.erb
+++ b/app/views/support/email_audits/index.html.erb
@@ -22,7 +22,7 @@
       <tbody class="govuk-table__body">
         <% @email_audits.each do |audit| %>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header"><%= audit.email_address %></th>
+            <th scope="row" class="govuk-table__header"><%= govuk_link_to audit.email_address, support_user_path(audit.user_id) %></th>
             <th scope="row" class="govuk-table__header"><%= audit.message_type %></th>
             <td class="govuk-table__cell"><%= audit.govuk_notify_status %></td>
           </tr>

--- a/spec/controllers/notify_callbacks_controller_spec.rb
+++ b/spec/controllers/notify_callbacks_controller_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe NotifyCallbacksController do
         expect {
           post :create, params: payload, format: :json
         }.to change { EmailAudit.count }.by(1)
+
+        audit = EmailAudit.last
+
+        expect(audit.email_address).to eql(user.email_address)
       end
 
       context 'when we do not have the email address' do


### PR DESCRIPTION
### Context

- https://trello.com/c/w2iRzC2P/1668-spike-store-status-of-email-notifications-sent

### Changes proposed in this pull request

- Notify callback populates `email_address` field on the audit
- link to user from the email audits index page view

### Guidance to review

```
curl --header "Content-Type: application/json" \
  --header "Authorization: Bearer password" \
  --request POST \
  --data '{"id":"GUID","reference":"EMAIL_AUDIT_ID","to":"EMAIL_ADDRESS","status":"delivered","notification_type":"email"}' \
  http://localhost:3000/notify_callbacks
```

- Use the above for an email address of user that exists, otherwise it is discarded
- `email_address` field should be populated
- Sign in as support user
- View email audits index view
- Should be able to click thru on audit to user page