### PR TITLE
Updated text on 'Your Organisations' page to be less terse

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,7 +4,7 @@ class SchoolsController < ApplicationController
   def index
     @schools = impersonated_or_current_user.schools
 
-    if impersonated_or_current_user.schools.size == 1 && \
+    if impersonated_or_current_user.schools.one? && \
         (impersonated_or_current_user.is_a_single_school_user? || !impersonated_or_current_user.is_responsible_body_user?)
       redirect_to home_school_path(impersonated_or_current_user.schools.first)
     end

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -5,6 +5,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
+    <p class="govuk-body">You have access to manage ordering on behalf of more than one organisation.</p>
+    <p class="govuk-body">Select which one you want to view:</p>
+
     <%- @schools.each do |school| %>
       <h2 class="govuk-heading-l govuk-!-font-size-27">
         <%= govuk_link_to school.name, home_school_path(school) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
         title: What happens next
     techsource_unavailable: Sorry, TechSource is unavailable
     your_schools: Your schools
-    your_organisations: Your organisations
+    your_organisations: Choose the organisation you want to view
   landing_pages:
     get_support:
       start: Get support

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -65,8 +65,8 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
 
         scenario 'it redirects to Your organisations' do
           sign_in_as user
-          expect(page).to have_text 'Your organisations'
-          expect(page).to have_link user.schools[0].name
+          expect(page).to have_text 'Choose the organisation you want to view'
+          expect(page).to have_link user.schools.first.name
           expect(page).to have_link user.responsible_body.name
         end
       end


### PR DESCRIPTION
### Context

Text on the 'Your Organisations' page was seen as being too terse.

### Changes proposed in this pull request

Apply updated text

### Guidance to review

https://ghwt-prototype.herokuapp.com/your-organisations
