### PR TITLE
[1766] use the national web archives cache of the local authorities register

### DIFF
--- a/app/models/local_authorities_in_england_register.rb
+++ b/app/models/local_authorities_in_england_register.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 class LocalAuthoritiesInEnglandRegister
-  URL = 'https://local-authority-eng.register.gov.uk/records.json?page-size=5000'.freeze
+  URL = 'https://webarchive.nationalarchives.gov.uk/20210122124652/https://local-authority-eng.register.gov.uk/records.json?page-size=5000'.freeze
 
   # we believe that
   # - combined authorities


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/1pnxPVA4/1766-find-an-alternative-authoritative-list-of-local-authorities-in-england) - The Register of Local Authorities in England, from which we were pulling an authoritative list of English LAs for import into the service, no longer exists. [The GOV.UK Registers service has been shut down, and all data moved to the National Archives and/or Github](https://dataingovernment.blog.gov.uk/2021/02/18/new-guidance-for-publishing-data/).  

### Changes proposed in this pull request

Update the URL used to pull in the data to point to the cached copy in the National Web Archives - this means we do not need to make any other changes to the import code, as the format is exactly the same as before.

### Guidance to review

`bundle exec rake import:local_authorities_in_england`
