### PR TITLE
Message telling users to get permission before inviting someone

### DIFF
--- a/app/views/school/users/index.html.erb
+++ b/app/views/school/users/index.html.erb
@@ -15,7 +15,7 @@
       <li>change who places orders for devices</li>
     </ul>
 
-    <p class="govuk-body">You can also choose to let up to 3 users:</p>
+    <p class="govuk-body govuk-!-margin-top-6">You can also choose to let up to 3 users:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
       <li>order devices</li>
       <li>use a <%= govuk_link_to 'Support Portal', 'https://computacenterprod.service-now.com/dfe' %> to report faults and <%= govuk_link_to 'view passwords needed to replace DfE settings', devices_guidance_subpage_path('preparing-microsoft-windows-laptops-and-tablets', anchor: 'getting-local-admin-and-bios-passwords-to-install-your-own-software-and-settings') %> on Microsoft Windows devices</li>

--- a/app/views/school/welcome_wizard/will_other_order.html.erb
+++ b/app/views/school/welcome_wizard/will_other_order.html.erb
@@ -17,7 +17,7 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :invite_user, legend: nil do %>
+      <%= f.govuk_radio_buttons_fieldset :invite_user, legend: {text: t(:question, scope: scope)} do %>
         <%= f.govuk_radio_button :invite_user,
                                  'yes',
                                  label: { text: t(:yes_label, scope: scope) } do %>

--- a/app/views/shared/_invite_someone_who_can.html.erb
+++ b/app/views/shared/_invite_someone_who_can.html.erb
@@ -1,5 +1,21 @@
+
 <p class="govuk-body">Invite someone in your school or college who:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
   <li>understands what devices are needed and who will get them</li>
   <li>can configure devices or give technical information</li>
+</ul>
+
+<h2 class="govuk-heading-s">
+  Get consent for us to share their information
+</h2>
+<p class="govuk-body">
+  When you invite someone, their name, email address and <span class="app-no-wrap">phone number</span> will be shared with TechSource. Before you invite them:
+</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+  <li>
+    give them this <%= govuk_link_to "information on how we look after personal information", privacy_general_privacy_notice_path %>
+  </li>
+  <li>
+    get consent for their details to be shared
+  </li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,7 +236,8 @@ en:
       techsource_account:
         title: Use the TechSource website to place orders
       will_other_order:
-        title: Do you need to give someone else access?
+        title: You can invite someone else to order
+        question: Do you need to give someone else access?
         yes_label: Yes, I need to add someone
         no_label: No, not at the moment
         errors:

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -206,7 +206,7 @@ RSpec.feature 'Navigate school welcome wizard' do
 
   def then_i_see_the_will_other_order_page
     expect(page).to have_current_path(welcome_wizard_will_other_order_school_path(urn: @user.school.urn))
-    expect(page).to have_text('Do you need to give someone else access?')
+    expect(page).to have_text('You can invite someone else to order')
   end
 
   def when_i_choose_yes_and_submit_the_form


### PR DESCRIPTION
Context:
https://trello.com/c/V2czUlbD/1760-notify-or-display-a-privacy-notice-when-a-new-user-has-been-added

Because we sometimes send an invited user’s details to TechSource before they have signed-in and seen the privacy policy we need the inviting user to show the privacy policy to the invited user before they invite them.

Manage users:

![localhost_3000_schools_106621_users_new(screenshot for design history) (1)](https://user-images.githubusercontent.com/8417288/112977907-8af94280-914e-11eb-8278-6a551433bdf7.png)


School wizard flow (if ordering is devolved to the school and user has TechSource account):

![localhost_3000_schools_106603_will-other-order(screenshot for design history)](https://user-images.githubusercontent.com/8417288/112977886-82087100-914e-11eb-9d2e-a3d183edf0c1.png)


We might want to consider removing the option to add a user from the school wizard flow because it doesn't seem likely a user will speak to the person they're inviting mid-flow.