### PR TITLE
[1777] ISS LA user interstitial

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -16,9 +16,7 @@ class LocalAuthority < ResponsibleBody
 
   validates :organisation_type, presence: true
 
-  def la_funded_place
-    schools.la_funded_place_establishment_type.first
-  end
+  has_one :la_funded_place, foreign_key: 'responsible_body_id'
 
   def create_la_funded_places!(urn:, device_allocation: 0, router_allocation: 0, extra_args: {})
     return if la_funded_place.present?

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,12 +6,12 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if user.la_funded_user? && user.is_responsible_body_user?
+    @call ||= if user.la_funded_user? && user.is_responsible_body_user? && user.responsible_body.la_funded_place&.device_allocations&.can_order_std_devices_now.present?
                 OpenStruct.new(
                   title: 'Laptops and internet access for state-funded pupils in independent settings',
                   partial: 'interstitials/la_funded_rb_user',
                 )
-              elsif user.la_funded_user?
+              elsif user.la_funded_user? && user.schools.la_funded_place.first&.device_allocations&.can_order_std_devices_now.present?
                 OpenStruct.new(
                   title: 'Get laptops for state-funded pupils at independent settings',
                   partial: 'interstitials/la_funded_user',

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,7 +6,12 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if user.la_funded_user?
+    @call ||= if user.la_funded_user? && user.is_responsible_body_user?
+                OpenStruct.new(
+                  title: 'Laptops and internet access for state-funded pupils in independent settings',
+                  partial: 'interstitials/la_funded_rb_user',
+                )
+              elsif user.la_funded_user?
                 OpenStruct.new(
                   title: 'Get laptops for state-funded pupils at independent settings',
                   partial: 'interstitials/la_funded_user',

--- a/app/services/personas/la_funded_place.rb
+++ b/app/services/personas/la_funded_place.rb
@@ -1,0 +1,49 @@
+class Personas::LaFundedPlace
+  def call
+    la
+    la_funded_place
+    la_user
+    la_funded_place_user
+  end
+
+private
+
+  def la_funded_place
+    @la_funded_place ||= la.la_funded_place || la.create_la_funded_place!(name: 'LA funded place') do |s|
+      s.urn = (School.maximum(:urn) || 800_000) + 1
+      s.address_1 = '14 High Street'
+      s.town = 'Cambridge'
+      s.county = 'Cambridgeshire'
+      s.postcode = 'CB1 0BE'
+    end
+
+    @la_funded_place.preorder_information || @la_funded_place.build_preorder_information(who_will_order_devices: 'school').save!
+
+    @la_funded_place
+  end
+
+  def la_funded_place_user
+    @la_funded_place_user ||= la_funded_place.users.find_or_create_by!(email_address: 'la.funded.user.1@example.com') do |u|
+      u.full_name = 'Jimmy Doe'
+      u.orders_devices = true
+    end
+  end
+
+  def la
+    @la ||= LocalAuthority.find_or_create_by!(name: 'Cambridgeshire') do |rb|
+      rb.organisation_type = 'county'
+      rb.who_will_order_devices = 'responsible_body'
+    end
+  end
+
+  def la_user
+    @la_user ||= la.users.find_or_create_by!(email_address: 'la.user.1@example.com') do |u|
+      u.full_name = 'Jane Doe'
+      u.orders_devices = true
+    end
+
+    unless @la_user.schools.include?(la_funded_place)
+      @la_user.schools << la_funded_place
+    end
+  end
+end

--- a/app/services/personas/la_funded_place.rb
+++ b/app/services/personas/la_funded_place.rb
@@ -2,6 +2,7 @@ class Personas::LaFundedPlace
   def call
     la
     la_funded_place
+    la_funded_place_allocation
     la_user
     la_funded_place_user
   end
@@ -20,6 +21,10 @@ private
     @la_funded_place.preorder_information || @la_funded_place.build_preorder_information(who_will_order_devices: 'school').save!
 
     @la_funded_place
+  end
+
+  def la_funded_place_allocation
+    @la_funded_place_allocation ||= la_funded_place.std_device_allocation || la_funded_place.create_std_device_allocation!(allocation: 200, cap: 200)
   end
 
   def la_funded_place_user
@@ -45,5 +50,7 @@ private
     unless @la_user.schools.include?(la_funded_place)
       @la_user.schools << la_funded_place
     end
+
+    @la_user
   end
 end

--- a/app/views/interstitials/_la_funded_rb_user.html.erb
+++ b/app/views/interstitials/_la_funded_rb_user.html.erb
@@ -1,0 +1,21 @@
+<h1 class="govuk-heading-xl">
+  Laptops and internet access for <span class="app-no-wrap">state-funded</span> pupils in independent settings
+</h1>
+
+<p class="govuk-body">
+  You can now order laptops for disadvantaged pupils funded by <%= @current_user.responsible_body.name %>, who:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>have a place at an independent special school, or through independent alternative provision</li>
+  <li>are eligible for free school meals</li>
+  <li>do not have access to a suitable device for remote education or catch-up learning</li>
+</ul>
+
+<p class="govuk-body">
+  You can also request internet access for these pupils.
+</p>
+
+<p class="govuk-body">
+  We’ve contacted the relevant team at <%= @current_user.responsible_body.name %> to let them know how to place orders.
+</p>

--- a/lib/tasks/personas.rake
+++ b/lib/tasks/personas.rake
@@ -3,5 +3,6 @@ namespace :db do
   task personas: :environment do
     Personas::SupportUser.new.call
     Personas::TrustWithSchools.new.call
+    Personas::LaFundedPlace.new.call
   end
 end

--- a/spec/services/interstitial_picker_spec.rb
+++ b/spec/services/interstitial_picker_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe InterstitialPicker do
+  describe 'calling interstitial picker for LA user + LA funded place user' do
+    let(:school) { create :la_funded_place }
+    let(:user) { create :user, schools: [school], responsible_body: la }
+    let(:service) { described_class.new(user: user) }
+    let(:la) { school.responsible_body }
+
+    context 'when an interstitial picker' do
+      it 'route to interstitials/la_funded_user' do
+        expect(service.call.partial).to eq 'interstitials/la_funded_rb_user'
+      end
+    end
+  end
+
   describe 'calling interstitial picker for la funded place' do
     let(:school) { create :la_funded_place }
     let(:user) { create :user, schools: [school] }

--- a/spec/services/interstitial_picker_spec.rb
+++ b/spec/services/interstitial_picker_spec.rb
@@ -1,27 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe InterstitialPicker do
-  describe 'calling interstitial picker for LA user + LA funded place user' do
-    let(:school) { create :la_funded_place }
-    let(:user) { create :user, schools: [school], responsible_body: la }
-    let(:service) { described_class.new(user: user) }
-    let(:la) { school.responsible_body }
+  describe '#call' do
+    context 'when LA user + LA funded place user' do
+      let(:school) { create :la_funded_place, std_device_allocation: allocation }
+      let(:user) { create :user, schools: [school], responsible_body: la }
+      let(:service) { described_class.new(user: user) }
+      let(:la) { school.responsible_body }
 
-    context 'when an interstitial picker' do
-      it 'route to interstitials/la_funded_user' do
-        expect(service.call.partial).to eq 'interstitials/la_funded_rb_user'
+      context 'when devices can be ordered' do
+        let(:allocation) { create :school_device_allocation, :with_std_allocation, :with_orderable_devices }
+
+        it 'uses partial interstitials/la_funded_user' do
+          expect(service.call.partial).to eq 'interstitials/la_funded_rb_user'
+        end
+      end
+
+      context 'when no devices can be ordered' do
+        let(:allocation) { create :school_device_allocation, :with_std_allocation }
+
+        it 'uses partial interstitials/school_user' do
+          expect(service.call.partial).to eq 'interstitials/school_user'
+        end
       end
     end
-  end
 
-  describe 'calling interstitial picker for la funded place' do
-    let(:school) { create :la_funded_place }
-    let(:user) { create :user, schools: [school] }
-    let(:service) { described_class.new(user: user) }
+    context 'when LA funded place user' do
+      let(:school) { create :la_funded_place, std_device_allocation: allocation }
+      let(:user) { create :user, schools: [school] }
+      let(:service) { described_class.new(user: user) }
 
-    context 'when an interstitial picker' do
-      it 'route to interstitials/la_funded_user' do
-        expect(service.call.partial).to eq 'interstitials/la_funded_user'
+      context 'when devices can be orderd' do
+        let(:allocation) { create :school_device_allocation, :with_std_allocation, :with_orderable_devices }
+
+        it 'uses partial interstitials/la_funded_user' do
+          expect(service.call.partial).to eq 'interstitials/la_funded_user'
+        end
+      end
+
+      context 'when no devices can be ordered' do
+        let(:allocation) { create :school_device_allocation, :with_std_allocation }
+
+        it 'uses partial interstitials/school_user' do
+          expect(service.call.partial).to eq 'interstitials/school_user'
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/utboJcpf/1777-add-state-funded-pupils-interstitial-for-rb-la-users
- https://trello.com/c/DrBn6QSl/1776-switch-off-state-funded-pupils-interstitial-for-rb-la-users-no-earlier-than-1-week-after-the-last-user-added

### Changes proposed in this pull request

- Show a slightly different interstitial for an LA user that also has access to an LA funded place
- For both the above user type and direct LA funded place users interstitial now only show if the allocation has devices available
- Added personas for ISS journeys
- Converted `la_funded_place` method to `has_one`

### Screenshots

![image](https://user-images.githubusercontent.com/92580/115253604-72b08e00-a124-11eb-9a33-912df5ab4b18.png)

### Guidance to review

- Visit https://dfe-ghwt-pr-1574.herokuapp.com
- Sign in as `la.funded.user.1@example.com` should be possible
- Sign in as `la.user.1@example.com` should now see slightly different interstitial screen
- ISS Interstitial screens should also no longer be displayed in both above cases in devices available to order drops to zero