### PR TITLE
[1768] fix intermittent CI spec failure in schools_controller_spec

### DIFF
--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -5,6 +5,7 @@ module ControllerHelper
   end
 
   def sign_in_as(user)
+    session.clear
     create_session_id!
     controller.send(:save_user_to_session!, user)
   end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/xkJrktMj/1768-fix-intermittent-spec-failure-on-ci-in-schoolscontrollerspecrb) - we've recently been seeing an intermittent spec failure in `spec/controllers/schools_controller_spec.rb:29`. [Example failed run](https://github.com/DFE-Digital/get-help-with-tech/runs/2166825974?check_suite_focus=true#step:16:1919). We've also seen it in users_controller_spec.rb. The failure has been seen on several different PRs, and always goes away when re-run.

I have not been able to reproduce the failure locally yet, but on inspection the most likely mechanism I can see for this is that the `sign_in_as` method doesn't clear out the session. So there may be an  `impersonated_user_id` that just occasionally gets persisted between specs due to either a timing issue or some particular order in which the specs get run every now and again.  

### Changes proposed in this pull request

* clear the session in `sign_in_as` for controller tests
 
### Guidance to review

V. difficult to prove that a very intermittent failure has definitively been fixed - only time will tell, I guess 
