### PR TITLE
[1707] add hashed name and number fields to anonymised EMDR dataset download

### DIFF
--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -2,7 +2,7 @@ class ExtraMobileDataRequest < ApplicationRecord
   has_paper_trail
 
   after_initialize :set_defaults
-  before_validation :normalise_device_phone_number, :normalise_name
+  before_validation :normalise_device_phone_number, :normalise_name, :update_hashes
 
   after_save :record_completion_if_needed!
 
@@ -167,5 +167,11 @@ private
 
   def record_completion_if_needed!
     ReportableEvent.create!(record: self, event_name: 'completion') if complete_status? && saved_change_to_status?
+  end
+
+  def update_hashes
+    self.hashed_account_holder_name = account_holder_name.nil? ? nil : Digest::MD5.hexdigest(account_holder_name)
+    self.hashed_normalised_name = normalised_name.nil? ? nil : Digest::MD5.hexdigest(normalised_name)
+    self.hashed_device_phone_number = device_phone_number.nil? ? nil : Digest::MD5.hexdigest(device_phone_number)
   end
 end

--- a/app/models/extra_mobile_data_request.rb
+++ b/app/models/extra_mobile_data_request.rb
@@ -11,6 +11,8 @@ class ExtraMobileDataRequest < ApplicationRecord
   belongs_to :responsible_body, optional: true
   belongs_to :school, optional: true
 
+  has_many :completion_events, -> { where(event_name: 'completion').order(event_time: :asc) }, as: :record, class_name: 'ReportableEvent'
+
   validates :status, presence: true
   validates :account_holder_name, presence: true
   validates :device_phone_number, presence: true, phone: { types: [:mobile], countries: [:gb] }, on: :create

--- a/app/services/exporters/mno_requests_csv.rb
+++ b/app/services/exporters/mno_requests_csv.rb
@@ -10,8 +10,12 @@ class Exporters::MnoRequestsCsv
     school_name
     responsible_body_id
     responsible_body_name
+    hashed_account_holder_name
+    hashed_normalised_name
+    hashed_device_phone_number
     status
     contract_type
+    first_completed_at
     created_at
     created_at_date
     updated_at
@@ -31,8 +35,12 @@ class Exporters::MnoRequestsCsv
           request.school&.name,
           request.responsible_body_id,
           request.responsible_body&.name,
+          request.hashed_account_holder_name,
+          request.hashed_normalised_name,
+          request.hashed_device_phone_number,
           request.status,
           request.contract_type,
+          request.completion_events.first&.event_time,
           request.created_at,
           request.created_at.strftime('%d/%m/%Y'),
           request.updated_at,

--- a/db/migrate/20210416125638_add_extra_mobile_data_request_hashed_name_and_number.rb
+++ b/db/migrate/20210416125638_add_extra_mobile_data_request_hashed_name_and_number.rb
@@ -1,0 +1,11 @@
+class AddExtraMobileDataRequestHashedNameAndNumber < ActiveRecord::Migration[6.1]
+  def change
+    add_column :extra_mobile_data_requests, :hashed_account_holder_name, :string, null: true
+    add_column :extra_mobile_data_requests, :hashed_normalised_name, :string, null: true
+    add_column :extra_mobile_data_requests, :hashed_device_phone_number, :string, null: true
+
+    add_index :extra_mobile_data_requests, :hashed_account_holder_name
+    add_index :extra_mobile_data_requests, :hashed_normalised_name
+    add_index :extra_mobile_data_requests, :hashed_device_phone_number
+  end
+end

--- a/db/migrate/20210416132319_populate_hashed_columns_on_extra_mobile_data_request.rb
+++ b/db/migrate/20210416132319_populate_hashed_columns_on_extra_mobile_data_request.rb
@@ -1,0 +1,12 @@
+class PopulateHashedColumnsOnExtraMobileDataRequest < ActiveRecord::Migration[6.1]
+  def change
+    sql = <<-SQL
+      UPDATE  extra_mobile_data_requests
+      SET     hashed_account_holder_name = MD5(account_holder_name),
+              hashed_normalised_name = MD5(normalised_name),
+              hashed_device_phone_number = MD5(device_phone_number)
+    SQL
+
+    ExtraMobileDataRequest.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_123002) do
+ActiveRecord::Schema.define(version: 2021_04_16_132319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,6 +182,12 @@ ActiveRecord::Schema.define(version: 2021_04_07_123002) do
     t.string "contract_type"
     t.bigint "school_id"
     t.string "normalised_name"
+    t.string "hashed_account_holder_name"
+    t.string "hashed_normalised_name"
+    t.string "hashed_device_phone_number"
+    t.index ["hashed_account_holder_name"], name: "index_extra_mobile_data_requests_on_hashed_account_holder_name"
+    t.index ["hashed_device_phone_number"], name: "index_extra_mobile_data_requests_on_hashed_device_phone_number"
+    t.index ["hashed_normalised_name"], name: "index_extra_mobile_data_requests_on_hashed_normalised_name"
     t.index ["mobile_network_id", "status", "created_at"], name: "index_emdr_on_mobile_network_id_and_status_and_created_at"
     t.index ["normalised_name"], name: "index_extra_mobile_data_requests_on_normalised_name"
     t.index ["responsible_body_id"], name: "index_extra_mobile_data_requests_on_responsible_body_id"

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -302,6 +302,32 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
     end
   end
 
+  describe 'updating the hashable fields' do
+    subject(:req) { create(:extra_mobile_data_request, account_holder_name: 'old name', device_phone_number: '07777111222') }
+
+    describe 'updating the account_holder_name' do
+      it 'updates the hashed_account_holder_name' do
+        expect { req.update!(account_holder_name: 'some new value') }.to change{ req.hashed_account_holder_name }.to(Digest::MD5.hexdigest('some new value'))
+      end
+
+      it 'updates the hashed_normalised_name' do
+        expect { req.update!(account_holder_name: 'Some New Value') }.to change(req, :hashed_normalised_name).to(Digest::MD5.hexdigest('somenewvalue'))
+      end
+    end
+
+    describe 'updating the device_phone_number' do
+      it 'updates the hashed_device_phone_number' do
+        expect { req.update!(device_phone_number: '07777888999') }.to change(req, :hashed_device_phone_number).to(Digest::MD5.hexdigest('07777888999'))
+      end
+
+      context 'when device_phone_number is nil' do
+        it 'updates the hashed_device_phone_number to nil' do
+          expect { req.update!(device_phone_number: nil) }.to change(req, :hashed_device_phone_number).to(nil)
+        end
+      end
+    end
+  end
+
   describe '#notify_account_holder_later' do
     let(:rb) { create(:trust) }
     let(:request) { build(:extra_mobile_data_request, responsible_body: rb, mobile_network: create(:mobile_network)) }

--- a/spec/models/extra_mobile_data_request_spec.rb
+++ b/spec/models/extra_mobile_data_request_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe ExtraMobileDataRequest, type: :model do
 
     describe 'updating the account_holder_name' do
       it 'updates the hashed_account_holder_name' do
-        expect { req.update!(account_holder_name: 'some new value') }.to change{ req.hashed_account_holder_name }.to(Digest::MD5.hexdigest('some new value'))
+        expect { req.update!(account_holder_name: 'some new value') }.to change(req, :hashed_account_holder_name).to(Digest::MD5.hexdigest('some new value'))
       end
 
       it 'updates the hashed_normalised_name' do


### PR DESCRIPTION
### Context

[Trello card](https://trello.com/c/YMBvNnni/1707-add-hashed-name-normalised-name-number-fields-to-the-anonymised-dataset-of-extramobiledatarequests-in-the-admin-ui) - the first time we generated an official number of completions by a certain date for the analysts, they asked for a dataset of all ExtraMobileDataRequests so that they could answer any future FOI requests or ministerial questions themselves, as their name would be on the published figure. We eventually agreed that an anonymised dataset would be ok if we hashed the personally-identifying fields - they would have unique references, but could never go back from the hashed values to the plain-text values. This took some time and manual effort, if they ask for similar datasets in future it should be automated as much as possible.

This also provides a step towards dealing smoothly with the August 2021 cut-off date at which our privacy policy says all PII will be deleted - we should be able to remove the plain text fields and just keep the hashed values. 

### Changes proposed in this pull request

* Add fields to `ExtraMobileDataRequest` for `hashed_account_holder_name`, `hashed_normalised_name` and `hashed_device_phone_number`
* Add AR hook method to update the hashed fields before validation
* Add specs to test they are correctly updated
* Add the hashed fields in to the anonymised dataset download
* Also add a `first_completed_at` field to the anonymised dataset, as that's what the analysts should be using in any cutoff date comparisons  

### Guidance to review

From support home, click on Service Performance > MNO
Scroll down and click on 'Download a CSV of anonymised extra mobile data requests'
