### PR TITLE
Add rails-erd gem for drawing entity relationship diagrams

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,8 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.6'
 
+  gem 'rails-erd'
+  
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.6'
 
   gem 'rails-erd'
-  
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       capybara (>= 2.4, < 4.0)
       mail
     childprocess (3.0.0)
+    choice (0.2.0)
     climate_control (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -264,6 +265,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rails_semantic_logger (4.5.0)
@@ -329,6 +335,8 @@ GEM
       rubocop
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
     rubyXL (3.4.17)
@@ -475,6 +483,7 @@ DEPENDENCIES
   pundit
   rack-throttle
   rails-controller-testing
+  rails-erd
   rails_semantic_logger
   railties (~> 6.1.3)
   redcarpet

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ For performing releases:
 - a bash-compatible shell (bash, or Mac OS/X)
 - [jq](https://github.com/stedolan/jq) (only required for listing remote Docker tags, not required for normal releases)
 
+For generating Entity Relationship Diagrams:
+
+- Graphviz
+
 ## Setting up the app in development
 
 1. Run `bundle install` to install the gem dependencies
@@ -72,6 +76,13 @@ bundle exec brakeman
 ```
 
 All the above are run automatically on GitHub Actions when pushing a PR.
+
+## Generating an Entity Relationship Diagram
+
+The `rails-erd` gem uses Graphviz to draw diagrams of the ActiveRecord models and their relationships.
+You can run it at any time using:
+
+`bundle exec rails erd`
 
 ## Integrations
 


### PR DESCRIPTION
### Context

While on-boarding the new devs, it struck me that it would be useful to be able to generate Entity Relationship Diagrams on-demand.

### Changes proposed in this pull request

* Add the `rails-erd` gem in development
* Add brief instructions to README.md

### Guidance to review

Review the `Generating an Entity Relationship Diagram` section in the README
Follow the instructions
If you get an ERD out of it, it's worked :)
