### PR TITLE
[1769] Order flow for ISS

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -4,7 +4,11 @@ class School::DevicesController < School::BaseController
       if impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
         render :can_order_for_specific_circumstances
       elsif impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order?
-        render :can_order
+        if @school.la_funded_place?
+          redirect_to get_laptops_school_path(@school)
+        else
+          render :can_order
+        end
       elsif impersonated_or_current_user.awaiting_techsource_account?
         render :can_order_awaiting_techsource
       else # user has no techsource account

--- a/app/controllers/school/home_controller.rb
+++ b/app/controllers/school/home_controller.rb
@@ -1,5 +1,10 @@
 class School::HomeController < School::BaseController
   def show
     @allocation = @school.std_device_allocation&.allocation || 0
+    if @school.la_funded_place?
+      render 'show_la_funded_place'
+    else
+      render
+    end
   end
 end

--- a/app/controllers/school/la_funded_places_chromebooks_controller.rb
+++ b/app/controllers/school/la_funded_places_chromebooks_controller.rb
@@ -1,0 +1,39 @@
+class School::LaFundedPlacesChromebooksController < School::BaseController
+  def edit
+    @chromebook_information_form = ChromebookInformationForm.new(
+      school: @school,
+      will_need_chromebooks: @school.preorder_information&.will_need_chromebooks,
+      school_or_rb_domain: @school.preorder_information&.school_or_rb_domain,
+      recovery_email_address: @school.preorder_information&.recovery_email_address,
+    )
+  end
+
+  def update
+    @preorder_info = @school.preorder_information
+    @chromebook_information_form = ChromebookInformationForm.new(
+      { school: @school }.merge(chromebook_params),
+    )
+
+    authorize @chromebook_information_form, policy_class: School::BasePolicy
+
+    if @chromebook_information_form.valid?
+      @preorder_info.update_chromebook_information_and_status!(chromebook_params)
+      flash[:success] = t(:success, scope: %w[school chromebooks])
+      redirect_to order_laptops_school_path(@school)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def after_updated_redirect_location
+    details_school_path(@school)
+  end
+
+  def chromebook_params
+    params.fetch(:chromebook_information_form, {}).permit(
+      :will_need_chromebooks,
+    )
+  end
+end

--- a/app/controllers/school/la_funded_places_chromebooks_controller.rb
+++ b/app/controllers/school/la_funded_places_chromebooks_controller.rb
@@ -5,6 +5,7 @@ class School::LaFundedPlacesChromebooksController < School::BaseController
       will_need_chromebooks: @school.preorder_information&.will_need_chromebooks,
       school_or_rb_domain: @school.preorder_information&.school_or_rb_domain,
       recovery_email_address: @school.preorder_information&.recovery_email_address,
+      will_need_chromebooks_message: custom_error_message,
     )
   end
 
@@ -21,6 +22,7 @@ class School::LaFundedPlacesChromebooksController < School::BaseController
       flash[:success] = t(:success, scope: %w[school chromebooks])
       redirect_to order_laptops_school_path(@school)
     else
+      @chromebook_information_form.will_need_chromebooks_message = custom_error_message
       render :edit, status: :unprocessable_entity
     end
   end
@@ -35,5 +37,9 @@ private
     params.fetch(:chromebook_information_form, {}).permit(
       :will_need_chromebooks,
     )
+  end
+
+  def custom_error_message
+    'Tell us if pupils will need Chromebooks'
   end
 end

--- a/app/controllers/school/la_funded_places_chromebooks_controller.rb
+++ b/app/controllers/school/la_funded_places_chromebooks_controller.rb
@@ -40,6 +40,6 @@ private
   end
 
   def custom_error_message
-    'Tell us if pupils will need Chromebooks'
+    I18n.t('page_titles.iss.will_need_chromebooks_error')
   end
 end

--- a/app/controllers/school/la_funded_places_controller.rb
+++ b/app/controllers/school/la_funded_places_controller.rb
@@ -1,0 +1,11 @@
+class School::LaFundedPlacesController < School::BaseController
+  def show; end
+
+  def order
+    if @school.preorder_information&.will_need_chromebooks.nil?
+      redirect_to funded_chromebooks_school_path(@school)
+    end
+  end
+
+  def laptop_types; end
+end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -1,12 +1,12 @@
 class ChromebookInformationForm
   include ActiveModel::Model
 
-  attr_accessor :school, :will_need_chromebooks, :will_need_chromebooks_message
+  attr_accessor :school, :will_need_chromebooks
+  attr_writer :will_need_chromebooks_message
   attr_reader :school_or_rb_domain, :recovery_email_address
 
   validates :will_need_chromebooks, presence: { message: lambda do |object, _|
-                                                            object.will_need_chromebooks_message
-                                                           # I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
+                                                           object.will_need_chromebooks_message
                                                          end }
 
   with_options if: :will_need_chromebooks_and_is_not_a_la_funded_school? do |condition|

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -1,11 +1,12 @@
 class ChromebookInformationForm
   include ActiveModel::Model
 
-  attr_accessor :school, :will_need_chromebooks
+  attr_accessor :school, :will_need_chromebooks, :will_need_chromebooks_message
   attr_reader :school_or_rb_domain, :recovery_email_address
 
   validates :will_need_chromebooks, presence: { message: lambda do |object, _|
-                                                           I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
+                                                            object.will_need_chromebooks_message
+                                                           # I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
                                                          end }
 
   with_options if: :will_need_chromebooks_and_is_not_a_la_funded_school? do |condition|
@@ -47,5 +48,14 @@ class ChromebookInformationForm
     else
       false
     end
+  end
+
+  def will_need_chromebooks_message
+    @will_need_chromebooks_message ||= default_error_message
+  end
+
+  def default_error_message
+    I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks',
+           institution_type: school&.institution_type || 'school')
   end
 end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -8,7 +8,7 @@ class ChromebookInformationForm
                                                            I18n.t('activemodel.errors.models.chromebook_information_form.custom_errors.will_need_chromebooks', institution_type: object.school&.institution_type || 'school')
                                                          end }
 
-  with_options if: :will_need_chromebooks? do |condition|
+  with_options if: :will_need_chromebooks_and_is_not_a_la_funded_school? do |condition|
     condition.validates :recovery_email_address,
                         presence: true,
                         email_address: true
@@ -34,6 +34,18 @@ class ChromebookInformationForm
   def recovery_email_address_cannot_be_same_domain_as_school_or_rb
     if recovery_email_address&.ends_with?(school_or_rb_domain)
       errors.add(:recovery_email_address, :cannot_be_same_domain_as_school_or_rb)
+    end
+  end
+
+  def will_need_chromebooks_and_is_not_a_la_funded_school?
+    if will_need_chromebooks?
+      if school.respond_to?(:la_funded_place?)
+        !school.la_funded_place?
+      else
+        true
+      end
+    else
+      false
     end
   end
 end

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -39,15 +39,7 @@ class ChromebookInformationForm
   end
 
   def will_need_chromebooks_and_is_not_a_la_funded_school?
-    if will_need_chromebooks?
-      if school.respond_to?(:la_funded_place?)
-        !school.la_funded_place?
-      else
-        true
-      end
-    else
-      false
-    end
+    will_need_chromebooks? && !school.la_funded_place?
   end
 
   def will_need_chromebooks_message

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -38,8 +38,11 @@ module ViewHelper
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
 
-  def link_to_devices_guidance_subpage(body, slug, html_options = {})
-    govuk_link_to body, devices_guidance_subpage_path(subpage_slug: slug), html_options
+  def link_to_devices_guidance_subpage(body, slug, html_options = {}, path_options = {})
+    opts = {
+      subpage_slug: slug,
+    }.merge(path_options)
+    govuk_link_to body, devices_guidance_subpage_path(opts), html_options
   end
 
   def breadcrumbs(items)

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -1,10 +1,6 @@
 class LaFundedPlace < CompulsorySchool
   def institution_type
-    'funded_places'
-  end
-
-  def name
-    'State-funded pupils in independent settings'
+    'local authority'
   end
 
   def techsource_urn

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -1,9 +1,9 @@
 class LaFundedPlace < CompulsorySchool
   def institution_type
-    'local authority'
+    'local_authority'
   end
 
   def techsource_urn
-    "iss #{responsible_body.name.downcase}"
+    "iss-#{responsible_body.name}".parameterize
   end
 end

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -2,4 +2,12 @@ class LaFundedPlace < CompulsorySchool
   def institution_type
     'funded_places'
   end
+
+  def name
+    'State-funded pupils in independent settings'
+  end
+
+  def techsource_urn
+    "iss #{responsible_body.name.downcase}"
+  end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -37,7 +37,7 @@ class LocalAuthority < ResponsibleBody
     }.reverse_merge(extra_args)
 
     funded_place = LaFundedPlace.create!(attrs)
-    funded_place.create_preorder_information!(who_will_order_devices: 'responsible_body')
+    funded_place.create_preorder_information!(who_will_order_devices: 'school')
     funded_place.device_allocations.std_device.create!(allocation: device_allocation)
     funded_place.device_allocations.coms_device.create!(allocation: router_allocation)
     funded_place

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -21,12 +21,12 @@ class LocalAuthority < ResponsibleBody
   end
 
   def create_la_funded_places!(urn:, device_allocation: 0, router_allocation: 0, extra_args: {})
-    return if la_funded_place.present?
+    return la_funded_place if la_funded_place.present?
 
     attrs = {
       responsible_body: self,
       urn: urn,
-      name: 'LA Funded Places',
+      name: 'State-funded pupils in independent special schools and alternative provision',
       establishment_type: 'la_funded_place',
       address_1: address_1,
       address_2: address_2,
@@ -36,10 +36,10 @@ class LocalAuthority < ResponsibleBody
       postcode: postcode,
     }.reverse_merge(extra_args)
 
-    funded_places = LaFundedPlace.create!(attrs)
-    funded_places.create_preorder_information!(who_will_order_devices: 'responsible_body', will_need_chromebooks: 'no')
-    funded_places.device_allocations.std_device.create!(allocation: device_allocation)
-    funded_places.device_allocations.coms_device.create!(allocation: router_allocation)
-    funded_places
+    funded_place = LaFundedPlace.create!(attrs)
+    funded_place.create_preorder_information!(who_will_order_devices: 'responsible_body')
+    funded_place.device_allocations.std_device.create!(allocation: device_allocation)
+    funded_place.device_allocations.coms_device.create!(allocation: router_allocation)
+    funded_place
   end
 end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -114,7 +114,8 @@ class PreorderInformation < ApplicationRecord
   end
 
   def chromebook_information_complete?
-    # do not want to hold them up being able to order
+    # if we remove the '&' it breaks 400+ specs as this is called by infer_status
+    # via callbacks
     return true if school&.la_funded_place_establishment_type?
 
     if will_need_chromebooks == 'yes'

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -109,7 +109,14 @@ class PreorderInformation < ApplicationRecord
     will_need_chromebooks == 'yes'
   end
 
+  def will_not_need_chromebooks?
+    will_need_chromebooks == 'no'
+  end
+
   def chromebook_information_complete?
+    # do not want to hold them up being able to order
+    return true if school&.la_funded_place_establishment_type?
+
     if will_need_chromebooks == 'yes'
       school_or_rb_domain.present? && recovery_email_address.present?
     else

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -89,11 +89,7 @@ class SchoolDeviceAllocation < ApplicationRecord
   end
 
   def devices_available_to_order
-    if has_virtual_cap_feature_flags? && is_in_virtual_cap_pool?
-      cap - devices_ordered
-    else
-      raw_cap - raw_devices_ordered
-    end
+    cap - devices_ordered
   end
 
   def is_in_virtual_cap_pool?

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -88,6 +88,14 @@ class SchoolDeviceAllocation < ApplicationRecord
     self[:allocation]
   end
 
+  def devices_available_to_order
+    if has_virtual_cap_feature_flags? && is_in_virtual_cap_pool?
+      cap - devices_ordered
+    else
+      raw_cap - raw_devices_ordered
+    end
+  end
+
   def is_in_virtual_cap_pool?
     school_virtual_cap.present?
   end

--- a/app/views/school/home/show_la_funded_place.html.erb
+++ b/app/views/school/home/show_la_funded_place.html.erb
@@ -1,0 +1,60 @@
+<%- title = t('page_titles.iss_home') %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs(school: @school, user: impersonated_or_current_user, items: 'Your account') %>
+<%- end %>
+<%- content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
+    <span class="govuk-caption-xl">State-funded pupils in independent schools and  alternative provision</span>
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.iss_order_devices'), order_devices_school_path(@school) %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>see how many laptops you have been allocated</li>
+      <li>place orders on the TechSource website</li>
+    </ul>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.signed_in_internet_access') , internet_school_path(@school) %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>request extra data for mobile devices</li>
+      <li>check the status of your data requests</li>
+      <li>request 4G wireless routers</li>
+    </ul>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.iss_details'), details_school_path(@school) %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>review your allocation</li>
+      <li>change your Chromebook settings</li>
+    </ul>
+
+    <h2 class="govuk-heading-l govuk-!-font-size-27">
+      <%= govuk_link_to t('page_titles.school_users'), school_users_path(@school) %>
+    </h2>
+
+    <p class="govuk-body">Use this section to give others:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>access to this service</li>
+      <li>access to the TechSource website (where they’ll place orders)</li>
+    </ul>
+  </div>
+  <%= render partial: 'shared/link_to_survey' %>
+</div>

--- a/app/views/school/home/show_la_funded_place.html.erb
+++ b/app/views/school/home/show_la_funded_place.html.erb
@@ -1,4 +1,4 @@
-<%- title = t('page_titles.iss_home') %>
+<%- title = t('page_titles.iss.home') %>
 <%- content_for :before_content do %>
   <%- school_breadcrumbs(school: @school, user: impersonated_or_current_user, items: 'Your account') %>
 <%- end %>
@@ -16,7 +16,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to t('page_titles.iss_order_devices'), order_devices_school_path(@school) %>
+      <%= govuk_link_to t('page_titles.iss.order_devices'), order_devices_school_path(@school) %>
     </h2>
 
     <p class="govuk-body">Use this section to:</p>
@@ -37,7 +37,7 @@
     </ul>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to t('page_titles.iss_details'), details_school_path(@school) %>
+      <%= govuk_link_to t('page_titles.iss.details'), details_school_path(@school) %>
     </h2>
 
     <p class="govuk-body">Use this section to:</p>

--- a/app/views/school/home/show_la_funded_place.html.erb
+++ b/app/views/school/home/show_la_funded_place.html.erb
@@ -21,7 +21,7 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>see how many laptops you have been allocated</li>
+      <li>see how many laptops you’ve been allocated</li>
       <li>place orders on the TechSource website</li>
     </ul>
 

--- a/app/views/school/la_funded_places/laptop_types.html.erb
+++ b/app/views/school/la_funded_places/laptop_types.html.erb
@@ -1,7 +1,7 @@
-<%- title = t('page_titles.iss_laptop_types') %>
+<%- title = t('page_titles.iss.laptop_types') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: [ { t('page_titles.iss_order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
+  <%- school_breadcrumbs items: [ { t('page_titles.iss.order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/la_funded_places/laptop_types.html.erb
+++ b/app/views/school/la_funded_places/laptop_types.html.erb
@@ -10,7 +10,7 @@
       <%= title %>
     </h1>
     <p class="govuk-body">
-      We recommend checking with schools, families or pupils as soon as possible to find out which device type and IT settings would be most suitable.
+      We recommend checking with your IT team, schools, families or pupils as soon as possible to find out which device type and IT settings would be most suitable.
     </p>
     <p class="govuk-body">
       Depending on availability, you can choose from:
@@ -31,7 +31,7 @@
       Google Chromebooks
     </h2>
     <p class="govuk-body">
-      You’ll need to provide us with the relevant school’s email domain for <span class="app-no-wrap">G Suite for Education</span>, and a recovery email address.
+      You’ll need to provide us with the relevant school’s email domain for Google Workspace for Education Fundementals (formerly <span class="app-no-wrap">G Suite for Education</span>), and a recovery email address.
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'See detailed laptop specifications', devices_guidance_subpage_path(subpage_slug: 'device-specification') %>

--- a/app/views/school/la_funded_places/laptop_types.html.erb
+++ b/app/views/school/la_funded_places/laptop_types.html.erb
@@ -1,0 +1,40 @@
+<%- title = t('page_titles.iss_laptop_types') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs items: [ { t('page_titles.iss_order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+    <p class="govuk-body">
+      We recommend checking with schools, families or pupils as soon as possible to find out which device type and IT settings would be most suitable.
+    </p>
+    <p class="govuk-body">
+      Depending on availability, you can choose from:
+    </p>
+    <h2 class="govuk-heading-s">
+      Standard Windows laptops
+    </h2>
+    <p class="govuk-body">
+      You’ll be responsible for arranging and maintaining safeguarding measures, like content filtering.
+    </p>
+    <h2 class="govuk-heading-s">
+      DfE Restricted Windows laptops
+    </h2>
+    <p class="govuk-body">
+      These have temporary safeguarding settings installed — content filtering and mobile device management software — which you’ll need to replace when they expire on 30 September 2021. You’ll need to reset these devices before you can apply new settings, or download some types of software.
+    </p>
+    <h2 class="govuk-heading-s">
+      Google Chromebooks
+    </h2>
+    <p class="govuk-body">
+      You’ll need to provide us with the relevant school’s email domain for <span class="app-no-wrap">G Suite for Education</span>, and a recovery email address.
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'See detailed laptop specifications', devices_guidance_subpage_path(subpage_slug: 'device-specification') %>
+    </p>
+  </div>
+</div>

--- a/app/views/school/la_funded_places/laptop_types.html.erb
+++ b/app/views/school/la_funded_places/laptop_types.html.erb
@@ -25,7 +25,7 @@
       DfE Restricted Windows laptops
     </h2>
     <p class="govuk-body">
-      These have temporary safeguarding settings installed — content filtering and mobile device management software — which you’ll need to replace when they expire on 30 September 2021. You’ll need to reset these devices before you can apply new settings, or download some types of software.
+      These have temporary safeguarding settings installed — content filtering and mobile device management software — which you’ll need to replace before they expire on 30 September 2021. You’ll need to reset these devices before you can apply new settings, or download some types of software.
     </p>
     <h2 class="govuk-heading-s">
       Google Chromebooks

--- a/app/views/school/la_funded_places/order.html.erb
+++ b/app/views/school/la_funded_places/order.html.erb
@@ -1,0 +1,112 @@
+<%- title = t('page_titles.school_order_devices') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      How to order
+    </h1>
+
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render partial: 'shared/half_term_delivery_suspension' %>
+
+    <h2 class="govuk-heading-m">
+      These laptops are currently in stock:
+    </h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Google Chromebooks
+      </li>
+      <li>
+        Standard Windows laptops
+      </li>
+      <li>
+        DfE Restricted Windows laptops — low stock, delivery may take longer than 5 working days
+      </li>
+    </ul>
+    <p class="govuk-body">
+    <%= govuk_link_to 'It’s important to check you’re ordering the best type of laptop for each pupil.', laptop_types_school_path(@school) %>
+    </p>
+
+    <h2 class="govuk-heading-m">Chromebooks</h2>
+
+    <% if @school.preorder_information.will_need_chromebooks? %>
+      <p class="govuk-body">
+        You’ve told us you’ll order Chromebooks –&nbsp;
+        <%= govuk_link_to funded_chromebooks_school_path(@school) do %>
+          Change <span class="govuk-visually-hidden">Chromebook preference</span>
+        <% end %>
+      </p>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          After you place your order you’ll get an email asking for:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            the domain the school has registered for G Suite for Education, for example ‘school.co.uk’
+          </li>
+          <li>
+            a recovery email address. This should be on a separate domain to the one registered for G Suite for Education. For example, if the domain registered for G Suite for Education is ‘school.com’, the recovery email cannot be ‘recovery@school.com’
+          </li>
+        </ul>
+        <p class="govuk-body">
+          The school’s IT support should be able to give you this information.
+        </p>
+      </div>
+    <% elsif @school.preorder_information.will_not_need_chromebooks? %>
+      <p class="govuk-body">
+        You have told us you will not order Chromebooks –&nbsp;
+        <%= govuk_link_to funded_chromebooks_school_path(@school) do %>
+          Change <span class="govuk-visually-hidden">Chromebook preference</span>
+        <%- end %>
+      </p>
+    <% else %>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          <strong>
+            You have not told us if you plan to order Google Chromebooks
+          </strong>
+        </p>
+        <p class="govuk-body">
+          If you order Chromebooks without letting us know first, they’ll be delivered without safeguarding settings and access to G Suite for Education.
+        </p>
+        <%= govuk_link_to 'Tell us if you’ll order Google Chromebooks', funded_chromebooks_school_path(@school) %>
+      </div>
+    <% end %>
+
+    <h2 class="govuk-heading-m">Your laptops will be delivered to:</h2>
+    <p class="govuk-body">
+      <%= @school.address_components.join('<br>').html_safe %>
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Contact us to change your delivery address.', support_ticket_path %>
+    </p>
+    <h2 class="govuk-heading-m">Information for your order</h2>
+    <p class="govuk-body">
+      You’ll place your order on a website called TechSource.
+    </p>
+    <p class="govuk-body">
+      When you’re asked for a URN, use ‘<strong><%= @school.techsource_urn %></strong>’.
+    </p>
+    <p class="govuk-body">
+    <% devices_available = @school.std_device_allocation.devices_available_to_order %>
+    If you place an order for more than <%= "#{devices_available} #{'laptop'.pluralize(devices_available)}" %>, your order will be cancelled.
+    </p>
+    <p class="govuk-body">
+      You can order all of your laptops at once, or place multiple orders.
+    </p>
+
+    <%# instead of partial shared/start_ordering_on_techsource %>
+    <h2 class="govuk-heading-m">How to sign in to TechSource for the first time</h2>
+    <p class="govuk-body">Use these details to sign in:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>User ID: <%= current_user.email_address %></li>
+      <li>Password: Use the ‘Forgotten password’ link to set a password the first time you sign in</li>
+    </ul>
+    <%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3', target: '_blank') -%>
+    <p class="govuk-body-s">on TechSource in a new window</p>
+  </div>
+</div>

--- a/app/views/school/la_funded_places/order.html.erb
+++ b/app/views/school/la_funded_places/order.html.erb
@@ -1,4 +1,4 @@
-<%- title = t('page_titles.school_order_devices') %>
+<%- title = t('page_titles.iss.how_to_order') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      How to order
+      <%= title %>
     </h1>
 
     <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
@@ -46,10 +46,10 @@
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            the domain the school has registered for G Suite for Education, for example ‘school.co.uk’
+            the domain the school has registered for Google Workspace for Education Fundementals (formerly G Suite for Education), for example ‘school.co.uk’
           </li>
           <li>
-            a recovery email address. This should be on a separate domain to the one registered for G Suite for Education. For example, if the domain registered for G Suite for Education is ‘school.com’, the recovery email cannot be ‘recovery@school.com’
+            a recovery email address. This should be on a separate domain to the one registered for Google Workspace for Education Fundementals. For example, if the domain registered for Google Workspace for Education Fundementals is ‘school.com’, the recovery email cannot be ‘recovery@school.com’
           </li>
         </ul>
         <p class="govuk-body">
@@ -71,7 +71,7 @@
           </strong>
         </p>
         <p class="govuk-body">
-          If you order Chromebooks without letting us know first, they’ll be delivered without safeguarding settings and access to G Suite for Education.
+          If you order Chromebooks without letting us know first, they’ll be delivered unsecured, without access to the Google Workspace for Education Fundementals (formerly G Suite for Education).
         </p>
         <%= govuk_link_to 'Tell us if you’ll order Google Chromebooks', funded_chromebooks_school_path(@school) %>
       </div>

--- a/app/views/school/la_funded_places/order.html.erb
+++ b/app/views/school/la_funded_places/order.html.erb
@@ -28,7 +28,7 @@
       </li>
     </ul>
     <p class="govuk-body">
-    <%= govuk_link_to 'It’s important to check you’re ordering the best type of laptop for each pupil.', laptop_types_school_path(@school) %>
+      <%= govuk_link_to 'It’s important to check you’re ordering the best type of laptop for each pupil.', laptop_types_school_path(@school) %>
     </p>
 
     <h2 class="govuk-heading-m">Chromebooks</h2>
@@ -84,6 +84,7 @@
     <p class="govuk-body">
       <%= govuk_link_to 'Contact us to change your delivery address.', support_ticket_path %>
     </p>
+
     <h2 class="govuk-heading-m">Information for your order</h2>
     <p class="govuk-body">
       You’ll place your order on a website called TechSource.
@@ -99,7 +100,6 @@
       You can order all of your laptops at once, or place multiple orders.
     </p>
 
-    <%# instead of partial shared/start_ordering_on_techsource %>
     <h2 class="govuk-heading-m">How to sign in to TechSource for the first time</h2>
     <p class="govuk-body">Use these details to sign in:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/school/la_funded_places/show.html.erb
+++ b/app/views/school/la_funded_places/show.html.erb
@@ -1,0 +1,76 @@
+<%- title = t('page_titles.iss_order_devices') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render partial: 'shared/half_term_delivery_suspension' %>
+
+    <%= render DeviceCountComponent.new(school: @school) %>
+
+    <p class="govuk-body">
+    You’ve been allocated <%= "#{@school.std_device_allocation&.cap} #{'laptop'.pluralize(@school.std_device_allocation.cap) }" %>.
+    </p>
+    <%= govuk_details summary: 'How your allocation has been calculated' do %>
+      <p class="govuk-body">
+      Your allocation estimate is based on the data <%= @school.responsible_body.name %> submitted in the latest published alternative provision census (2020).
+      </p>
+      <p class="govuk-body">
+      We’ve allocated one laptop for each pupil in years 3 to 11 that <%= @school.responsible_body.name %> reported as having a state-funded place at an independent setting, and also being eligible for free school meals.
+      </p>
+      <p class="govuk-body">
+      You can request internet access for these pupils if they need it too.
+      </p>
+      <h3 class="govuk-heading-m">Tell us if your allocation is wrong</h3>
+      <p class="govuk-body">
+      Tell us how many pupils <%= @school.responsible_body.name %> funds who:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          have a place at an independent special setting, or independent alternative provision
+        </li>
+        <li>
+          are eligible for free school meals
+        </li>
+        <li>
+          do not have access to a suitable device for remote education, and for use in face-to-face learning
+        </li>
+      </ul>
+      <p class="govuk-body">
+      Do not send any personal information, like names of pupils or dates of birth.
+      </p>
+      <p class="govuk-body">
+      Email this information to <%= ghwt_contact_mailto %>.
+      </p>
+    <% end %>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">
+      Before you order
+    </h2>
+    <p class="govuk-body">
+    We recommend checking with schools, families or pupils as soon as possible to find out which device type and IT settings would be most suitable.
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Check what types of laptop are available', laptop_types_school_path(@school) %>
+    </p>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">
+      Ownership and responsibility
+    </h2>
+    <p class="govuk-body">
+    <%= @school.responsible_body.name %> will own these laptops and is responsible for:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+      <li>making sure laptops have appropriate safety and security measures installed and maintained – <%= link_to_devices_guidance_subpage 'read about laptop safeguarding', 'safeguarding-for-device-users' %></li>
+      <li>fixing any technical issues –&nbsp; <%= link_to_devices_guidance_subpage 'read about how to organise repairs', 'replace-a-faulty-device' %></li>
+      <li>distributing the laptops safely –&nbsp; <%= link_to_devices_guidance_subpage 'read about how to get devices to pupils', 'device-distribution-and-ownership', {}, anchor: 'distributing-devices' %>
+      <li>redistributing the laptops if pupils move school or leave education</li>
+    </ul>
+    <%= govuk_link_to 'Continue', order_laptops_school_path(@school), button: true %>
+  </div>
+</div>

--- a/app/views/school/la_funded_places/show.html.erb
+++ b/app/views/school/la_funded_places/show.html.erb
@@ -1,4 +1,4 @@
-<%- title = t('page_titles.iss_order_devices') %>
+<%- title = t('page_titles.iss.order_devices') %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
   <%- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
@@ -14,21 +14,24 @@
     <%= render DeviceCountComponent.new(school: @school) %>
 
     <p class="govuk-body">
-    You’ve been allocated <%= "#{@school.std_device_allocation&.cap} #{'laptop'.pluralize(@school.std_device_allocation.cap) }" %>.
+      You’ve been allocated <%= "#{@school.std_device_allocation.cap} #{'laptop'.pluralize(@school.std_device_allocation.cap)}" %>.
     </p>
     <%= govuk_details summary: 'How your allocation has been calculated' do %>
       <p class="govuk-body">
-      Your allocation estimate is based on the data <%= @school.responsible_body.name %> submitted in the latest published alternative provision census (2020).
+        Your allocation estimate is based on the data <%= @school.responsible_body.name %>
+        submitted in the latest published alternative provision census (2020).
       </p>
       <p class="govuk-body">
-      We’ve allocated one laptop for each pupil in years 3 to 11 that <%= @school.responsible_body.name %> reported as having a state-funded place at an independent setting, and also being eligible for free school meals.
+        We’ve allocated one laptop for each pupil in years 3 to 11 that
+        <%= @school.responsible_body.name %> reported as having a state-funded
+        place at an independent setting, and also being eligible for free school meals.
       </p>
       <p class="govuk-body">
-      You can request internet access for these pupils if they need it too.
+        You can request internet access for these pupils if they need it too.
       </p>
       <h3 class="govuk-heading-m">Tell us if your allocation is wrong</h3>
       <p class="govuk-body">
-      Tell us how many pupils <%= @school.responsible_body.name %> funds who:
+        Tell us how many pupils <%= @school.responsible_body.name %> funds who:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
@@ -42,28 +45,25 @@
         </li>
       </ul>
       <p class="govuk-body">
-      Do not send any personal information, like names of pupils or dates of birth.
+        Do not send any personal information, like names of pupils or dates of birth.
       </p>
       <p class="govuk-body">
-      Email this information to <%= ghwt_contact_mailto %>.
+        Email this information to <%= ghwt_contact_mailto %>.
       </p>
     <% end %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6">
-      Before you order
-    </h2>
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Before you order</h2>
     <p class="govuk-body">
-    We recommend checking with schools, families or pupils as soon as possible to find out which device type and IT settings would be most suitable.
+      We recommend checking with schools, families or pupils as soon as possible
+      to find out which device type and IT settings would be most suitable.
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'Check what types of laptop are available', laptop_types_school_path(@school) %>
     </p>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6">
-      Ownership and responsibility
-    </h2>
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Ownership and responsibility</h2>
     <p class="govuk-body">
-    <%= @school.responsible_body.name %> will own these laptops and is responsible for:
+      <%= @school.responsible_body.name %> will own these laptops and is responsible for:
     </p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
       <li>making sure laptops have appropriate safety and security measures installed and maintained – <%= link_to_devices_guidance_subpage 'read about laptop safeguarding', 'safeguarding-for-device-users' %></li>

--- a/app/views/school/la_funded_places/show.html.erb
+++ b/app/views/school/la_funded_places/show.html.erb
@@ -24,7 +24,7 @@
       <p class="govuk-body">
         We’ve allocated one laptop for each pupil in years 3 to 11 that
         <%= @school.responsible_body.name %> reported as having a state-funded
-        place at an independent setting, and also being eligible for free school meals.
+        place at an independent special school or alternative provision, and also being eligible for free school meals.
       </p>
       <p class="govuk-body">
         You can request internet access for these pupils if they need it too.
@@ -54,7 +54,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">Before you order</h2>
     <p class="govuk-body">
-      We recommend checking with schools, families or pupils as soon as possible
+      We recommend checking with your IT team, schools, families or pupils as soon as possible
       to find out which device type and IT settings would be most suitable.
     </p>
     <p class="govuk-body">

--- a/app/views/school/la_funded_places_chromebooks/edit.html.erb
+++ b/app/views/school/la_funded_places_chromebooks/edit.html.erb
@@ -1,10 +1,10 @@
 <%-
-  title = t('page_titles.iss_chromebooks')
+  title = t('page_titles.iss.chromebooks')
   scope = 'activerecord.attributes.preorder_information.will_need_chromebooks'
 %>
 <%- content_for :title, title %>
 <%- content_for :before_content do %>
-  <%- school_breadcrumbs items: [ { t('page_titles.iss_order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
+  <%- school_breadcrumbs items: [ { t('page_titles.iss.order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
 <%- end %>
 
 <div class="govuk-grid-row">

--- a/app/views/school/la_funded_places_chromebooks/edit.html.erb
+++ b/app/views/school/la_funded_places_chromebooks/edit.html.erb
@@ -1,0 +1,44 @@
+<%-
+  title = t('page_titles.iss_chromebooks')
+  scope = 'activerecord.attributes.preorder_information.will_need_chromebooks'
+%>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%- school_breadcrumbs items: [ { t('page_titles.iss_order_devices') => order_devices_school_path(@school)}, title], school: @school, user: impersonated_or_current_user %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+    <%= form_for @chromebook_information_form, url: update_funded_chromebooks_school_path(@school), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p class="govuk-body">
+        We need to know this so we can apply the right settings to the laptops you order. You can change your answer later.
+      </p>
+
+      <%= f.govuk_radio_buttons_fieldset( :will_need_chromebooks, legend: {text: ""} ) do %>
+        <%= f.govuk_radio_button(:will_need_chromebooks,
+                                 'yes',
+                                 label: { text: t(:yes, scope: scope) }) do %>
+          <p class="govuk-body">
+            When you order you’ll be contacted by email for G Suite for Education license information.
+          </p>
+        <%- end %>
+        <%= f.govuk_radio_button  :will_need_chromebooks,
+                                  'no',
+                                  label: { text: t(:no, scope: scope) } %>
+        <%= f.govuk_radio_button(:will_need_chromebooks,
+                                 'i_dont_know',
+                                 label: { text: t(:im_not_sure, scope: scope) }) do %>
+          <p class="govuk-body">
+            If you order Chromebooks without letting us know first, they’ll be delivered without safeguarding settings and access to G Suite for Education.
+          </p>
+        <%- end %>
+      <%- end %>
+      <%= f.govuk_submit 'Continue' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/school/la_funded_places_chromebooks/edit.html.erb
+++ b/app/views/school/la_funded_places_chromebooks/edit.html.erb
@@ -24,7 +24,7 @@
                                  'yes',
                                  label: { text: t(:yes, scope: scope) }) do %>
           <p class="govuk-body">
-            When you order you’ll be contacted by email for G Suite for Education license information.
+            When you order you’ll receive an email asking you to provide relevant Google Workspace for Education Fundementals (formerly G Suite for Education) license information.
           </p>
         <%- end %>
         <%= f.govuk_radio_button  :will_need_chromebooks,
@@ -34,7 +34,7 @@
                                  'i_dont_know',
                                  label: { text: t(:im_not_sure, scope: scope) }) do %>
           <p class="govuk-body">
-            If you order Chromebooks without letting us know first, they’ll be delivered without safeguarding settings and access to G Suite for Education.
+            If you order Chromebooks without letting us know first, they’ll be delivered unsecured, without access to Google Workspace for Education Fundementals (formerly G Suite for Education).
           </p>
         <%- end %>
       <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
       details: Check your details
       laptop_types: Find out what type of laptop pupils need
       chromebooks: Will your order include Google Chromebooks?
-
+      will_need_chromebooks_error: Tell us if pupils will need Chromebooks?
     support:
       home: Support
       schools:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
       laptop_types: Find out what type of laptop pupils need
       chromebooks: Will your order include Google Chromebooks?
       will_need_chromebooks_error: Tell us if pupils will need Chromebooks?
+      how_to_order: How to order
     support:
       home: Support
       schools:
@@ -254,7 +255,7 @@ en:
         title: Will you order Chromebooks?
         'yes': Yes, we will need Chromebooks
         'no': No, we do not need Chromebooks
-        i_dont_know: I don’t know
+        i_dont_know: I do not know
         errors:
           choice: Tell us whether you will need Chromebooks
       what_happens_next:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,11 +62,12 @@ en:
     general_privacy_notice: How we look after personal information as part of the Get help with technology programme
     what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe: What to do if you cannot get laptops, tablets or internet access from DfE
     how_to_access_the_get_help_with_technology_service: How to access the Get help with technology service
-    iss_home: Get laptops and internet access
-    iss_order_devices: Get laptops
-    iss_details: Check your details
-    iss_laptop_types: Find out what type of laptop pupils need
-    iss_chromebooks: Will your order include Google Chromebooks?
+    iss:
+      home: Get laptops and internet access
+      order_devices: Get laptops
+      details: Check your details
+      laptop_types: Find out what type of laptop pupils need
+      chromebooks: Will your order include Google Chromebooks?
 
     support:
       home: Support

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,11 @@ en:
     general_privacy_notice: How we look after personal information as part of the Get help with technology programme
     what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe: What to do if you cannot get laptops, tablets or internet access from DfE
     how_to_access_the_get_help_with_technology_service: How to access the Get help with technology service
+    iss_home: Get laptops and internet access
+    iss_order_devices: Get laptops
+    iss_details: Check your details
+    iss_laptop_types: Find out what type of laptop pupils need
+    iss_chromebooks: Will your order include Google Chromebooks?
 
     support:
       home: Support
@@ -703,8 +708,10 @@ en:
           predecessor_split_school: Predecessor - Split School
       preorder_information:
         will_need_chromebooks:
-          "yes": Yes, we will order Chromebooks
+          'yes': Yes, we’ll order Chromebooks
           'no': No, we will not order Chromebooks
+          i_dont_know: I don’t know
+          im_not_sure: I’m not sure
         status:
           needs_contact: Needs a contact
           needs_info: Needs information

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,11 @@ Rails.application.routes.draw do
       get '/what-happens-next', to: 'school/welcome_wizard#what_happens_next', as: :welcome_wizard_what_happens_next
       patch '/next(/:step)', to: 'school/welcome_wizard#next_step', as: :welcome_wizard
       patch '/prev', to: 'school/welcome_wizard#previous_step', as: :welcome_wizard_previous
+      get '/get-laptops', to: 'school/la_funded_places#show', as: :get_laptops
+      get '/order-laptops', to: 'school/la_funded_places#order', as: :order_laptops
+      get '/funded-pupils-chromebooks/edit', to: 'school/la_funded_places_chromebooks#edit', as: :funded_chromebooks
+      patch '/funded-pupils-chromebooks', to: 'school/la_funded_places_chromebooks#update', as: :update_funded_chromebooks
+      get '/laptop-types', to: 'school/la_funded_places#laptop_types', as: :laptop_types
       resources :users, as: 'school_users', only: %i[index new create edit update], module: 'school'
 
       scope module: :school do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -58,7 +58,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details without links to change it' do
-      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we will order Chromebooks')
+      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we’ll order Chromebooks')
       expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
     end
@@ -100,7 +100,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details and allows them to be edited' do
-      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we will order Chromebooks')
+      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we’ll order Chromebooks')
       expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
 
@@ -127,7 +127,7 @@ describe Support::SchoolDetailsSummaryListComponent do
     end
 
     it 'shows the chromebook details and allows them to be edited' do
-      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we will order Chromebooks')
+      expect(value_for_row(result, 'Ordering Chromebooks?').text).to include('Yes, we’ll order Chromebooks')
       expect(value_for_row(result, 'Domain').text).to include('school.domain.org')
       expect(value_for_row(result, 'Recovery email').text).to include('admin@recovery.org')
 

--- a/spec/features/computacenter/download_csv_files_spec.rb
+++ b/spec/features/computacenter/download_csv_files_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Download CSV files' do
           school = School.find(request.schools.first)
           expect(school).not_to eq(school_with_incomplete_request)
           expect(request.id.to_s).to eq(csv[i]['id'])
-          expect(request.created_at.to_s).to eq(csv[i]['created_at'])
+          expect(request.created_at).to be_within(1.second).of(Time.zone.parse(csv[i]['created_at']))
           expect(school.urn.to_s).to eq(csv[i]['urn'])
           expect(school.computacenter_reference).to eq(csv[i]['shipTo'])
           expect(request.responsible_body.computacenter_reference).to eq(csv[i]['soldTo'])

--- a/spec/features/computacenter/download_csv_files_spec.rb
+++ b/spec/features/computacenter/download_csv_files_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Download CSV files' do
           school = School.find(request.schools.first)
           expect(school).not_to eq(school_with_incomplete_request)
           expect(request.id.to_s).to eq(csv[i]['id'])
-          expect(request.created_at).to be_within(1.second).of(Time.zone.parse(csv[i]['created_at']))
+          expect(request.created_at).to be_within(2.seconds).of(Time.zone.parse(csv[i]['created_at']))
           expect(school.urn.to_s).to eq(csv[i]['urn'])
           expect(school.computacenter_reference).to eq(csv[i]['shipTo'])
           expect(request.responsible_body.computacenter_reference).to eq(csv[i]['soldTo'])

--- a/spec/features/ordering_for_la_funded_devices_spec.rb
+++ b/spec/features/ordering_for_la_funded_devices_spec.rb
@@ -1,0 +1,174 @@
+require 'rails_helper'
+
+RSpec.feature 'Ordering for LA-funded devices', type: :feature do
+  before do
+    given_there_is_an_independent_settings_school
+    given_i_am_signed_in_as_an_independent_settings_school_user
+    given_i_am_on_the_independent_settings_school_page
+  end
+
+  context 'when laptops are available' do
+    before { given_i_have_not_ordered_all_my_laptops }
+
+    scenario 'ordering laptops when I need Chromebooks' do
+      when_i_click_on_get_laptops
+      then_i_see_i_have_laptops_remaining
+      when_i_click_on_continue
+      then_i_am_asked_whether_i_need_chromebooks
+      when_i_answer_yes
+      when_i_click_on_continue
+      then_i_see_the_how_to_order_page
+      then_i_see_the_confirmation_i_will_order_chromebooks
+      then_i_see_the_delivery_address
+      then_i_see_how_to_sign_in_to_techsource
+    end
+
+    scenario 'ordering laptops when I do not need Chromebooks' do
+      when_i_click_on_get_laptops
+      then_i_see_i_have_laptops_remaining
+      when_i_click_on_continue
+      then_i_am_asked_whether_i_need_chromebooks
+      when_i_answer_no
+      when_i_click_on_continue
+      then_i_see_the_how_to_order_page
+      then_i_see_the_confirmation_i_will_not_order_chromebooks
+      then_i_see_the_delivery_address
+      then_i_see_how_to_sign_in_to_techsource
+    end
+
+    scenario 'ordering laptops when I am not sure I need Chromebooks' do
+      when_i_click_on_get_laptops
+      then_i_see_i_have_laptops_remaining
+      when_i_click_on_continue
+      then_i_am_asked_whether_i_need_chromebooks
+      when_i_answer_im_not_sure
+      when_i_click_on_continue
+      then_i_see_the_how_to_order_page
+      then_i_see_confirmation_i_have_not_indicated_whether_i_will_order_chromebooks
+      then_i_see_the_delivery_address
+      then_i_see_how_to_sign_in_to_techsource
+    end
+
+    scenario 'ordering laptops when a choice has already been made on Chromebooks' do
+      given_i_have_already_confirmed_that_i_will_order_chromebooks
+      when_i_click_on_get_laptops
+      then_i_see_i_have_laptops_remaining
+      when_i_click_on_continue
+      then_i_see_the_how_to_order_page
+      then_i_see_the_confirmation_i_will_order_chromebooks
+      then_i_see_the_delivery_address
+      then_i_see_how_to_sign_in_to_techsource
+    end
+
+    scenario 'ordering laptops when I previously was not sure I needed Chromebooks' do
+      given_i_have_already_answered_that_i_was_not_sure_that_i_will_order_chromebooks
+      when_i_click_on_get_laptops
+      then_i_see_i_have_laptops_remaining
+      when_i_click_on_continue
+      then_i_see_the_how_to_order_page
+      then_i_see_confirmation_i_have_not_indicated_whether_i_will_order_chromebooks
+      then_i_see_the_delivery_address
+      then_i_see_how_to_sign_in_to_techsource
+    end
+  end
+
+  context 'when there are no laptops left to order' do
+    before { given_i_have_ordered_all_of_my_laptops }
+
+    scenario 'ordering laptops when no laptops left to order' do
+      when_i_click_on_get_laptops
+      then_i_see_i_have_no_laptops_remaining
+    end
+  end
+
+  def given_there_is_an_independent_settings_school
+    @school = create(:la_funded_place, :can_order, :with_preorder_information)
+    @school.preorder_information.update!(who_will_order_devices: 'responsible_body')
+  end
+
+  def given_i_am_signed_in_as_an_independent_settings_school_user
+    @user = create(:la_funded_place_user, :with_a_confirmed_techsource_account, :has_seen_privacy_notice, school: @school)
+    sign_in_as(@user)
+  end
+
+  def given_i_am_on_the_independent_settings_school_page
+    expect(page).to have_selector('.govuk-caption-xl', text: 'State-funded pupils in independent schools and alternative provision')
+    expect(page).to have_selector('h1', text: 'Get laptops and internet access')
+  end
+
+  def given_i_have_already_confirmed_that_i_will_order_chromebooks
+    @school.preorder_information.update!(will_need_chromebooks: 'yes')
+  end
+
+  def given_i_have_not_ordered_all_my_laptops
+    @school.device_allocations.std_device.create!(allocation: 2, cap: 2, devices_ordered: 1)
+  end
+
+  def given_i_have_ordered_all_of_my_laptops
+    @school.device_allocations.std_device.create!(allocation: 50, cap: 50, devices_ordered: 50)
+  end
+
+  def given_i_have_already_answered_that_i_was_not_sure_that_i_will_order_chromebooks
+    @school.preorder_information.update!(will_need_chromebooks: 'i_dont_know')
+  end
+
+  def then_i_see_confirmation_i_have_not_indicated_whether_i_will_order_chromebooks
+    expect(page).to have_text('You have not told us if you plan to order Google Chromebooks')
+  end
+
+  def when_i_answer_no
+    choose 'No, we will not order Chromebooks'
+  end
+
+  def when_i_answer_im_not_sure
+    choose 'I’m not sure'
+  end
+
+  def then_i_see_the_how_to_order_page
+    expect(page).to have_selector('h1', text: 'How to order')
+  end
+
+  def then_i_see_the_confirmation_i_will_not_order_chromebooks
+    expect(page).to have_text('You have told us you will not order Chromebooks')
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_am_asked_whether_i_need_chromebooks
+    expect(page).to have_selector('h1', text: 'Will your order include Google Chromebooks?')
+  end
+
+  def when_i_answer_yes
+    choose 'Yes, we’ll order Chromebooks'
+  end
+
+  def then_i_see_the_confirmation_i_will_order_chromebooks
+    expect(page).to have_text('You’ve told us you’ll order Chromebooks')
+  end
+
+  def then_i_see_the_delivery_address
+    expect(@school.address_1).to be_present
+    expect(page).to have_text(@school.address_1)
+  end
+
+  def then_i_see_how_to_sign_in_to_techsource
+    expect(page).to have_selector('h2', text: 'How to sign in to TechSource for the first time')
+    expect(page).to have_text("User ID: #{@user.email_address}")
+    expect(page).to have_link('Start now')
+  end
+
+  def when_i_click_on_get_laptops
+    click_on 'Get laptops'
+  end
+
+  def then_i_see_i_have_laptops_remaining
+    expect(page).to have_content('You’ve been allocated 2 laptops')
+  end
+
+  def then_i_see_i_have_no_laptops_remaining
+    expect(page).to have_selector('h1', text: 'You’ve ordered all the devices you can')
+    expect(page).to have_text('You’ve ordered 50 of 50 devices')
+  end
+end

--- a/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
+++ b/spec/features/responsible_body/providing_a_schools_preorder_information_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def and_choose_yes_they_will_need_chromebooks
-    choose 'Yes, we will order Chromebooks'
+    choose 'Yes, we’ll order Chromebooks'
   end
 
   def it_shows_me_fields_for_domain_and_recovery_email_address

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -26,13 +26,13 @@ RSpec.feature 'Change school Chromebook information' do
       end
 
       it 'lets me choose Yes or No' do
-        expect(page).to have_field('Yes, we will order Chromebooks')
+        expect(page).to have_field('Yes, we’ll order Chromebooks')
         expect(page).to have_field('No, we will not order Chromebooks')
       end
 
       context 'when I choose Yes' do
         before do
-          choose('Yes, we will order Chromebooks')
+          choose('Yes, we’ll order Chromebooks')
         end
 
         it 'shows a recovery email field' do
@@ -55,7 +55,7 @@ RSpec.feature 'Change school Chromebook information' do
       end
 
       it 'shows an error when I do not supply valid information' do
-        choose('Yes, we will order Chromebooks')
+        choose('Yes, we’ll order Chromebooks')
         fill_in('School or local authority email domain registered for G Suite for Education', with: '')
         click_on 'Save'
         expect(page).to have_http_status(:unprocessable_entity)
@@ -64,7 +64,7 @@ RSpec.feature 'Change school Chromebook information' do
       end
 
       it 'goes back to the school details page when I save valid information' do
-        choose('Yes, we will order Chromebooks')
+        choose('Yes, we’ll order Chromebooks')
         fill_in('School or local authority email domain registered for G Suite for Education', with: 'some.domain.org')
         fill_in('Recovery email address', with: 'someone@someotherdomain.org')
         click_on 'Save'

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Navigate school welcome wizard' do
     when_i_click_continue
     then_i_see_privacy_policy
     when_i_click_continue
-    then_i_see_homepage
+    then_i_see_the_la_funded_places_homepage
   end
 
   scenario 'step through the wizard as the first user for a school that has available allocation' do
@@ -195,8 +195,8 @@ RSpec.feature 'Navigate school welcome wizard' do
     expect(page).to have_text('Before you continue, please read the privacy notice.')
   end
 
-  def then_i_see_homepage
-    expect(page).to have_text('place orders access the Computacenter TechSource website to order devices')
+  def then_i_see_the_la_funded_places_homepage
+    expect(page).to have_selector('h1', text: 'Get laptops and internet access')
   end
 
   def then_i_see_a_welcome_page_for_my_school

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       sign_in_as user
       expect(page).to have_current_path(before_you_can_order_school_path(school))
       expect(page).to have_text 'Before you can order'
-      choose 'I don’t know'
+      choose 'I do not know'
       click_on 'Save'
       expect(page).to have_text user.school.name
     end

--- a/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
+++ b/spec/features/support/editing_chromebook_details_for_a_school_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Editing a school’s Chromebook details from the support area' do
       .school_details['Ordering Chromebooks?']
       .follow_action_link
 
-    choose 'Yes, we will order Chromebooks'
+    choose 'Yes, we’ll order Chromebooks'
     fill_in 'School or local authority', with: 'somedomain.com'
     fill_in 'Recovery email address', with: 'someone@someotherdomain.com'
     click_on 'Save'
@@ -80,7 +80,7 @@ RSpec.feature 'Editing a school’s Chromebook details from the support area' do
   end
 
   def then_the_chromebook_details_are_updated_in_the_support_console
-    expect(school_details_page.school_details['Ordering Chromebooks?'].value).to eq('Yes, we will order Chromebooks')
+    expect(school_details_page.school_details['Ordering Chromebooks?'].value).to eq('Yes, we’ll order Chromebooks')
     expect(school_details_page.school_details['Domain'].value).to eq('somedomain.com')
     expect(school_details_page.school_details['Recovery email'].value).to eq('someone@someotherdomain.com')
   end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -56,4 +56,27 @@ RSpec.describe ChromebookInformationForm do
       expect(form.errors[:will_need_chromebooks]).to include('Tell us whether the Educational foundation will need Chromebooks')
     end
   end
+
+  context 'LA school' do
+    let(:school) { create(:la_funded_place) }
+
+    let(:form) do
+      described_class.new(school: school,
+                          will_need_chromebooks: will_need_chromebooks)
+    end
+
+    context 'when :will_need_chromebooks is blank' do
+      let(:will_need_chromebooks) { nil }
+
+      it 'is not valid' do
+        expect(form.valid?).to be_falsey
+      end
+
+      it 'has an error message including the schools institution_type' do
+        form.validate
+        # TODO: update message
+        expect(form.errors[:will_need_chromebooks]).to include('Tell us whether the funded_places will need Chromebooks')
+      end
+    end
+  end
 end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe ChromebookInformationForm do
 
     let(:form) do
       described_class.new(school: school,
-                          will_need_chromebooks: will_need_chromebooks)
+                          will_need_chromebooks: will_need_chromebooks,
+                          will_need_chromebooks_message: 'Tell us if pupils will need Chromebooks')
     end
 
     context 'when :will_need_chromebooks is blank' do
@@ -74,8 +75,7 @@ RSpec.describe ChromebookInformationForm do
 
       it 'has an error message including the schools institution_type' do
         form.validate
-        # TODO: update message
-        expect(form.errors[:will_need_chromebooks]).to include('Tell us whether the funded_places will need Chromebooks')
+        expect(form.errors[:will_need_chromebooks]).to include('Tell us if pupils will need Chromebooks')
       end
     end
   end

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe ChromebookInformationForm do
   let(:will_need_chromebooks) { 'yes' }
   let(:recovery_email_address) { 'ab@c.com' }
   let(:school_or_rb_domain) { 'school.sch.uk' }
-  let(:school) { instance_double(CompulsorySchool, institution_type: 'Educational foundation') }
+  let(:school) do
+    instance_double(CompulsorySchool,
+                    institution_type: 'Educational foundation',
+                    la_funded_place?: false)
+  end
   let(:form) do
     described_class.new(school: school,
                         will_need_chromebooks: will_need_chromebooks,

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -372,4 +372,45 @@ RSpec.describe PreorderInformation, type: :model do
       end
     end
   end
+
+  describe '#chromebook_information_complete?' do
+    context 'la funded places' do
+      let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: true) }
+      let(:school) { create(:la_funded_place, :centrally_managed, responsible_body: local_authority) }
+
+      subject(:preorder_info) { school.preorder_information }
+
+      context 'when chromebooks needed' do
+        before do
+          preorder_info.update!(will_need_chromebooks: 'yes',
+                                school_or_rb_domain: 'school.org',
+                                recovery_email_address: 'school@example.com')
+        end
+
+        it 'does not require a G Suite domain' do
+          preorder_info.school_or_rb_domain = nil
+          expect(preorder_info.chromebook_information_complete?).to be true
+        end
+
+        it 'does not require a recovery email address' do
+          preorder_info.recovery_email_address = nil
+          expect(preorder_info.chromebook_information_complete?).to be true
+        end
+      end
+
+      context 'when no chromebooks needed' do
+        it 'returns true' do
+          preorder_info.update!(will_need_chromebooks: 'no')
+          expect(preorder_info.chromebook_information_complete?).to be true
+        end
+      end
+
+      context 'when we do not know if chromebooks are needed' do
+        it 'returns true' do
+          preorder_info.update!(will_need_chromebooks: nil)
+          expect(preorder_info.chromebook_information_complete?).to be true
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/xppMclNt/1769-order-flow-for-iss)
Order flow for state-funded pupils in independent settings

### Changes proposed in this pull request
Added pages for device ordering flow for `LaFundedPlace` type `School`

### Guidance to review
__Setup__
1. Add a `LaFundedPlace` school to a LocalAuthority e.g.
```ruby
my_la_funded_place = LocalAuthority.first.create_la_funded_places!(urn: 999000, device_allocation: 10)
```
2. Add a user to the school
```ruby
my_la_funded_place.users << my_user
```
3. Up the device cap to the allocation amount
```ruby
my_la_funded_place.std_device_allocation.update!(cap: 10)
```
4. Set the new school to order 
```ruby
my_la_funded_place.can_order!
```
5. Sign-in as the user associated with the school (and choose the school after sign-in if necessary)
6. The journey starts at the home page for the school and by following the `Get laptops` link
![image](https://user-images.githubusercontent.com/333931/115701611-decb0600-a35f-11eb-8d95-59036b2c3d2d.png)
![image](https://user-images.githubusercontent.com/333931/115701659-ebe7f500-a35f-11eb-9414-aa10fe6bb511.png)
![image](https://user-images.githubusercontent.com/333931/115701752-015d1f00-a360-11eb-940f-b7fb73836d62.png)
![image](https://user-images.githubusercontent.com/333931/115701828-1c2f9380-a360-11eb-8def-c565aee9eeb4.png)
![image](https://user-images.githubusercontent.com/333931/115701861-25b8fb80-a360-11eb-96be-5d8b9eb99ef6.png)
![image](https://user-images.githubusercontent.com/333931/115702002-4f722280-a360-11eb-91fd-adc9299e88c6.png)
![image](https://user-images.githubusercontent.com/333931/115702111-6ca6f100-a360-11eb-8d9d-6548224ce9ea.png)

