### PR TITLE
1721 build the service dashboard

### DIFF
--- a/app/components/support/percentage_tile_component.html.erb
+++ b/app/components/support/percentage_tile_component.html.erb
@@ -1,0 +1,4 @@
+<div class="app-card<%= colour == :default ? '' : " app-card--#{colour}" %>">
+  <span class="<%= count_class %>"><%= percentage %>%</span>
+  <%= label %>
+</div>

--- a/app/components/support/percentage_tile_component.rb
+++ b/app/components/support/percentage_tile_component.rb
@@ -1,0 +1,16 @@
+module Support
+  class PercentageTileComponent < ViewComponent::Base
+    attr_reader :percentage, :label, :colour
+
+    def initialize(percentage:, label:, colour: :default, size: :regular)
+      @percentage = percentage
+      @label = label
+      @colour = colour
+      @size = size
+    end
+
+    def count_class
+      @size == :regular ? 'app-card__count' : 'app-card__secondary-count'
+    end
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -185,6 +185,14 @@ module ViewHelper
     govuk_link_to 'Complete a survey', 'https://docs.google.com/forms/d/e/1FAIpQLSd9g4jlGTXM6FLOxgfyEIoAWZuhAweL7A6kx5qhDYpwguznAg/viewform?usp=sf_link'
   end
 
+  def humanized_number(value)
+    if value > 999_999
+      number_to_human(value, format: '%n%u', precision: 2, significant: false, strip_insignificant_zeros: false, units: { million: 'm' })
+    else
+      number_with_delimiter(value)
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -21,6 +21,22 @@ class SchoolDeviceAllocation < ApplicationRecord
     where(device_type: device_type)
   end
 
+  def self.has_fully_ordered
+    where('devices_ordered > 0 AND cap = devices_ordered')
+  end
+
+  def self.has_partially_ordered
+    where('devices_ordered > 0 AND cap > devices_ordered')
+  end
+
+  def self.has_not_ordered
+    where(devices_ordered: 0)
+  end
+
+  def self.has_not_fully_ordered
+    where('cap > devices_ordered')
+  end
+
   def self.by_computacenter_device_type(cc_device_type)
     by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type))
   end

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -13,33 +13,13 @@ class SchoolDeviceAllocation < ApplicationRecord
 
   validates_with CapAndAllocationValidator
 
-  def self.can_order_std_devices_now
-    by_device_type('std_device').where('cap > devices_ordered')
-  end
-
-  def self.by_device_type(device_type)
-    where(device_type: device_type)
-  end
-
-  def self.has_fully_ordered
-    where('devices_ordered > 0 AND cap = devices_ordered')
-  end
-
-  def self.has_partially_ordered
-    where('devices_ordered > 0 AND cap > devices_ordered')
-  end
-
-  def self.has_not_ordered
-    where(devices_ordered: 0)
-  end
-
-  def self.has_not_fully_ordered
-    where('cap > devices_ordered')
-  end
-
-  def self.by_computacenter_device_type(cc_device_type)
-    by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type))
-  end
+  scope :has_fully_ordered, -> { where('devices_ordered > 0 AND cap = devices_ordered') }
+  scope :has_partially_ordered, -> { where('devices_ordered > 0 AND cap > devices_ordered') }
+  scope :has_not_ordered, -> { where(devices_ordered: 0) }
+  scope :has_not_fully_ordered, -> { where('cap > devices_ordered') }
+  scope :by_device_type, ->(device_type) { where(device_type: device_type) }
+  scope :can_order_std_devices_now, -> { by_device_type('std_device').where('cap > devices_ordered') }
+  scope :by_computacenter_device_type, ->(cc_device_type) { by_device_type(Computacenter::CapTypeConverter.to_dfe_type(cc_device_type)) }
 
   def computacenter_cap
     # value to pass to computacenter

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -31,43 +31,99 @@ class Support::ServicePerformance
     1_302_110
   end
 
+  def total_routers_available
+    SchoolDeviceAllocation.coms_device.sum(:allocation)
+  end
+
   def total_devices_ordered
     SchoolDeviceAllocation.std_device.sum(:devices_ordered)
+  end
+
+  def total_routers_ordered
+    SchoolDeviceAllocation.coms_device.sum(:devices_ordered)
   end
 
   def total_devices_remaining
     SchoolDeviceAllocation.std_device.sum('allocation - devices_ordered')
   end
 
+  def total_routers_remaining
+    SchoolDeviceAllocation.coms_device.sum('allocation - devices_ordered')
+  end
+
+  # def number_of_devolved_schools_that_have_fully_ordered
+  #   @number_of_devolved_schools_that_have_fully_ordered ||=
+  #     School
+  #     .gias_status_open
+  #     .that_will_order_devices
+  #     .joins(:device_allocations)
+  #     .merge(SchoolDeviceAllocation.std_device.has_fully_ordered)
+  #     .count
+  # end
+
   def number_of_devolved_schools_that_have_fully_ordered
     @number_of_devolved_schools_that_have_fully_ordered ||=
-      School
-      .gias_status_open
-      .that_will_order_devices
-      .joins(:device_allocations)
-      .merge(SchoolDeviceAllocation.std_device.has_fully_ordered)
-      .count
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_fully_ordered)
+  end
+
+  def number_of_devolved_schools_that_have_fully_ordered_routers
+    @number_of_devolved_schools_that_have_fully_ordered_routers ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_fully_ordered)
   end
 
   def number_of_devolved_schools_that_have_partially_ordered
     @number_of_devolved_schools_that_have_partially_ordered ||=
-      School
-      .gias_status_open
-      .that_will_order_devices
-      .joins(:device_allocations)
-      .merge(SchoolDeviceAllocation.std_device.has_partially_ordered)
-      .count
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_partially_ordered)
+  end
+
+  def number_of_devolved_schools_that_have_partially_ordered_routers
+    @number_of_devolved_schools_that_have_partially_ordered_routers ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_partially_ordered)
   end
 
   def number_of_devolved_schools_that_have_not_ordered
     @number_of_devolved_schools_that_have_not_ordered ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_not_ordered)
+  end
+
+  def number_of_devolved_schools_that_have_not_ordered_routers
+    @number_of_devolved_schools_that_have_not_ordered_routers ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('allocation > 0 AND devices_ordered = 0'))
+  end
+
+  def number_of_devolved_schools_that_have_a_router_allocation
+    @number_of_devolved_schools_that_have_a_router_allocation ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('allocation > 0'))
+  end
+
+  def number_of_devolved_schools_that_have(scope:)
       School
       .gias_status_open
       .that_will_order_devices
       .joins(:device_allocations)
-      .merge(SchoolDeviceAllocation.std_device.has_not_ordered)
+      .merge(scope)
       .count
   end
+
+  # def number_of_devolved_schools_that_have_partially_ordered
+  #   @number_of_devolved_schools_that_have_partially_ordered ||=
+  #     School
+  #     .gias_status_open
+  #     .that_will_order_devices
+  #     .joins(:device_allocations)
+  #     .merge(SchoolDeviceAllocation.std_device.has_partially_ordered)
+  #     .count
+  # end
+
+  # def number_of_devolved_schools_that_have_not_ordered
+  #   @number_of_devolved_schools_that_have_not_ordered ||=
+  #     School
+  #     .gias_status_open
+  #     .that_will_order_devices
+  #     .joins(:device_allocations)
+  #     .merge(SchoolDeviceAllocation.std_device.has_not_ordered)
+  #     .count
+  # end
 
   def percentage_of_devolved_schools_that_have_fully_ordered
     (number_of_devolved_schools_that_have_fully_ordered * 100.0 / number_of_devolved_schools).round
@@ -83,6 +139,18 @@ class Support::ServicePerformance
 
   def percentage_of_responsible_bodies_that_have_signed_in
     (number_of_responsible_bodies_that_have_signed_in * 100.0 / number_of_responsible_bodies).round
+  end
+
+  def percentage_of_devolved_schools_that_have_fully_ordered_routers
+    (number_of_devolved_schools_that_have_fully_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
+  end
+
+  def percentage_of_devolved_schools_that_have_partially_ordered_routers
+    (number_of_devolved_schools_that_have_partially_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
+  end
+
+  def percentage_of_devolved_schools_that_have_not_ordered_routers
+    (number_of_devolved_schools_that_have_not_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
   end
 
   def number_of_responsible_bodies_that_have_signed_in
@@ -127,8 +195,27 @@ class Support::ServicePerformance
       .count('DISTINCT(responsible_body_id)')
   end
 
+  def number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
+    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.coms_device.has_partially_ordered)
+      .count('DISTINCT(responsible_body_id)')
+  end
+
   def number_of_responsible_bodies_managing_centrally_that_have_not_ordered
     number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation
+    @number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation ||=
+      School
+      .gias_status_open
+      .that_are_centrally_managed
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.coms_device.where('allocation > 0'))
+      .count('DISTINCT(responsible_body_id)')
   end
 
   def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered
@@ -141,6 +228,14 @@ class Support::ServicePerformance
 
   def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered
     (number_of_responsible_bodies_managing_centrally_that_have_not_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
+    (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+  end
+
+  def unclaimed_devices_by_day
+    [RemainingDevicesCalculator.new.current_unclaimed_totals] + RemainingDeviceCount.order(date_of_count: :desc).first(6)
   end
 
   def responsible_body_users_signed_in_at_least_once
@@ -217,6 +312,30 @@ class Support::ServicePerformance
       .count
       .sort_by { |_k, v| v }
       .reverse
+  end
+
+  def number_of_devolved_schools_that_have_made_extra_mobile_data_requests
+    ExtraMobileDataRequest.from_schools.count('DISTINCT(school_id)')
+  end
+
+  def number_of_responsible_bodies_that_have_made_extra_mobile_data_requests
+    ExtraMobileDataRequest.from_responsible_bodies.count('DISTINCT(responsible_body_id)')
+  end
+
+  def extra_mobile_data_requests_by_mobile_network_brand_and_status(scope: ExtraMobileDataRequest)
+    data = scope
+      .joins(:mobile_network)
+      .group("mobile_networks.brand", "CASE when status like 'problem_%' or status = 'cancelled' or status = 'unavailable' then 'problem' else status end")
+      .count
+
+    # put statuses under the brand
+    result = data.inject({}) do |h, (k,v)|
+      h[k[0]] = {} if h[k[0]].nil?
+      h[k[0]][k[1]] = v
+      h
+    end
+    result.each { |k,v| v['total'] = v.values.sum }
+    result.sort_by { |_k,v| v['total'] }.reverse
   end
 
   def total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest)

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -26,6 +26,34 @@ class Support::ServicePerformance
       .count
   end
 
+  def total_devices_available
+    # SchoolDeviceAllocation.std_device.sum(:allocation)
+    1_302_110
+  end
+
+  def total_devices_ordered
+    SchoolDeviceAllocation.std_device.sum(:devices_ordered)
+  end
+
+  def total_devices_remaining
+    SchoolDeviceAllocation.std_device.sum('allocation - devices_ordered')
+  end
+
+  def number_of_devolved_schools_that_have_fully_ordered
+    @number_of_devolved_schools_that_have_fully_ordered ||=
+      School
+      .gias_status_open
+      .that_will_order_devices
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.std_device)
+      .where('school_device_allocations.cap > school_device_allocations.devices_ordered')
+      .count
+  end
+
+  def percentage_of_devolved_schools_that_have_fully_ordered
+    (number_of_devolved_schools_that_have_fully_ordered * 100.0 / number_of_devolved_schools).round
+  end
+
   def percentage_of_responsible_bodies_that_have_signed_in
     (number_of_responsible_bodies_that_have_signed_in * 100.0 / number_of_responsible_bodies).round
   end

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -45,13 +45,40 @@ class Support::ServicePerformance
       .gias_status_open
       .that_will_order_devices
       .joins(:device_allocations)
-      .merge(SchoolDeviceAllocation.std_device)
-      .where('school_device_allocations.cap > school_device_allocations.devices_ordered')
+      .merge(SchoolDeviceAllocation.std_device.has_fully_ordered)
+      .count
+  end
+
+  def number_of_devolved_schools_that_have_partially_ordered
+    @number_of_devolved_schools_that_have_partially_ordered ||=
+      School
+      .gias_status_open
+      .that_will_order_devices
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.std_device.has_partially_ordered)
+      .count
+  end
+
+  def number_of_devolved_schools_that_have_not_ordered
+    @number_of_devolved_schools_that_have_not_ordered ||=
+      School
+      .gias_status_open
+      .that_will_order_devices
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.std_device.has_not_ordered)
       .count
   end
 
   def percentage_of_devolved_schools_that_have_fully_ordered
     (number_of_devolved_schools_that_have_fully_ordered * 100.0 / number_of_devolved_schools).round
+  end
+
+  def percentage_of_devolved_schools_that_have_partially_ordered
+    (number_of_devolved_schools_that_have_partially_ordered * 100.0 / number_of_devolved_schools).round
+  end
+
+  def percentage_of_devolved_schools_that_have_not_ordered
+    (number_of_devolved_schools_that_have_not_ordered * 100.0 / number_of_devolved_schools).round
   end
 
   def percentage_of_responsible_bodies_that_have_signed_in
@@ -69,6 +96,51 @@ class Support::ServicePerformance
     @number_of_responsible_bodies ||= ResponsibleBody
       .gias_status_open
       .count
+  end
+
+  def number_of_responsible_bodies_managing_centrally
+    @number_of_responsible_bodies_managing_centrally ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .count('DISTINCT(responsible_body_id)')
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_fully_ordered
+    number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered
+    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.std_device.has_not_fully_ordered)
+      .count('DISTINCT(responsible_body_id)')
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.std_device.has_partially_ordered)
+      .count('DISTINCT(responsible_body_id)')
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_not_ordered
+    number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered
+    (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+    (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered
+    (number_of_responsible_bodies_managing_centrally_that_have_not_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
   end
 
   def responsible_body_users_signed_in_at_least_once

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -195,6 +195,23 @@ class Support::ServicePerformance
       .count('DISTINCT(responsible_body_id)')
   end
 
+  def number_of_responsible_bodies_managing_centrally_that_have_not_ordered
+    number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers
+    number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation - number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers
+  end
+
+  def number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers
+    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .joins(:device_allocations)
+      .merge(SchoolDeviceAllocation.coms_device.has_not_fully_ordered)
+      .count('DISTINCT(responsible_body_id)')
+  end
+
   def number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
     @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers ||= School
       .gias_status_open
@@ -204,8 +221,9 @@ class Support::ServicePerformance
       .count('DISTINCT(responsible_body_id)')
   end
 
-  def number_of_responsible_bodies_managing_centrally_that_have_not_ordered
-    number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+  def number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers
+    @number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers ||=
+      number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
   end
 
   def number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation
@@ -230,8 +248,16 @@ class Support::ServicePerformance
     (number_of_responsible_bodies_managing_centrally_that_have_not_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
   end
 
+  def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers
+    (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+  end
+
   def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
     (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers
+    (number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
   end
 
   def unclaimed_devices_by_day

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -1,10 +1,15 @@
 class Support::ServicePerformance
   def percentage_of_devolved_schools_that_have_signed_in
-    (number_of_devolved_schools_that_have_signed_in * 100.0 / number_of_devolved_schools).round
+    if number_of_devolved_schools.positive?
+      (number_of_devolved_schools_that_have_signed_in * 100.0 / number_of_devolved_schools).round
+    else
+      0
+    end
   end
 
   def number_of_devolved_schools_that_have_signed_in
-    @number_of_devolved_schools_that_have_signed_in ||= School
+    @number_of_devolved_schools_that_have_signed_in ||=
+      School
       .gias_status_open
       .that_will_order_devices
       .joins(user_schools: :user)
@@ -13,62 +18,51 @@ class Support::ServicePerformance
   end
 
   def number_of_devolved_schools
-    @number_of_devolved_schools ||= School
+    @number_of_devolved_schools ||=
+      School
       .gias_status_open
       .that_will_order_devices
       .count
   end
 
   def number_of_centrally_managed_schools
-    @number_of_centrally_managed_schools ||= School
+    @number_of_centrally_managed_schools ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .count
   end
 
   def total_devices_available
-    # SchoolDeviceAllocation.std_device.sum(:allocation)
-    1_302_110
-  end
-
-  def total_routers_available
-    SchoolDeviceAllocation.coms_device.sum(:allocation)
+    SchoolDeviceAllocation.std_device.sum(:allocation)
   end
 
   def total_devices_ordered
     SchoolDeviceAllocation.std_device.sum(:devices_ordered)
   end
 
-  def total_routers_ordered
-    SchoolDeviceAllocation.coms_device.sum(:devices_ordered)
-  end
-
   def total_devices_remaining
     SchoolDeviceAllocation.std_device.sum('allocation - devices_ordered')
+  end
+
+  def total_routers_available
+    SchoolDeviceAllocation.coms_device.sum(:allocation)
+  end
+
+  def total_routers_ordered
+    SchoolDeviceAllocation.coms_device.sum(:devices_ordered)
   end
 
   def total_routers_remaining
     SchoolDeviceAllocation.coms_device.sum('allocation - devices_ordered')
   end
 
-  # def number_of_devolved_schools_that_have_fully_ordered
-  #   @number_of_devolved_schools_that_have_fully_ordered ||=
-  #     School
-  #     .gias_status_open
-  #     .that_will_order_devices
-  #     .joins(:device_allocations)
-  #     .merge(SchoolDeviceAllocation.std_device.has_fully_ordered)
-  #     .count
-  # end
-
+  #
+  # devolved schools - devices
+  #
   def number_of_devolved_schools_that_have_fully_ordered
     @number_of_devolved_schools_that_have_fully_ordered ||=
       number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_fully_ordered)
-  end
-
-  def number_of_devolved_schools_that_have_fully_ordered_routers
-    @number_of_devolved_schools_that_have_fully_ordered_routers ||=
-      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_fully_ordered)
   end
 
   def number_of_devolved_schools_that_have_partially_ordered
@@ -76,14 +70,46 @@ class Support::ServicePerformance
       number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_partially_ordered)
   end
 
-  def number_of_devolved_schools_that_have_partially_ordered_routers
-    @number_of_devolved_schools_that_have_partially_ordered_routers ||=
-      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_partially_ordered)
-  end
-
   def number_of_devolved_schools_that_have_not_ordered
     @number_of_devolved_schools_that_have_not_ordered ||=
       number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.std_device.has_not_ordered)
+  end
+
+  def percentage_of_devolved_schools_that_have_fully_ordered
+    if number_of_devolved_schools.positive?
+      (number_of_devolved_schools_that_have_fully_ordered * 100.0 / number_of_devolved_schools).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_devolved_schools_that_have_partially_ordered
+    if number_of_devolved_schools.positive?
+      (number_of_devolved_schools_that_have_partially_ordered * 100.0 / number_of_devolved_schools).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_devolved_schools_that_have_not_ordered
+    if number_of_devolved_schools.positive?
+      (number_of_devolved_schools_that_have_not_ordered * 100.0 / number_of_devolved_schools).round
+    else
+      0
+    end
+  end
+
+  #
+  # devolved schools - routers
+  #
+  def number_of_devolved_schools_that_have_fully_ordered_routers
+    @number_of_devolved_schools_that_have_fully_ordered_routers ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_fully_ordered)
+  end
+
+  def number_of_devolved_schools_that_have_partially_ordered_routers
+    @number_of_devolved_schools_that_have_partially_ordered_routers ||=
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.has_partially_ordered)
   end
 
   def number_of_devolved_schools_that_have_not_ordered_routers
@@ -96,89 +122,79 @@ class Support::ServicePerformance
       number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('allocation > 0'))
   end
 
+  def percentage_of_devolved_schools_that_have_fully_ordered_routers
+    if number_of_devolved_schools_that_have_a_router_allocation.positive?
+      (number_of_devolved_schools_that_have_fully_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_devolved_schools_that_have_partially_ordered_routers
+    if number_of_devolved_schools_that_have_a_router_allocation.positive?
+      (number_of_devolved_schools_that_have_partially_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_devolved_schools_that_have_not_ordered_routers
+    if number_of_devolved_schools_that_have_a_router_allocation.positive?
+      (number_of_devolved_schools_that_have_not_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
+    else
+      0
+    end
+  end
+
   def number_of_devolved_schools_that_have(scope:)
-      School
-      .gias_status_open
-      .that_will_order_devices
-      .joins(:device_allocations)
-      .merge(scope)
-      .count
+    School
+    .gias_status_open
+    .that_will_order_devices
+    .joins(:device_allocations)
+    .merge(scope)
+    .count
   end
 
-  # def number_of_devolved_schools_that_have_partially_ordered
-  #   @number_of_devolved_schools_that_have_partially_ordered ||=
-  #     School
-  #     .gias_status_open
-  #     .that_will_order_devices
-  #     .joins(:device_allocations)
-  #     .merge(SchoolDeviceAllocation.std_device.has_partially_ordered)
-  #     .count
-  # end
-
-  # def number_of_devolved_schools_that_have_not_ordered
-  #   @number_of_devolved_schools_that_have_not_ordered ||=
-  #     School
-  #     .gias_status_open
-  #     .that_will_order_devices
-  #     .joins(:device_allocations)
-  #     .merge(SchoolDeviceAllocation.std_device.has_not_ordered)
-  #     .count
-  # end
-
-  def percentage_of_devolved_schools_that_have_fully_ordered
-    (number_of_devolved_schools_that_have_fully_ordered * 100.0 / number_of_devolved_schools).round
-  end
-
-  def percentage_of_devolved_schools_that_have_partially_ordered
-    (number_of_devolved_schools_that_have_partially_ordered * 100.0 / number_of_devolved_schools).round
-  end
-
-  def percentage_of_devolved_schools_that_have_not_ordered
-    (number_of_devolved_schools_that_have_not_ordered * 100.0 / number_of_devolved_schools).round
-  end
-
+  #
+  # responsible bodies
+  #
   def percentage_of_responsible_bodies_that_have_signed_in
     (number_of_responsible_bodies_that_have_signed_in * 100.0 / number_of_responsible_bodies).round
   end
 
-  def percentage_of_devolved_schools_that_have_fully_ordered_routers
-    (number_of_devolved_schools_that_have_fully_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
-  end
-
-  def percentage_of_devolved_schools_that_have_partially_ordered_routers
-    (number_of_devolved_schools_that_have_partially_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
-  end
-
-  def percentage_of_devolved_schools_that_have_not_ordered_routers
-    (number_of_devolved_schools_that_have_not_ordered_routers * 100.0 / number_of_devolved_schools_that_have_a_router_allocation).round
-  end
-
   def number_of_responsible_bodies_that_have_signed_in
-    @number_of_responsible_bodies_that_have_signed_in ||= User
+    @number_of_responsible_bodies_that_have_signed_in ||=
+      User
       .where.not(responsible_body: nil)
       .signed_in_at_least_once
       .count('DISTINCT(responsible_body_id)')
   end
 
   def number_of_responsible_bodies
-    @number_of_responsible_bodies ||= ResponsibleBody
+    @number_of_responsible_bodies ||=
+      ResponsibleBody
       .gias_status_open
       .count
   end
 
   def number_of_responsible_bodies_managing_centrally
-    @number_of_responsible_bodies_managing_centrally ||= School
+    @number_of_responsible_bodies_managing_centrally ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .count('DISTINCT(responsible_body_id)')
   end
 
+  #
+  # responsible bodies - centrally managed devices
+  #
   def number_of_responsible_bodies_managing_centrally_that_have_fully_ordered
     number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered
   end
 
   def number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered
-    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered ||= School
+    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .joins(:device_allocations)
@@ -187,7 +203,8 @@ class Support::ServicePerformance
   end
 
   def number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
-    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered ||= School
+    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .joins(:device_allocations)
@@ -199,12 +216,40 @@ class Support::ServicePerformance
     number_of_responsible_bodies_managing_centrally - number_of_responsible_bodies_managing_centrally_that_have_fully_ordered - number_of_responsible_bodies_managing_centrally_that_have_partially_ordered
   end
 
+  def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered
+    if number_of_responsible_bodies_managing_centrally.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered
+    if number_of_responsible_bodies_managing_centrally.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+    else
+      0
+    end
+  end
+
+  def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered
+    if number_of_responsible_bodies_managing_centrally.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_not_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
+    else
+      0
+    end
+  end
+
+  #
+  # responsible bodies - centrally managed routers
+  #
   def number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers
     number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation - number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers
   end
 
   def number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers
-    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers ||= School
+    @number_of_responsible_bodies_managing_centrally_that_have_not_fully_ordered_routers ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .joins(:device_allocations)
@@ -213,7 +258,8 @@ class Support::ServicePerformance
   end
 
   def number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
-    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers ||= School
+    @number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers ||=
+      School
       .gias_status_open
       .that_are_centrally_managed
       .joins(:device_allocations)
@@ -236,30 +282,33 @@ class Support::ServicePerformance
       .count('DISTINCT(responsible_body_id)')
   end
 
-  def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered
-    (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
-  end
-
-  def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered
-    (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
-  end
-
-  def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered
-    (number_of_responsible_bodies_managing_centrally_that_have_not_ordered * 100.0 / number_of_responsible_bodies_managing_centrally).round
-  end
-
   def percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers
-    (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    if number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    else
+      0
+    end
   end
 
   def percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers
-    (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    if number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    else
+      0
+    end
   end
 
   def percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers
-    (number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    if number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation.positive?
+      (number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers * 100.0 / number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation).round
+    else
+      0
+    end
   end
 
+  #
+  # unclaimed devices
+  #
   def unclaimed_devices_by_day
     [RemainingDevicesCalculator.new.current_unclaimed_totals] + RemainingDeviceCount.order(date_of_count: :desc).first(6)
   end
@@ -351,17 +400,17 @@ class Support::ServicePerformance
   def extra_mobile_data_requests_by_mobile_network_brand_and_status(scope: ExtraMobileDataRequest)
     data = scope
       .joins(:mobile_network)
-      .group("mobile_networks.brand", "CASE when status like 'problem_%' or status = 'cancelled' or status = 'unavailable' then 'problem' else status end")
+      .group('mobile_networks.brand', "CASE when status like 'problem_%' or status = 'cancelled' or status = 'unavailable' then 'problem' else status end")
       .count
 
-    # put statuses under the brand
-    result = data.inject({}) do |h, (k,v)|
+    # put statuses and counts under the brand
+    result = data.each_with_object({}) do |(k, v), h|
       h[k[0]] = {} if h[k[0]].nil?
       h[k[0]][k[1]] = v
-      h
     end
-    result.each { |k,v| v['total'] = v.values.sum }
-    result.sort_by { |_k,v| v['total'] }.reverse
+    # calculate the totals
+    result.each { |_k, v| v['total'] = v.values.sum }
+    result.sort_by { |_k, v| v['total'] }.reverse
   end
 
   def total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest)

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -1,11 +1,45 @@
 class Support::ServicePerformance
-  def devolved_school_users_that_have_signed_in_at_least_once
-    User
-      .where(responsible_body: nil)
+  def percentage_of_devolved_schools_that_have_signed_in
+    (number_of_devolved_schools_that_have_signed_in * 100.0 / number_of_devolved_schools).round
+  end
+
+  def number_of_devolved_schools_that_have_signed_in
+    @number_of_devolved_schools_that_have_signed_in ||= School
+      .gias_status_open
+      .that_will_order_devices
+      .joins(user_schools: :user)
+      .where('users.sign_in_count > 0')
+      .count('DISTINCT(schools.id)')
+  end
+
+  def number_of_devolved_schools
+    @number_of_devolved_schools ||= School
+      .gias_status_open
+      .that_will_order_devices
+      .count
+  end
+
+  def number_of_centrally_managed_schools
+    @number_of_centrally_managed_schools ||= School
+      .gias_status_open
+      .that_are_centrally_managed
+      .count
+  end
+
+  def percentage_of_responsible_bodies_that_have_signed_in
+    (number_of_responsible_bodies_that_have_signed_in * 100.0 / number_of_responsible_bodies).round
+  end
+
+  def number_of_responsible_bodies_that_have_signed_in
+    @number_of_responsible_bodies_that_have_signed_in ||= User
+      .where.not(responsible_body: nil)
       .signed_in_at_least_once
-      .joins(:schools)
-      .merge(School.that_will_order_devices)
-      .distinct
+      .count('DISTINCT(responsible_body_id)')
+  end
+
+  def number_of_responsible_bodies
+    @number_of_responsible_bodies ||= ResponsibleBody
+      .gias_status_open
       .count
   end
 

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -1,4 +1,14 @@
 class Support::ServicePerformance
+  def devolved_school_users_that_have_signed_in_at_least_once
+    User
+      .where(responsible_body: nil)
+      .signed_in_at_least_once
+      .joins(:schools)
+      .merge(School.that_will_order_devices)
+      .distinct
+      .count
+  end
+
   def responsible_body_users_signed_in_at_least_once
     User
       .where.not(responsible_body: nil)

--- a/app/views/support/service_performance/_devices.html.erb
+++ b/app/views/support/service_performance/_devices.html.erb
@@ -1,0 +1,117 @@
+<h2 class="govuk-heading-l">Devices</h2>
+<%- i18n_scope = 'support.devices_performance' %>
+
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.total_devices_available),
+               label: t(:total_devices_available, scope: i18n_scope),
+               colour: :blue) %>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.total_devices_ordered),
+                 label: t(:total_devices_ordered, scope: i18n_scope),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.total_devices_remaining),
+                 label: t(:total_devices_remaining, scope: i18n_scope),
+                 colour: :orange) %>
+  </div>
+</div>
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Devices remaining by day (last 7 days)</h3>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Date</th>
+      <th class="govuk-table__header govuk-table__header--numeric">Total remaining</th>
+      <th class="govuk-table__header govuk-table__header--numeric">Remaining from:<br>Schools ordering their own</th>
+      <th class="govuk-table__header govuk-table__header--numeric">Remaining from:<br>RBs ordering centrally</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">10 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">95,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">85,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,000</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">9 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">95,200</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">85,200</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,000</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">8 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">7 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">6 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">5 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">4 March 2021</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
+    </tr>
+  </tbody>
+</table>
+<p class="govuk-body"><%= govuk_link_to 'Download CSV of all dates', '#' %></p>
+
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Schools</h3>
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.number_of_devolved_schools),
+               label: t(:devolved_schools, scope: i18n_scope),
+               colour: :blue) %>
+</div>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered),
+                 label: t(:devolved_schools_that_have_fully_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_devolved_schools_that_have_fully_ordered,
+                          total: @stats.number_of_devolved_schools),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered),
+                 label: t(:devolved_schools_that_have_fully_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_devolved_schools_that_have_fully_ordered,
+                          total: @stats.number_of_devolved_schools),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered),
+                 label: t(:devolved_schools_that_have_fully_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_devolved_schools_that_have_fully_ordered,
+                          total: @stats.number_of_devolved_schools),
+                 colour: :green) %>
+  </div>
+</div>

--- a/app/views/support/service_performance/_devices.html.erb
+++ b/app/views/support/service_performance/_devices.html.erb
@@ -22,6 +22,7 @@
                  colour: :orange) %>
   </div>
 </div>
+
 <h3 class="govuk-heading-m govuk-!-margin-top-7">Devices remaining by day (last 7 days)</h3>
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -98,20 +99,59 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render Support::PercentageTileComponent.new(
-                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered),
-                 label: t(:devolved_schools_that_have_fully_ordered_html,
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_partially_ordered),
+                 label: t(:devolved_schools_that_have_partially_ordered_html,
                           scope: i18n_scope,
-                          amount: @stats.number_of_devolved_schools_that_have_fully_ordered,
+                          amount: @stats.number_of_devolved_schools_that_have_partially_ordered,
                           total: @stats.number_of_devolved_schools),
+                 colour: :orange) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_not_ordered),
+                 label: t(:devolved_schools_that_have_not_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_devolved_schools_that_have_not_ordered,
+                          total: @stats.number_of_devolved_schools),
+                 colour: :red) %>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Responsible bodies</h3>
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.number_of_responsible_bodies_managing_centrally),
+               label: t(:responsible_bodies_managing_centrally_html,
+                        scope: i18n_scope,
+                        school_count: @stats.number_of_centrally_managed_schools),
+                        colour: :blue) %>
+</div>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered),
+                 label: t(:responsible_bodies_that_have_fully_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_fully_ordered,
+                          total: @stats.number_of_responsible_bodies_managing_centrally),
                  colour: :green) %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render Support::PercentageTileComponent.new(
-                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered),
-                 label: t(:devolved_schools_that_have_fully_ordered_html,
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered),
+                 label: t(:responsible_bodies_that_have_partially_ordered_html,
                           scope: i18n_scope,
-                          amount: @stats.number_of_devolved_schools_that_have_fully_ordered,
-                          total: @stats.number_of_devolved_schools),
-                 colour: :green) %>
+                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_partially_ordered,
+                          total: @stats.number_of_responsible_bodies_managing_centrally),
+                 colour: :orange) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered),
+                 label: t(:responsible_bodies_that_have_not_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_not_ordered,
+                          total: @stats.number_of_responsible_bodies_managing_centrally),
+                 colour: :red) %>
   </div>
 </div>

--- a/app/views/support/service_performance/_devices.html.erb
+++ b/app/views/support/service_performance/_devices.html.erb
@@ -34,51 +34,17 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">10 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">95,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">85,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,000</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">9 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">95,200</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">85,200</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,000</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">8 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">7 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">6 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">5 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">4 March 2021</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">96,100</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">86,000</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">10,100</td>
-    </tr>
+    <% @stats.unclaimed_devices_by_day.each do |row| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= row.date_of_count.strftime('%d %B %Y') %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= humanized_number(row.total_remaining) %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= humanized_number(row.remaining_from_devolved_schools) %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= humanized_number(row.remaining_from_managed_schools) %></td>
+      </tr>
+    <%- end %>
   </tbody>
 </table>
-<p class="govuk-body"><%= govuk_link_to 'Download CSV of all dates', '#' %></p>
+<p class="govuk-body"><%= govuk_link_to 'Download CSV of all dates', support_performance_remaining_device_counts_path(format: :csv) %></p>
 
 <h3 class="govuk-heading-m govuk-!-margin-top-7">Schools</h3>
 <div class="govuk-!-margin-bottom-4">

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">
     <%= render Support::TileComponent.new(
-                 count: @stats.total_extra_mobile_data_requests,
+                 count: humanized_number(@stats.total_extra_mobile_data_requests),
                  label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests),
                  colour: :blue) %>
   </div>
@@ -14,27 +14,27 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['new'] || 0,
+                 count: humanized_number(@stats.extra_mobile_data_requests_by_status['new'] || 0),
                  label: 'new',
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['in_progress'] || 0,
+                 count: humanized_number(@stats.extra_mobile_data_requests_by_status['in_progress'] || 0),
                  label: 'in progress',
                  colour: :orange,
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: (@stats.total_extra_mobile_data_requests_with_problems || 0) + (@stats.extra_mobile_data_requests_by_status['cancelled'] || 0),
+                 count: humanized_number((@stats.total_extra_mobile_data_requests_with_problems || 0) + (@stats.extra_mobile_data_requests_by_status['cancelled'] || 0)),
                  label: 'not valid',
                  colour: :red,
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status['complete'] || 0,
+                 count: humanized_number(@stats.extra_mobile_data_requests_by_status['complete'] || 0),
                  label: 'completed',
                  colour: :green,
                  size: :reduced) %>
@@ -60,7 +60,7 @@
         <td class="govuk-table__cell"><%= row[0] %></td>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['new'] || 0 %></td>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['in_progress'] || 0 %></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['completed'] || 0 %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['complete'] || 0 %></td>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['problem'] || 0 %></td>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['total'] || 0 %></td>
       </tr>

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -1,10 +1,12 @@
-<h2 class="govuk-heading-l">Mobile data requests from responsible bodies</h2>
+<%- i18n_scope = 'support.devices_performance' %>
+
+<h2 class="govuk-heading-l">Mobile data requests</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">
     <%= render Support::TileComponent.new(
-                 count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_responsible_bodies),
-                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_responsible_bodies)),
+                 count: @stats.total_extra_mobile_data_requests,
+                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests),
                  colour: :blue) %>
   </div>
 </div>
@@ -12,116 +14,79 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['new'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status['new'] || 0,
                  label: 'new',
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['in_progress'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status['in_progress'] || 0,
                  label: 'in progress',
+                 colour: :orange,
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: (@stats.total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest.from_responsible_bodies) || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['cancelled'] || 0),
-                 label: 'not valid or cancelled',
+                 count: (@stats.total_extra_mobile_data_requests_with_problems || 0) + (@stats.extra_mobile_data_requests_by_status['cancelled'] || 0),
+                 label: 'not valid',
                  colour: :red,
                  size: :reduced) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_responsible_bodies)['complete'] || 0,
+                 count: @stats.extra_mobile_data_requests_by_status['complete'] || 0,
                  label: 'completed',
                  colour: :green,
                  size: :reduced) %>
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-top-4">
-  <div class="govuk-grid-column-one-half">
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Network</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Requests</th>
-        </tr>
-      </thead>
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Requests by network</h3>
+<table class="govuk-table govuk-!-margin-top-4">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Network</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">New</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">In progress</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Completed</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Problem</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Total</th>
+    </tr>
+  </thead>
 
-      <tbody class="govuk-table__body">
-        <% @stats.extra_mobile_data_requests_by_mobile_network_brand(scope: ExtraMobileDataRequest.from_responsible_bodies).each do |mno_name, count| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= mno_name %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= count %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+  <tbody class="govuk-table__body">
+    <% @stats.extra_mobile_data_requests_by_mobile_network_brand_and_status.each do |row| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= row[0] %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['new'] || 0 %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['in_progress'] || 0 %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['completed'] || 0 %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['problem'] || 0 %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[1]['total'] || 0 %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<p class="givuk-body">
+<%= govuk_link_to 'Download a CSV of anonymised extra mobile data requests', support_performance_mno_requests_path(format: :csv) %>
+</p>
 
-<h2 class="govuk-heading-l">Mobile data requests from schools</h2>
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Who has made requests</h3>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
-  <div class="govuk-grid-column-full">
-    <%= render Support::TileComponent.new(
-                 count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_schools),
-                 label: t(:requests, scope: %i[support service_performance], count: @stats.total_extra_mobile_data_requests(scope: ExtraMobileDataRequest.from_schools)),
-                 colour: :blue) %>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['new'] || 0,
-                 label: 'new',
-                 size: :reduced) %>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['in_progress'] || 0,
-                 label: 'in progress',
-                 size: :reduced) %>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <%= render Support::TileComponent.new(
-                 count: (@stats.total_extra_mobile_data_requests_with_problems(scope: ExtraMobileDataRequest.from_schools) || 0) + (@stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['cancelled'] || 0),
-                 label: 'not valid or cancelled',
-                 colour: :red,
-                 size: :reduced) %>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <%= render Support::TileComponent.new(
-                 count: @stats.extra_mobile_data_requests_by_status(scope: ExtraMobileDataRequest.from_schools)['complete'] || 0,
-                 label: 'completed',
-                 colour: :green,
-                 size: :reduced) %>
-  </div>
-</div>
-
-<div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-one-half">
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Network</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Requests</th>
-        </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        <% @stats.extra_mobile_data_requests_by_mobile_network_brand(scope: ExtraMobileDataRequest.from_schools).each do |mno_name, count| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= mno_name %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= count %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.number_of_devolved_schools_that_have_made_extra_mobile_data_requests),
+                 label: t(:devolved_schools_extra_mobile_requests_html,
+                          scope: i18n_scope,
+                          total: humanized_number(@stats.number_of_devolved_schools))) %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.number_of_responsible_bodies_that_have_made_extra_mobile_data_requests),
+                 label: t(:responsible_bodies_extra_mobile_requests_html,
+                          scope: i18n_scope,
+                          total: humanized_number(@stats.number_of_responsible_bodies_managing_centrally),
+                          school_count: humanized_number(@stats.number_of_centrally_managed_schools))) %>
   </div>
 </div>
-
-<h2 class="govuk-heading-l">Anonymised mobile data requests</h2>
-
-<%= link_to 'Download CSV', support_performance_mno_requests_path(format: :csv), class: 'govuk-button' %>

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -67,7 +67,7 @@
     <% end %>
   </tbody>
 </table>
-<p class="givuk-body">
+<p class="govuk-body">
 <%= govuk_link_to 'Download a CSV of anonymised extra mobile data requests', support_performance_mno_requests_path(format: :csv) %>
 </p>
 

--- a/app/views/support/service_performance/_routers.html.erb
+++ b/app/views/support/service_performance/_routers.html.erb
@@ -71,11 +71,11 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-third">
     <%= render Support::PercentageTileComponent.new(
-                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered),
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers),
                  label: t(:responsible_bodies_that_have_fully_ordered_html,
                           scope: i18n_scope,
-                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_fully_ordered,
-                          total: @stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation),
+                          amount: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_fully_ordered_routers),
+                          total: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation)),
                  colour: :green) %>
   </div>
   <div class="govuk-grid-column-one-third">
@@ -89,11 +89,11 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render Support::PercentageTileComponent.new(
-                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered),
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers),
                  label: t(:responsible_bodies_that_have_not_ordered_html,
                           scope: i18n_scope,
-                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_not_ordered,
-                          total: @stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation),
+                          amount: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_not_ordered_routers),
+                          total: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation)),
                  colour: :red) %>
   </div>
 </div>

--- a/app/views/support/service_performance/_routers.html.erb
+++ b/app/views/support/service_performance/_routers.html.erb
@@ -1,0 +1,99 @@
+<h2 class="govuk-heading-l">Routers</h2>
+<%- i18n_scope = 'support.routers_performance' %>
+
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.total_routers_available),
+               label: t(:total_routers_available, scope: i18n_scope),
+               colour: :blue) %>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.total_routers_ordered),
+                 label: t(:total_routers_ordered, scope: i18n_scope),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: humanized_number(@stats.total_routers_remaining),
+                 label: t(:total_routers_remaining, scope: i18n_scope),
+                 colour: :orange) %>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Schools</h3>
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.number_of_devolved_schools_that_have_a_router_allocation),
+               label: t(:devolved_schools, scope: i18n_scope),
+               colour: :blue) %>
+</div>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_fully_ordered_routers),
+                 label: t(:devolved_schools_that_have_fully_ordered_routers_html,
+                          scope: i18n_scope,
+                          amount: humanized_number(@stats.number_of_devolved_schools_that_have_fully_ordered_routers),
+                          total: humanized_number(@stats.number_of_devolved_schools_that_have_a_router_allocation)),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_partially_ordered_routers),
+                 label: t(:devolved_schools_that_have_partially_ordered_routers_html,
+                          scope: i18n_scope,
+                          amount: humanized_number(@stats.number_of_devolved_schools_that_have_partially_ordered_routers),
+                          total: humanized_number(@stats.number_of_devolved_schools_that_have_a_router_allocation)),
+                 colour: :orange) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_devolved_schools_that_have_not_ordered_routers),
+                 label: t(:devolved_schools_that_have_not_ordered_routers_html,
+                          scope: i18n_scope,
+                          amount: humanized_number(@stats.number_of_devolved_schools_that_have_not_ordered_routers),
+                          total: humanized_number(@stats.number_of_devolved_schools_that_have_a_router_allocation)),
+                 colour: :red) %>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-margin-top-7">Responsible bodies</h3>
+<div class="govuk-!-margin-bottom-4">
+  <%= render Support::TileComponent.new(
+               count: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation),
+               label: t(:responsible_bodies_managing_centrally,
+                        scope: i18n_scope),
+                        colour: :blue) %>
+</div>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_fully_ordered),
+                 label: t(:responsible_bodies_that_have_fully_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_fully_ordered,
+                          total: @stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation),
+                 colour: :green) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers),
+                 label: t(:responsible_bodies_that_have_partially_ordered_html,
+                          scope: i18n_scope,
+                          amount: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_partially_ordered_routers),
+                          total: humanized_number(@stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation)),
+                 colour: :orange) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render Support::PercentageTileComponent.new(
+                 percentage: humanized_number(@stats.percentage_of_responsible_bodies_managing_centrally_that_have_not_ordered),
+                 label: t(:responsible_bodies_that_have_not_ordered_html,
+                          scope: i18n_scope,
+                          amount: @stats.number_of_responsible_bodies_managing_centrally_that_have_not_ordered,
+                          total: @stats.number_of_responsible_bodies_managing_centrally_that_have_schools_with_a_router_allocation),
+                 colour: :red) %>
+  </div>
+</div>

--- a/app/views/support/service_performance/_sign_ins.html.erb
+++ b/app/views/support/service_performance/_sign_ins.html.erb
@@ -1,0 +1,14 @@
+<h2 class="govuk-heading-l">Sign-ins</h2>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+      count: @stats.responsible_body_users_signed_in_at_least_once,
+      label: t(:users_signed_in, scope: %i[support service_performance], count: @stats.responsible_body_users_signed_in_at_least_once)) %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+                 count: @stats.number_of_different_responsible_bodies_signed_in,
+                 label: t(:responsible_bodies, scope: %i[support service_performance], count: @stats.number_of_different_responsible_bodies_signed_in)) %>
+  </div>
+</div>

--- a/app/views/support/service_performance/_sign_ins.html.erb
+++ b/app/views/support/service_performance/_sign_ins.html.erb
@@ -1,14 +1,20 @@
 <h2 class="govuk-heading-l">Sign-ins</h2>
-
-<div class="govuk-grid-row govuk-!-margin-bottom-4">
+<%- i18n_scope = 'support.service_performance' %>
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-one-half">
-    <%= render Support::TileComponent.new(
-      count: @stats.responsible_body_users_signed_in_at_least_once,
-      label: t(:users_signed_in, scope: %i[support service_performance], count: @stats.responsible_body_users_signed_in_at_least_once)) %>
+    <%= render Support::PercentageTileComponent.new(
+      percentage: @stats.percentage_of_devolved_schools_that_have_signed_in,
+      label: t(:devolved_schools_that_have_signed_in_html,
+               scope: i18n_scope,
+               amount: number_with_delimiter(@stats.number_of_devolved_schools_that_have_signed_in),
+               total: number_with_delimiter(@stats.number_of_devolved_schools))) %>
   </div>
   <div class="govuk-grid-column-one-half">
-    <%= render Support::TileComponent.new(
-                 count: @stats.number_of_different_responsible_bodies_signed_in,
-                 label: t(:responsible_bodies, scope: %i[support service_performance], count: @stats.number_of_different_responsible_bodies_signed_in)) %>
+    <%= render Support::PercentageTileComponent.new(
+      percentage: @stats.percentage_of_responsible_bodies_that_have_signed_in,
+      label: t(:responsible_bodies_that_have_signed_in_html,
+               scope: i18n_scope,
+               amount: number_with_delimiter(@stats.number_of_responsible_bodies_that_have_signed_in),
+               total: number_with_delimiter(@stats.number_of_responsible_bodies))) %>
   </div>
 </div>

--- a/app/views/support/service_performance/_who_orders.html.erb
+++ b/app/views/support/service_performance/_who_orders.html.erb
@@ -1,0 +1,14 @@
+<h2 class="govuk-heading-l">Who orders</h2>
+<%- i18n_scope = 'support.service_performance' %>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+      count: @stats.number_of_devolved_schools,
+      label: t(:devolved_schools, scope: i18n_scope, count: @stats.number_of_devolved_schools)) %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render Support::TileComponent.new(
+      count: @stats.number_of_centrally_managed_schools,
+      label: t(:centrally_managed_schools, scope: i18n_scope, count: @stats.number_of_centrally_managed_schools)) %>
+  </div>
+</div>

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -19,9 +19,7 @@
   <% end %>
 
   <% component.slot(:tab, title: 'Devices') do %>
-    <%= render partial: 'responsible_body_sign_ins' %>
-
-    <%= render partial: 'preorder_information' %>
+    <%= render partial: 'devices' %>
   <% end %>
 
   <% component.slot(:tab, title: 'MNO') do %>

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -27,6 +27,6 @@
   <% end %>
 
   <% component.slot(:tab, title: 'Routers') do %>
-    <%= render partial: 'mobile_data_requests' %>
+    <%= render partial: 'routers' %>
   <% end %>
 <%- end %>

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -13,13 +13,21 @@
 </h1>
 
 <%= govuk_tabs(title: 'Contents') do |component| %>
+  <% component.slot(:tab, title: 'Service') do %>
+    <%= render partial: 'sign_ins' %>
+  <% end %>
+
   <% component.slot(:tab, title: 'Devices') do %>
     <%= render partial: 'responsible_body_sign_ins' %>
 
     <%= render partial: 'preorder_information' %>
   <% end %>
 
-  <% component.slot(:tab, title: 'Connectivity') do %>
+  <% component.slot(:tab, title: 'MNO') do %>
+    <%= render partial: 'mobile_data_requests' %>
+  <% end %>
+
+  <% component.slot(:tab, title: 'Routers') do %>
     <%= render partial: 'mobile_data_requests' %>
   <% end %>
 <%- end %>

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -15,6 +15,7 @@
 <%= govuk_tabs(title: 'Contents') do |component| %>
   <% component.slot(:tab, title: 'Service') do %>
     <%= render partial: 'sign_ins' %>
+    <%= render partial: 'who_orders' %>
   <% end %>
 
   <% component.slot(:tab, title: 'Devices') do %>

--- a/app/webpacker/styles/_card.scss
+++ b/app/webpacker/styles/_card.scss
@@ -16,8 +16,8 @@
 }
 
 .app-card--green {
-  background: govuk-colour("green");
-  color: govuk-colour("white");
+  color: govuk-shade(govuk-colour("green"), 20);
+  background: govuk-tint(govuk-colour("green"), 80);
 }
 
 .app-card--yellow {
@@ -31,6 +31,11 @@
 .app-card--red {
   color: govuk-shade(govuk-colour("red"), 30);
   background: govuk-tint(govuk-colour("red"), 80);
+}
+
+.app-card--orange {
+  color: govuk-shade(govuk-colour("orange"), 55);
+  background: govuk-tint(govuk-colour("orange"), 70);
 }
 
 .app-card--white {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,6 +416,10 @@ en:
       devolved_schools_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
       devolved_schools_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
       devolved_schools_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
+      responsible_bodies_managing_centrally_html: responsible bodies managing orders centrally<br/>on behalf of %{school_count} schools
+      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
       decision_made:
         one: school has had a decision made about who will place orders
         other: schools have had a decision made about who will place orders

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,6 +388,14 @@ en:
       update:
         success: We’ve saved the new allocation
     service_performance:
+      devolved_schools_that_have_signed_in_html: of devolved schools signed in<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_signed_in_html: of responsible bodies signed in<br/>(%{amount} out of %{total})
+      devolved_schools:
+        one: school orders their own devices
+        other: schools order their own devices
+      centrally_managed_schools:
+        one: school is managed centrally
+        other: schools are managed centrally
       requests:
         one: request
         other: requests

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -409,6 +409,13 @@ en:
         one: responsible body has given all the information needed for at least one school
         other: responsible bodies have given all the information needed for at least one school
     devices_performance:
+      total_devices_available: total devices available
+      total_devices_ordered: devices shipped
+      total_devices_remaining: remaining
+      devolved_schools: devolved schools
+      devolved_schools_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
       decision_made:
         one: school has had a decision made about who will place orders
         other: schools have had a decision made about who will place orders

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -420,6 +420,20 @@ en:
       responsible_bodies_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
       responsible_bodies_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
       responsible_bodies_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
+      devolved_schools_extra_mobile_requests_html: devolved schools<br/>(out of %{total})
+      responsible_bodies_extra_mobile_requests_html: responsible bodies managing orders centrally<br/>(out of %{total}, and on behalf of %{school_count} schools)
+    routers_performance:
+      total_routers_available: total routers available
+      total_routers_ordered: routers shipped
+      total_routers_remaining: routers remaining
+      devolved_schools: schools that have a router allocation 
+      devolved_schools_that_have_fully_ordered_routers_html: ordered their full allocation<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_partially_ordered_routers_html: ordered but have routers left<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_not_ordered_routers_html: have not ordered<br/>(%{amount} out of %{total})
+      responsible_bodies_managing_centrally: responsible bodies managing centrally have a school with a router allocation
+      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_partially_ordered_html: ordered but have routers left<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
       decision_made:
         one: school has had a decision made about who will place orders
         other: schools have had a decision made about who will place orders

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,8 +388,8 @@ en:
       update:
         success: We’ve saved the new allocation
     service_performance:
-      devolved_schools_that_have_signed_in_html: of devolved schools signed in<br/>(%{amount} out of %{total})
-      responsible_bodies_that_have_signed_in_html: of responsible bodies signed in<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_signed_in_html: of devolved schools signed in <br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_signed_in_html: of responsible bodies signed in <br/>(%{amount} out of %{total})
       devolved_schools:
         one: school orders their own devices
         other: schools order their own devices
@@ -413,27 +413,27 @@ en:
       total_devices_ordered: devices shipped
       total_devices_remaining: remaining
       devolved_schools: devolved schools
-      devolved_schools_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
-      devolved_schools_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
-      devolved_schools_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
-      responsible_bodies_managing_centrally_html: responsible bodies managing orders centrally<br/>on behalf of %{school_count} schools
-      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
-      responsible_bodies_that_have_partially_ordered_html: ordered but have devices left<br/>(%{amount} out of %{total})
-      responsible_bodies_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
-      devolved_schools_extra_mobile_requests_html: devolved schools<br/>(out of %{total})
-      responsible_bodies_extra_mobile_requests_html: responsible bodies managing orders centrally<br/>(out of %{total}, and on behalf of %{school_count} schools)
+      devolved_schools_that_have_fully_ordered_html: ordered their full allocation <br/>(%{amount} out of %{total})
+      devolved_schools_that_have_partially_ordered_html: ordered but have devices left <br/>(%{amount} out of %{total})
+      devolved_schools_that_have_not_ordered_html: have not ordered <br/>(%{amount} out of %{total})
+      responsible_bodies_managing_centrally_html: responsible bodies managing orders centrally <br/>on behalf of %{school_count} schools
+      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation <br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_partially_ordered_html: ordered but have devices left <br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_not_ordered_html: have not ordered <br/>(%{amount} out of %{total})
+      devolved_schools_extra_mobile_requests_html: devolved schools <br/>(out of %{total})
+      responsible_bodies_extra_mobile_requests_html: responsible bodies managing orders centrally <br/>(out of %{total}, and on behalf of %{school_count} schools)
     routers_performance:
       total_routers_available: total routers available
       total_routers_ordered: routers shipped
       total_routers_remaining: routers remaining
       devolved_schools: schools that have a router allocation 
-      devolved_schools_that_have_fully_ordered_routers_html: ordered their full allocation<br/>(%{amount} out of %{total})
-      devolved_schools_that_have_partially_ordered_routers_html: ordered but have routers left<br/>(%{amount} out of %{total})
-      devolved_schools_that_have_not_ordered_routers_html: have not ordered<br/>(%{amount} out of %{total})
+      devolved_schools_that_have_fully_ordered_routers_html: ordered their full allocation <br/>(%{amount} out of %{total})
+      devolved_schools_that_have_partially_ordered_routers_html: ordered but have routers left <br/>(%{amount} out of %{total})
+      devolved_schools_that_have_not_ordered_routers_html: have not ordered <br/>(%{amount} out of %{total})
       responsible_bodies_managing_centrally: responsible bodies managing centrally have a school with a router allocation
-      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation<br/>(%{amount} out of %{total})
-      responsible_bodies_that_have_partially_ordered_html: ordered but have routers left<br/>(%{amount} out of %{total})
-      responsible_bodies_that_have_not_ordered_html: have not ordered<br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_fully_ordered_html: ordered their full allocation <br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_partially_ordered_html: ordered but have routers left <br/>(%{amount} out of %{total})
+      responsible_bodies_that_have_not_ordered_html: have not ordered <br/>(%{amount} out of %{total})
       decision_made:
         one: school has had a decision made about who will place orders
         other: schools have had a decision made about who will place orders

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -23,11 +23,11 @@ FactoryBot.define do
     end
 
     trait :manages_orders do
-      association :preorder_information, :school_will_order
+      preorder_information { association :preorder_information, :school_will_order, school: instance }
     end
 
     trait :centrally_managed do
-      association :preorder_information, :rb_will_order
+      preorder_information { association :preorder_information, :rb_will_order, school: instance }
     end
 
     trait :with_headteacher_contact do

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -61,8 +61,8 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   def given_there_devolved_schools_and_centrally_managed_schools
-    devolved_schools = create_list(:school, 2, :manages_orders)
-    managed_schools = create_list(:school, 4, :centrally_managed)
+    create_list(:school, 2, :manages_orders)
+    create_list(:school, 4, :centrally_managed)
   end
 
   def given_there_are_available_shipped_and_remaining_devices
@@ -105,7 +105,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
     virgin = create(:mobile_network, brand: 'Virgin')
     rb = create(:local_authority, :in_connectivity_pilot)
     rb_requester = create(:user, responsible_body: rb)
-    managed_schools = create_list(:school, 3, :centrally_managed)
+    create_list(:school, 3, :centrally_managed)
     schools = create_list(:school, 3, :manages_orders)
     school_requester = create(:user)
     schools[0].users << school_requester

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
     ee = create(:mobile_network, brand: 'EE')
     three = create(:mobile_network, brand: 'Three')
     virgin = create(:mobile_network, brand: 'Virgin')
-    rb = create(:local_authority, :in_connectivity_pilot)
+    rb = create(:local_authority)
     rb_requester = create(:user, responsible_body: rb)
     create_list(:school, 3, :centrally_managed)
     schools = create_list(:school, 3, :manages_orders)


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/YqzQCGGs/1721-build-the-service-dashboard)
Implement the redesign of the service performance dashboard

### Changes proposed in this pull request
New service performance dashboard.

### Guidance to review
There is a lot of complexity in here, switching between queries about devolved schools to responsible body's centrally managed schools, so checking the values displayed against the your local data, one tab at a time, is probably the way to review this.
![image](https://user-images.githubusercontent.com/333931/111819349-22050580-88d8-11eb-8def-a631657ab07c.png)
![image](https://user-images.githubusercontent.com/333931/111819426-3ba64d00-88d8-11eb-8fa5-741818196ac4.png)
![image](https://user-images.githubusercontent.com/333931/111819508-5082e080-88d8-11eb-80e2-f714e5a701ac.png)
![image](https://user-images.githubusercontent.com/333931/111819549-609ac000-88d8-11eb-9d87-8298e7e172d2.png)
