### PR TITLE
[1785] Add git so gems via git can be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add libxml2-dev libxslt-dev build-base postgresql-dev tzdata
 RUN wget https://data.iana.org/time-zones/tzdb/tzdata.zi -O /usr/share/zoneinfo/tzdata.zi && \
     /usr/sbin/zic -b fat /usr/share/zoneinfo/tzdata.zi
 
-RUN apk add nodejs yarn postgresql-contrib libpq less
+RUN apk add nodejs yarn postgresql-contrib libpq less git
 
 ENV RAILS_ROOT /var/www/${APPNAME}
 RUN mkdir -p $RAILS_ROOT


### PR DESCRIPTION
### Context

- https://trello.com/c/ygU488Vz/1785-fix-blocking-mimemagic-issue

### Changes proposed in this pull request

- We need to install a gem via git as the source version includes a dependency with licensing issue
- In order to achieve this the docker image now needs git as a dependency

### Guidance to review

- `docker build .` succeeds