### PR TITLE
Align totals in performance page using cap instead of allocation

### DIFF
--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -34,27 +34,42 @@ class Support::ServicePerformance
   end
 
   def total_devices_available
-    SchoolDeviceAllocation.std_device.sum(:cap)
+    sum_allocation(device_type: 'std_device', sum_expression: 'cap')
   end
 
   def total_devices_ordered
-    SchoolDeviceAllocation.std_device.sum(:devices_ordered)
+    sum_allocation(device_type: 'std_device', sum_expression: 'devices_ordered')
   end
 
   def total_devices_remaining
-    SchoolDeviceAllocation.std_device.sum('cap - devices_ordered')
+    sum_allocation(device_type: 'std_device', sum_expression: 'cap - devices_ordered')
   end
 
   def total_routers_available
-    SchoolDeviceAllocation.coms_device.sum(:cap)
+    sum_allocation(device_type: 'coms_device', sum_expression: 'cap')
   end
 
   def total_routers_ordered
-    SchoolDeviceAllocation.coms_device.sum(:devices_ordered)
+    sum_allocation(device_type: 'coms_device', sum_expression: 'devices_ordered')
   end
 
   def total_routers_remaining
-    SchoolDeviceAllocation.coms_device.sum('cap - devices_ordered')
+    sum_allocation(device_type: 'coms_device', sum_expression: 'cap - devices_ordered')
+  end
+
+  def sum_allocation(device_type:, sum_expression:)
+    devolved = SchoolDeviceAllocation
+      .where(device_type: device_type)
+      .joins(school: :preorder_information)
+      .merge(School.gias_status_open)
+      .where(preorder_information: { who_will_order_devices: 'school' })
+      .sum(sum_expression)
+    managed = SchoolDeviceAllocation
+      .where(device_type: device_type)
+      .joins(school: :preorder_information)
+      .where(preorder_information: { who_will_order_devices: 'responsible_body' })
+      .sum(sum_expression)
+    devolved + managed
   end
 
   #

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -34,7 +34,7 @@ class Support::ServicePerformance
   end
 
   def total_devices_available
-    SchoolDeviceAllocation.std_device.sum(:allocation)
+    SchoolDeviceAllocation.std_device.sum(:cap)
   end
 
   def total_devices_ordered
@@ -42,11 +42,11 @@ class Support::ServicePerformance
   end
 
   def total_devices_remaining
-    SchoolDeviceAllocation.std_device.sum('allocation - devices_ordered')
+    SchoolDeviceAllocation.std_device.sum('cap - devices_ordered')
   end
 
   def total_routers_available
-    SchoolDeviceAllocation.coms_device.sum(:allocation)
+    SchoolDeviceAllocation.coms_device.sum(:cap)
   end
 
   def total_routers_ordered
@@ -54,7 +54,7 @@ class Support::ServicePerformance
   end
 
   def total_routers_remaining
-    SchoolDeviceAllocation.coms_device.sum('allocation - devices_ordered')
+    SchoolDeviceAllocation.coms_device.sum('cap - devices_ordered')
   end
 
   #
@@ -114,12 +114,12 @@ class Support::ServicePerformance
 
   def number_of_devolved_schools_that_have_not_ordered_routers
     @number_of_devolved_schools_that_have_not_ordered_routers ||=
-      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('allocation > 0 AND devices_ordered = 0'))
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('cap > 0 AND devices_ordered = 0'))
   end
 
   def number_of_devolved_schools_that_have_a_router_allocation
     @number_of_devolved_schools_that_have_a_router_allocation ||=
-      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('allocation > 0'))
+      number_of_devolved_schools_that_have(scope: SchoolDeviceAllocation.coms_device.where('cap > 0'))
   end
 
   def percentage_of_devolved_schools_that_have_fully_ordered_routers
@@ -278,7 +278,7 @@ class Support::ServicePerformance
       .gias_status_open
       .that_are_centrally_managed
       .joins(:device_allocations)
-      .merge(SchoolDeviceAllocation.coms_device.where('allocation > 0'))
+      .merge(SchoolDeviceAllocation.coms_device.where('cap > 0'))
       .count('DISTINCT(responsible_body_id)')
   end
 


### PR DESCRIPTION
### Context
The service performance page displays different device remaining totals to the `RemainingDeviceCount` list. This is because the `allocation` value has been used in the performance figures and the `cap` value in the remaining devices calculation and also closed schools are not included in the `RemainingDeviceCount` figures.

### Changes proposed in this pull request
Use `cap` figures in calculations for remaining devices
Use the sum of separate devolved + managed schools totals to align with `RemainingDeviceCount` (managed has to consider closed schools, devolved calc does not)

### Guidance to review

