### PR TITLE
[1742] Add completed_at on DonatedDeviceRequest

### DIFF
--- a/app/controllers/responsible_body/donated_devices/interest_controller.rb
+++ b/app/controllers/responsible_body/donated_devices/interest_controller.rb
@@ -117,7 +117,7 @@ class ResponsibleBody::DonatedDevices::InterestController < ResponsibleBody::Bas
   def check_answers
     if request.post?
       authorize @request, policy_class: ResponsibleBody::DonatedDevicePolicy
-      @request.complete!
+      @request.mark_as_complete!
       redirect_to responsible_body_donated_devices_opted_in_path
     end
   end

--- a/app/controllers/school/donated_devices/interest_controller.rb
+++ b/app/controllers/school/donated_devices/interest_controller.rb
@@ -82,7 +82,7 @@ class School::DonatedDevices::InterestController < School::BaseController
   def check_answers
     if request.post?
       authorize @request, policy_class: School::DonatedDevicePolicy
-      @request.complete!
+      @request.mark_as_complete!
       redirect_to opted_in_donated_devices_school_path(@school)
     end
   end

--- a/app/models/donated_device_request.rb
+++ b/app/models/donated_device_request.rb
@@ -37,6 +37,10 @@ class DonatedDeviceRequest < ApplicationRecord
     where(responsible_body: responsible_body)
   end
 
+  def mark_as_complete!
+    update!(status: 'complete', completed_at: Time.zone.now)
+  end
+
 private
 
   def units_are_present_and_in_range

--- a/db/migrate/20210317122937_add_completed_at_to_donated_devices.rb
+++ b/db/migrate/20210317122937_add_completed_at_to_donated_devices.rb
@@ -1,0 +1,6 @@
+class AddCompletedAtToDonatedDevices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :donated_device_requests, :completed_at, :datetime, null: true
+    add_index :donated_device_requests, :completed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_133757) do
+ActiveRecord::Schema.define(version: 2021_03_17_122937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,8 @@ ActiveRecord::Schema.define(version: 2021_03_15_133757) do
     t.bigint "responsible_body_id"
     t.string "status", default: "incomplete", null: false
     t.string "opt_in_choice"
+    t.datetime "completed_at"
+    t.index ["completed_at"], name: "index_donated_device_requests_on_completed_at"
     t.index ["responsible_body_id"], name: "index_donated_device_requests_on_responsible_body_id"
     t.index ["user_id"], name: "index_donated_device_requests_on_user_id"
   end

--- a/spec/controllers/responsible_body/donated_devices/interest_controller_spec.rb
+++ b/spec/controllers/responsible_body/donated_devices/interest_controller_spec.rb
@@ -34,4 +34,21 @@ RSpec.describe ResponsibleBody::DonatedDevices::InterestController do
       end
     end
   end
+
+  describe '#check_answers' do
+    let(:user) { create(:trust_user) }
+    let(:rb) { user.responsible_body }
+    let(:device_request) { create(:donated_device_request, :wants_laptops, :opt_in_all, :wants_full_amount, user: user, responsible_body: rb, schools: rb.schools.pluck(:id)) }
+
+    before do
+      create(:school, responsible_body: rb)
+      device_request
+      sign_in_as user
+    end
+
+    it 'sets completed_at' do
+      post :check_answers, params: { id: rb.id }
+      expect(device_request.reload.completed_at).to be_within(10.seconds).of(Time.zone.now)
+    end
+  end
 end

--- a/spec/controllers/school/donated_devices/interest_controller_spec.rb
+++ b/spec/controllers/school/donated_devices/interest_controller_spec.rb
@@ -33,4 +33,20 @@ RSpec.describe School::DonatedDevices::InterestController do
       end
     end
   end
+
+  describe '#check_answers' do
+    let(:user) { create(:school_user) }
+    let(:school) { user.school }
+    let(:device_request) { create(:donated_device_request, :wants_laptops, :opt_in_all, :wants_full_amount, user: user, schools: [school.id]) }
+
+    before do
+      device_request
+      sign_in_as user
+    end
+
+    it 'sets completed_at' do
+      post :check_answers, params: { urn: school.urn }
+      expect(device_request.reload.completed_at).to be_within(10.seconds).of(Time.zone.now)
+    end
+  end
 end

--- a/spec/models/donated_device_request_spec.rb
+++ b/spec/models/donated_device_request_spec.rb
@@ -86,4 +86,16 @@ RSpec.describe DonatedDeviceRequest, type: :model do
       expect(request.errors[:units]).to be_present
     end
   end
+
+  describe '#mark_as_complete' do
+    let(:school) { create(:school) }
+
+    subject(:model) { build(:donated_device_request, :wants_laptops, :opt_in_all, :wants_full_amount, schools: [school.id]) }
+
+    it 'sets status as complete and completed_at stamp' do
+      model.mark_as_complete!
+      expect(model.status).to eql('complete')
+      expect(model.completed_at).to be_within(10.seconds).of(Time.zone.now)
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/6qIGYe5w/1742-add-completed-at-time-to-donated-device-requests

### Changes proposed in this pull request

- This is part 1 of 2 changes in order to provide continuity of service
- First part...
- Add `completed_at` column on `DonatedDeviceRequest` and index it
- This is set to the time when the user completes the request
- Second part will involve the following...
- Data migration to backfill `completed_at` on previous requests based on `created_at`
- 2 changes to `DonatedDeviceRequestsExporter`
- `created_at` value will use `completed_at` instead
- ordering of requests will now use `completed_at`

### Guidance to review

- Sign in as school or rb user
- Create a new donated device request
- `completed_at` should be populated with the current time
