### PR TITLE
[1837] Fix ComputacenterMailer error

### DIFF
--- a/app/mailers/computacenter_mailer.rb
+++ b/app/mailers/computacenter_mailer.rb
@@ -41,11 +41,11 @@ private
       school_name: @school.name,
       urn: @school.urn,
       new_cap_value: @new_cap_value,
-      ship_to_number: @school.computacenter_reference,
+      ship_to_number: @school.computacenter_reference || 'Not set',
       responsible_body_name: @school.responsible_body.name,
       responsible_body_type: @school.responsible_body.humanized_type,
       responsible_body_reference: @school.responsible_body.computacenter_identifier,
-      sold_to_number: @school.responsible_body.computacenter_reference,
+      sold_to_number: @school.responsible_body.computacenter_reference || 'Not set',
     }
   end
 

--- a/spec/mailers/computacenter_mailer_spec.rb
+++ b/spec/mailers/computacenter_mailer_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe ComputacenterMailer do
+  subject(:mailer) { described_class.new }
+
+  # rubocop:disable RSpec/SubjectStub
+  # Otherwise not able to inject custom params
+  describe '#notify_of_devices_cap_change' do
+    context 'when shipTo and soldTo not set' do
+      let(:school) { build(:school, computacenter_reference: nil, responsible_body: rb) }
+      let(:rb) { build(:trust, computacenter_reference: nil) }
+
+      before do
+        allow(mailer).to receive(:params).and_return({ school: school })
+      end
+
+      it 'displays Not set' do
+        mail = mailer.notify_of_devices_cap_change
+        expect(mail[:personalisation].unparsed_value[:ship_to_number]).to eq('Not set')
+        expect(mail[:personalisation].unparsed_value[:sold_to_number]).to eq('Not set')
+      end
+    end
+  end
+
+  describe '#notify_of_comms_cap_change' do
+    context 'when shipTo and soldTo not set' do
+      let(:school) { build(:school, computacenter_reference: nil, responsible_body: rb) }
+      let(:rb) { build(:trust, computacenter_reference: nil) }
+
+      before do
+        allow(mailer).to receive(:params).and_return({ school: school })
+      end
+
+      it 'displays Not set' do
+        mail = mailer.notify_of_comms_cap_change
+        expect(mail[:personalisation].unparsed_value[:ship_to_number]).to eq('Not set')
+        expect(mail[:personalisation].unparsed_value[:sold_to_number]).to eq('Not set')
+      end
+    end
+  end
+
+  describe '#notify_of_school_can_order' do
+    context 'when shipTo and soldTo not set' do
+      let(:school) { build(:school, computacenter_reference: nil, responsible_body: rb) }
+      let(:rb) { build(:trust, computacenter_reference: nil) }
+
+      before do
+        allow(mailer).to receive(:params).and_return({ school: school })
+      end
+
+      it 'displays Not set' do
+        mail = mailer.notify_of_school_can_order
+        expect(mail[:personalisation].unparsed_value[:ship_to_number]).to eq('Not set')
+        expect(mail[:personalisation].unparsed_value[:sold_to_number]).to eq('Not set')
+      end
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/KbFsgMk6/1837-computercenter-require-a-shipto-but-their-api-returns-success-for-cap-updates-without-a-shipto
- Error would happen when new school or rb has been added
- And we set the allocation/cap
- But computacenter has not set soldTo or shipTo yet

### Changes proposed in this pull request

- When we personalisation for `ComputacenterMailer` we send a placeholder string `Not set` instead of `nil` which `Notify` does not accept
- This way at last computacenter will receive the email with some values missing rather than no email at all
- Also this will not cause an error on our side

### Guidance to review

- Sign in as support user
- Create a new school sans `computacenter_reference`
- Make the school have a cap and allocation greater than zero and able to order
- Should see the mailer being sent with placeholder values