### PR TITLE
1793 impersonation fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,7 @@ private
   def impersonated_or_current_user
     impersonated_user || current_user
   end
+  helper_method :impersonated_or_current_user
 
   def save_user_to_session!(user = @current_user)
     # prevent duplicate key errors if they're already signed_in

--- a/app/controllers/school/before_can_order_controller.rb
+++ b/app/controllers/school/before_can_order_controller.rb
@@ -1,7 +1,7 @@
 class School::BeforeCanOrderController < School::ChromebooksController
   def edit
     @chromebook_information_form = ChromebookInformationForm.new(
-      school: @current_user.school,
+      school: impersonated_or_current_user.school,
     )
   end
 

--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,11 +1,11 @@
 class School::DevicesController < School::BaseController
   def order
     if @school.can_order_devices_right_now?
-      if @current_user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
+      if impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
         render :can_order_for_specific_circumstances
-      elsif @current_user.has_an_active_techsource_account? && @school.can_order?
+      elsif impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order?
         render :can_order
-      elsif @current_user.awaiting_techsource_account?
+      elsif impersonated_or_current_user.awaiting_techsource_account?
         render :can_order_awaiting_techsource
       else # user has no techsource account
         render :school_can_order_user_cannot

--- a/app/controllers/school/welcome_wizard_controller.rb
+++ b/app/controllers/school/welcome_wizard_controller.rb
@@ -32,7 +32,7 @@ class School::WelcomeWizardController < School::BaseController
 private
 
   def set_wizard
-    @wizard = @current_user.welcome_wizard_for(@school) || @current_user.school_welcome_wizards.create!(school: @school)
+    @wizard = impersonated_or_current_user.welcome_wizard_for(@school) || impersonated_or_current_user.school_welcome_wizards.create!(school: @school)
   end
 
   def resume_wizard

--- a/app/controllers/support/impersonates_controller.rb
+++ b/app/controllers/support/impersonates_controller.rb
@@ -11,9 +11,9 @@ class Support::ImpersonatesController < Support::BaseController
   end
 
   def destroy
-    session.delete(:impersonated_user_id)
+    impersonated_user_id = session.delete(:impersonated_user_id)
 
-    redirect_to root_url_for(current_user)
+    redirect_to support_user_path(impersonated_user_id)
   end
 
 private

--- a/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_schools.html.erb
@@ -29,6 +29,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Help signing in to TechSource</h2>
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: impersonated_or_current_user.email_address } %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -56,6 +56,6 @@
       </p>
     <%- end %>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: impersonated_or_current_user.email_address } %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
@@ -18,7 +18,7 @@
 
     <p class="govuk-body">We’ll contact you if you can place more orders.</p>
 
-    <% if @current_user.orders_devices? && @current_user.techsource_account_confirmed? %>
+    <% if impersonated_or_current_user.orders_devices? && impersonated_or_current_user.techsource_account_confirmed? %>
       <p class="govuk-body"><%= link_to 'View your order history on TechSource', techsource_start_path %></p>
     <% end %>
   </div>

--- a/app/views/responsible_body/devices/schools/order_devices.html.erb
+++ b/app/views/responsible_body/devices/schools/order_devices.html.erb
@@ -44,6 +44,6 @@
       If you try to order more than <%= what_to_order_allocation_list(allocations: @school.device_allocations) %> the order will be cancelled.
     </p>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address, school_urn: @school.urn } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: impersonated_or_current_user.email_address, school_urn: @school.urn } %>
   </div>
 </div>

--- a/app/views/school/details/show.html.erb
+++ b/app/views/school/details/show.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs(school: @school, user: @current_user, items: t('page_titles.school_details')) %>
+  <%- school_breadcrumbs(school: @school, user: impersonated_or_current_user, items: t('page_titles.school_details')) %>
 <% end %>
 <% content_for :title, t('page_titles.school_details') %>
 

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_order_devices') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -58,6 +58,6 @@
 
     <p class="govuk-body">If you need to change your delivery address, <%= govuk_link_to "contact us", support_ticket_path %>.</p>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address, school_urn: @school.urn } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: impersonated_or_current_user.email_address, school_urn: @school.urn } %>
   </div>
 </div>

--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_order_devices_soon') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: 'Order devices', school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: 'Order devices', school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_order_devices') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -21,6 +21,6 @@
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">It’s important to know how many devices you can order before you sign in. Please order only what you need. If you try to order more than you’ve been allocated, the order will be cancelled.</p>
 
-    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: @current_user.email_address, school_urn: @school.urn } %>
+    <%= render partial: 'shared/start_ordering_on_techsource', locals: { email_address: impersonated_or_current_user.email_address, school_urn: @school.urn } %>
   </div>
 </div>

--- a/app/views/school/devices/cannot_order.html.erb
+++ b/app/views/school/devices/cannot_order.html.erb
@@ -1,9 +1,9 @@
-<%- who_cannot_order = @current_user.orders_devices? ? 'school_user' : 'school' %>
+<%- who_cannot_order = impersonated_or_current_user.orders_devices? ? 'school_user' : 'school' %>
 <%- title = t("page_titles.#{who_cannot_order}_cannot_order_devices.title") %>
 
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: 'Order devices', school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: 'Order devices', school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
     <p class="govuk-body">Ordering will be opened for your school as soon as possible.</p>
     <p class="govuk-body">We’ll email you when you can place an order.</p>
 
-    <% unless @current_user.orders_devices? %>
+    <% unless impersonated_or_current_user.orders_devices? %>
       <h2 class="govuk-heading-m">
         You will not be able to place orders yourself
       </h2>

--- a/app/views/school/devices/cannot_order_as_cap_reached.html.erb
+++ b/app/views/school/devices/cannot_order_as_cap_reached.html.erb
@@ -1,8 +1,8 @@
-<%- who_orders = @current_user.orders_devices? ? 'user' : 'school' %>
+<%- who_orders = impersonated_or_current_user.orders_devices? ? 'user' : 'school' %>
 <%- title = t("page_titles.school.devices.cannot_order_as_cap_reached.#{who_orders}.title") %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: 'Order devices', school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: 'Order devices', school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
 
     <p class="govuk-body">We’ll contact you if you can place more orders.</p>
 
-    <% if @current_user.orders_devices? && @current_user.techsource_account_confirmed? %>
+    <% if impersonated_or_current_user.orders_devices? && impersonated_or_current_user.techsource_account_confirmed? %>
       <p class="govuk-body"><%= govuk_link_to 'View your order history on TechSource', techsource_start_path %></p>
     <% end %>
   </div>

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_can_order_devices') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/donated_devices/interest/new.html.erb
+++ b/app/views/school/donated_devices/interest/new.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.donated_devices.school.interest.new.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -22,7 +22,7 @@
 
     <p class="govuk-body">You can use this service to opt-in to receive these devices.</p>
     <p class="govuk-body">This is not a Department for Education offer and no device support will be available. There’s no guarantee you’ll receive any devices.</p>
-  
+
     <%= form_for @form, url: interest_donated_devices_school_path(@school), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -1,6 +1,6 @@
 <%- title = @school.name %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs(school: @school, user: @current_user, items: 'Your account') %>
+  <%- school_breadcrumbs(school: @school, user: impersonated_or_current_user, items: 'Your account') %>
 <%- end %>
 <%- content_for :title, title %>
 

--- a/app/views/school/internet/home/show.html.erb
+++ b/app/views/school/internet/home/show.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school.internet.home.show.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/internet/mobile/extra_data_requests/guidance.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/guidance.html.erb
@@ -5,7 +5,7 @@
       { t('page_titles.school.internet.home.show.title') => internet_school_path(@school) },
       title
     ],
-    user: @current_user,
+    user: impersonated_or_current_user,
     school: @school) %>
 <% end %>
 

--- a/app/views/school/internet/mobile/extra_data_requests/index.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/index.html.erb
@@ -6,7 +6,7 @@
       { t('page_titles.request_extra_mobile_data') => extra_data_guidance_internet_mobile_school_path(@school) },
       title
     ],
-    user: @current_user,
+    user: impersonated_or_current_user,
     school: @school) %>
 <% end %>
 

--- a/app/views/school/users/edit.html.erb
+++ b/app/views/school/users/edit.html.erb
@@ -7,7 +7,7 @@
       title,
     ],
     school: @school,
-    user: @current_user) %>
+    user: impersonated_or_current_user) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.school_users') -%>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: title, school: @school, user: @current_user %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/users/new.html.erb
+++ b/app/views/school/users/new.html.erb
@@ -1,12 +1,12 @@
 <%- title = t('page_titles.invite_school_user.title') %>
 <%- content_for :title, title_with_error_prefix(title, @user.errors.any?) %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs( items: [
-                            { t('page_titles.school_users') => school_users_path(@school) },
-                            title,
-                          ],
-                          school: @school,
-                          user: @current_user ) %>
+  <%- school_breadcrumbs(items: [
+                           { t('page_titles.school_users') => school_users_path(@school) },
+                           title,
+                         ],
+                         school: @school,
+                         user: impersonated_or_current_user) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/welcome_wizard/allocation.html.erb
+++ b/app/views/school/welcome_wizard/allocation.html.erb
@@ -5,7 +5,7 @@
     <%= form_for @wizard, url: welcome_wizard_school_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl">
-        <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+        <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
         <%= title %>
       </h1>
 

--- a/app/views/school/welcome_wizard/chromebooks.html.erb
+++ b/app/views/school/welcome_wizard/chromebooks.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+      <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
       <%= title %>
     </h1>
 

--- a/app/views/school/welcome_wizard/devices_you_can_order.html.erb
+++ b/app/views/school/welcome_wizard/devices_you_can_order.html.erb
@@ -5,7 +5,7 @@
     <%= form_for @wizard, url: welcome_wizard_school_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl">
-        <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+        <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
         <%= title %>
       </h1>
 

--- a/app/views/school/welcome_wizard/techsource_account.html.erb
+++ b/app/views/school/welcome_wizard/techsource_account.html.erb
@@ -5,7 +5,7 @@
     <%= form_for @wizard, url: welcome_wizard_school_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl">
-        <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+        <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
         <%= title %>
       </h1>
 

--- a/app/views/school/welcome_wizard/what_happens_next.html.erb
+++ b/app/views/school/welcome_wizard/what_happens_next.html.erb
@@ -5,7 +5,7 @@
     <%= form_for @wizard, url: welcome_wizard_school_path(step: @wizard.step) do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl">
-        <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+        <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
         <%= title %>
       </h1>
 
@@ -18,7 +18,7 @@
         <li>change your Chromebook settings</li>
       </ul>
 
-      <%= f.govuk_submit (@current_user.has_multiple_schools? ? "Finish and go to #{@school.institution_type} overview" : "Finish and go to homepage" ) %>
+      <%= f.govuk_submit (impersonated_or_current_user.has_multiple_schools? ? "Finish and go to #{@school.institution_type} overview" : "Finish and go to homepage" ) %>
     <%- end %>
   </div>
 </div>

--- a/app/views/school/welcome_wizard/will_other_order.html.erb
+++ b/app/views/school/welcome_wizard/will_other_order.html.erb
@@ -9,7 +9,7 @@
       html: { autocomplete: 'off' } do |f| %>
       <%= f.hidden_field :step %>
       <h1 class="govuk-heading-xl">
-        <%- if @current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
+        <%- if impersonated_or_current_user.has_multiple_schools? %><span class="govuk-caption-l"><%= @school.name %></span><%- end %>
         <%= title %>
       </h1>
 

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,4 +1,4 @@
-<%- title = @current_user.is_responsible_body_user? ? t('page_titles.your_organisations') : t('page_titles.your_schools') %>
+<%- title = impersonated_or_current_user.is_responsible_body_user? ? t('page_titles.your_organisations') : t('page_titles.your_schools') %>
 <%- content_for :title, title %>
 
 <div class="govuk-grid-row">
@@ -10,9 +10,9 @@
         <%= govuk_link_to school.name, home_school_path(school) %>
       </h2>
     <%- end %>
-    <%- if @current_user.responsible_body.present? %>
+    <%- if impersonated_or_current_user.responsible_body.present? %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to @current_user.responsible_body.name, responsible_body_home_path %>
+        <%= govuk_link_to impersonated_or_current_user.responsible_body.name, responsible_body_home_path %>
       </h2>
     <%- end %>
   </div>

--- a/spec/controllers/support/impersonates_controller_spec.rb
+++ b/spec/controllers/support/impersonates_controller_spec.rb
@@ -44,9 +44,10 @@ RSpec.describe Support::ImpersonatesController do
       expect(session[:impersonated_user_id]).to be_blank
     end
 
-    it 'redirects to support user start page' do
+    it 'redirects to support the user page' do
+      session[:impersonated_user_id] = impersonated_user.id
       delete :destroy
-      expect(response).to redirect_to('/support')
+      expect(response).to redirect_to("/support/users/#{impersonated_user.id}")
     end
   end
 end

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'school/home/show.html.erb' do
+  let(:template) { subject }
+
   let(:school) { user.school }
   let(:user) { build(:school_user) }
 
@@ -10,7 +12,7 @@ RSpec.describe 'school/home/show.html.erb' do
   end
 
   it 'always shows the Get internet access section' do
-    render template: subject, locals: { impersonated_or_current_user: user }
+    render template: template, locals: { impersonated_or_current_user: user }
     expect(rendered).to include('Get internet access')
   end
 end

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'school/home/show.html.erb' do
   end
 
   it 'always shows the Get internet access section' do
-    render
+    render template: subject, locals: { impersonated_or_current_user: user }
     expect(rendered).to include('Get internet access')
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/qlCn7NiP/1793-impersonation-not-showing-correct-info

### Changes proposed in this pull request

- Support agents when impersonating users would experience impersonation correctly
- This ensure scopes are associated with the impersonated user and not the current user
- Also on stopping of impersonation redirect support user to the user profile page and not the homepage for a less disjointed experience

### Guidance to review

- Sign in as support user without out TechSource account
- Impersonate a user with TechSource account
- On the order page should show user has TechSource account