### PR TITLE
Fix support email on "Get support" page

### DIFF
--- a/app/views/support_tickets/start.html.erb
+++ b/app/views/support_tickets/start.html.erb
@@ -24,7 +24,7 @@
       href: support_ticket_describe_yourself_path) %>
 
     <p class="govuk-body govuk-!-margin-top-3">
-      If you’d rather not answer these questions, you can email <a href="COVID.TECHNOLOGY@education.gov.uk" class="govuk-link">COVID.TECHNOLOGY@education.gov.uk</a>
+      If you’d rather not answer these questions, you can email <a href="mailto:COVID.TECHNOLOGY@education.gov.uk" class="govuk-link">COVID.TECHNOLOGY@education.gov.uk</a>
       instead. We’ll still aim to respond to you within 3 working days.
 
     <p class="govuk-body">You can also find out more about the Department for Education’s Get help with technology programme on <a href="https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19" class="govuk-link">GOV.UK</a>.</p>


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Email address needs to use `mailto:`
### Guidance to review

