### PR TITLE
Remove reference to `http-parser` gem in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem 'activerecord', '~> 6.1.3'
 gem 'actionmailer', '~> 6.1.3'
 gem 'railties', '~> 6.1.3'
 
-# Allows development on M1 Apple Silicon
-gem 'http-parser', '~> 1.2.3'
-
 # Canonical meta tag
 gem 'canonical-rails', git: 'https://github.com/asmega/canonical-rails.git', ref: '1b9426229dfa5136326f5ce4963e8e8d1cb3b23c'
 gem 'chronic'


### PR DESCRIPTION
Now that `Gemfile.lock` is updated, we don't have to provide this within the `Gemfile`. This makes previous PR (#1491) equivalent to `bundle update http` as per Phil Lee's suggestion. 

### Context 
Not having a new version of `http-parser` meant the app wouldn't work on newer Apple Silicon M1 CPUs. This is a rework of https://github.com/DFE-Digital/get-help-with-tech/pull/1491 

### Changes proposed in this pull request 
Get reference to `http-parser` gem out of `Gemfile` 

### Guidance to review