### PR TITLE
[1238] Can disable notifications in update service

### DIFF
--- a/app/services/school_order_state_and_cap_update_service.rb
+++ b/app/services/school_order_state_and_cap_update_service.rb
@@ -2,6 +2,7 @@ class SchoolOrderStateAndCapUpdateService
   include Computacenter::CapChangeNotifier
 
   attr_accessor :school, :order_state, :caps
+  attr_reader :disable_user_notifications
 
   def initialize(school:, order_state:, std_device_cap: nil, coms_device_cap: nil)
     @school = school
@@ -10,6 +11,7 @@ class SchoolOrderStateAndCapUpdateService
       { device_type: 'std_device', cap: std_device_cap },
       { device_type: 'coms_device', cap: coms_device_cap },
     ]
+    @disable_user_notifications = false
   end
 
   def update!
@@ -41,7 +43,11 @@ class SchoolOrderStateAndCapUpdateService
     # notifying users should only happen after successful completion of the Computacenter
     # cap update, because it's possible for that to fail and the whole thing
     # is rolled back
-    SchoolCanOrderDevicesNotifications.new(school: school).call
+    SchoolCanOrderDevicesNotifications.new(school: school).call unless disable_user_notifications
+  end
+
+  def disable_user_notifications!
+    @disable_user_notifications = true
   end
 
 private

--- a/spec/services/school_order_state_and_cap_update_service_spec.rb
+++ b/spec/services/school_order_state_and_cap_update_service_spec.rb
@@ -281,6 +281,14 @@ RSpec.describe SchoolOrderStateAndCapUpdateService do
         expect { service.update! }.not_to have_enqueued_mail(ComputacenterMailer, :notify_of_devices_cap_change)
       end
     end
+
+    context 'when #disable_user_notifications! called first' do
+      it 'does not send any notifications' do
+        service.disable_user_notifications!
+        service.update!
+        expect(notifications).not_to have_received(:call)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/c8nB3ikw/1238-allow-bulk-opening-page-to-work-with-many-thousands-of-urns

### Changes proposed in this pull request

- Can disable notifications in `SchoolOrderStateAndCapUpdateService`

### Guidance to review

- Code review