### PR TITLE
1715 techsource planned maintenance outages

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,12 @@
     },
     "SECRET_KEY_BASE": {
       "required": true
+    },
+    "FEATURES_show_component_previews": {
+      "value": "active"
+    },
+    "FEATURES_display_sign_in_token_links": {
+      "value": "active"
     }
   },
   "formation": {

--- a/app/components/computacenter/tech_source_maintenance_banner_component.html.erb
+++ b/app/components/computacenter/tech_source_maintenance_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= render GovukComponent::Warning.new(text: message,
+                                       html_attributes: {
+                                         data: { module: 'app-tech-source-maintenance-banner' }
+                                       }) %>

--- a/app/components/computacenter/tech_source_maintenance_banner_component.rb
+++ b/app/components/computacenter/tech_source_maintenance_banner_component.rb
@@ -1,0 +1,14 @@
+class Computacenter::TechSourceMaintenanceBannerComponent < ViewComponent::Base
+  MAINTENANCE_WINDOW = Computacenter::TechSource::MAINTENANCE_WINDOW
+  DATE_TIME_FORMAT = '%A %-d %B %I:%M%P'.freeze
+
+  def message
+    "The TechSource website will be closed for maintenance on #{MAINTENANCE_WINDOW.first.strftime(DATE_TIME_FORMAT)}. You can order devices when it reopens on #{MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)}."
+  end
+
+  def render?
+    display_from = 2.days.before(MAINTENANCE_WINDOW.first.beginning_of_day)
+    display_until = MAINTENANCE_WINDOW.last
+    (display_from..display_until).cover? Time.zone.now
+  end
+end

--- a/app/components/computacenter/tech_source_maintenance_banner_component.rb
+++ b/app/components/computacenter/tech_source_maintenance_banner_component.rb
@@ -3,7 +3,7 @@ class Computacenter::TechSourceMaintenanceBannerComponent < ViewComponent::Base
   DATE_TIME_FORMAT = '%A %-d %B %I:%M%P'.freeze
 
   def message
-    "The TechSource website will be closed for maintenance on #{MAINTENANCE_WINDOW.first.strftime(DATE_TIME_FORMAT)}. You can order devices when it reopens on #{MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)}."
+    "The TechSource website will be closed for maintenance on <span class=\"app-no-wrap\">#{MAINTENANCE_WINDOW.first.strftime(DATE_TIME_FORMAT)}.</span> You can order devices when it reopens on <span class=\"app-no-wrap\">#{MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)}.</span>".html_safe
   end
 
   def render?

--- a/app/models/computacenter/tech_source.rb
+++ b/app/models/computacenter/tech_source.rb
@@ -1,5 +1,5 @@
 class Computacenter::TechSource
-  MAINTENANCE_WINDOW = (Time.zone.parse('3 Apr 2021 09:00')..Time.zone.parse('3 Apr 2021 12:00')).freeze
+  MAINTENANCE_WINDOW = (Time.zone.parse('10 Apr 2021 09:00')..Time.zone.parse('10 Apr 2021 13:00')).freeze
 
   def url
     Settings.computacenter.techsource_url

--- a/app/models/computacenter/tech_source.rb
+++ b/app/models/computacenter/tech_source.rb
@@ -1,27 +1,11 @@
 class Computacenter::TechSource
-  NEXT_MAINTENANCE = {
-    window_start: Time.zone.local(2021, 4, 3, 9, 0, 0),
-    window_end: Time.zone.local(2021, 4, 3, 12, 0, 0),
-    maintenance_on_date: Date.new(2021, 4, 3),
-    reopened_on_date: Date.new(2021, 4, 4),
-  }.freeze
-
-  def next_maintenance
-    NEXT_MAINTENANCE
-  end
+  MAINTENANCE_WINDOW = (Time.zone.parse('3 Apr 2021 09:00')..Time.zone.parse('3 Apr 2021 12:00')).freeze
 
   def url
     Settings.computacenter.techsource_url
   end
 
-  def warn_users_about_upcoming_maintenance_window?
-    now = Time.zone.now
-    (now >= next_maintenance[:maintenance_on_date].at_beginning_of_day - 2.days) &&
-      now <= next_maintenance[:reopened_on_date].at_beginning_of_day
-  end
-
   def unavailable?
-    now = Time.zone.now
-    now >= next_maintenance[:window_start] && now <= next_maintenance[:window_end]
+    MAINTENANCE_WINDOW.cover? Time.zone.now
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -2,6 +2,7 @@ class FeatureFlag
   PERMANENT_SETTINGS = %i[
     rate_limiting
     display_sign_in_token_links
+    show_component_previews
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
@@ -7,7 +7,7 @@
       You’ve ordered all the devices you can
     </h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
   </div>
 </div>
 

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -6,7 +6,7 @@
       <%= t('page_titles.order_devices.title') %>
     </h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.order_devices.order_for_specific_circumstances') %>
     </h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
 
     <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order.</p>
 

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
 
     <%= render DeviceCountComponent.new(school: @school) %>

--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
 
     <p class="govuk-body">You’ll be able to order <%= what_to_order_allocation_list(allocations: @school.device_allocations) %> soon.</p>
 

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
 
     <%= render DeviceCountComponent.new(school: @school) %>
 

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -9,7 +9,7 @@
     <span class="govuk-caption-xl">Order devices</span>
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <%= render partial: 'shared/techsource_unavailable_banner' %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
 
     <%= render DeviceCountComponent.new(school: @school) %>
 

--- a/app/views/shared/_techsource_unavailable_banner.html.erb
+++ b/app/views/shared/_techsource_unavailable_banner.html.erb
@@ -1,4 +1,0 @@
-<% techsource = Computacenter::TechSource.new %>
-<% if techsource.warn_users_about_upcoming_maintenance_window? %>
-  <%= render GovukComponent::Warning.new(text: "The TechSource website will be closed for maintenance on #{techsource.next_maintenance[:maintenance_on_date].strftime('%A %-d %B')}. You can order devices when it reopens on #{techsource.next_maintenance[:reopened_on_date].strftime('%A %-d %B')}.") %>
-<%- end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,6 @@ module GovukRailsBoilerplate
 
     config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
     config.view_component.preview_controller = "ComponentPreviewController"
+    config.view_component.show_previews = (ENV['FEATURES_show_component_previews'] == 'active')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.view_component.show_previews = true
 end

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_preview.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_preview.rb
@@ -1,0 +1,11 @@
+Computacenter::TechSourceMaintenanceBannerComponent.class_eval do
+  def render?
+    true
+  end
+end
+
+class Computacenter::TechSourceMaintenanceBannerComponentPreview < ViewComponent::Preview
+  def displaying_notice
+    render(Computacenter::TechSourceMaintenanceBannerComponent.new)
+  end
+end

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_preview.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_preview.rb
@@ -1,11 +1,12 @@
-Computacenter::TechSourceMaintenanceBannerComponent.class_eval do
-  def render?
-    true
-  end
-end
-
 class Computacenter::TechSourceMaintenanceBannerComponentPreview < ViewComponent::Preview
   def displaying_notice
-    render(Computacenter::TechSourceMaintenanceBannerComponent.new)
+    @component = Computacenter::TechSourceMaintenanceBannerComponent.new
+    @component.class_eval do
+      def render?
+        true
+      end
+    end
+
+    render(@component)
   end
 end

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::TechSourceMaintenanceBannerComponent, type: :component do
+  alias_method :component, :page
+
+  describe '#message' do
+    context 'within window' do
+      before do
+        stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW',
+                   Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 22:00'))
+        Timecop.travel(Time.zone.parse('4 Jan 2021 15:00'))
+      end
+
+      specify { expect(described_class.new.message).to eq('The TechSource website will be closed for maintenance on Monday 4 January 09:00am. You can order devices when it reopens on Monday 4 January 10:00pm.') }
+    end
+  end
+
+  describe '#render?' do
+    before do
+      stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW',
+                 Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00'))
+    end
+
+    context 'one minute before midnight two days before' do
+      before do
+        Timecop.travel(Time.zone.parse('1 Jan 2021 23:59'))
+        render_inline(described_class.new)
+      end
+
+      specify { expect(component.text).not_to be_present }
+    end
+
+    context 'one minute after midnight two days before' do
+      before do
+        Timecop.travel(Time.zone.parse('2 Jan 2021 00:01'))
+        render_inline(described_class.new)
+      end
+
+      specify { expect(component.text).to be_present }
+    end
+
+    context 'one minute before end of maintenance window' do
+      before do
+        Timecop.travel(Time.zone.parse('4 Jan 2021 09:59'))
+        render_inline(described_class.new)
+      end
+
+      specify { expect(component.text).to be_present }
+    end
+
+    context 'one minute after maintenance window' do
+      before do
+        Timecop.travel(Time.zone.parse('4 Jan 2021 10:01'))
+        render_inline(described_class.new)
+      end
+
+      specify { expect(component.text).not_to be_present }
+    end
+  end
+end

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Computacenter::TechSourceMaintenanceBannerComponent, type: :compo
         Timecop.travel(Time.zone.parse('4 Jan 2021 15:00'))
       end
 
-      specify { expect(described_class.new.message).to eq('The TechSource website will be closed for maintenance on Monday 4 January 09:00am. You can order devices when it reopens on Monday 4 January 10:00pm.') }
+      specify { expect(described_class.new.message).to eq('The TechSource website will be closed for maintenance on <span class="app-no-wrap">Monday 4 January 09:00am.</span> You can order devices when it reopens on <span class="app-no-wrap">Monday 4 January 10:00pm.</span>') }
     end
   end
 

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe TechsourceLauncherController, type: :controller do
       end
 
       it 'renders the unavailable page' do
+        stub_const('Computacenter::TechSource::MAINTENANCE_WINDOW', Time.zone.local(2020, 11, 28, 7, 0, 0)..Time.zone.local(2020, 11, 28, 14, 0, 0))
         get 'start'
         expect(response).to render_template('unavailable')
         expect(response).to have_http_status(:ok)

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -10,15 +10,6 @@ RSpec.feature 'TechSource availability for school' do
            full_name: 'AAA Smith')
   end
 
-  before do
-    stub_const('Computacenter::TechSource::NEXT_MAINTENANCE', {
-      window_start: Time.zone.local(2020, 11, 28, 7, 0, 0),
-      window_end: Time.zone.local(2020, 11, 28, 23, 0, 0),
-      maintenance_on_date: Date.new(2020, 11, 28),
-      reopened_on_date: Date.new(2020, 11, 29),
-    })
-  end
-
   after do
     Timecop.return
   end
@@ -72,27 +63,35 @@ RSpec.feature 'TechSource availability for school' do
   end
 
   def given_it_is_well_before_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 11, 20, 23, 0, 0))
+    Timecop.travel(Time.zone.parse('20 Nov 2020 23:00'))
+    stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW', Time.zone.parse('3 Dec 2020 09:00')..Time.zone.parse('3 Dec 2020 22:00'))
   end
 
   def given_it_is_less_than_2_days_before_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
+    Timecop.travel(Time.zone.parse('2 Dec 2020 23:00'))
+    stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW', Time.zone.parse('3 Dec 2020 09:00')..Time.zone.parse('3 Dec 2020 22:00'))
   end
 
   def given_it_is_during_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 11, 28, 8, 0, 0))
+    Timecop.travel(Time.zone.parse('3 Dec 2020 09:01'))
+    downtime = Time.zone.parse('3 Dec 2020 09:00')..Time.zone.parse('3 Dec 2020 22:00')
+    stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW', downtime)
+    # Below line is needed to stub out the models version of thw MAINTENANCE_WINDOW because this is used for the redirect
+    # journey to the "unavailable" page and they need to be for the same period
+    stub_const('Computacenter::TechSource::MAINTENANCE_WINDOW', downtime)
   end
 
   def given_it_is_after_the_techsource_maintenance_window
-    Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
+    Timecop.travel(Time.zone.parse('4 Dec 2020 23:00'))
+    stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW', Time.zone.parse('3 Dec 2020 09:00')..Time.zone.parse('3 Dec 2020 22:00'))
   end
 
   def then_i_see_a_warning_notice
-    expect(page).to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
+    expect(page).to have_selector('[data-module="app-tech-source-maintenance-banner"]')
   end
 
   def then_i_do_not_see_a_warning_notice
-    expect(page).not_to have_text('The TechSource website will be closed for maintenance on Saturday 28 November. You can order devices when it reopens on Sunday 29 November.')
+    expect(page).to have_no_selector('[data-module="app-tech-source-maintenance-banner"]')
   end
 
   def when_i_click_the_start_now_button


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Enabled view components preview for review apps (thanks @asmega)
- Adds new component for TechSource Maintenance banner
- Refactors existing feature and fixes two bugs identified
### Guidance to review
Sign in as `trust.user.1@example.com` and visit https://dfe-ghwt-pr-1533.herokuapp.com/responsible-body/devices/order-devices. You should see the banner telling the user that techsource will not be available.
![image](https://user-images.githubusercontent.com/3441519/114172407-88a49e80-992d-11eb-9809-509e4a8c2d4a.png)
