### PR TITLE
[1653] Use more govuk components

### DIFF
--- a/app/components/extra_mobile_data_request_status_component.html.erb
+++ b/app/components/extra_mobile_data_request_status_component.html.erb
@@ -1,3 +1,1 @@
-<span class="govuk-tag govuk-tag--<%= colour %> request-status-<%= status %>">
-  <%= label %>
-</span>
+<%= govuk_tag(text: label, colour: colour) %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,10 +16,10 @@ module ApplicationHelper
     ]
   end
 
-  def api_token_status_class(status)
+  def api_token_status_colour(status)
     {
-      active: 'govuk-tag--green',
-      revoked: 'govuk-tag--grey',
+      active: 'green',
+      revoked: 'red',
     }[status.to_sym]
   end
 end

--- a/app/views/computacenter/api_tokens/_api_token.html.erb
+++ b/app/views/computacenter/api_tokens/_api_token.html.erb
@@ -9,17 +9,15 @@
     <%= l(api_token.created_at, format: :long) %>
   </td>
   <td class="govuk-table__cell">
-    <span class="govuk-tag <%= api_token_status_class(api_token.status) %> request-status-<%= api_token.status %>">
-      <%= api_token.translated_enum_value(:status) %>
-    </span>
+    <%= render(GovukComponent::Tag.new(text: api_token.translated_enum_value(:status), colour: api_token_status_colour(api_token.status))) %>
   </td>
   <td class="govuk-table__cell govuk-form-group display-child-forms-inline govuk-table__cell--nowrap">
     <%- if api_token.active? %>
-      <%= button_to 'Revoke', computacenter_api_token_path(api_token), method: :patch, params: { api_token: { status: 'revoked' } }, class: "govuk-button govuk-button--secondary", form_class: 'govuk-form-group' %>
+      <%= govuk_button_to 'Revoke', computacenter_api_token_path(api_token), method: :patch, params: { api_token: { status: 'revoked' } }, class: "govuk-button--secondary", form_class: 'govuk-form-group' %>
     <%- else %>
-      <%= button_to 'Activate', computacenter_api_token_path(api_token), method: :patch, params: { api_token: { status: 'active' } }, class: "govuk-button govuk-button--secondary", form_class: 'govuk-form-group' %>
+      <%= govuk_button_to 'Activate', computacenter_api_token_path(api_token), method: :patch, params: { api_token: { status: 'active' } }, class: "govuk-button--secondary", form_class: 'govuk-form-group' %>
     <%- end %>
-    <%= button_to 'Delete', computacenter_api_token_path(api_token), method: :delete, class: "govuk-button govuk-button--secondary", form_class: 'govuk-form-group' %>
+    <%= govuk_button_to 'Delete', computacenter_api_token_path(api_token), method: :delete, class: "govuk-button--warning", form_class: 'govuk-form-group' %>
 
   </td>
 </tr>

--- a/app/views/computacenter/api_tokens/index.html.erb
+++ b/app/views/computacenter/api_tokens/index.html.erb
@@ -1,4 +1,5 @@
 <%- content_for :title, t('page_titles.api_tokens') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/computacenter/multi_domain_chromebooks/index.html.erb
+++ b/app/views/computacenter/multi_domain_chromebooks/index.html.erb
@@ -1,6 +1,6 @@
 <% title = t('page_titles.computacenter.multi_domain_chromebooks') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/computacenter/responsible_body_changes/edit.html.erb
+++ b/app/views/computacenter/responsible_body_changes/edit.html.erb
@@ -1,6 +1,6 @@
-<%- content_for :before_content, govuk_link_to('Back', computacenter_responsible_body_changes_path, class: 'govuk-back-link') %>
 <%- title = t('page_titles.computacenter.responsible_body_changes_edit') %>
 <%- content_for :title, title %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_responsible_body_changes_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">

--- a/app/views/computacenter/responsible_body_changes/index.html.erb
+++ b/app/views/computacenter/responsible_body_changes/index.html.erb
@@ -1,6 +1,6 @@
 <% title = t('page_titles.computacenter.responsible_body_changes') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -1,6 +1,6 @@
-<%- content_for :before_content, govuk_link_to('Back', computacenter_school_changes_path, class: 'govuk-back-link') %>
 <%- title = t('page_titles.computacenter.school_changes_edit') %>
 <%- content_for :title, title %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_school_changes_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">

--- a/app/views/computacenter/school_changes/index.html.erb
+++ b/app/views/computacenter/school_changes/index.html.erb
@@ -1,6 +1,6 @@
 <% title = t('page_titles.computacenter.school_changes') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/computacenter/techsource/new.html.erb
+++ b/app/views/computacenter/techsource/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.computacenter.techsource') %>
-<% content_for :before_content, govuk_link_to('Back', computacenter_home_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/computacenter/techsource/summary.html.erb
+++ b/app/views/computacenter/techsource/summary.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.computacenter.techsource') %>
-<% content_for :before_content, govuk_link_to('Back', computacenter_techsource_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_techsource_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,12 +1,6 @@
 <h1 class="govuk-heading-xl">Forbidden</h1>
 
-<div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    You're not allowed to do that.
-  </strong>
-</div>
+<%= govuk_warning text: 'You’re not allowed to do that.' %>
 
 <p class="govuk-body">You may have mistyped the address or the permissions for this page may have changed.</p>
 <p class="govuk-body">If you think you should have access to this page, contact support.</p>

--- a/app/views/guides_for_parents_carers_students/index.html.erb
+++ b/app/views/guides_for_parents_carers_students/index.html.erb
@@ -15,7 +15,6 @@
       <%= t('landing_pages.guides_parents_carers_students.details') %>
     </p>
 
-
     <h2 class="govuk-heading-m govuk-!-margin-top-7">
       Laptops and tablets guides
     </h2>

--- a/app/views/landing_pages/digital_platforms.md
+++ b/app/views/landing_pages/digital_platforms.md
@@ -17,7 +17,7 @@ The platforms are purpose-built for remote learning in a way that a school or co
 Teachers can:
 
 * communicate with pupils and students and deliver lessons via video calls
-* record virtual lessons 
+* record virtual lessons
 * set tasks
 * let pupils and students work together through supervised group calls
 * give personalised feedback via video or within shared documents
@@ -28,7 +28,7 @@ Teachers can:
 
 Using a digital education platform allows teachers, pupils and students to continue education if a school or college closes.
 
-[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/lead-your-approach/why-every-school-should-be-using-digital-education-platform/) has information on why you should make the move to a digital education platform, if you have not already. 
+[The Key for School Leaders website](https://covid19.thekeysupport.com/covid-19/deliver-remote-learning/lead-your-approach/why-every-school-should-be-using-digital-education-platform/) has information on why you should make the move to a digital education platform, if you have not already.
 
 ## Who can apply
 
@@ -64,15 +64,15 @@ Trusts and sponsors can apply on behalf of their schools and colleges.
 
 ## What happens after you apply
 
-A member from either Google or Microsoft will receive your request. They’ll confirm if you’re eligible for the programme and, if so, they’ll assign you to an IT supplier. 
+A member from either Google or Microsoft will receive your request. They’ll confirm if you’re eligible for the programme and, if so, they’ll assign you to an IT supplier.
 
-Your IT supplier will contact you within 2 days to agree a day and time to start the process of setting up the platform for your school or college. 
+Your IT supplier will contact you within 2 days to agree a day and time to start the process of setting up the platform for your school or college.
 
-It will take only a few days to install your platform if you respond quickly to the IT supplier’s requests to agree to the scope of work, and share user data and any other relevant information. 
+It will take only a few days to install your platform if you respond quickly to the IT supplier’s requests to agree to the scope of work, and share user data and any other relevant information.
 
 ## How to claim your grant funding
 
-After you complete your support request form, you'll receive an email from the DfE Digital Infrastructure Payments team with details on how to claim your grant. 
+After you complete your support request form, you'll receive an email from the DfE Digital Infrastructure Payments team with details on how to claim your grant.
 
 Once your platform is set up, you can claim the following grant funding:
 

--- a/app/views/landing_pages/edtech_demonstrator_programme.md
+++ b/app/views/landing_pages/edtech_demonstrator_programme.md
@@ -1,6 +1,6 @@
 ## About the programme
 
-The [EdTech Demonstrator programme](https://edtech-demonstrator.lgfl.net/home) launched in 2019 to offer peer-to-peer support on the effective use of technology in education. It currently focuses on helping schools and colleges to provide remote and blended education. 
+The [EdTech Demonstrator programme](https://edtech-demonstrator.lgfl.net/home) launched in 2019 to offer peer-to-peer support on the effective use of technology in education. It currently focuses on helping schools and colleges to provide remote and blended education.
 
 The programme is tailored to the needs of each school or college, but will include training and support through:
 
@@ -28,23 +28,23 @@ Demonstrators are [schools and colleges](https://edtech-demonstrator.lgfl.net/de
 ## Who the programme is for
 Any publicly funded school or college in England can apply for support from an EdTech Demonstrator. Independent schools and training providers are not eligible for the scheme.
 
-The programme offers support to schools and colleges who are setting up a [new online learning platform](/digital-platforms). 
+The programme offers support to schools and colleges who are setting up a [new online learning platform](/digital-platforms).
 
 It can also help those that would like support to develop their approach to remote learning to improve learner outcomes, engagement and wellbeing.
 
 ## How to apply for free training and support
 
-Visit the EdTech Demonstrator website to [complete this form and register your interest](https://edtech-demonstrator.lgfl.net/register-your-interest). You’ll then be contacted to find out more about your needs. 
+Visit the EdTech Demonstrator website to [complete this form and register your interest](https://edtech-demonstrator.lgfl.net/register-your-interest). You’ll then be contacted to find out more about your needs.
 
 ## The long-term benefits of the programme
 
 The EdTech Demonstrator programme is funded by the DfE until the end of March 2021.
 
-Schools and colleges will receive facilitated support from demonstrators through continuous professional development (CPD). 
+Schools and colleges will receive facilitated support from demonstrators through continuous professional development (CPD).
 
 You can [watch video testimonials](https://edtech-demonstrator.lgfl.net/about/how-it-works) from demonstrators and some of the schools and colleges they work with on the EdTech Demonstrator website.
 
 ## Contact us
-To apply for free training and support, visit the EdTech Demonstrator website to [complete this form](https://edtech-demonstrator.lgfl.net/register-your-interest). 
+To apply for free training and support, visit the EdTech Demonstrator website to [complete this form](https://edtech-demonstrator.lgfl.net/register-your-interest).
 
 If you have a question about the EdTech Demonstrator Programme email EdTech.TEAM@education.gov.uk.

--- a/app/views/layouts/page_with_toc.html.erb
+++ b/app/views/layouts/page_with_toc.html.erb
@@ -1,16 +1,7 @@
-<%= content_for :title, @title  %>
+<%= content_for :title, @title %>
 
 <%- content_for :before_content do %>
-  <div class="govuk-breadcrumbs ">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Home", root_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= @title %>
-      </li>
-    </ol>
-  </div>
+  <%= govuk_breadcrumbs(breadcrumbs: { 'Home' => root_path, @title => nil }) %>
 <% end %>
 
 <% content_for :content do %>

--- a/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/report_problem.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', mno_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: mno_extra_mobile_data_requests_path) %>
 <%- content_for :title, t('page_titles.report_a_problem') %>
 
 <div class="govuk-grid-row">

--- a/app/views/mno/extra_mobile_data_requests/search_results.html.erb
+++ b/app/views/mno/extra_mobile_data_requests/search_results.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.requests_for_extra_mobile_data') %>
-<% content_for :before_content, govuk_link_to('Back', mno_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: mno_extra_mobile_data_requests_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/new.html.erb
@@ -1,6 +1,6 @@
 <% title = t('page_titles.extra_mobile_data_requests_csv_update') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', mno_extra_mobile_data_requests_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: mno_extra_mobile_data_requests_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
+++ b/app/views/mno/extra_mobile_data_requests_csv_update/summary.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', new_mno_extra_mobile_data_requests_csv_update_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: new_mno_extra_mobile_data_requests_csv_update_path) %>
 <% end %>
 <% content_for :title, t('page_titles.weve_processed_your_csv') %>
 

--- a/app/views/pages/how_request_4g_routers.html.erb
+++ b/app/views/pages/how_request_4g_routers.html.erb
@@ -57,7 +57,7 @@
       For local authorities and academy trusts
     </h3>
 
-     <p class="govuk-inset-text">
+    <p class="govuk-inset-text">
       Local authorities and academy trusts that received 4G wireless routers from DfE during the 2020 summer term are expected to reallocate any unused routers to children in need before ordering new ones. Your key contact can log in to the <%= govuk_link_to 'Support Portal', 'https://computacenterprod.service-now.com/dfe' %> to check router use.
     </p>
 

--- a/app/views/responsible_body/devices/change_who_will_order/edit.html.erb
+++ b/app/views/responsible_body/devices/change_who_will_order/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_school_path(@school.urn)) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.change_who_will_order'), @form.errors.any?) %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/devices/chromebook_information/edit.html.erb
+++ b/app/views/responsible_body/devices/chromebook_information/edit.html.erb
@@ -1,7 +1,6 @@
 <%- title = t('page_titles.responsible_body_devices_chromebooks') %>
 <%- content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(urn: @school.urn), class: 'govuk-back-link') %>
-
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_school_path(urn: @school.urn)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/devices/schools/order_devices.html.erb
+++ b/app/views/responsible_body/devices/schools/order_devices.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.responsible_body.devices.order_devices') %>
-<% content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(urn: @school.urn), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_school_path(urn: @school.urn)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -1,5 +1,4 @@
 <%- content_for :before_content do %>
-<!-- govuk_link_to('Back', responsible_body_devices_schools_path, class: 'govuk-back-link') -->
   <%= breadcrumbs([{ "Home" => root_path },
                   { "Your account" => responsible_body_home_path },
                   { t('page_titles.responsible_body_devices_home') => responsible_body_devices_path },

--- a/app/views/responsible_body/devices/who_to_contact/edit.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_school_path(@school.urn)) %>
 <%- content_for :title, @school.name %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/devices/who_to_contact/new.html.erb
+++ b/app/views/responsible_body/devices/who_to_contact/new.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_schools_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_schools_path) %>
 <%- content_for :title, @school.name %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/devices/who_will_order/edit.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_devices_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_path) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.who_will_order'), @form.errors.any?) %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/devices/who_will_order/show.html.erb
+++ b/app/views/responsible_body/devices/who_will_order/show.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_devices_who_will_order_edit_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_devices_who_will_order_edit_path) %>
 
 <%- title = t(@responsible_body.who_will_order_devices.to_sym, scope: %i[page_titles who_will_order_show]) %>
 <%- content_for :title, title %>

--- a/app/views/responsible_body/donated_devices/interest/about.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/about.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.about.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_home_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_home_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,11 +10,11 @@
     <p class="govuk-body">A variety of devices are being donated. The devices a school or college could get might not all be the same.</p>
 
     <p class="govuk-body">Every device will meet the <%= govuk_link_to 'minimum requirements needed for remote learning', 'https://www.computacenter.com/uk/daily-mail', target: '_blank', rel: 'noopener noreferrer' %>.</p>
-    
+
     <h2 class="govuk-heading-m">Configure at your own cost</h2>
     <p class="govuk-body">Devices are provided with factory settings, schools and colleges will need to configure them at their own cost before lending them to children and young people.</p>
-    <p class="govuk-body govuk-!-margin-bottom-7">Schools and colleges will need to purchase licences for any Google Chromebooks they receive.</p>    
-  
+    <p class="govuk-body govuk-!-margin-bottom-7">Schools and colleges will need to purchase licences for any Google Chromebooks they receive.</p>
+
     <p class="govuk-body">
       <%= govuk_button_link_to 'Continue', responsible_body_donated_devices_queue_path(@school) %>
     </p>

--- a/app/views/responsible_body/donated_devices/interest/address.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/address.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_how_many_devices_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_how_many_devices_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/all_or_some_schools.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/all_or_some_schools.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.all_or_some_schools.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_interest_confirmation_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_interest_confirmation_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/check_answers.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/check_answers.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_disclaimer_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_disclaimer_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/device_types.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/device_types.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_all_or_some_schools_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_all_or_some_schools_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/disclaimer.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/disclaimer.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_address_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_address_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/how_many_devices.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/how_many_devices.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_what_devices_do_you_want_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_what_devices_do_you_want_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/interest_confirmation.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/interest_confirmation.html.erb
@@ -1,7 +1,6 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.interest_confirmation.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_queue_path, class: 'govuk-back-link') %>
-
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_queue_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/new.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/new.html.erb
@@ -1,11 +1,10 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.new.title') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => root_path },
+  <%= breadcrumbs([{ "Home" => root_path },
                   { "Your account" => responsible_body_home_path },
                   title
-]) %>
-
+  ]) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/opted_in.html.erb
@@ -13,14 +13,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
-      <h1 class="govuk-panel__title">
-        <%= title %>
-      </h1>
-      <div class="govuk-panel__body">
-        They are in the queue to receive&nbsp;devices
-      </div>
-    </div>
+    <%= govuk_panel(title: title,
+                    body: 'They are in the queue to receive&nbsp;devices'.html_safe,
+                    classes: 'govuk-!-margin-bottom-8'
+                   ) %>
+
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">
       If it’s their turn in the queue, you’ll get an email confirmation and Computacenter will deliver devices directly to the school or college.

--- a/app/views/responsible_body/donated_devices/interest/queue.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/queue.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.donated_devices.responsible_body.interest.queue.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_about_devices_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_about_devices_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/donated_devices/interest/select_schools.html.erb
+++ b/app/views/responsible_body/donated_devices/interest/select_schools.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', responsible_body_donated_devices_all_or_some_schools_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_donated_devices_all_or_some_schools_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -1,7 +1,6 @@
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => root_path },
                   'Your account' ,
-
                  ]) %>
 <% end %>
 

--- a/app/views/responsible_body/internet/mobile/bulk_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/bulk_requests/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_internet_mobile_extra_data_requests_type_path) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.upload_a_spreadsheet_of_extra_data_requests'), @upload_form.errors.any?) %>
 <div class="govuk-grid-row">
   <%= form_for @upload_form,

--- a/app/views/responsible_body/internet/mobile/bulk_requests/summary.html.erb
+++ b/app/views/responsible_body/internet/mobile/bulk_requests/summary.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', new_responsible_body_internet_mobile_bulk_request_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: new_responsible_body_internet_mobile_bulk_request_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/new.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', responsible_body_internet_mobile_extra_data_guidance_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: responsible_body_internet_mobile_extra_data_guidance_path) %>
 <% end %>
 <% content_for :title, title_with_error_prefix(t('page_titles.how_would_you_like_to_submit_information'), @submission_type.errors.any?) %>
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/internet/mobile/extra_data_requests/show.html.erb
+++ b/app/views/responsible_body/internet/mobile/extra_data_requests/show.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: responsible_body_internet_mobile_extra_data_requests_path) %>
 <% end %>
 <%- title = "#{@request.mobile_network.brand} request #{@request.device_phone_number.first(2)}...#{@request.device_phone_number.last(4)}" %>
 <% content_for :title, title %>

--- a/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/confirm.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', new_responsible_body_internet_mobile_manual_request_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: new_responsible_body_internet_mobile_manual_request_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
+++ b/app/views/responsible_body/internet/mobile/manual_requests/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', responsible_body_internet_mobile_extra_data_requests_type_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: responsible_body_internet_mobile_extra_data_requests_type_path) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.who_needs_the_data'), @extra_mobile_data_request.errors.any?) %>
 
 <div class="govuk-grid-row">

--- a/app/views/responsible_body/users/edit.html.erb
+++ b/app/views/responsible_body/users/edit.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.edit_responsible_body_user') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', responsible_body_users_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: responsible_body_users_path) %>
 <% end %>
 <%- content_for :title, title_with_error_prefix(title, @rb_user.errors.any?) %>
 

--- a/app/views/responsible_body/users/new.html.erb
+++ b/app/views/responsible_body/users/new.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.new_responsible_body_user') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', responsible_body_users_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: responsible_body_users_path) %>
 <% end %>
 <%- content_for :title, title_with_error_prefix(title, @rb_user.errors.any?) %>
 

--- a/app/views/school/chromebooks/edit.html.erb
+++ b/app/views/school/chromebooks/edit.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.school_edit_chromebooks') %>
 <%- content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', details_school_path(@school), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: details_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/about.html.erb
+++ b/app/views/school/donated_devices/interest/about.html.erb
@@ -1,7 +1,6 @@
 <%- title = t('page_titles.donated_devices.school.interest.about.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', interest_donated_devices_school_path(@school), class: 'govuk-back-link') %>
-
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: interest_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -14,10 +13,10 @@
     <h2 class="govuk-heading-m">
       Configure at your own cost
     </h2>
-  
+
     <p class="govuk-body">Devices are provided with factory settings and you will need to configure them at your own cost before lending them to children and young people.</p>
-    <p class="govuk-body govuk-!-margin-bottom-7">You will need to purchase licences for any Google Chromebooks you receive.</p>    
-  
+    <p class="govuk-body govuk-!-margin-bottom-7">You will need to purchase licences for any Google Chromebooks you receive.</p>
+
     <p class="govuk-body">
       <%= govuk_button_link_to 'Continue', queue_donated_devices_school_path(@school) %>
     </p>

--- a/app/views/school/donated_devices/interest/address.html.erb
+++ b/app/views/school/donated_devices/interest/address.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', how_many_devices_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: how_many_devices_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/check_answers.html.erb
+++ b/app/views/school/donated_devices/interest/check_answers.html.erb
@@ -3,8 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', disclaimer_donated_devices_school_path(@school), class: 'govuk-back-link') %>
-
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: disclaimer_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/device_types.html.erb
+++ b/app/views/school/donated_devices/interest/device_types.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', interest_confirmation_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: interest_confirmation_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/disclaimer.html.erb
+++ b/app/views/school/donated_devices/interest/disclaimer.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', address_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: address_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/how_many_devices.html.erb
+++ b/app/views/school/donated_devices/interest/how_many_devices.html.erb
@@ -3,7 +3,7 @@
   title = t('title', scope: scope)
 %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', what_devices_do_you_want_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: what_devices_do_you_want_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/interest_confirmation.html.erb
+++ b/app/views/school/donated_devices/interest/interest_confirmation.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.donated_devices.school.interest.interest_confirmation.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', queue_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: queue_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/donated_devices/interest/opted_in.html.erb
+++ b/app/views/school/donated_devices/interest/opted_in.html.erb
@@ -12,14 +12,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
-      <h1 class="govuk-panel__title">
-        <%= title %>
-      </h1>
-      <div class="govuk-panel__body">
-        You’re in the queue to receive&nbsp;devices
-      </div>
-    </div>
+    <%= govuk_panel(title: title,
+                    body: 'You’re in the queue to receive&nbsp;devices'.html_safe,
+                    classes: 'govuk-!-margin-bottom-8'
+                   ) %>
+
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">
       If it’s your turn in the queue, you’ll get an email confirmation and Computacenter will deliver your preferred devices to:

--- a/app/views/school/donated_devices/interest/queue.html.erb
+++ b/app/views/school/donated_devices/interest/queue.html.erb
@@ -1,22 +1,20 @@
 <%- title = t('page_titles.donated_devices.school.interest.queue.title') %>
 <%- content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', about_devices_donated_devices_school_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: about_devices_donated_devices_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-
     <p class="govuk-body">We do not know how many devices will be donated. Opting in to this offer will put you in a queue.</p>
     <p class="govuk-body">Newly donated devices will be distributed to opted-in schools, colleges and further education institutions at the top of the queue.</p>
     <p class="govuk-body">There’s no guarantee you will get any devices.</p>
-  
 
     <h2 class="govuk-heading-m">You do not need to place an order</h2>
 
     <p class="govuk-body">When it’s your turn, your devices will be automatically delivered to your <%= @school.institution_type %>. Computacenter will email you if you’re going to receive devices.</p>
     <p class="govuk-body">Donated devices are in addition to your allocation.</p>
-  
+
     <p class="govuk-body">
       <%= govuk_button_link_to 'Continue', interest_confirmation_donated_devices_school_path(@school) %>
     </p>

--- a/app/views/school/internet/mobile/bulk_requests/new.html.erb
+++ b/app/views/school/internet/mobile/bulk_requests/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', extra_data_requests_type_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: extra_data_requests_type_internet_mobile_school_path(@school)) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.upload_a_spreadsheet_of_extra_data_requests'), @upload_form.errors.any?) %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/internet/mobile/bulk_requests/summary.html.erb
+++ b/app/views/school/internet/mobile/bulk_requests/summary.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.weve_processed_your_spreadsheet') %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', extra_data_guidance_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: extra_data_guidance_internet_mobile_school_path(@school)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/internet/mobile/extra_data_requests/new.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/new.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', extra_data_guidance_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: extra_data_guidance_internet_mobile_school_path(@school)) %>
 <% end %>
 
 <% content_for :title, title_with_error_prefix(t('page_titles.how_would_you_like_to_submit_information'), @submission_type.errors.any?) %>

--- a/app/views/school/internet/mobile/extra_data_requests/show.html.erb
+++ b/app/views/school/internet/mobile/extra_data_requests/show.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', extra_data_requests_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: extra_data_requests_internet_mobile_school_path(@school)) %>
 <% end %>
 <%- title = "#{@request.mobile_network.brand} request #{@request.device_phone_number.first(2)}...#{@request.device_phone_number.last(4)}" %>
 <% content_for :title, title %>

--- a/app/views/school/internet/mobile/manual_requests/confirm.html.erb
+++ b/app/views/school/internet/mobile/manual_requests/confirm.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', new_internet_mobile_manual_request_path(@school), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: new_internet_mobile_manual_request_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/school/internet/mobile/manual_requests/new.html.erb
+++ b/app/views/school/internet/mobile/manual_requests/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_link_to('Back', extra_data_requests_type_internet_mobile_school_path(@school), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: extra_data_requests_type_internet_mobile_school_path(@school)) %>
 <% content_for :title, title_with_error_prefix(t('page_titles.who_needs_the_data'), @extra_mobile_data_request.errors.any?) %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/addresses/edit.html.erb
+++ b/app/views/support/addresses/edit.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.addresses.edit') %>
 <%- content_for :title, title_with_error_prefix(title, @school.errors.any?) %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', support_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: support_school_path(@school)) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/addresses/edit.html.erb
+++ b/app/views/support/addresses/edit.html.erb
@@ -12,7 +12,7 @@
 
     <% unless @school.computacenter_change == 'none' %>
       <p class="govuk-body">
-        <strong class="govuk-tag govuk-tag--red">PENDING</strong> Computacenter still needs to update this address
+        <%= govuk_tag text: 'PENDING', colour: 'red' %> Computacenter still needs to update this address
       </p>
     <% end %>
 

--- a/app/views/support/email_audits/index.html.erb
+++ b/app/views/support/email_audits/index.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.email_audits.index') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', support_home_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: support_home_path) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/home/feature_flags.html.erb
+++ b/app/views/support/home/feature_flags.html.erb
@@ -26,9 +26,9 @@
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= feature %></th>
             <% if FeatureFlag.active?(feature) %>
-              <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Active</strong></td>
+              <td class="govuk-table__cell"><%= govuk_tag(text: 'Active', colour: 'green') %></td>
             <% else %>
-              <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not active</strong></td>
+              <td class="govuk-table__cell"><%= govuk_tag(text: 'Not active', colour: 'red') %></td>
             <% end %>
           </tr>
         <% end %>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -13,34 +13,8 @@
       <%= @responsible_body.name %>
     </h1>
 
-    <div class="govuk-tabs" data-module="govuk-tabs">
-      <h2 class="govuk-tabs__title">
-        Contents
-      </h2>
-
-      <ul class="govuk-tabs__list">
-        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <a class="govuk-tabs__tab" href="#schools-colleges">
-            Schools and colleges
-          </a>
-        </li>
-
-        <li class="govuk-tabs__list-item">
-          <a class="govuk-tabs__tab" href="#users">
-            Users
-          </a>
-        </li>
-
-        <%- if @responsible_body.extra_mobile_data_requests.present? %>
-          <li class="govuk-tabs__list-item">
-            <a class="govuk-tabs__tab" href="#mobile-data-requests">
-              Mobile data requests
-            </a>
-          </li>
-        <%- end %>
-      </ul>
-
-      <div class="govuk-tabs__panel" id="schools-colleges">
+    <%= render GovukComponent::Tabs.new(title: 'Contents') do |component| %>
+      <% component.slot(:tab, title: 'Schools and colleges') do %>
         <h2 class="govuk-heading-l">Schools and colleges</h2>
 
         <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
@@ -170,10 +144,10 @@
               <% end %>
             </tbody>
           </table>
-        <%- end %>
-      </div>
+        <% end %>
+      <% end %>
 
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">
+      <% component.slot(:tab, title: 'Users') do %>
         <h2 class="govuk-heading-l">Users</h2>
 
         <% if policy(User).new? %>
@@ -197,15 +171,15 @@
         <% else %>
           <p class="govuk-body">None</p>
         <% end %>
-      </div>
+      <% end %>
 
       <%- if @responsible_body.extra_mobile_data_requests.present? %>
-        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="mobile-data-requests">
+        <% component.slot(:tab, title: 'Mobile data requests') do %>
           <h2 class="govuk-heading-l">Mobile data requests</h2>
 
           <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @responsible_body.extra_mobile_data_requests) %>
-        </div>
-      <%- end %>
-    </div>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/support/schools/confirm_invitation.html.erb
+++ b/app/views/support/schools/confirm_invitation.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Invite #{@school.name} – Support" %>
-<%- content_for :before_content, govuk_link_to('Back', support_responsible_body_path(@school.responsible_body), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_responsible_body_path(@school.responsible_body)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/schools/devices/allocation/adjust_allocations_for_many_schools.html.erb
+++ b/app/views/support/schools/devices/allocation/adjust_allocations_for_many_schools.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support.allocation.adjust_allocations_for_many_schools') %>
 <% content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', adjust_allocations_for_many_schools_support_schools_path, class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: adjust_allocations_for_many_schools_support_schools_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">

--- a/app/views/support/schools/devices/allocation/edit.html.erb
+++ b/app/views/support/schools/devices/allocation/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', support_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_school_path(@school.urn)) %>
 <%- title = t("page_titles.support_edit_allocation.#{device_type}") %>
 <%- content_for :title, title %>
 

--- a/app/views/support/schools/devices/chromebooks/edit.html.erb
+++ b/app/views/support/schools/devices/chromebooks/edit.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support_edit_chromebook_details') %>
 <%- content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', support_school_path(@school.urn), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: support_school_path(@school.urn)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/schools/devices/order_status/confirm.html.erb
+++ b/app/views/support/schools/devices/order_status/confirm.html.erb
@@ -1,5 +1,5 @@
 <%- pass_through_params = {support_enable_orders_form: {order_state: @form.order_state, device_cap: @form.device_cap}} %>
-<%- content_for :before_content, govuk_link_to('Back', support_school_devices_enable_orders_path({school_urn: @school.urn}.merge(pass_through_params)), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_school_devices_enable_orders_path({school_urn: @school.urn}.merge(pass_through_params))) %>
 <%- title = t('page_titles.support_order_status.confirm_enable_orders') %>
 <%- content_for :title, title %>
 

--- a/app/views/support/schools/devices/order_status/edit.html.erb
+++ b/app/views/support/schools/devices/order_status/edit.html.erb
@@ -1,4 +1,4 @@
-<%- content_for :before_content, govuk_link_to('Back', support_school_path(@school.urn), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_school_path(@school.urn)) %>
 <%- title = t('page_titles.support_order_status.enable_orders') %>
 <%- content_for :title, title %>
 

--- a/app/views/support/schools/devices/order_status/summary.html.erb
+++ b/app/views/support/schools/devices/order_status/summary.html.erb
@@ -3,7 +3,7 @@
 %>
 <% content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', devices_enable_orders_for_many_schools_support_schools_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: devices_enable_orders_for_many_schools_support_schools_path) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/schools/opt_outs/edit.html.erb
+++ b/app/views/support/schools/opt_outs/edit.html.erb
@@ -1,7 +1,7 @@
 <%- title = t('page_titles.support.schools.opt_outs.edit') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%= govuk_link_to('Back', support_school_path(@school), class: 'govuk-back-link') %>
+  <%= govuk_back_link(text: 'Back', href: support_school_path(@school)) %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/schools/results.html.erb
+++ b/app/views/support/schools/results.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.support.devices.schools.results') %>
-<% content_for :before_content, govuk_link_to('Back', search_support_schools_path, class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: search_support_schools_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -18,49 +18,11 @@
 </div>
 
 <% if @school.gias_status_closed? %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning</span>
-      This <%= @school.institution_type %> has permanently closed
-    </strong>
-  </div>
+  <%= govuk_warning(text: "This #{@school.institution_type} has permanently closed") %>
 <% end %>
 
-<div class="govuk-tabs" data-module="govuk-tabs">
-  <h2 class="govuk-tabs__title">
-    Contents
-  </h2>
-
-  <ul class="govuk-tabs__list">
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab" href="#overview">
-        Overview
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#users">
-        Users
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#notifications">
-        Notifications
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#timeline">
-        Timeline
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#related">
-        Related schools (<%= @school.school_links.count %>)
-      </a>
-    </li>
-  </ul>
-
-  <div class="govuk-tabs__panel" id="overview">
+<%= render GovukComponent::Tabs.new(title: 'Contents') do |component| %>
+  <% component.slot(:tab, title: 'Overview') do %>
     <h2 class="govuk-heading-l">Overview</h2>
 
     <%= render Support::SchoolDetailsSummaryListComponent.new(school: @school, viewer: @current_user) %>
@@ -69,9 +31,9 @@
       <h2 class="govuk-heading-l govuk-!-margin-top-9">Mobile data requests</h2>
       <%= render Support::ExtraMobileDataRequestsSummaryListComponent.new(requests: @school.extra_mobile_data_requests) %>
     <%- end %>
-  </div>
+  <% end %>
 
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="users">
+  <% component.slot(:tab, title: 'Users') do %>
     <h2 class="govuk-heading-l">Users</h2>
 
     <% if policy(User).new? && @school.can_invite_users? %>
@@ -93,9 +55,9 @@
     <% else %>
       <p class="govuk-body">None</p>
     <% end %>
-  </div>
+  <% end %>
 
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="notifications">
+  <% component.slot(:tab, title: 'Notifications') do %>
     <h2 class="govuk-heading-l">Notifications</h2>
 
     <% if @email_audits.present? %>
@@ -103,9 +65,9 @@
     <% else %>
       <p class="govuk-body">None</p>
     <% end %>
-  </div>
+  <% end %>
 
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="timeline">
+  <% component.slot(:tab, title: 'Timeline') do %>
     <h2 class="govuk-heading-l">Timeline</h2>
 
     <table class="govuk-table">
@@ -144,9 +106,9 @@
         <% end %>
       </tbody>
     </table>
-  </div>
+  <% end %>
 
-  <div class="govuk-tabs__panel" id="related">
+  <% component.slot(:tab, title: "Related schools (#{@school.school_links.count})") do %>
     <h2 class="govuk-heading-l">Related schools</h2>
 
     <% if @school.school_links.present? %>
@@ -172,5 +134,5 @@
         There are no related schools
       </p>
     <% end %>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/app/views/support/users/confirm_destroy.html.erb
+++ b/app/views/support/users/confirm_destroy.html.erb
@@ -1,5 +1,5 @@
 <%- title = t('page_titles.confirm_destroy_user') %>
-<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_user_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/users/edit.html.erb
+++ b/app/views/support/users/edit.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.edit_user') %>
 <%- content_for :title, title_with_error_prefix(title, @user.errors.any?) %>
-<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_user_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/users/responsible_body/edit.html.erb
+++ b/app/views/support/users/responsible_body/edit.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support.users.responsible_bodies.edit') %>
 <% content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_user_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support.users.schools.index') %>
 <% content_for :title, title %>
-<%- content_for :before_content, govuk_link_to('Back', support_user_path(@user), class: 'govuk-back-link') %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_user_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support.users.schools.new') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', support_user_schools_path(@user), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: support_user_schools_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -1,6 +1,6 @@
 <%- title = t('page_titles.support.users.schools.new') %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_link_to('Back', support_user_schools_path(@user), class: 'govuk-back-link') %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: support_user_schools_path(@user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,7 +11,7 @@
 
     <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :name_or_urn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+      <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
       <%= f.hidden_field :school_urn %>
       <%= f.govuk_submit 'Search again' %>
     <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -851,6 +851,8 @@ en:
         name: Name
         name_hint: Must be unique, and between 2 and 64 characters long
         create: Generate
+      destroy:
+        success: API token has been deleted
     sold_to:
       update:
         success: "Sold To reference for %{name} is %{sold_to}"

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature ResponsibleBody do
     scenario 'visiting the page shows a :forbidden error' do
       visit responsible_body_home_path
 
-      expect(page).to have_content("You're not allowed to do that")
+      expect(page).to have_content('You’re not allowed to do that')
       expect(page).to have_http_status(:forbidden)
     end
   end

--- a/spec/features/support/managing_gias_updates_spec.rb
+++ b/spec/features/support/managing_gias_updates_spec.rb
@@ -223,6 +223,6 @@ RSpec.feature 'Managing GIAS updates to schools from the support area', type: :f
 
   def then_i_see_a_forbidden_message
     expect(page).to have_text('Forbidden')
-    expect(page).to have_text("You're not allowed to do that")
+    expect(page).to have_text('You’re not allowed to do that')
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/IXSDAOYw/1653-switching-out-hardcoded-markup-to-use-govuk-components

### Changes proposed in this pull request

- Convert the majority of hard crafted govuk components to use govuk components gem
- There are a few remaining that have odd quirks that I have left as is
- Minor tweaks:
- Adding missing translations
- Fixed missing back links or breadcrumbs
- Fix smart quotes

### Guidance to review

- Where hardcoded components have been swapped out these should render the same as the replaced versions