### PR TITLE
[1821] allow support to query ExtraMobileDataRequest completions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'http-parser', '~> 1.2.3'
 
 # Canonical meta tag
 gem 'canonical-rails', git: 'https://github.com/asmega/canonical-rails.git', ref: '1b9426229dfa5136326f5ce4963e8e8d1cb3b23c'
+gem 'chronic'
 gem 'dotenv-rails'
 # Having Faker here rather than in dev/test lets us still create
 # fake data in the deployed Docker container

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       mail
     childprocess (3.0.0)
     choice (0.2.0)
+    chronic (0.10.2)
     climate_control (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -464,6 +465,7 @@ DEPENDENCIES
   canonical-rails!
   capybara (~> 3.35)
   capybara-email
+  chronic
   climate_control
   config
   database_cleaner-active_record

--- a/app/controllers/support/service_performance_controller.rb
+++ b/app/controllers/support/service_performance_controller.rb
@@ -3,6 +3,7 @@ class Support::ServicePerformanceController < Support::BaseController
 
   def index
     skip_policy_scope
+    @completion_date_form = Support::RequestCompletionsForm.new(performance_params)
     @stats = Support::ServicePerformance.new
   end
 
@@ -14,5 +15,11 @@ class Support::ServicePerformanceController < Support::BaseController
     now = Time.zone.now
 
     send_file exporter.path, filename: "mno-requests-#{now.strftime('%Y')}-#{now.strftime('%m')}-#{now.strftime('%d')}.csv", type: 'text/csv'
+  end
+
+private
+
+  def performance_params
+    params.fetch(:completions, {}).permit(:from, :to)
   end
 end

--- a/app/form_objects/support/request_completions_form.rb
+++ b/app/form_objects/support/request_completions_form.rb
@@ -1,0 +1,22 @@
+class Support::RequestCompletionsForm
+  include ActiveModel::Model
+
+  attr_accessor :from, :to
+
+  def initialize(params={})
+    @from = Chronic.parse params[:from]
+    @to = Chronic.parse params[:to]
+  end
+
+  def dates_description
+    if @from.present?
+      if @to.present?
+        "between #{@from.to_s(:govuk_date_and_time)} and #{@to.to_s(:govuk_date_and_time)}"
+      else
+        "since #{@from.to_s(:govuk_date_and_time)}"
+      end
+    else
+      "up to #{(@to || Time.zone.now.utc).to_s(:govuk_date_and_time)}"
+    end
+  end
+end

--- a/app/form_objects/support/request_completions_form.rb
+++ b/app/form_objects/support/request_completions_form.rb
@@ -3,7 +3,7 @@ class Support::RequestCompletionsForm
 
   attr_accessor :from, :to
 
-  def initialize(params={})
+  def initialize(params = {})
     @from = Chronic.parse params[:from]
     @to = Chronic.parse params[:to]
   end

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -405,7 +405,7 @@ class Support::ServicePerformance
   end
 
   def extra_mobile_data_request_completions(from: nil, to: nil)
-    scope  = ReportableEvent.where(event_name: 'completion', record_type: 'ExtraMobileDataRequest')
+    scope = ReportableEvent.where(event_name: 'completion', record_type: 'ExtraMobileDataRequest')
     scope = scope.where('event_time >= ?', from) if from.present?
     scope = scope.where('event_time <= ?', to) if to.present?
     scope.count

--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -404,6 +404,13 @@ class Support::ServicePerformance
       .reverse
   end
 
+  def extra_mobile_data_request_completions(from: nil, to: nil)
+    scope  = ReportableEvent.where(event_name: 'completion', record_type: 'ExtraMobileDataRequest')
+    scope = scope.where('event_time >= ?', from) if from.present?
+    scope = scope.where('event_time <= ?', to) if to.present?
+    scope.count
+  end
+
   def number_of_devolved_schools_that_have_made_extra_mobile_data_requests
     ExtraMobileDataRequest.from_schools.count('DISTINCT(school_id)')
   end

--- a/app/views/support/service_performance/_mobile_data_requests.html.erb
+++ b/app/views/support/service_performance/_mobile_data_requests.html.erb
@@ -41,6 +41,28 @@
   </div>
 </div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h3 class="govuk-heading-m govuk-!-margin-top-7">
+      <%= @stats.extra_mobile_data_request_completions(from: @completion_date_form.from, to: @completion_date_form.to) %>
+      requests completed
+      <%= @completion_date_form.dates_description %>
+    </h3>
+    <%= govuk_details(summary: 'Calculate completions for different dates') do %>
+      <p class="govuk-body">
+        Both fields are optional. You can enter dates and times in any format supported by <%= govuk_link_to 'Chronic', 'https://github.com/mojombo/chronic#examples' %>
+      </p>
+      <%- uri = URI.parse(request.url) %>
+      <%- uri.fragment = 'mno' %>
+      <%= form_for @completion_date_form, as: 'completions', url: uri.to_s, method: :get do |f| %>
+        <%= f.govuk_text_field :from, width: 'one-quarter', label: {text: 'From'} %>
+        <%= f.govuk_text_field :to, width: 'one-quarter', label: {text: 'To'} %>
+        <%= f.govuk_submit 'Calculate' %>
+      <%- end %>
+    <%- end %>
+  </div>
+</div>
+
 <h3 class="govuk-heading-m govuk-!-margin-top-7">Requests by network</h3>
 <table class="govuk-table govuk-!-margin-top-4">
   <thead class="govuk-table__head">

--- a/spec/factories/reportable_events.rb
+++ b/spec/factories/reportable_events.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :reportable_event do
+    trait :extra_mobile_data_request_completion do
+      event_name { 'completion' }
+      association(:record, factory: :extra_mobile_data_request)
+      event_time { Time.zone.now.utc }
+    end
+  end
+end

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -41,6 +41,20 @@ RSpec.feature 'Viewing service performance', type: :feature do
     then_i_see_stats_about_extra_mobile_data_requests
   end
 
+  scenario 'DfE users can query for completions between given dates' do
+    given_there_are_some_completion_events
+
+    when_i_sign_in_as_a_dfe_user
+    and_i_follow_links_to_the_service_performance_page
+    and_i_select_the_mno_tab
+    then_i_see_the_number_of_completions_up_to_the_current_date
+
+    when_i_enter_from_and_to_dates
+    and_click_calculate
+    then_i_see_the_correct_number
+    and_i_see_the_dates_i_entered_in_govuk_format
+  end
+
   scenario 'DfE users see service stats about routers' do
     given_there_are_available_shipped_and_remaining_routers
 
@@ -130,6 +144,37 @@ RSpec.feature 'Viewing service performance', type: :feature do
                 mobile_network: virgin,
                 responsible_body: rb,
                 created_by_user: rb_requester)
+  end
+
+  def given_there_are_some_completion_events
+    create_list(:reportable_event, 4, :extra_mobile_data_request_completion, event_time: 2.weeks.ago)
+    create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.weeks.ago)
+    create_list(:reportable_event, 1, :extra_mobile_data_request_completion, event_time: 2.hours.ago)
+  end
+
+  def then_i_see_the_number_of_completions_up_to_the_current_date
+    within('#mno') do
+      expect(page).to have_text "7 requests completed up to now"
+    end
+  end
+
+  def when_i_enter_from_and_to_dates
+    within('#mno') do
+      fill_in 'From date/time', with: (Time.zone.now.utc - 10.days).to_date.iso8601
+      fill_in 'To date/time', with: '2 days ago'
+    end
+  end
+
+  def then_i_see_the_correct_number
+    within('#mno') do
+      expect(page).to have_text "2 requests completed"
+    end
+  end
+
+  def and_i_see_the_dates_i_entered_in_govuk_format
+    within('#mno') do
+      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date_and_time)} and #{(Time.zone.now.utc - 2.days).to_date.to_s(:govuk_date_and_time)} "
+    end
   end
 
   def when_i_sign_in_as_a_dfe_user

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def given_there_are_some_completion_events
     create_list(:reportable_event, 4, :extra_mobile_data_request_completion, event_time: 2.weeks.ago)
-    create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.weeks.ago)
+    create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.week.ago)
     create_list(:reportable_event, 1, :extra_mobile_data_request_completion, event_time: 2.hours.ago)
   end
 
@@ -167,7 +167,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def then_i_see_the_correct_number
     within('#mno') do
-      expect(page).to have_text "2 requests completed"
+      expect(page).to have_text '2 requests completed'
     end
   end
 

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -160,7 +160,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def when_i_enter_from_and_to_dates
     within('#mno') do
-      find( 'summary', text: 'Calculate completions for different dates' ).click
+      find('summary', text: 'Calculate completions for different dates').click
       fill_in 'From', with: (Time.zone.now.utc - 10.days).to_date.iso8601
       fill_in 'To', with: '2 days ago'
     end

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -154,7 +154,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def then_i_see_the_number_of_completions_up_to_the_current_date
     within('#mno') do
-      expect(page).to have_text "7 requests completed up to now"
+      expect(page).to have_text "7 requests completed up to #{Time.zone.now.utc.to_s(:govuk_date_and_time)}"
     end
   end
 
@@ -173,7 +173,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def and_i_see_the_dates_i_entered_in_govuk_format
     within('#mno') do
-      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date_and_time)} and #{(Time.zone.now.utc - 2.days).to_date.to_s(:govuk_date_and_time)} "
+      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_s(:govuk_date_and_time)} and #{(Time.zone.now.utc - 2.days).to_s(:govuk_date_and_time)} "
     end
   end
 

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -154,15 +154,20 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def then_i_see_the_number_of_completions_up_to_the_current_date
     within('#mno') do
-      expect(page).to have_text "7 requests completed up to #{Time.zone.now.utc.to_s(:govuk_date_and_time)}"
+      expect(page).to have_text "7 requests completed up to #{Time.zone.now.utc.to_s(:govuk_date_and_time)}".gsub(/(\s)+/, '\1')
     end
   end
 
   def when_i_enter_from_and_to_dates
     within('#mno') do
-      fill_in 'From date/time', with: (Time.zone.now.utc - 10.days).to_date.iso8601
-      fill_in 'To date/time', with: '2 days ago'
+      find( 'summary', text: 'Calculate completions for different dates' ).click
+      fill_in 'From', with: (Time.zone.now.utc - 10.days).to_date.iso8601
+      fill_in 'To', with: '2 days ago'
     end
+  end
+
+  def and_click_calculate
+    click_on('Calculate')
   end
 
   def then_i_see_the_correct_number
@@ -173,7 +178,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def and_i_see_the_dates_i_entered_in_govuk_format
     within('#mno') do
-      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_s(:govuk_date_and_time)} and #{(Time.zone.now.utc - 2.days).to_s(:govuk_date_and_time)} "
+      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date)} at 12:00pm and #{(Time.zone.now - 2.days).to_s(:govuk_date_and_time)}"
     end
   end
 

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -178,7 +178,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def and_i_see_the_dates_i_entered_in_govuk_format
     within('#mno') do
-      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date)} at 12:00pm and #{(Time.zone.now - 2.days).to_s(:govuk_date_and_time)}".gsub(/(\s)+/, '\1')
+      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date)} at 12:00pm and #{(Time.zone.now.utc - 2.days).to_s(:govuk_date_and_time)}".gsub(/(\s)+/, '\1')
     end
   end
 

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -178,7 +178,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
 
   def and_i_see_the_dates_i_entered_in_govuk_format
     within('#mno') do
-      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date)} at 12:00pm and #{(Time.zone.now - 2.days).to_s(:govuk_date_and_time)}"
+      expect(page).to have_text "requests completed between #{(Time.zone.now.utc - 10.days).to_date.to_s(:govuk_date)} at 12:00pm and #{(Time.zone.now - 2.days).to_s(:govuk_date_and_time)}".gsub(/(\s)+/, '\1')
     end
   end
 

--- a/spec/models/support/service_performance_spec.rb
+++ b/spec/models/support/service_performance_spec.rb
@@ -160,4 +160,37 @@ RSpec.describe Support::ServicePerformance, type: :model do
       end
     end
   end
+
+  describe '#extra_mobile_data_request_completions' do
+    before do
+      create_list(:reportable_event, 4, :extra_mobile_data_request_completion, event_time: 2.weeks.ago)
+      create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.weeks.ago)
+      create_list(:reportable_event, 1, :extra_mobile_data_request_completion, event_time: 2.hours.ago)
+      create_list(:reportable_event, 3, :extra_mobile_data_request_completion, event_time: Time.now.utc + 2.hours)
+    end
+
+    context 'given no params' do
+      it 'returns the total number of completions regardless of time' do
+        expect(stats.extra_mobile_data_request_completions).to eq(10)
+      end
+    end
+
+    context 'given a datetime as from:' do
+      it 'returns the total number of completions after the given datetime' do
+        expect(stats.extra_mobile_data_request_completions(from: 10.days.ago)).to eq(6)
+      end
+
+      context 'given a datetime as to:' do
+        it 'returns the total number of completions between the given datetimes' do
+          expect(stats.extra_mobile_data_request_completions(from: 10.days.ago, to: 2.minutes.ago)).to eq(3)
+        end
+      end
+    end
+
+    context 'given a datetime as to:' do
+      it 'returns the total number of completions before the given datetime' do
+        expect(stats.extra_mobile_data_request_completions(to: 10.days.ago)).to eq(4)
+      end
+    end
+  end
 end

--- a/spec/models/support/service_performance_spec.rb
+++ b/spec/models/support/service_performance_spec.rb
@@ -164,9 +164,9 @@ RSpec.describe Support::ServicePerformance, type: :model do
   describe '#extra_mobile_data_request_completions' do
     before do
       create_list(:reportable_event, 4, :extra_mobile_data_request_completion, event_time: 2.weeks.ago)
-      create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.weeks.ago)
+      create_list(:reportable_event, 2, :extra_mobile_data_request_completion, event_time: 1.week.ago)
       create_list(:reportable_event, 1, :extra_mobile_data_request_completion, event_time: 2.hours.ago)
-      create_list(:reportable_event, 3, :extra_mobile_data_request_completion, event_time: Time.now.utc + 2.hours)
+      create_list(:reportable_event, 3, :extra_mobile_data_request_completion, event_time: Time.zone.now.utc + 2.hours)
     end
 
     context 'given no params' do


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/AA7dPOWD/1821-add-ability-to-query-for-extramobiledatarequest-completions-up-to-a-given-date-time-to-support-ui) - now that we have an agreed monthly schedule for reporting MNO request completions, and we also have a working method of recording completions in a separate table as they happen, we can and should add the ability to query for completions between dates into the support UI. 

### Changes proposed in this pull request

* Add a bit of UI to `/support/performance` to explicitly display the completions
* Add a form for querying between dates, tucked away behind a summary/details component until you need it

### Guidance to review

#### Data setup
You will need some `ReportableEvent` records, with `event_name: 'completion'` and `record_type: 'ExtraMobileDataRequest'`
The easiest way is to generate some `ExtraMobileDataRequest` records (either using the `FakeDataService`, or actually submitting them in the school / responsible body UI) and then either complete them in the `/mno/` UI), or run something like this:

```
ExtraMobileDataRequest.where(status: 'complete').each{ |r| ReportableEvent.create!(event_name: 'completion', record: r, event_time: r.updated_at) }
```
If you are creating them all at once, you might want to stagger the event_times, something like: `event_time: r.updated_at - ((rand*10).to_i * 1.day) `

#### Testing the UI

* Login as a support user
* Go to Support home > Service performance > MNO
* Scroll down to just below the tiles of counts by status
* Try entering different Chronic-compatible/incompatible date formats, make sure it doesn't break on anything unexpected (it should just treat unparsable strings as nils) 

### Screenshots

![Screenshot from 2021-04-01 16-52-40](https://user-images.githubusercontent.com/134501/113322169-43b8b080-930c-11eb-9cfa-215dad2b9609.png)

![Screenshot from 2021-04-01 16-54-14](https://user-images.githubusercontent.com/134501/113322166-43201a00-930c-11eb-86c2-bcecf68d7489.png)