### PR TITLE
Add "Guides for parents, carers & students" page

### DIFF
--- a/app/controllers/guides_for_parents_carers_students_controller.rb
+++ b/app/controllers/guides_for_parents_carers_students_controller.rb
@@ -1,0 +1,3 @@
+class GuidesForParentsCarersStudentsController < ApplicationController
+  def index; end
+end

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -21,8 +21,5 @@
 
     <%= render partial: 'page_link_and_description', collection: @responsible_body_pages, as: :page %>
 
-    <h2 class="govuk-heading-l">Guidance to be shared with students and families using the devices</h2>
-
-    <%= render partial: 'page_link_and_description', collection: @device_user_pages, as: :page %>
   </div>
 </div>

--- a/app/views/guides_for_parents_carers_students/index.html.erb
+++ b/app/views/guides_for_parents_carers_students/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, t('landing_pages.guides_parents_carers_students.title') %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => root_path },
+                  t('landing_pages.guides_parents_carers_students.title'),
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('landing_pages.guides_parents_carers_students.title' ) %>
+    </h1>
+
+    <p class="govuk-body-l">
+      <%= t('landing_pages.guides_parents_carers_students.details') %>
+    </p>
+
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-7">
+      Laptops and tablets guides
+    </h2>
+
+    <ul class="govuk-list govuk-list--spaced">
+      <li>
+        <%= govuk_link_to t('devices_guidance.getting_started_with_your_microsoft_windows_device.title'), '/devices/getting-started-with-your-microsoft-windows-device'%>
+      </li>
+      <li>
+        <%= govuk_link_to t('devices_guidance.getting_started_with_your_google_chromebook.title'), '/devices/getting-started-with-your-google-chromebook'%>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-7">
+      4G wireless router guides
+    </h2>
+
+    <ul class="govuk-list govuk-list--spaced">
+      <li>
+        <%= govuk_link_to t('devices_guidance.4g_user_guidance.title'), '/devices/4g-user-guidance'%>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/layouts/multipage_guide.html.erb
+++ b/app/views/layouts/multipage_guide.html.erb
@@ -8,10 +8,17 @@
 <% end %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
-                  { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },
-                  @page.title,
-                 ]) %>
+  <% if @page.audience == 'parents_carers_students' %>
+    <% breadcrumbs([{ "Home" => root_path },
+                    { t('landing_pages.guides_parents_carers_students.title') => guides_for_parents_carers_and_students_path },
+                    @page.title,
+                   ]) %>
+  <% else %>
+    <% breadcrumbs([{ "Get help with technology" => root_path },
+                    { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },
+                    @page.title,
+                   ]) %>
+  <% end %>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/pages/home_page.html.erb
+++ b/app/views/pages/home_page.html.erb
@@ -57,6 +57,18 @@
       or support to set up a new digital platform through the Get help with technology programme,
       or if you&rsquo;re developing your approach to remote education, reducing teacher workloads and improving outcomes for children and young people.
     </p>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      <%= govuk_link_to  t('landing_pages.guides_parents_carers_students.title') ,
+                         guides_for_parents_carers_and_students_path %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= t('landing_pages.guides_parents_carers_students.details') %>
+    </p>
+
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,9 @@ en:
       title: Get funding and support to set up a digital education platform
     edtech_demonstrator_programme:
       title: Get free training and support to set up and use technology effectively
+    guides_parents_carers_students:
+      title: Guides for parents, guardians, pupils and students
+      details: Get help guides to share with the children, young people and carers using the laptops, tablets and 4G wireless routers provided by DfE.
   cookie_preferences:
     success: Your cookie preferences have been saved
   devices_guidance:
@@ -296,17 +299,17 @@ en:
       description: Guidance for Microsoft Windows devices provided with safeguarding and mobile device management software and how to install your own.
       audience: responsible_body_users
     getting_started_with_your_microsoft_windows_device:
-      title: Getting started with your Microsoft Windows device
+      title: How to get started with your Microsoft Windows laptop or tablet
       description: User guidance for Microsoft Windows devices to share with children, young people and their carers.
-      audience: device_users
+      audience: parents_carers_students
     preparing_chromebooks:
       title: Preparing Chromebooks
       description: Guidance on how to enrol Google Chromebooks on your domain, how to install Cisco Umbrella content filtering, and set up instructions for local authorities, trusts, schools and further education institutions.
       audience: responsible_body_users
     getting_started_with_your_google_chromebook:
-      title: Getting started with your Google Chromebook
+      title: How to get started with your Google Chromebook
       description: User guidance for Google Chromebooks to share with children, young people and their carers.
-      audience: device_users
+      audience: parents_carers_students
     preparing_ipads:
       title: Preparing iPads
       description: Find out how to enrol your iPads in Apple School Manager (ASM), set up your iPads and make the most out of them.
@@ -318,7 +321,7 @@ en:
     4g_user_guidance:
       title: How to get started with your 4G wireless router
       description: User guidance for 4G wireless routers to share with children, young people and their carers.
-      audience: device_users
+      audience: parents_carers_students
     device_distribution_and_ownership:
       title: Device ownership and distribution
       description: Guidance on who owns devices, and information on insuring devices, asset management and loan agreements.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resource :notify_callbacks, only: [:create]
 
+  get '/guides-for-parents-carers-and-students', to: 'guides_for_parents_carers_students#index'
   get '/digital-platforms', to: 'landing_pages#digital_platforms', as: :digital_platforms_landing_page
   get '/EdTech-demonstrator-programme', to: 'landing_pages#edtech_demonstrator_programme', as: :edtech_demonstrator_programme_landing_page
 

--- a/spec/features/start_journey_spec.rb
+++ b/spec/features/start_journey_spec.rb
@@ -20,6 +20,13 @@ RSpec.feature 'View pages', type: :feature do
     and_the_page_title_should_be_set(@digital_platforms_page, 'Get funding and support to set up a digital education platform')
   end
 
+  scenario 'user is a parent,carer or student would like to find out how to use their device' do
+    when_i_visit_the_home_page
+    and_i_click_on_guides_for_parents_link
+    then_i_should_see_the_guides_for_parents_carers_students_page
+    and_the_page_title_should_be_set(@guides_parents_carers_students_page, 'Guides for parents, guardians, pupils and students')
+  end
+
 private
 
   def when_i_visit_the_home_page
@@ -39,6 +46,10 @@ private
     @home_page.digital_platforms_page_link.click
   end
 
+  def and_i_click_on_guides_for_parents_link
+    @home_page.guides_parents_carers_students_link.click
+  end
+
   def then_i_should_see_the_edtech_programme_page
     @edtech_landing_page ||= PageObjects::LandingPages::EdtechDemonstratorProgrammePage.new
     expect(@edtech_landing_page).to be_displayed
@@ -47,6 +58,11 @@ private
   def then_i_should_see_the_digital_platforms_page
     @digital_platforms_page ||= PageObjects::LandingPages::DigitalPlatformsPage.new
     expect(@digital_platforms_page).to be_displayed
+  end
+
+  def then_i_should_see_the_guides_for_parents_carers_students_page
+    @guides_parents_carers_students_page ||= PageObjects::GuidesForParentsCarersStudents::IndexPage.new
+    expect(@guides_parents_carers_students_page).to be_displayed
   end
 
   def and_the_page_title_should_be_set(current_page, title)

--- a/spec/page_objects/guides_for_parents_carers_students/index_page.rb
+++ b/spec/page_objects/guides_for_parents_carers_students/index_page.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module GuidesForParentsCarersStudents
+    class IndexPage < PageObjects::BasePage
+      set_url '/guides-for-parents-carers-and-students'
+    end
+  end
+end

--- a/spec/page_objects/pages/home_page.rb
+++ b/spec/page_objects/pages/home_page.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       element :digital_platforms_page_link, '[data-service-section="digital-platforms"] a'
       element :edtech_landing_page_link, '[data-service-section="edtech"] a'
+      element :guides_parents_carers_students_link, 'a[text()="Guides for parents, guardians, pupils and students"]'
     end
   end
 end


### PR DESCRIPTION
## Context
We are restructuring the device guidance page and one of the changes is to remove this from the device guidance page and make it more prominent on the home page.

## Changes proposed in this pull request
- build a second-level page for the guides
- Add a copy & link to the home page which will take the user to the new  to the new page
- Remove the heading copy relating to this guidance from the existing device guidance page
## Guidance to review

Visit https://dfe-ghwt-pr-1448.herokuapp.com/ to see the changes