### PR TITLE
[1708] add reportable_events table & record EMDR completions

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -4,6 +4,8 @@ class ExtraMobileDataRequest < ApplicationRecord
   after_initialize :set_defaults
   before_validation :normalise_device_phone_number, :normalise_name
 
+  after_save :record_completion_if_needed!
+
   belongs_to :created_by_user, class_name: 'User', optional: true
   belongs_to :mobile_network, optional: true # set to optional as we already validate on the presence of mobile_network_id and we don't want duplicate validation errors
   belongs_to :responsible_body, optional: true
@@ -161,5 +163,9 @@ private
 
   def set_defaults
     self.status ||= :new if new_record?
+  end
+
+  def record_completion_if_needed!
+    ReportableEvent.create!(record: self, event_name: 'completion') if complete_status? && saved_change_to_status?
   end
 end

--- a/app/models/reportable_event.rb
+++ b/app/models/reportable_event.rb
@@ -1,0 +1,13 @@
+class ReportableEvent < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :record, polymorphic: true, optional: true
+
+  before_validation :populate_defaults!, on: :create
+
+  validates :event_name, presence: true
+
+  def populate_defaults!
+    self.event_time ||= Time.zone.now.utc
+  end
+end

--- a/db/migrate/20210317144941_add_reportable_events.rb
+++ b/db/migrate/20210317144941_add_reportable_events.rb
@@ -1,0 +1,14 @@
+class AddReportableEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reportable_events do |t|
+      t.string      :event_name
+      t.string      :record_type, null: true
+      t.bigint      :record_id, null: true
+      t.datetime    :event_time
+      t.timestamps
+    end
+
+    add_index :reportable_events, %i[event_name event_time record_type record_id], name: 'ix_re_name_time_type_id'
+    add_index :reportable_events, %i[record_type record_id event_name event_time], name: 'ix_re_type_id_name_time'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_17_122937) do
+ActiveRecord::Schema.define(version: 2021_03_17_144941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,17 @@ ActiveRecord::Schema.define(version: 2021_03_17_122937) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["date_of_count"], name: "index_remaining_device_counts_on_date_of_count"
+  end
+
+  create_table "reportable_events", force: :cascade do |t|
+    t.string "event_name"
+    t.string "record_type"
+    t.bigint "record_id"
+    t.datetime "event_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_name", "event_time", "record_type", "record_id"], name: "ix_re_name_time_type_id"
+    t.index ["record_type", "record_id", "event_name", "event_time"], name: "ix_re_type_id_name_time"
   end
 
   create_table "responsible_bodies", force: :cascade do |t|

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -419,12 +419,20 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     let(:reportable_event) { ReportableEvent.last }
 
     context 'that is complete' do
-      let(:saving_the_request) { create(:extra_mobile_data_request, status: 'in_progress') }
+      let(:saving_the_request) { create(:extra_mobile_data_request, status: 'complete') }
 
       it 'adds a ReportableEvent with the correct parameters' do
         expect { saving_the_request }.to change(ReportableEvent, :count).by(1)
-        expect(reportable_event).to have_attributes(event_name: 'completion', record_type: 'ExtraMobileDataRequest', record_id: request.id)
+        expect(reportable_event).to have_attributes(event_name: 'completion', record_type: 'ExtraMobileDataRequest', record_id: saving_the_request.id)
         expect(reportable_event.event_time).to be_within(1.second).of(Time.zone.now.utc)
+      end
+    end
+
+    context 'that is not complete' do
+      let(:saving_the_request) { create(:extra_mobile_data_request, status: 'new') }
+
+      it 'does not add a ReportableEvent' do
+        expect { saving_the_request }.not_to change(ReportableEvent, :count)
       end
     end
   end

--- a/spec/models/reportable_event_spec.rb
+++ b/spec/models/reportable_event_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ReportableEvent do
+  it { is_expected.to be_versioned }
+  it { is_expected.to validate_presence_of(:event_name) }
+
+  describe 'being created' do
+    context 'when there is no event_time' do
+      it 'defaults event_time to now' do
+        event = ReportableEvent.create!(event_name: 'Testing')
+        expect(event.event_time).to be_within(1.second).of(Time.zone.now.utc)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Full context is in the [Trello card](https://trello.com/c/bl6bdgcM/1708-improve-the-way-we-report-on-significant-events-by-recording-them-as-reportable-events) - TL;DR is that when we're running reports, we can't rely on current status & updated_at as a reliable indicator of _when_ the current status was set. We need a better way of recording reportable events.

### Changes proposed in this pull request

* Add reportable_events table and `ReportableEvent` model class
* Record `completion` events for `ExtraMobileDataRequests`

### Guidance to review

I'd like to run this as-is on production for a few days, just to double-check that the events are being recorded reliably when triggered by all known methods. Once we're happy that that's the case, I can add a migration to backfill completion events for the existing data, switch over the ad-hoc reporting code to use that table, and bring that ad-hoc code into the main codebase.
