### PR TITLE
[1754] Remove in_connectivity_pilot code

### DIFF
--- a/app/controllers/responsible_body/internet/base_controller.rb
+++ b/app/controllers/responsible_body/internet/base_controller.rb
@@ -1,9 +1,2 @@
 class ResponsibleBody::Internet::BaseController < ResponsibleBody::BaseController
-  before_action :require_connectivity_pilot_participation!
-
-private
-
-  def require_connectivity_pilot_participation!
-    render 'errors/forbidden', status: :forbidden unless @responsible_body.in_connectivity_pilot?
-  end
 end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -109,15 +109,11 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def has_connectivity_feature_flags?
-    in_connectivity_pilot? && (has_centrally_managed_schools? || is_a_local_authority?)
+    has_centrally_managed_schools? || is_a_local_authority?
   end
 
   def has_multiple_chromebook_domains_in_managed_schools?
     schools.gias_status_open.joins(:preorder_information).merge(PreorderInformation.responsible_body_will_order_devices).filter_map(&:chromebook_domain).uniq.count > 1
-  end
-
-  def self.in_connectivity_pilot
-    where(in_connectivity_pilot: true)
   end
 
   def self.chosen_who_will_order

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,6 @@ class User < ApplicationRecord
 
   scope :signed_in_at_least_once, -> { where('sign_in_count > 0') }
   scope :responsible_body_users, -> { where.not(responsible_body: nil) }
-  scope :from_responsible_body_in_connectivity_pilot, -> { joins(:responsible_body).where('responsible_bodies.in_connectivity_pilot = ?', true) }
   scope :from_responsible_body_or_schools, -> { left_joins(:user_schools).where('responsible_body_id IS NOT NULL or user_schools.id IS NOT NULL') }
   scope :mno_users, -> { where.not(mobile_network: nil) }
   scope :who_can_order_devices, -> { where(orders_devices: true) }

--- a/app/services/personas/pentest_users.rb
+++ b/app/services/personas/pentest_users.rb
@@ -30,7 +30,7 @@ private
   end
 
   def validate!
-    raise "Couldn't find an RB that's in_connectivity_pilot and has schools, and has said who will order" if @responsible_body.blank?
+    raise "Couldn't find an RB that has schools, and has said who will order" if @responsible_body.blank?
     raise "Couldn't find a school in #{@responsible_body.name} that can order but has not completed the welcome wizard" if @school.blank?
     raise "Couldn't find a mobile network with more than one ExtraMobileDataRequest" if @mobile_network.blank?
   end
@@ -46,11 +46,10 @@ private
   end
 
   def find_responsible_body
-    # we want a responsible_body that has schools, and is in_connectivity_pilot
+    # we want a responsible_body that has schools
     # and has specified who will order
     ResponsibleBody.joins(:schools).joins(schools: [:preorder_information])
                    .where.not(who_will_order_devices: nil)
-                   .where(in_connectivity_pilot: true)
                    .where(schools: { status: 'open' })
                    .first
   end

--- a/app/services/personas/trust_with_schools.rb
+++ b/app/services/personas/trust_with_schools.rb
@@ -32,7 +32,6 @@ private
   def trust
     @trust ||= Trust.find_or_create_by!(name: 'Elizabeth Trust') do |rb|
       rb.organisation_type = 'Multi-academy trust'
-      rb.in_connectivity_pilot = true
       rb.who_will_order_devices = 'school'
       rb.address_1 = '1 Grey Street'
       rb.town = 'Newcastle'

--- a/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
+++ b/spec/controllers/responsible_body/internet/mobile/extra_data_requests_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ResponsibleBody::Internet::Mobile::ExtraDataRequestsController, t
 
     before do
       school.preorder_information.responsible_body_will_order_devices!
-      responsible_body.update!(in_connectivity_pilot: true)
       sign_in_as local_authority_user
     end
 

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
     computacenter_reference { Faker::Number.number(digits: 8) }
     status                  { 'open' }
 
-    trait :in_connectivity_pilot do
-      in_connectivity_pilot       { true }
-    end
-
     trait :manages_centrally do
       who_will_order_devices      { 'responsible_body' }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -34,21 +34,21 @@ FactoryBot.define do
     end
 
     factory :local_authority_user do
-      association :responsible_body, factory: %i[local_authority in_connectivity_pilot]
+      association :responsible_body, factory: %i[local_authority]
     end
 
     factory :trust_user do
-      association :responsible_body, factory: %i[trust in_connectivity_pilot]
+      association :responsible_body, factory: %i[trust]
     end
 
     factory :single_academy_trust_user do
-      association :responsible_body, factory: %i[trust single_academy_trust in_connectivity_pilot]
+      association :responsible_body, factory: %i[trust single_academy_trust]
       school { build(:school, :academy, responsible_body: responsible_body) }
       orders_devices { true }
     end
 
     factory :fe_college_user do
-      association :responsible_body, factory: %i[further_education_college in_connectivity_pilot]
+      association :responsible_body, factory: %i[further_education_college]
       school { build(:fe_school, responsible_body: responsible_body) }
       orders_devices { true }
     end

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
 
   before do
     school.preorder_information.responsible_body_will_order_devices!
-    responsible_body.update!(in_connectivity_pilot: true)
     sign_in_as rb_user
   end
 

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -50,35 +50,14 @@ RSpec.feature ResponsibleBody do
         schools[0].preorder_information.responsible_body_will_order_devices!
       end
 
-      context 'with the in_connectivity_pilot flag set' do
-        before do
-          responsible_body.update!(in_connectivity_pilot: true)
-        end
-
-        it 'shows link to get extra data' do
-          visit responsible_body_home_path
-          expect(page).to have_link('Get internet access')
-        end
-      end
-
-      context 'with the in_connectivity_pilot flag not set' do
-        before do
-          responsible_body.update!(in_connectivity_pilot: false)
-        end
-
-        it 'does not show link to get extra data' do
-          visit responsible_body_home_path
-          expect(page).not_to have_link('Get internet access')
-        end
+      it 'shows link to get extra data' do
+        visit responsible_body_home_path
+        expect(page).to have_link('Get internet access')
       end
     end
 
     context 'with a trust devolved to all schools' do
       let(:responsible_body) { create(:trust) }
-
-      before do
-        responsible_body.update!(in_connectivity_pilot: true)
-      end
 
       it 'does not show link to get extra data' do
         visit responsible_body_home_path
@@ -87,10 +66,6 @@ RSpec.feature ResponsibleBody do
     end
 
     context 'with a local authority devolved to all schools' do
-      before do
-        responsible_body.update!(in_connectivity_pilot: true)
-      end
-
       it 'shows link to get extra data' do
         visit responsible_body_home_path
         expect(page).to have_link('Get internet access')

--- a/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
+++ b/spec/features/responsible_body/submitting_a_spreadsheet_request_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature 'Submitting a bulk ExtraMobileDataRequest request', type: :feature
 
     before do
       school.preorder_information.responsible_body_will_order_devices!
-      responsible_body.update!(in_connectivity_pilot: true)
 
       mobile_network
       sign_in_as user

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
 
     before do
       school.preorder_information.responsible_body_will_order_devices!
-      responsible_body.update!(in_connectivity_pilot: true)
 
       mobile_network
       sign_in_as user

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing service performance', type: :feature do
-  let(:local_authority) { create(:local_authority, :in_connectivity_pilot) }
+  let(:local_authority) { create(:local_authority) }
 
   scenario 'DfE users see service stats about responsible body user engagement' do
     given_there_have_been_sign_ins_from_responsible_body_and_mno_users

--- a/spec/services/personas/pentest_users_spec.rb
+++ b/spec/services/personas/pentest_users_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Personas::PentestUsers do
   end
 
   describe '#find_responsible_body' do
-    let!(:responsible_body_with_closed_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
-    let!(:responsible_body_with_open_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally) }
+    let!(:responsible_body_with_closed_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :manages_centrally) }
+    let!(:responsible_body_with_open_schools_and_in_pilot_and_has_said_who_will_order) { create(:local_authority, :with_schools, :manages_centrally) }
 
     before do
       create(:local_authority)
-      create(:local_authority, :with_schools, in_connectivity_pilot: false)
-      create(:local_authority, :with_schools, :in_connectivity_pilot, who_will_order_devices: nil)
+      create(:local_authority, :with_schools)
+      create(:local_authority, :with_schools, who_will_order_devices: nil)
       responsible_body_with_closed_schools_and_in_pilot_and_has_said_who_will_order.schools.each do |school|
         school.create_preorder_information!(who_will_order_devices: 'responsible_body')
         school.update!(status: 'closed')
@@ -45,7 +45,7 @@ RSpec.describe Personas::PentestUsers do
 
     before do
       create(:school, :with_preorder_information, :in_lockdown, responsible_body: other_responsible_body)
-      personas.responsible_body = create(:local_authority, :with_schools, :in_connectivity_pilot, :manages_centrally)
+      personas.responsible_body = create(:local_authority, :with_schools, :manages_centrally)
       personas.responsible_body.schools.last(2).each do  |school|
         school.update!(order_state: 'can_order', status: 'closed')
         school.create_preorder_information!(who_will_order_devices: 'responsible_body')


### PR DESCRIPTION
### Context

- https://trello.com/c/2EGJW2DV/1754-remove-inconnectivitypilot

### Changes proposed in this pull request

- Remove any code using `in_connectivity_pilot` as it is no longer used or needed
- The db column has not been deleted but can be deleted once all code using it has been removed

### Guidance to review

- Sign in as centrally ordering RB
- Regardless of `in_connectivity_pilot` state should see internet access section