### PR TITLE
Add global `Timecop.return` hook

### DIFF
--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe TechsourceLauncherController, type: :controller do
         sign_in_as user
       end
 
-      after do
-        Timecop.return
-      end
-
       it 'renders the unavailable page' do
         stub_const('Computacenter::TechSource::MAINTENANCE_WINDOW', Time.zone.local(2020, 11, 28, 7, 0, 0)..Time.zone.local(2020, 11, 28, 14, 0, 0))
         get 'start'
@@ -48,10 +44,6 @@ RSpec.describe TechsourceLauncherController, type: :controller do
       before do
         Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
         sign_in_as user
-      end
-
-      after do
-        Timecop.return
       end
 
       it 'redirects to techsource' do

--- a/spec/features/techsource_availability_for_responsible_body_spec.rb
+++ b/spec/features/techsource_availability_for_responsible_body_spec.rb
@@ -6,10 +6,6 @@ RSpec.feature 'TechSource availability for responsible body' do
   let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: local_authority) }
   let(:techsource) { Computacenter::TechSource.new }
 
-  after do
-    Timecop.return
-  end
-
   scenario 'well before the techsource maintenance window' do
     given_it_is_well_before_the_techsource_maintenance_window
     given_i_am_signed_in_as_a_la_user

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -10,10 +10,6 @@ RSpec.feature 'TechSource availability for school' do
            full_name: 'AAA Smith')
   end
 
-  after do
-    Timecop.return
-  end
-
   scenario 'well before the techsource maintenance window' do
     given_it_is_well_before_the_techsource_maintenance_window
     given_i_am_signed_in_as_a_school_user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before(:each) do
+    Timecop.return
+  end
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be


### PR DESCRIPTION
### Context

Specs which used the Timecop gem had there own `after` hooks to make sure `Timecop.return` was used so system time changes didn't bleed into other specs. 

This PR adds a global `before` hook so `Timecop.return` is always called so nobody has to remember to do it themselves anymore. 

This commit has been manually verified to work with RSpec features as well as unit specs.

### Changes proposed in this pull request

Adds global `before` hook. Having this in a `before` hook is safer than having it in an `after` hook because an `after` hook isn't guaranteed to be run (when a spec errors).

There are some calls to `Timecop.return` which are kept in because they're called multiple times in the middle of a spec to set and reset specific behaviour.

### Guidance to review

