### PR TITLE
Add Vodafone SIM offer to Daily Mail opted-in page

### DIFF
--- a/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
@@ -46,5 +46,7 @@
     </ul>
     <h2 class="govuk-heading-m">Preferred number of devices</h2>
     <p class="govuk-body"><%= @request.number_of_devices_selected %></p>
+
+    <%= render partial: 'shared/sim_offer' %>
   </div>
 </div>

--- a/app/views/school/donated_devices/interest/opted_in.html.erb
+++ b/app/views/school/donated_devices/interest/opted_in.html.erb
@@ -35,5 +35,7 @@
     </ul>
     <h2 class="govuk-heading-m">Preferred number of devices</h2>
     <p class="govuk-body"><%= @request.number_of_devices_selected %></p>
+
+    <%= render partial: 'shared/sim_offer' %>
   </div>
 </div>

--- a/app/views/shared/_sim_offer.html.erb
+++ b/app/views/shared/_sim_offer.html.erb
@@ -1,0 +1,22 @@
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<h2 class="govuk-heading-m">
+  Get free Vodafone SIM cards
+</h2>
+
+<p class="govuk-body">The Mail Force Computers for Kids charity campaign has partnered with Vodafone to offer 150,000 free SIM cards to schools and colleges.</p>
+
+<p class="govuk-body">Each SIM card comes with 30GB of data. This must be used within 90 days after the SIM card is activated.</p>
+<p class="govuk-body">You can request up to 50 SIM cards for your pupils and students. They’re available on a first come, first served basis.</p>
+
+<p class="govuk-body">If you want to make a request, <%= govuk_link_to 'visit the Vodafone website', 'https://www.vodafone.co.uk/mobile/pay-as-you-go-plans/schools-connected' %> and follow these steps:</p>
+
+<ol class="govuk-list govuk-list--number">
+  <li>Open the online application form</li>
+  <li>Search for your school or college using your postcode</li>
+  <li>Enter contact details for your headteacher or principal</li>
+  <li>Choose how many SIM cards you want</li>
+</ol>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'Request SIM cards from Vodafone', 'https://www.vodafone.co.uk/mobile/pay-as-you-go-plans/schools-connected' %>
+</p>


### PR DESCRIPTION
Once users have opted into the Daily Mail offer, we include a nudge about a similar offer that's making Vodafone SIM cards available to schools.

We've kept this in the Daily Mail section to keep it clear that this is not a DfE offer.

https://trello.com/c/jsmJNLjm