### PR TITLE
[1736] Support can opt school out of notifications

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -9,9 +9,27 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
              else
                address_read_only_row
              end
+    array << receiving_communications_row
   end
 
 private
+
+  def receiving_communications_row
+    {
+      key: 'Receiving communications',
+      value: receiving_communications_value,
+      action: 'Change <span class="govuk-visually-hidden">communications preference</span>'.html_safe,
+      action_path: edit_support_school_opt_out_path(@school),
+    }
+  end
+
+  def receiving_communications_value
+    if @school.opted_out_of_comms_at
+      'No, opted out of receiving communications as they do not want their remaining allocation'
+    else
+      'Yes, receiving communications'
+    end
+  end
 
   def school_name_editable_row
     {

--- a/app/controllers/support/schools/opt_outs_controller.rb
+++ b/app/controllers/support/schools/opt_outs_controller.rb
@@ -1,0 +1,28 @@
+class Support::Schools::OptOutsController < Support::BaseController
+  before_action :set_school
+  before_action { authorize @school }
+
+  def edit; end
+
+  def update
+    if form_params[:opt_out] == '1'
+      @school.opt_out!
+      flash[:success] = 'School has been opted out'
+    else
+      @school.opt_in!
+      flash[:success] = 'School has been opted back in'
+    end
+
+    redirect_to support_school_path(@school)
+  end
+
+private
+
+  def set_school
+    @school ||= School.where_urn_or_ukprn(params[:school_urn]).first!
+  end
+
+  def form_params
+    params.require(:school).permit(:opt_out)
+  end
+end

--- a/app/form_objects/support/opt_out_form.rb
+++ b/app/form_objects/support/opt_out_form.rb
@@ -1,0 +1,9 @@
+class Support::OptOutForm
+  include ActiveModel::Model
+
+  attr_accessor :school
+
+  def opt_out
+    !!school.opted_out_of_comms_at ? 1 : 0
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -196,6 +196,18 @@ class School < ApplicationRecord
     update!(status: 'closed', computacenter_change: 'closed') unless gias_status_closed?
   end
 
+  def opt_out!
+    update!(opted_out_of_comms_at: Time.zone.now)
+  end
+
+  def opt_in!
+    update!(opted_out_of_comms_at: nil)
+  end
+
+  def opted_out?
+    !!opted_out_of_comms_at
+  end
+
 private
 
   def maybe_generate_user_changes

--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -42,6 +42,8 @@ private
   end
 
   def what_message_to_send(school, user)
+    return if school.opted_out?
+
     if status?(nil, 'needs_contact', school: school) && user.in?(school.responsible_body.users)
       :nudge_rb_to_add_school_contact
     elsif status?('needs_info', 'school_contacted', school: school) && user.in?(school.organisation_users)

--- a/app/views/support/schools/opt_outs/edit.html.erb
+++ b/app/views/support/schools/opt_outs/edit.html.erb
@@ -1,0 +1,31 @@
+<%- title = t('page_titles.support.schools.opt_outs.edit') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_link_to('Back', support_school_path(@school), class: 'govuk-back-link') %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <div class="govuk-body">
+      By opting outing of communications a user from the school has expressed that they no longer wish to use the remainder of their allocation. This will prevent us from sending any further updates to them about unclaimed devices.
+    </div>
+
+    <%= form_with model: Support::OptOutForm.new(school: @school), url: support_school_opt_out_path, method: :put, scope: :school do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% opt_out_options = [OpenStruct.new(id: 1, name: 'Opt out and no longer receive communications'),
+                            OpenStruct.new(id: 0, name: 'Opt in and receive communcations')] %>
+
+      <%= f.govuk_collection_radio_buttons :opt_out, opt_out_options, :id, :name,
+        legend: { text: 'Opt school out of further notifications' }
+      %>
+
+      <%= f.govuk_submit 'Save' %>
+    <%- end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,9 @@ en:
         edit: Update address
       email_audits:
         index: Email audits
+      schools:
+        opt_outs:
+          edit: Change communication preference
     support_extra_mobile_data_requests: Requests for extra mobile data
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,10 @@ Rails.application.routes.draw do
     resources :schools, only: %i[show edit update], param: :urn do
       resource :addresses, only: %i[edit update], path: 'address'
 
+      scope module: 'schools' do
+        resource :opt_out, only: %i[edit update], path: 'opt-out'
+      end
+
       collection do
         get 'search'
         get 'results'
@@ -249,6 +253,7 @@ Rails.application.routes.draw do
         get '/devices/adjust-allocations/for-many-schools', to: 'schools/devices/allocation#collect_urns_and_allocations_for_many_schools'
         patch '/devices/adjust-allocations/for-many-schools', to: 'schools/devices/allocation#adjust_allocations_for_many_schools', as: :adjust_allocations_for_many_schools
       end
+
       get '/invite', to: 'schools#confirm_invitation', as: :confirm_invitation
       post '/invite', to: 'schools#invite'
       resources :users, only: %i[new create], controller: 'users'

--- a/db/migrate/20210318130347_add_opted_out_at_to_schools.rb
+++ b/db/migrate/20210318130347_add_opted_out_at_to_schools.rb
@@ -1,0 +1,5 @@
+class AddOptedOutAtToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :opted_out_of_comms_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 2021_03_19_142213) do
     t.integer "ukprn"
     t.text "fe_type"
     t.boolean "hide_mno", default: false
+    t.datetime "opted_out_of_comms_at"
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"

--- a/spec/controllers/support/schools/opt_outs_controller_spec.rb
+++ b/spec/controllers/support/schools/opt_outs_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Support::Schools::OptOutsController do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school) }
+
+  before do
+    sign_in_as support_user
+  end
+
+  describe '#edit' do
+    it 'works' do
+      get :edit, params: { school_urn: school.urn }
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    context 'opting out' do
+      it 'sets school#opted_out_of_comms_at with timestamp' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '1' } }
+        expect(school.reload.opted_out_of_comms_at).to be_within(10.seconds).of(Time.zone.now)
+      end
+
+      it 'redirects back to school' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '1' } }
+        expect(response).to redirect_to(support_school_path(school))
+      end
+
+      it 'sets flash success' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '1' } }
+        expect(flash[:success]).to be_present
+      end
+    end
+
+    context 'opting back in' do
+      let(:school) { create(:school, opted_out_of_comms_at: 1.day.ago) }
+
+      it 'sets nullifies school#opted_out_of_comms_at' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '0' } }
+        expect(school.reload.opted_out_of_comms_at).to be_nil
+      end
+
+      it 'redirects back to school' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '0' } }
+        expect(response).to redirect_to(support_school_path(school))
+      end
+
+      it 'sets flash success' do
+        post :update, params: { school_urn: school.urn, school: { opt_out: '1' } }
+        expect(flash[:success]).to be_present
+      end
+    end
+  end
+end

--- a/spec/features/support/schools/opt_out_spec.rb
+++ b/spec/features/support/schools/opt_out_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.feature 'Updating addresses' do
+  let(:support_user) { create(:support_user) }
+  let(:school) { create(:school) }
+  let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+
+  before do
+    sign_in_as support_user
+  end
+
+  scenario 'opting out a school' do
+    given_a_school_that_is_opted_in
+    when_support_user_visits_school_page
+    then_they_see('Yes, receiving communications')
+
+    when_they_click('Change communications preference')
+    then_they_see('Change communication preference')
+    and_no_opt_in_should_be_checked
+
+    when_they_choose('Opt out and no longer receive communications')
+    and_click('Save')
+    then_they_should_see_the_school_page
+    and_they_see('No, opted out of receiving communications')
+  end
+
+  scenario 'opting in a school' do
+    given_a_school_that_is_opted_out
+    when_support_user_visits_school_page
+    then_they_see('No, opted out of receiving communications')
+
+    when_they_click('Change communications preference')
+    then_they_see('Change communication preference')
+    and_yes_opt_out_should_be_checked
+
+    when_they_choose('Opt in and receive communcations')
+    and_click('Save')
+    then_they_should_see_the_school_page
+    and_they_see('Yes, receiving communications')
+  end
+
+  def given_a_school_that_is_opted_in
+    @school = create(:school)
+  end
+
+  def given_a_school_that_is_opted_out
+    @school = create(:school, opted_out_of_comms_at: 1.day.ago)
+  end
+
+  def when_support_user_visits_school_page
+    school_page.load(urn: @school.urn)
+  end
+
+  def then_they_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def when_they_click(string)
+    page.click_link(string)
+  end
+
+  def and_no_opt_in_should_be_checked
+    expect(page.find_field('school-opt-out-0-field')).to be_checked
+  end
+
+  def and_yes_opt_out_should_be_checked
+    expect(page.find_field('school-opt-out-1-field')).to be_checked
+  end
+
+  def when_they_choose(string)
+    page.choose(string)
+  end
+
+  def and_click(string)
+    page.click_button(string)
+  end
+
+  def then_they_should_see_the_school_page
+    expect(school_page).to be_displayed
+  end
+
+  def and_they_see(string)
+    then_they_see(string)
+  end
+end

--- a/spec/models/school_can_order_devices_notifications_spec.rb
+++ b/spec/models/school_can_order_devices_notifications_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe SchoolCanOrderDevicesNotifications do
           }.not_to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer')
         end
       end
+
+      context 'school has opted out but would have received notification' do
+        let!(:user) do
+          create(:school_user,
+                 school: school,
+                 techsource_account_confirmed_at: 1.second.ago,
+                 orders_devices: true)
+        end
+
+        before do
+          school.update(opted_out_of_comms_at: 1.day.ago)
+        end
+
+        it 'does not notify the user' do
+          expect {
+            service.call
+          }.not_to have_enqueued_job.on_queue('mailers').with('CanOrderDevicesMailer', 'user_can_order', 'deliver_now', params: { user: user, school: school }, args: [])
+        end
+      end
     end
 
     context 'when school ordering centrally in virtual cap which is ready changes from cannot_order to can_order' do


### PR DESCRIPTION
### Context

- https://trello.com/c/DegS78mW/1736-create-a-flag-in-service-to-not-contact-users-who-told-us-they-do-not-need-devices

### Changes proposed in this pull request

- Added db column `opted_out_at` on `School`
- Support users can opt a school out of comms which will set the above value
- They can also remove the value to opt them back in
- `SchoolCanOrderDevicesNotifications` takes the above value into consideration and will not send any notifications if set

### Screenshots

Support school show page when opted in (default state)
![image](https://user-images.githubusercontent.com/92580/111807134-8caf4480-88ca-11eb-988b-38ee1a3aaa62.png)

Change page on default state (opted in and about to opt them out)
![image](https://user-images.githubusercontent.com/92580/111972722-ab455380-8af5-11eb-9fbe-41bd3d7e4ec8.png)

Support school show page when opted out
![image](https://user-images.githubusercontent.com/92580/111807406-d13ae000-88ca-11eb-9653-f2e21b39417a.png)

### Guidance to review

- Sign in as support user
- Find a school
- Should be opted in
- Opt them out
- Should be opted out
- Change order state so they get a nudge email
- Should no longer receive a nudge email