### PR TITLE
[1754] Remove in_connectivity_pilot column

### DIFF
--- a/db/migrate/20210323112956_rm_rb_connectivity_pilot.rb
+++ b/db/migrate/20210323112956_rm_rb_connectivity_pilot.rb
@@ -1,0 +1,5 @@
+class RmRbConnectivityPilot < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :responsible_bodies, :in_connectivity_pilot, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_142213) do
+ActiveRecord::Schema.define(version: 2021_03_23_112956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -233,7 +233,6 @@ ActiveRecord::Schema.define(version: 2021_03_19_142213) do
     t.string "companies_house_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "in_connectivity_pilot", default: false
     t.string "who_will_order_devices"
     t.string "computacenter_reference"
     t.string "gias_group_uid"


### PR DESCRIPTION
### Context

- https://trello.com/c/2EGJW2DV/1754-remove-inconnectivitypilot
- From production:

```
ResponsibleBody.pluck(:in_connectivity_pilot).uniq
=> [true]
```

### Changes proposed in this pull request

- Migration to remove db column
- No longer used therefore can be safely deleted

### Guidance to review

- Column is removed and app works as expected