### PR TITLE
[1710] Expose CC ship and sold to in support

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -9,10 +9,26 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
              else
                address_read_only_row
              end
+    array << sold_to_row
+    array << ship_to_row
     array << receiving_communications_row
   end
 
 private
+
+  def sold_to_row
+    {
+      key: 'Computacenter SoldTo',
+      value: @school.responsible_body.computacenter_reference || 'Not present',
+    }
+  end
+
+  def ship_to_row
+    {
+      key: 'Computacenter ShipTo',
+      value: @school.computacenter_reference || 'Not present',
+    }
+  end
 
   def receiving_communications_row
     {

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -31,7 +31,7 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def show
-    @school = School.where_urn_or_ukprn(params[:urn]).first!
+    @school = School.includes(:responsible_body).where_urn_or_ukprn(params[:urn]).first!
     @users = policy_scope(@school.users).not_deleted
     @email_audits = @school.email_audits.order(created_at: :desc)
     @timeline = Timeline::School.new(school: @school)

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -194,4 +194,36 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(result.text).to include(school.postcode.to_s)
     end
   end
+
+  describe 'computacenter soldTo' do
+    it 'returns RB computacenter_reference' do
+      expect(value_for_row(result, 'Computacenter SoldTo').text).to include(school.responsible_body.computacenter_reference)
+    end
+
+    context 'when not set' do
+      before do
+        school.responsible_body.update(computacenter_reference: nil)
+      end
+
+      it 'returns placeholder copy' do
+        expect(value_for_row(result, 'Computacenter SoldTo').text).to include('Not present')
+      end
+    end
+  end
+
+  describe 'computacenter shipTo' do
+    it 'returns school computacenter_reference' do
+      expect(value_for_row(result, 'Computacenter ShipTo').text).to include(school.computacenter_reference)
+    end
+
+    context 'when not set' do
+      before do
+        school.update(computacenter_reference: nil)
+      end
+
+      it 'returns placeholder copy' do
+        expect(value_for_row(result, 'Computacenter ShipTo').text).to include('Not present')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/nc73aLHo/1710-expose-shipto-and-soldto-for-support

### Changes proposed in this pull request

- Expose CC sold and ship to in support when viewing a school

### Screenshots

When data not set
![image](https://user-images.githubusercontent.com/92580/112330045-9ca29c00-8caf-11eb-82b0-fde8a8ade8f8.png)

When data is set
![image](https://user-images.githubusercontent.com/92580/112330098-a75d3100-8caf-11eb-8318-e080da892fde.png)

### Guidance to review

- Sign in as support user
- View a school
- Should see ship and sold to values
