### PR TITLE
Promote git action text update

### DIFF
--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       from:
-        description: 'Promote from environment'
+        description: 'Promote from environment (`dev` or `staging`)'
         required: true
         default: 'dev'
       to:
-        description: 'To environment'
+        description: 'To environment (`staging` or `prod`)'
         required: true
         default: 'staging'
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Computacenter TechSource - this app will post cap update requests to TechSource 
 In the normal flow of things, the simplest way to perform a release is by using the Github Actions we have set up on this repository.
 
 Merging a Pull Request to `main` will automatically run the tests and perform a release to the 'dev' environment.
-Once this has completed (you can check the currently deployed commit SHA from http://get-help-with-tec-dev.london.cloudapps.digital/healthcheck.json, and make sure it matches 'main'), you can then promote that image from `dev` to `staging`, and then from `staging` to `prod` as follows:
+Once this has completed (you can check the currently deployed commit SHA from http://get-help-with-tech-dev.london.cloudapps.digital/healthcheck.json, and make sure it matches 'main'), you can then promote that image from `dev` to `staging`, and then from `staging` to `prod` as follows:
 
 1. Click the 'Actions' tab
 2. Under 'Workflows' on the left, click 'Promote container between environments'


### PR DESCRIPTION
### Context

In the promote Github Action it's not clear with our production environment is called `production` or `prod`. The correct one is `prod` and whilst there seems to be no way to constrain users to this, this PR adds descriptive text to inform users of this instead. 

### Changes proposed in this pull request

* Fix URL typo in README
* Add text to Github Action description to prompt users to use the correct environments

### Guidance to review

