### PR TITLE
Refactored query into longer form as something wasn't calculating right

### DIFF
--- a/app/services/remaining_devices_calculator.rb
+++ b/app/services/remaining_devices_calculator.rb
@@ -7,22 +7,22 @@ class RemainingDevicesCalculator
     ).tap(&:valid?)
   end
 
+private
+
   def remaining_from_devolved_schools
-    remaining_amount_for(School.gias_status_open.that_will_order_devices)
+    SchoolDeviceAllocation
+      .std_device
+      .joins(school: :preorder_information)
+      .where(preorder_information: { who_will_order_devices: 'school' })
+      .where(school: { status: 'open'})
+      .sum('cap - devices_ordered')
   end
 
   def remaining_from_managed_schools
-    remaining_amount_for(School.that_are_centrally_managed)
-  end
-
-private
-
-  def remaining_amount_for(school_ordering_type)
     SchoolDeviceAllocation
       .std_device
-      .joins(:school)
-      .merge(school_ordering_type)
-      .where('devices_ordered < cap')
+      .joins(school: :preorder_information)
+      .where(preorder_information: { who_will_order_devices: 'responsible_body' })
       .sum('cap - devices_ordered')
   end
 end

--- a/app/services/remaining_devices_calculator.rb
+++ b/app/services/remaining_devices_calculator.rb
@@ -14,7 +14,7 @@ private
       .std_device
       .joins(school: :preorder_information)
       .where(preorder_information: { who_will_order_devices: 'school' })
-      .where(school: { status: 'open'})
+      .where(school: { status: 'open' })
       .sum('cap - devices_ordered')
   end
 


### PR DESCRIPTION
### Context
https://ukgovernmentdfe.slack.com/archives/C01A7DVKE9J/p1616090224032500?thread_ts=1616089945.032200&cid=C01A7DVKE9J

The unclaimed devices calculation was not working as expected. Not 100% sure why, maybe a cartesian product issue when the SQL is generated.
Expanding the query to be more explicit results in the correct values when tested on the console in production.

### Changes proposed in this pull request
Refactored the queries in `RemainingDevicesCalculator`

### Guidance to review

The refactored queries now produce the same result as hand crafted SQL on the prod rails console.

```
[1] pry(main)> SchoolDeviceAllocation
.std_device
.joins(school: :preorder_information)
.where(preorder_information: { who_will_order_devices: 'school' })
.where(school: { status: 'open'})
.sum('cap - devices_ordered')
=> 10155                          
[2] pry(main)> result = School.connection.execute("select sum(sda.cap - sda.devices_ordered) from school_device_allocations sda join schools s on s.id = sda.school_id join preorder_information pi on pi.school_id = s.id where sda.device_type='std_device' and pi.who_will_order_devices='school' and s.status='open'")[0]

=> {"sum"=>10155}
[3] pry(main)>     SchoolDeviceAllocation
      .std_device
      .joins(school: :preorder_information)
      .where(preorder_information: { who_will_order_devices: 'responsible_body' })
[3] pry(main)> SchoolDeviceAllocation
.std_device
.joins(school: :preorder_information)
.where(preorder_information: { who_will_order_devices: 'responsible_body' })
.sum('cap - devices_ordered')
=> 4240                     
[4] pry(main)> result = School.connection.execute("select sum(sda.cap - sda.devices_ordered) from school_device_allocations sda join schools s on s.id = sda.school_id join preorder_information pi on pi.school_id = s.id where sda.device_type='std_device' and pi.who_will_order_devices='responsible_body'")[0]

=> {"sum"=>4240}
```
