### PR TITLE
[1788] fix issue with ReportableEvents not being recorded

### DIFF
--- a/app/controllers/mno/extra_mobile_data_requests_controller.rb
+++ b/app/controllers/mno/extra_mobile_data_requests_controller.rb
@@ -48,9 +48,11 @@ class Mno::ExtraMobileDataRequestsController < Mno::BaseController
       ids = (bulk_update_params[:extra_mobile_data_request_ids] || []).reject(&:empty?)
       extra_mobile_data_request_scope
                .where('extra_mobile_data_requests.id IN (?)', ids)
-               .update_all(new_attributes)
+               .each do |req|
+        req.update!(new_attributes)
+      end
       redirect_to mno_extra_mobile_data_requests_path(find_requests_params)
-    rescue ActiveRecord::StatementInvalid, ArgumentError => e
+    rescue ActiveRecord::RecordInvalid, ArgumentError => e
       logger.error e
       flash[:error] = "I couldn't apply that update"
       render :index, status: :unprocessable_entity

--- a/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
+++ b/spec/controllers/mno/extra_mobile_data_requests_csv_update_controller_spec.rb
@@ -38,7 +38,7 @@ describe Mno::ExtraMobileDataRequestsCsvUpdateController, type: :controller do
     end
 
     it 'accepts a valid CSV file in Windows-1252 character encoding' do
-      upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/extra-mobile-data-request-utf8.csv'), 'application/vnd.ms-excel')
+      upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/extra-mobile-data-request-windows-1252.csv'), 'application/vnd.ms-excel')
 
       post :create, params: { mno_csv_status_update_form: { upload: upload } }
       expect(response).to render_template(:summary)

--- a/spec/services/extra_mobile_data_request_status_importer_spec.rb
+++ b/spec/services/extra_mobile_data_request_status_importer_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe ExtraMobileDataRequestStatusImporter, type: :model do
       expect(request.reload.status).to eq('complete')
     end
 
+    it 'records a ReportableEvent with the right attributes for each completion' do
+      expect { importer.import! }.to change(ReportableEvent.where(record_type: 'ExtraMobileDataRequest', event_name: 'completion'), :count).from(0).to(1)
+    end
+
     it 'returns a summary of the import' do
       summary = importer.import!
       expect(summary.has_updated_requests?).to be true


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/b/JOgdYLg8/team-board-ghwt-service-team) - we have `after_save` hooks in place to record completion events when an `ExtraMobileDataRequest` is updated to `complete`. However, the most common usage pattern is  `bulk_update` which uses `update_all` to update many records at once in pure SQL, bypassing ActiveRecord hooks - so we're not actually recording events yet.

### Changes proposed in this pull request

* Make the bulk_update method update the individual records one-by-one (there can never be more than 100 records per page, so this should not be too much of an overhead)
* Add explicit controller/service-level tests for correct behaviour 

### Guidance to review

* Log in as a user with a non-nil mobile_network_id, and some requests present on that MobileNetwork (you can use the `FakeDataService` to generate some if needed)
* From the console, note the initial value of `ReportableEvent.count`
* Use the bulk update to set some requests to `complete`
* From the console, check that the value of `ReportableEvent.count` has increased correctly
* Repeat using the download/upload spreadsheet update mechanism


