### PR TITLE
Focussed links on the start page banner have low contrast

### DIFF
--- a/app/webpacker/styles/components/_start-page-banner.scss
+++ b/app/webpacker/styles/components/_start-page-banner.scss
@@ -16,6 +16,10 @@
     color: govuk-colour("white");
   }
 
+  .govuk-phase-banner__text .govuk-link:focus {
+    color: govuk-colour('black');
+  }
+
   .govuk-tag {
     color: govuk-colour("white");
     border: 1px solid govuk-colour("light-blue");
@@ -29,6 +33,10 @@
 
   .govuk-link {
     color: govuk-colour("white");
+  }
+
+  .govuk-link:focus {
+    color: govuk-colour('black');
   }
 
   @include govuk-media-query($from: tablet) {


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

#### Before


https://user-images.githubusercontent.com/3441519/111643173-a5e6c100-87f6-11eb-923e-676d00e10877.mp4


#### After

https://user-images.githubusercontent.com/3441519/111643119-9a939580-87f6-11eb-94a1-55d5c3177e56.mp4
