### PR TITLE
[1798] fix undefined method is_responsible_body_user? for nil

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -60,6 +60,7 @@ class SignInTokensController < ApplicationController
 
   def sent
     @current_user = User.where(sign_in_token: params[:token]).first
+    render(:token_not_recognised, status: :bad_request) unless @current_user.present?
   end
 
   def hide_nav_menu?

--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -60,7 +60,7 @@ class SignInTokensController < ApplicationController
 
   def sent
     @current_user = User.where(sign_in_token: params[:token]).first
-    render(:token_not_recognised, status: :bad_request) unless @current_user.present?
+    render(:token_not_recognised, status: :bad_request) if @current_user.blank?
   end
 
   def hide_nav_menu?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
     <div class="app-phase-banner">
       <div class="govuk-width-container">
         <%= render GovukComponent::PhaseBanner.new(phase: 'Alpha') do
-          if SessionService.is_signed_in?(session) && (current_user.is_responsible_body_user? || current_user.is_school_user?)
+          if SessionService.is_signed_in?(session) && (current_user&.is_responsible_body_user? || current_user&.is_school_user?)
             "#{t('user_feedback')} – #{user_feedback_link}".html_safe
           else
             "This is a new service – your #{ghwt_contact_mailto(label: "feedback", subject: "Feedback")} will help us to improve it.".html_safe

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
 
         it 'renders token_not_recognised with status :bad_request' do
           visit sent_token_path(token: 'something_that_does_not_exist')
-          expect(page).to have_content("We didn’t recognise that link")
+          expect(page).to have_content('We didn’t recognise that link')
           expect(page).to have_http_status(:bad_request)
         end
       end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -92,4 +92,26 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
       expect(page).to have_link('Request a new sign-in link', href: sign_in_path)
     end
   end
+
+  describe 'going directly to the token sent page' do
+    context 'with a valid session' do
+      let(:user) { create(:school_user) }
+
+      before do
+        sign_in_as(user)
+      end
+
+      context 'but an invalid token (bug #1798)' do
+        it 'does not throw an error' do
+          expect { visit sent_token_path(token: 'something_that_does_not_exist') }.not_to raise_error
+        end
+
+        it 'renders token_not_recognised with status :bad_request' do
+          visit sent_token_path(token: 'something_that_does_not_exist')
+          expect(page).to have_content("We didn’t recognise that link")
+          expect(page).to have_http_status(:bad_request)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/yOWUsU32/1798-fix-undefined-method-isresponsiblebodyuser-for-nilnilclass) - there's some occasional edge case that results in an error on the sign_in_token sent page, whereby the user has a valid session but no `current_user`. On investigation, I found that this can happen when a user signs in successfully, but then goes back to the "Check your email" / sign-in token sent page. That page is uses the token given on the URL to assign `@current_user`, as there is no valid session yet, but if the user goes _back_ to an already-user token sent page, the token will not be valid anymore. 

### Changes proposed in this pull request

Stop this edge case throwing an error
Add a spec example for it

### Guidance to review

Try signing in, then using your browser back button to go back to the 'Check your email' page.
It should not throw an error
It should display "We didn't recognise that link"