### PR TITLE
[1689] Add component previews

### DIFF
--- a/app/components/responsible_body/pooled_device_count_component.html.erb
+++ b/app/components/responsible_body/pooled_device_count_component.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-panel__body govuk-!-font-size-24">
     <%= ordered_string -%>
   </div>
-  
+
   <% if show_action && action.present? %>
     <%= govuk_button_link_to action.first[0], action.first[1], class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-1' %>
   <% end %>

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -1,0 +1,12 @@
+class ComponentPreviewController < ViewComponentsController
+  layout 'application'
+
+  def hide_nav_menu?
+    false
+  end
+
+  def impersonated_user
+    nil
+  end
+  helper_method :impersonated_user
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,8 @@ module GovukRailsBoilerplate
     # modern browsers because they can cause additional vulnerabilities
     # (see https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#x-xss-protection-header)
     config.action_dispatch.default_headers['X-XSS-Protection'] = '0'
+
+    config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+    config.view_component.preview_controller = "ComponentPreviewController"
   end
 end

--- a/spec/components/previews/email_audit_list_component_preview.rb
+++ b/spec/components/previews/email_audit_list_component_preview.rb
@@ -1,0 +1,6 @@
+class EmailAuditListComponentPreview < ViewComponent::Preview
+  def default
+    audits = FactoryBot.build_list(:email_audit, 3, created_at: 3.days.ago)
+    render(Support::EmailAuditListComponent.new(audits))
+  end
+end

--- a/spec/components/previews/nav_component_preview.rb
+++ b/spec/components/previews/nav_component_preview.rb
@@ -1,0 +1,9 @@
+class NavComponentPreview < ViewComponent::Preview
+  def computacenter_user
+    # see html.erb
+  end
+
+  def support_user
+    # see html.erb
+  end
+end

--- a/spec/components/previews/nav_component_preview/computacenter_user.html.erb
+++ b/spec/components/previews/nav_component_preview/computacenter_user.html.erb
@@ -1,0 +1,3 @@
+<div style="background-color: black;">
+  <%= render(NavComponent.new(user: User.new(is_computacenter: true), current_path: '/')) %>
+</div>

--- a/spec/components/previews/nav_component_preview/support_user.html.erb
+++ b/spec/components/previews/nav_component_preview/support_user.html.erb
@@ -1,0 +1,3 @@
+<div style="background-color: black;">
+  <%= render(NavComponent.new(user: User.new(is_support: true), current_path: '/')) %>
+</div>

--- a/spec/components/previews/next_school_link_component_preview.rb
+++ b/spec/components/previews/next_school_link_component_preview.rb
@@ -1,0 +1,6 @@
+class NextSchoolLinkComponentPreview < ViewComponent::Preview
+  def with_next_school
+    school = School.all.sample
+    render(ResponsibleBody::NextSchoolLinkComponent.new(current_school: school, recordsets: [School.all]))
+  end
+end

--- a/spec/components/previews/pooled_device_count_component_preview.rb
+++ b/spec/components/previews/pooled_device_count_component_preview.rb
@@ -1,0 +1,79 @@
+class PooledDeviceCountComponentPreview < ViewComponent::Preview
+  def ordered_devices_and_none_left
+    rb = FactoryBot.build(:trust)
+    rb.virtual_cap_pools = [VirtualCapPool.new(device_type: 'std_device', devices_ordered: 10)]
+
+    component = ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: rb)
+
+    component.instance_eval do
+      def allocations
+        responsible_body.virtual_cap_pools
+      end
+    end
+
+    render(component)
+  end
+
+  def ordered_all_and_none_left
+    rb = FactoryBot.build(:trust)
+    rb.virtual_cap_pools = [VirtualCapPool.new(device_type: 'std_device', devices_ordered: 10),
+                            VirtualCapPool.new(device_type: 'coms_device', devices_ordered: 10)]
+
+    component = ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: rb)
+
+    component.instance_eval do
+      def allocations
+        responsible_body.virtual_cap_pools
+      end
+    end
+
+    render(component)
+  end
+
+  def ordered_routers_and_none_left
+    rb = FactoryBot.build(:trust)
+    rb.virtual_cap_pools = [VirtualCapPool.new(device_type: 'coms_device', devices_ordered: 10)]
+
+    component = ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: rb)
+
+    component.instance_eval do
+      def allocations
+        responsible_body.virtual_cap_pools
+      end
+    end
+
+    render(component)
+  end
+
+  def not_ordered_and_devices_plus_routers_left
+    rb = FactoryBot.build(:trust)
+    rb.virtual_cap_pools = [VirtualCapPool.new(device_type: 'std_device', cap: 2, devices_ordered: 0),
+                            VirtualCapPool.new(device_type: 'coms_device', cap: 3, devices_ordered: 0)]
+
+    component = ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: rb)
+
+    component.instance_eval do
+      def allocations
+        responsible_body.virtual_cap_pools
+      end
+    end
+
+    render(component)
+  end
+
+  def ordered_and_devices_plus_routers_left
+    rb = FactoryBot.build(:trust)
+    rb.virtual_cap_pools = [VirtualCapPool.new(device_type: 'std_device', cap: 3, devices_ordered: 1),
+                            VirtualCapPool.new(device_type: 'coms_device', cap: 4, devices_ordered: 2)]
+
+    component = ResponsibleBody::PooledDeviceCountComponent.new(responsible_body: rb)
+
+    component.instance_eval do
+      def allocations
+        responsible_body.virtual_cap_pools
+      end
+    end
+
+    render(component)
+  end
+end

--- a/spec/components/previews/school_preorder_status_tag_component_preview.rb
+++ b/spec/components/previews/school_preorder_status_tag_component_preview.rb
@@ -1,0 +1,26 @@
+class SchoolPreorderStatusTagComponentPreview < ViewComponent::Preview
+  STATUS = %w[
+    needs_contact
+    needs_info
+    school_contacted
+    school_will_be_contacted
+    school_ready
+    ready
+    rb_can_order
+    school_can_order
+    ordered
+  ].freeze
+  WHO_ORDER = %w[responsible_body school].freeze
+  VIEWER = [Trust.new, FurtherEducationCollege.new].freeze
+
+  STATUS.each do |status|
+    WHO_ORDER.each do |who_order|
+      VIEWER.each do |viewer|
+        define_method("#{who_order}_orders_#{status}_#{viewer.class.to_s.underscore}_viewing") do
+          school = OpenStruct.new(preorder_status_or_default: status, who_will_order_devices: who_order)
+          render(SchoolPreorderStatusTagComponent.new(school: school, viewer: viewer))
+        end
+      end
+    end
+  end
+end

--- a/spec/components/previews/start_page_banner_component_preview.rb
+++ b/spec/components/previews/start_page_banner_component_preview.rb
@@ -1,0 +1,5 @@
+class StartPageBannerComponentPreview < ViewComponent::Preview
+  def default
+    render(StartPageBannerComponent.new)
+  end
+end

--- a/spec/components/previews/summary_list_component_preview.rb
+++ b/spec/components/previews/summary_list_component_preview.rb
@@ -1,0 +1,32 @@
+class SummaryListComponentPreview < ViewComponent::Preview
+  def one_row
+    rows = [
+      key: 'Name',
+      value: 'Lando Calrissian',
+      action: 'Name',
+      change_path: '/some/url',
+    ]
+
+    render(SummaryListComponent.new(rows: rows))
+  end
+
+  def multiple_rows
+    rows = []
+
+    rows << {
+      key: 'Name',
+      value: 'Lando Calrissian',
+      action: 'Name',
+      change_path: '/some/url',
+    }
+
+    rows << {
+      key: 'Email',
+      value: 'lando@example.com',
+      action: 'Email',
+      change_path: '/some/url',
+    }
+
+    render(SummaryListComponent.new(rows: rows))
+  end
+end

--- a/spec/components/previews/tab_component_preview.rb
+++ b/spec/components/previews/tab_component_preview.rb
@@ -1,0 +1,9 @@
+class TabComponentPreview < ViewComponent::Preview
+  def unselected_tab
+    render(TabComponent.new(path: '/my/resource/path', label: '3 blind mice', selected: false))
+  end
+
+  def selected_tab
+    render(TabComponent.new(path: '/my/resource/path', label: '3 blind mice', selected: true))
+  end
+end

--- a/spec/components/previews/tile_component_preview.rb
+++ b/spec/components/previews/tile_component_preview.rb
@@ -1,0 +1,13 @@
+class TileComponentPreview < ViewComponent::Preview
+  def default
+    render(Support::TileComponent.new(count: 123_456, label: 'schools'))
+  end
+
+  def other_size
+    render(Support::TileComponent.new(count: 123_456, label: 'schools', size: :other))
+  end
+
+  def custom_colour
+    render(Support::TileComponent.new(count: 123_456, label: 'schools', colour: 'red'))
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/yIXkXW6J/1689-add-previews-of-view-components-in-various-states

### Changes proposed in this pull request

- Adds preview functionality of view components in various states
- Some components have been missed out as they seem to only add wrapping divs and having the previews don't seem to offer much value. We probably want to cull superfluous components first then add previews for the remaining components

### Screenshots

Added component list
![image](https://user-images.githubusercontent.com/92580/113743468-9ffc4580-96fb-11eb-8be7-7464283a0658.png)

Example component preview
![image](https://user-images.githubusercontent.com/92580/113743596-c0c49b00-96fb-11eb-85eb-74c643ba7bab.png)

### Guidance to review

- Visit http://localhost:3000/rails/view_components/
- Click on previews to view components in various states