### PR TITLE
Add `launchy` gem and reorder gems in `test` block alphabetically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,10 +148,11 @@ group :test do
   gem 'climate_control'
   gem 'database_cleaner-active_record'
   gem 'fakeredis', require: 'fakeredis/rspec'
+  gem 'launchy'
+  gem 'rails-controller-testing'
+  gem 'shoulda-matchers', '~> 4.5'
   gem 'timecop'
   gem 'webdrivers', '~> 4.6'
-  gem 'shoulda-matchers', '~> 4.5'
-  gem 'rails-controller-testing'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
       i18n (< 2)
     inflection (1.0.0)
     jwt (2.2.2)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -475,6 +477,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   http
   i18n-debug
+  launchy
   listen (>= 3.0.5, < 3.6)
   logstash-logger (~> 0.26.1)
   mail-notify


### PR DESCRIPTION
### Context

Allows `save_and_open_page` to open system browser window when added within specs. This makes the process of 
seeing the situation within a browser easier.

### Changes proposed in this pull request

* Add `launchy` gem
* Reorder `test` block alphabetically

### Guidance to review

