### PR TITLE
[1778] Email audits only shows problematic emails

### DIFF
--- a/app/controllers/support/email_audits_controller.rb
+++ b/app/controllers/support/email_audits_controller.rb
@@ -2,6 +2,6 @@ class Support::EmailAuditsController < Support::BaseController
   before_action { authorize EmailAudit }
 
   def index
-    @email_audits = EmailAudit.order(id: :desc).limit(300)
+    @email_audits = EmailAudit.problematic.order(id: :desc).limit(300)
   end
 end

--- a/app/models/email_audit.rb
+++ b/app/models/email_audit.rb
@@ -6,5 +6,5 @@ class EmailAudit < ApplicationRecord
 
   scope :sent_to, ->(email_address) { where(email_address: email_address) }
 
-  scope :problematic, -> { where(govuk_notify_status: %w[permanent-failure temporary-failure technical-failure]) }
+  scope :problematic, -> { where.not(govuk_notify_status: 'delivered') }
 end

--- a/app/views/support/email_audits/index.html.erb
+++ b/app/views/support/email_audits/index.html.erb
@@ -15,6 +15,7 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Recipient</th>
           <th scope="col" class="govuk-table__header">Message type</th>
+          <th scope="col" class="govuk-table__header">Sent at</th>
           <th scope="col" class="govuk-table__header">Status</th>
         </tr>
       </thead>
@@ -24,6 +25,7 @@
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= govuk_link_to audit.email_address, support_user_path(audit.user_id) %></th>
             <th scope="row" class="govuk-table__header"><%= audit.message_type %></th>
+            <th scope="row" class="govuk-table__header"><%= l audit.created_at, format: :short %></th>
             <td class="govuk-table__cell"><%= audit.govuk_notify_status %></td>
           </tr>
         <% end %>

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -69,7 +69,7 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>view emails the service has recently sent</li>
+      <li>view recent emails with delivery issues</li>
     </ul>
 
     <% if policy(:support).technical_support? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
       addresses:
         edit: Update address
       email_audits:
-        index: Email audits
+        index: Recent emails with delivery issues
     support_extra_mobile_data_requests: Requests for extra mobile data
     support_responsible_bodies: Responsible bodies
     support_school_contacts_edit: Edit school contact

--- a/spec/controllers/support/email_audits_controller_spec.rb
+++ b/spec/controllers/support/email_audits_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Support::EmailAuditsController do
+  let(:support_user) { create(:support_user) }
+
+  describe '#index' do
+    before do
+      sign_in_as support_user
+    end
+
+    it 'returns with status code 200' do
+      get :index
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/4p5Bo5nW/1778-tweak-email-audits-to-show-only-problematic-emails

### Changes proposed in this pull request

- Only show emails with delivery issues
- As we don't care about emails that were sent successfully
- Also added `Sent at` so triage is easier

### Guidance to review

- Sign as support user
- View email audits
- Should only show problematic ones