### PR TITLE
Specify version to allow development on M1 Apple Silicon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'activerecord', '~> 6.1.3'
 gem 'actionmailer', '~> 6.1.3'
 gem 'railties', '~> 6.1.3'
 
+# Allows development on M1 Apple Silicon
+gem 'http-parser', '~> 1.2.3'
+
 # Canonical meta tag
 gem 'canonical-rails', git: 'https://github.com/asmega/canonical-rails.git', ref: '1b9426229dfa5136326f5ce4963e8e8d1cb3b23c'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http-parser (1.2.1)
+    http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
@@ -456,6 +456,7 @@ DEPENDENCIES
   govuk-components (>= 1.1.5)
   govuk_design_system_formbuilder
   http
+  http-parser (~> 1.2.3)
   i18n-debug
   listen (>= 3.0.5, < 3.6)
   logstash-logger (~> 0.26.1)


### PR DESCRIPTION
### Context

Couldn't get `rails` commands to work with current version of `http-parser` on newer Apple Silicon.

### Changes proposed in this pull request

Update `http-parser` version.

### Guidance to review

https://github.com/cotag/http-parser/issues/12