### PR TITLE
Fix Email audit component preview

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,7 +477,6 @@ DEPENDENCIES
   govuk-components (>= 1.1.5)
   govuk_design_system_formbuilder
   http
-  http-parser (~> 1.2.3)
   i18n-debug
   listen (>= 3.0.5, < 3.6)
   logstash-logger (~> 0.26.1)

--- a/spec/components/previews/email_audit_list_component_preview.rb
+++ b/spec/components/previews/email_audit_list_component_preview.rb
@@ -1,6 +1,25 @@
 class EmailAuditListComponentPreview < ViewComponent::Preview
   def default
-    audits = FactoryBot.build_list(:email_audit, 3, created_at: 3.days.ago)
-    render(Support::EmailAuditListComponent.new(audits))
+    render(Support::EmailAuditListComponent.new(mock_audit))
+  end
+
+private
+
+  def mock_audit
+    [OpenStruct.new({ template: SecureRandom.uuid,
+                      created_at: Time.zone.now,
+                      user: OpenStruct.new({ full_name: 'Ken Block' }),
+                      email_address: 'ken.block@example.com',
+                      message_type: 'user_can_order_but_action_needed' }),
+     OpenStruct.new({ template: SecureRandom.uuid,
+                      created_at: Time.zone.now - 5.minutes,
+                      user: OpenStruct.new({ full_name: 'Ken Block' }),
+                      email_address: 'ken.block@example.com',
+                      message_type: 'user_can_order' }),
+     OpenStruct.new({ template: SecureRandom.uuid,
+                      created_at: Time.zone.now - 15.minutes,
+                      user: OpenStruct.new({ full_name: 'Sally Block' }),
+                      email_address: 'ken.block@example.com',
+                      message_type: 'nudge_rb_to_add_school_contact' })]
   end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Switch from FactoryBot to OpenStruct
### Guidance to review

Visit https://dfe-ghwt-pr-1554.herokuapp.com/rails/view_components/email_audit_list_component/default, pages loads and displays an example of the component being used