### PR TITLE
[1759] allow rack-throttle to use Redis & update sign-in paths

### DIFF
--- a/config/initializers/rack_throttle.rb
+++ b/config/initializers/rack_throttle.rb
@@ -11,9 +11,20 @@ class RackThrottleConfig
     { method: 'DELETE', limit: Integer(Settings.throttling.limits.delete) },
     { method: 'GET', limit: Integer(Settings.throttling.limits.get) },
     { method: 'GET', path: '/token/.*', limit: Integer(Settings.throttling.limits['/token'].get) },
-    { method: 'GET', path: '/sign_in_tokens/.*', limit: Integer(Settings.throttling.limits['/sign_in_tokens'].get) },
+    { method: 'GET', path: '/sign-in/.*', limit: Integer(Settings.throttling.limits['/sign-in'].get) },
+    { method: 'POST', path: '/sign-in/.*', limit: Integer(Settings.throttling.limits['/sign-in'].post) },
   ].freeze
   DEFAULT = Settings.throttling.default_limit
+
+  def self.redis_url
+    if ENV['REDIS_URL'].present?
+      ENV['REDIS_URL']
+    elsif ENV['VCAP_SERVICES'].present?
+      require 'v_cap_services_config'
+      redis_config = VCapServicesConfig.new.first_service_matching('redis')
+      redis_config['credentials']['uri']
+    end
+  end
 end
 
 # only do this if enabled, so that we don't throttle features specs, for instance
@@ -23,5 +34,7 @@ if FeatureFlag.active?(:rate_limiting)
                                           default: RackThrottleConfig::DEFAULT,
                                           code: 429,
                                           message: File.read(Rails.root.join('public/429.html')),
-                                          type: 'text/html; charset=utf-8'
+                                          type: 'text/html; charset=utf-8',
+                                          cache: RackThrottleConfig.redis_url.present? ? Redis.new(url: RackThrottleConfig.redis_url) : {},
+                                          key_prefix: :throttle
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,8 +91,9 @@ throttling:
     put: 4
     /token:
       get: 4
-    /sign_in_tokens:
-      get: 4
+    /sign-in:
+      get: 2
+      post: 2
 
 logstash:
   host: # Fill in with logstash host, leave blank to disable


### PR DESCRIPTION
### Context

[Trello card 1759](https://trello.com/c/kd2X19Xi/1759-check-that-rate-limiting-is-working-as-expected) - The pen test identified that the rate-limiting we have in place is not quite working as expected. The `rack-throttle` gem applies the limits at the `Rack::Middleware` layer, and the default configuration is to track limits in memory - which means that the thresholds are effectively per-container-instance as well as per-client per-second.  

Also, it looks like the paths for `sign-in` and `tokens` have changed since the rate-limiting was put in place, so the specific limits for generating and validating sign-in tokens were being ignored.

### Changes proposed in this pull request

* allow `rack-throttle` to track limits in redis if it's configured, falling back to in-memory for local dev. This should give us true per-client-ip-per-second limits, regardless of number of instances
* correct the paths of the sign-in limits
* adjust the specific limits for the sign-in process down to 2 per client IP per second

### Guidance to review

