### PR TITLE
[1742] Change DonatedDeviceRequest csv order

### DIFF
--- a/app/services/donated_device_requests_exporter.rb
+++ b/app/services/donated_device_requests_exporter.rb
@@ -43,7 +43,7 @@ private
       School.where(id: request.schools).includes(:responsible_body).each do |school|
         csv << [
           request.id,
-          request.created_at,
+          request.completed_at,
           school.urn,
           school.computacenter_reference,
           school.responsible_body.computacenter_reference,
@@ -58,6 +58,6 @@ private
   end
 
   def donated_device_requests
-    DonatedDeviceRequest.complete.includes(:user).order(:asc)
+    DonatedDeviceRequest.complete.includes(:user).order(completed_at: :asc)
   end
 end

--- a/spec/factories/donated_device_requests.rb
+++ b/spec/factories/donated_device_requests.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
 
     trait :complete do
       status { 'complete' }
+      completed_at { Time.zone.now }
     end
   end
 end

--- a/spec/services/donated_device_requests_exporter_spec.rb
+++ b/spec/services/donated_device_requests_exporter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DonatedDeviceRequestsExporter, type: :model do
       CSV.read(filename, headers: true).each do |request|
         record = DonatedDeviceRequest.find(request['id'])
         school = School.find(record.schools.first)
-        expect(record.created_at.utc).to be_within(1.second).of(Time.zone.parse(request['created_at']).utc)
+        expect(record.completed_at.utc).to be_within(1.second).of(Time.zone.parse(request['created_at']).utc)
         expect(school.urn.to_s).to eq(request['urn'])
         expect(school.computacenter_reference).to eq(request['shipTo'])
         expect(school.responsible_body.computacenter_reference).to eq(request['soldTo'])


### PR DESCRIPTION
### Context

- https://trello.com/c/6qIGYe5w/1742-add-completed-at-time-to-donated-device-requests

### Changes proposed in this pull request

- Part 2 of 2
- Part 1 can be found in 2d5e22849a766b40ca02fc0e56a18f13c34e6fe5
- CSV `created_at` value is now `completed_at` to better reflect when request was made
- Change order of donated device requests order by `completed_at`
- Caveats of this fix is if the user changes an existing request it will be bump other requests to the bottom so may cause a record to be consumed again

### Guidance to review

- Sign in as school user 1
- Start the donated device request process but do not finish
- Sign in as school user 2
- Start the donated device request process and finish
- Sign in as school user 1
- Finish the donated device request process
- Download CSV export
- User 2 request should come first then user 1
