### PR TITLE
1732 make breadcrumbs consistent

### DIFF
--- a/app/components/school/school_breadcrumbs_component.rb
+++ b/app/components/school/school_breadcrumbs_component.rb
@@ -27,7 +27,8 @@ class School::SchoolBreadcrumbsComponent < ViewComponent::Base
 
   def single_school_scope
     [
-      { 'Home' => home_school_path(school) },
+      { 'Home' => root_path },
+      { 'Your account' => home_school_path(school) },
     ]
   end
 

--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, t('page_titles.devices_guidance_how_to_order') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   "Get laptops",
                  ]) %>
 <% end %>

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :devices_service, true %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   t('landing_pages.get_support_guides.title'),
                  ]) %>
 <% end %>

--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "#{@title} – #{t('page_titles.guide_to_collecting_mobile_information')}" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   { t('page_titles.about_increasing_mobile_data_short') => about_increasing_mobile_data_path },
                   t('page_titles.guide_to_collecting_mobile_information'),

--- a/app/views/layouts/multipage_guide.html.erb
+++ b/app/views/layouts/multipage_guide.html.erb
@@ -14,7 +14,7 @@
                     @page.title,
                    ]) %>
   <% else %>
-    <% breadcrumbs([{ "Get help with technology" => root_path },
+    <% breadcrumbs([{ "Home" => root_path },
                     { t('landing_pages.get_support_guides.title') => devices_guidance_index_path },
                     @page.title,
                    ]) %>

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-breadcrumbs ">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Get help with technology", root_path, class: 'govuk-breadcrumbs__link' %>
+        <%= link_to "Home", root_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item">
         <%= @title %>

--- a/app/views/pages/about_increasing_mobile_data.html.erb
+++ b/app/views/pages/about_increasing_mobile_data.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.about_increasing_mobile_data') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.about_increasing_mobile_data_short'),
                  ]) %>

--- a/app/views/pages/choosing_help_with_internet_access.html.erb
+++ b/app/views/pages/choosing_help_with_internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.choosing_help_with_internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.choosing_help_with_internet_access'),
                  ]) %>

--- a/app/views/pages/computers_for_kids_privacy_notice.html.erb
+++ b/app/views/pages/computers_for_kids_privacy_notice.html.erb
@@ -1,7 +1,8 @@
 <% title = t('page_titles.computers_for_kids_privacy_notice') %>
 <% content_for :title, title %>
 <% content_for :before_content do %>
-  <% breadcrumbs([{ "Privacy" => privacy_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Privacy" => privacy_path },
                   title,
                  ]) %>
 <% end %>

--- a/app/views/pages/dfe_windows_privacy_notice.html.erb
+++ b/app/views/pages/dfe_windows_privacy_notice.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, t('page_titles.dfe_windows_privacy_notice') %>
 <% content_for :before_content do %>
-  <% breadcrumbs([{ "Privacy" => privacy_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Privacy" => privacy_path },
                   "Privacy notice for end users of Microsoft Windows devices",
                  ]) %>
 <% end %>

--- a/app/views/pages/general_privacy_notice.html.erb
+++ b/app/views/pages/general_privacy_notice.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, t('page_titles.general_privacy_notice') %>
 <% content_for :before_content do %>
-  <% breadcrumbs([{ "Privacy" => privacy_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Privacy" => privacy_path },
                   "Privacy notice for local authorities, academy trusts and schools",
                  ]) %>
 <% end %>

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.how_request_4g_routers') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
                   t('page_titles.how_request_4g_routers'),
                  ]) %>

--- a/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
+++ b/app/views/pages/how_to_access_the_get_help_with_technology_service.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.how_to_access_the_get_help_with_technology_service') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   t('page_titles.how_to_access_the_get_help_with_technology_service'),
                  ]) %>
 <% end %>

--- a/app/views/pages/increasing_mobile_data_privacy_notice.html.erb
+++ b/app/views/pages/increasing_mobile_data_privacy_notice.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, t('page_titles.increasing_mobile_data_privacy_notice') %>
 <% content_for :before_content do %>
-  <% breadcrumbs([{ "Privacy" => privacy_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Privacy" => privacy_path },
                   "Privacy notice for increasing mobile data scheme",
                  ]) %>
 <% end %>

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.internet_access') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   t('page_titles.internet_access'),
                  ]) %>
 <% end %>

--- a/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
+++ b/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe') %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   t('page_titles.what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe'),
                  ]) %>
 <% end %>
@@ -80,7 +80,7 @@
       You cannot request laptops, tablets or internet access for children and young people in social care.
     </p>
     <p class="govuk-body">
-      <%= govuk_link_to 'Find out which disadvantaged pupils and students are eligible for devices', 'https://get-help-with-tech.education.gov.uk/devices/about-the-offer#ordering-devices-for-schools-colleges-academy-trusts-and-local-authorities-from-september-2020' %> from their school, college or FE institution. 
+      <%= govuk_link_to 'Find out which disadvantaged pupils and students are eligible for devices', 'https://get-help-with-tech.education.gov.uk/devices/about-the-offer#ordering-devices-for-schools-colleges-academy-trusts-and-local-authorities-from-september-2020' %> from their school, college or FE institution.
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'Read about devices provided for social care in the 2020 summer term', 'https://www.gov.uk/guidance/laptops-tablets-and-4g-wireless-routers-provided-during-coronavirus-covid-19' %>.
@@ -116,7 +116,7 @@
       Schools, colleges and further education institutions in <span class="app-no-wrap">Northern Ireland</span>, Scotland and Wales
     </h2>
     <p class="govuk-body">
-      The Get help with technology programme is only available in England. Contact your devolved administration to find out about similar support programmes. These may include: 
+      The Get help with technology programme is only available in England. Contact your devolved administration to find out about similar support programmes. These may include:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li><%= govuk_link_to 'Northern Ireland – Education Restart', 'https://www.education-ni.gov.uk/landing-pages/education-restart' %></li>

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -1,8 +1,8 @@
 <%- title = t('page_titles.responsible_body_devices_home') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-    { 'Home' => responsible_body_home_path },
+  <% breadcrumbs([{ "Home" => root_path },
+    { 'Your account' => responsible_body_home_path },
     title,
   ]) %>
 <% end %>

--- a/app/views/responsible_body/devices/home/tell_us.html.erb
+++ b/app/views/responsible_body/devices/home/tell_us.html.erb
@@ -1,8 +1,8 @@
 <%- title = t('page_titles.responsible_body_devices_tell_us') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
+  <% breadcrumbs([ { "Home" => root_path },
+                   { "Your account" => responsible_body_home_path },
                    title,
                  ]) %>
 <% end %>

--- a/app/views/responsible_body/devices/orders/_heading.html.erb
+++ b/app/views/responsible_body/devices/orders/_heading.html.erb
@@ -1,8 +1,8 @@
 <%- title = t('page_titles.order_devices.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-    { 'Home' => responsible_body_home_path },
+  <% breadcrumbs([{ "Home" => root_path },
+    { 'Your account' => responsible_body_home_path },
     { "#{t('page_titles.responsible_body_devices_home')}" => responsible_body_devices_path },
     title,
   ]) %>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -3,10 +3,10 @@
 <% content_for :browser_title, title %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   { t('page_titles.responsible_body_devices_home') => responsible_body_devices_path },
-                   title ,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  { t('page_titles.responsible_body_devices_home') => responsible_body_devices_path },
+                  title ,
                  ]) %>
 <% end %>
 

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -1,4 +1,13 @@
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_schools_path, class: 'govuk-back-link') %>
+<%- content_for :before_content do %>
+<!-- govuk_link_to('Back', responsible_body_devices_schools_path, class: 'govuk-back-link') -->
+  <%= breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  { t('page_titles.responsible_body_devices_home') => responsible_body_devices_path },
+                  { t('page_titles.responsible_body_schools_list') => responsible_body_devices_schools_path },
+                  @school.name
+                 ]) %>
+<% end %>
+
 <%- content_for :title, @school.name %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/donated_devices/interest/new.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/new.html.erb
@@ -1,10 +1,11 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.new.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   title
-                 ]) %>
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  title
+]) %>
+
 <% end %>
 
 <div class="govuk-grid-row">
@@ -25,7 +26,7 @@
 
     <p class="govuk-body">You can use this service to opt schools and colleges in to receive these devices.</p>
     <p class="govuk-body">This is not a Department for Education offer and no device support will be available. There’s no guarantee schools or colleges will receive any devices.</p>
-  
+
     <%= form_for @form, url: responsible_body_donated_devices_interest_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/responsible_body/donated_devices/interest/not_interested.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/not_interested.html.erb
@@ -1,9 +1,9 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.not_interested.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   title
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  title
                  ]) %>
 <% end %>
 
@@ -12,7 +12,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <p class="govuk-body">You can still opt in later if you change your mind.<p>
-    
+
     <p class="govuk-body">
       <%= govuk_link_to 'Return to your homepage', responsible_body_home_path %>
     </p>

--- a/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
@@ -4,10 +4,10 @@
 %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-    { 'Home' => responsible_body_home_path },
-    { "#{t('page_titles.responsible_body_devices_home')}" => responsible_body_devices_path },
-    'Donated devices',
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Your account' => responsible_body_home_path },
+                  { "#{t('page_titles.responsible_body_devices_home')}" => responsible_body_devices_path },
+                  'Donated devices',
   ]) %>
 <% end %>
 

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,3 +1,10 @@
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ "Home" => root_path },
+                  'Your account' ,
+
+                 ]) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/responsible_body/internet/home/show.html.erb
+++ b/app/views/responsible_body/internet/home/show.html.erb
@@ -1,9 +1,9 @@
 <%- title = t('page_titles.responsible_body_internet_home') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   title ,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  title ,
                  ]) %>
 <% end %>
 

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/guidance.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/guidance.html.erb
@@ -1,11 +1,11 @@
 <%- title = t('page_titles.request_extra_mobile_data') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   { t('page_titles.responsible_body_internet_home') => responsible_body_internet_path },
-                   title,
-                 ]) %>
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  { t('page_titles.responsible_body_internet_home') => responsible_body_internet_path },
+                  title,
+                ]) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/index.html.erb
@@ -1,11 +1,11 @@
 <%- title = t('page_titles.your_requests') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   { t('page_titles.responsible_body_internet_home') => responsible_body_internet_path },
-                   { t('page_titles.request_extra_mobile_data') => responsible_body_internet_mobile_extra_data_guidance_path },
-                   title
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  { t('page_titles.responsible_body_internet_home') => responsible_body_internet_path },
+                  { t('page_titles.request_extra_mobile_data') => responsible_body_internet_mobile_extra_data_guidance_path },
+                  title
                  ]) %>
 <% end %>
 

--- a/app/views/responsible_body/users/index.html.erb
+++ b/app/views/responsible_body/users/index.html.erb
@@ -6,9 +6,9 @@
 
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => responsible_body_home_path },
-                   title ,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { "Your account" => responsible_body_home_path },
+                  title ,
                  ]) %>
 <% end %>
 

--- a/app/views/school/details/show.html.erb
+++ b/app/views/school/details/show.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', home_school_path, class: 'govuk-back-link') %>
+  <%- school_breadcrumbs(school: @school, user: @current_user, items: t('page_titles.school_details')) %>
 <% end %>
 <% content_for :title, t('page_titles.school_details') %>
 

--- a/app/views/school/donated_devices/interest/not_interested.html.erb
+++ b/app/views/school/donated_devices/interest/not_interested.html.erb
@@ -1,7 +1,8 @@
 <%- title = t('page_titles.donated_devices.school.interest.not_interested.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => home_school_path(@school) },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Your account' => home_school_path(@school) },
                   'Donated devices',
                  ]) %>
 <%- end %>
@@ -11,7 +12,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <p class="govuk-body">You can still opt in later if you change your mind.<p>
-    
+
     <p class="govuk-body">
       <%= govuk_link_to 'Return to your homepage', home_school_path %>
     </p>

--- a/app/views/school/donated_devices/interest/opted_in.html.erb
+++ b/app/views/school/donated_devices/interest/opted_in.html.erb
@@ -4,7 +4,8 @@
 %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Home' => home_school_path(@school) },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Your account' => home_school_path(@school) },
                   'Donated devices',
                  ]) %>
 <%- end %>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -1,6 +1,6 @@
 <%- title = @school.name %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs(school: @school, user: @current_user, items: title) %>
+  <%- school_breadcrumbs(school: @school, user: @current_user, items: 'Your account') %>
 <%- end %>
 <%- content_for :title, title %>
 

--- a/app/views/support/extra_mobile_data_requests/index.html.erb
+++ b/app/views/support/extra_mobile_data_requests/index.html.erb
@@ -1,8 +1,8 @@
 <%- title = t('page_titles.support_extra_mobile_data_requests') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([
-                   { "Home" => support_home_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                   { "Support home" => support_home_path },
                    title
                  ]) %>
 <% end %>

--- a/app/views/support/gias/home/index.html.erb
+++ b/app/views/support/gias/home/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.gias_updates') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     title,
   ]) %>

--- a/app/views/support/gias/schools_to_add/index.html.erb
+++ b/app/views/support/gias/schools_to_add/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.gias_schools_to_add') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.gias_updates') => support_gias_home_path },
     title,

--- a/app/views/support/gias/schools_to_add/show.html.erb
+++ b/app/views/support/gias/schools_to_add/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Add #{@school.name} - Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.gias_updates') => support_gias_home_path },
     { t('page_titles.gias_schools_to_add') => support_gias_schools_to_add_index_path },

--- a/app/views/support/gias/schools_to_close/index.html.erb
+++ b/app/views/support/gias/schools_to_close/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.gias_schools_to_close') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.gias_updates') => support_gias_home_path },
     title,

--- a/app/views/support/gias/schools_to_close/show.html.erb
+++ b/app/views/support/gias/schools_to_close/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Close #{@school.name} - Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.gias_updates') => support_gias_home_path },
     { t('page_titles.gias_schools_to_close') => support_gias_schools_to_close_index_path },

--- a/app/views/support/home/feature_flags.html.erb
+++ b/app/views/support/home/feature_flags.html.erb
@@ -1,8 +1,9 @@
 <%- title = t('page_titles.support.feature_flags') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Support home' => support_home_path },
-                   title,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Support home' => support_home_path },
+                  title,
                  ]) %>
 <% end %>
 

--- a/app/views/support/home/schools.html.erb
+++ b/app/views/support/home/schools.html.erb
@@ -1,8 +1,9 @@
 <%- title = t('page_titles.support.schools.home') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Support home' => support_home_path },
-                   title,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Support home' => support_home_path },
+                  title,
                  ]) %>
 <% end %>
 

--- a/app/views/support/home/technical_support.html.erb
+++ b/app/views/support/home/technical_support.html.erb
@@ -1,8 +1,9 @@
 <%- title = t('page_titles.support.technical_support') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Support home' => support_home_path },
-                   title,
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Support home' => support_home_path },
+                  title,
                  ]) %>
 <% end %>
 

--- a/app/views/support/responsible_bodies/index.html.erb
+++ b/app/views/support/responsible_bodies/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support_responsible_bodies') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     title,
   ]) %>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@responsible_body.name} – Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
     @responsible_body.name,

--- a/app/views/support/schools/devices/allocation/collect_urns_and_allocations_for_many_schools.html.erb
+++ b/app/views/support/schools/devices/allocation/collect_urns_and_allocations_for_many_schools.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.allocation.adjust_allocations_for_many_schools') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support.schools.home') => support_schools_path },
     title,

--- a/app/views/support/schools/devices/order_status/collect_urns_to_allow_many_schools_to_order.html.erb
+++ b/app/views/support/schools/devices/order_status/collect_urns_to_allow_many_schools_to_order.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support_bulk_allocation') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support.schools.home') => support_schools_path },
     title,

--- a/app/views/support/schools/edit.html.erb
+++ b/app/views/support/schools/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@school.name} – Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
     { @school.responsible_body.name => support_responsible_body_path(@school.responsible_body) },

--- a/app/views/support/schools/history.html.erb
+++ b/app/views/support/schools/history.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@school.name} – Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
     { @school.responsible_body.name => support_responsible_body_path(@school.responsible_body) },

--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.devices.schools.search') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support.schools.home') => support_schools_path },
     title,

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@school.name} – Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support_responsible_bodies') => support_responsible_bodies_path },
     { @school.responsible_body.name => support_responsible_body_path(@school.responsible_body) },

--- a/app/views/support/service_performance/index.html.erb
+++ b/app/views/support/service_performance/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.service_performance') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     title,
   ]) %>

--- a/app/views/support/users/results.html.erb
+++ b/app/views/support/users/results.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.users.results') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     { t('page_titles.support.users.search') => search_support_users_path },
     title,

--- a/app/views/support/users/search.html.erb
+++ b/app/views/support/users/search.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.users.search') %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     title,
   ]) %>

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@user.full_name} – Support" %>
 <%- content_for :before_content do %>
-  <%= breadcrumbs([
+  <%= breadcrumbs([{ "Home" => root_path },
     { 'Support home' => support_home_path },
     @user.full_name,
   ]) %>

--- a/app/views/support/zendesk_statistics/index.html.erb
+++ b/app/views/support/zendesk_statistics/index.html.erb
@@ -1,7 +1,8 @@
 <%- title = t('page_titles.support.zendesk_statistics') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ 'Support home' => support_home_path },
+  <% breadcrumbs([{ "Home" => root_path },
+                  { 'Support home' => support_home_path },
                    title,
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which academy trust do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which academy trust do you work for?',
                  ]) %>

--- a/app/views/support_tickets/check_your_request.html.erb
+++ b/app/views/support_tickets/check_your_request.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Check your answers before submitting your request' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Check your answers',
                  ]) %>

--- a/app/views/support_tickets/college_details.html.erb
+++ b/app/views/support_tickets/college_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which college do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which college do you work for?',
                  ]) %>

--- a/app/views/support_tickets/contact_details.html.erb
+++ b/app/views/support_tickets/contact_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we contact you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we contact you?',
                  ]) %>

--- a/app/views/support_tickets/describe_yourself.html.erb
+++ b/app/views/support_tickets/describe_yourself.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.describe_yourself')%>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   t('landing_pages.get_support.describe_yourself'),
                  ]) %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which local authority do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which local authority do you work for?',
                  ]) %>

--- a/app/views/support_tickets/parent_support.html.erb
+++ b/app/views/support_tickets/parent_support.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Contact your school, college or local authority for support' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Contact your school, college or local authority for support',
                  ]) %>

--- a/app/views/support_tickets/school_details.html.erb
+++ b/app/views/support_tickets/school_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Which school do you work for?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Which school do you work for?',
                  ]) %>

--- a/app/views/support_tickets/start.html.erb
+++ b/app/views/support_tickets/start.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('landing_pages.get_support.start') %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   t('landing_pages.get_support.start'),
                  ]) %>
 <% end %>

--- a/app/views/support_tickets/support_details.html.erb
+++ b/app/views/support_tickets/support_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'How can we help you?' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'How can we help you?',
                  ]) %>

--- a/app/views/support_tickets/support_needs.html.erb
+++ b/app/views/support_tickets/support_needs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "What do you need help with?" %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   "What do you need help with?",
                  ]) %>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title,  'Support request sent' %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Get help with technology" => root_path },
+  <% breadcrumbs([{ "Home" => root_path },
                   {t('landing_pages.get_support.start') => support_ticket_path},
                   'Support request sent',
                  ]) %>


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

Visit https://dfe-ghwt-pr-1453.herokuapp.com/

- Navigate to a few pages as a user who is not signed in.

Sign in as `school.user.1@example.com`, `trust.user.1@example.com`, `support.user.1@example.com`

For each of these users, 

- the breadcrumbs should start with `Home > ....`
- Home in the breadcrumb should take the user back to the programme home page