### PR TITLE
[1422] Remove hardcoded autocomplete javascript

### DIFF
--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -14,7 +14,13 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:search_type, legend: { size: 'xl', text: title, tag: 'h1' }) do %>
         <%= f.govuk_radio_button :search_type, :single, label: { text: 'Search by name, URN or UKPRN' } do %>
-          <%= f.govuk_text_field :name_or_identifier, hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+          <%= f.govuk_text_field :name_or_identifier,
+                                 hint: { text: 'Enter part of a school name, URN or UKPRN' },
+                                 data: {
+                                   autocomplete_school: true,
+                                   autocomplete_school_path: '/support/schools/results',
+                                   autocomplete_school_hidden_field: 'school_search_form_identifier',
+                                 } %>
           <%= f.hidden_field :identifier %>
         <% end %>
         <%= f.govuk_radio_button :search_type, :multiple, label: { text: 'Search for multiple schools by URN or UKPRN' } do %>

--- a/app/views/support/schools/search.html.erb
+++ b/app/views/support/schools/search.html.erb
@@ -32,17 +32,20 @@
                                 rows: 10 %>
         <% end %>
         <%= f.govuk_radio_button :search_type, :responsible_body_or_order_state, label: { text: 'Search by responsible body or order state' } do %>
-          <%= f.govuk_collection_select   :responsible_body_id,
-                                          @search_form.select_responsible_body_options,
-                                          :id,
-                                          :name,
-                                          label: { text: 'Responsible body' } %>
+          <%= f.govuk_collection_select :responsible_body_id,
+                                        @search_form.select_responsible_body_options,
+                                        :id,
+                                        :name,
+                                        label: { text: 'Responsible body' },
+                                        data: {
+                                          autocomplete_rb: true,
+                                        } %>
 
-          <%= f.govuk_collection_select   :order_state,
-                                          @search_form.select_order_state_options,
-                                          :value,
-                                          :label,
-                                          label: { text: 'Order state' } %>
+          <%= f.govuk_collection_select :order_state,
+                                        @search_form.select_order_state_options,
+                                        :value,
+                                        :label,
+                                        label: { text: 'Order state' } %>
         <% end %>
       <% end %>
 

--- a/app/views/support/users/responsible_body/edit.html.erb
+++ b/app/views/support/users/responsible_body/edit.html.erb
@@ -19,8 +19,10 @@
               @user_responsible_body_form.select_responsible_body_options,
               :id,
               :name,
-              label: { text: 'New responsible body' }
-              ) %>
+              label: { text: 'New responsible body' },
+              data: {
+                autocomplete_rb: true,
+              }) %>
           <% end %>
           <%= f.govuk_radio_button :change, 'remove', label: { text: 'Remove user from responsible body' }, link_errors: true %>
         <% end %>
@@ -32,8 +34,10 @@
           :id,
           :name,
           label: { text: 'Add user to a responsible body' },
-          options: { include_blank: true }
-          ) %>
+          options: { include_blank: true },
+          data: {
+            autocomplete_rb: true,
+          }) %>
       <%- end %>
       <%= f.govuk_submit 'Update' %>
     <% end %>

--- a/app/views/support/users/schools/index.html.erb
+++ b/app/views/support/users/schools/index.html.erb
@@ -18,7 +18,14 @@
 
     <%= form_for @user_school_form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_fieldset legend: { text: 'Grant access to a school', size: 'm' } do %>
-        <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+        <%= f.govuk_text_field :name_or_urn_or_ukprn,
+          width: 'two-thirds',
+          hint: { text: 'Enter part of a school name, URN or UKPRN' },
+          data: {
+            autocomplete_school: true,
+            autocomplete_school_path: '/support/schools/results',
+            autocomplete_school_hidden_field: 'support_school_suggestion_form_school_urn',
+          } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit %>
       <%- end %>

--- a/app/views/support/users/schools/new.html.erb
+++ b/app/views/support/users/schools/new.html.erb
@@ -47,7 +47,14 @@
 
     <%= govuk_details(summary: 'Try another school') do %>
       <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
-        <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+        <%= f.govuk_text_field :name_or_urn_or_ukprn,
+          width: 'two-thirds',
+          hint: { text: 'Enter part of a school name, URN or UKPRN' },
+          data: {
+            autocomplete_school: true,
+            autocomplete_school_path: '/support/schools/results',
+            autocomplete_school_hidden_field: 'support_school_suggestion_form_school_urn',
+          } %>
         <%= f.hidden_field :school_urn %>
         <%= f.govuk_submit 'Search again' %>
       <%- end %>

--- a/app/views/support/users/schools/search_again.html.erb
+++ b/app/views/support/users/schools/search_again.html.erb
@@ -11,7 +11,14 @@
 
     <%= form_for @form, url: support_user_schools_path(@user) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :name_or_urn_or_ukprn, width: 'two-thirds', hint: { text: 'Enter part of a school name, URN or UKPRN' } %>
+      <%= f.govuk_text_field :name_or_urn_or_ukprn,
+        width: 'two-thirds',
+        hint: { text: 'Enter part of a school name, URN or UKPRN' },
+        data: {
+          autocomplete_school: true,
+          autocomplete_school_path: '/support/schools/results',
+          autocomplete_school_hidden_field: 'support_school_suggestion_form_school_urn',
+        } %>
       <%= f.hidden_field :school_urn %>
       <%= f.govuk_submit 'Search again' %>
     <%- end %>

--- a/app/views/support_tickets/academy_details.html.erb
+++ b/app/views/support_tickets/academy_details.html.erb
@@ -17,8 +17,11 @@
       </h1>
 
       <%= f.govuk_collection_select :academy_name, @form.multi_academy_trust_list, :name, :name,
-                                    label: {text: 'Academy trust name', size: 's'},
-                                    options: { include_blank: true }%>
+                                    label: { text: 'Academy trust name', size: 's' },
+                                    options: { include_blank: true },
+                                    data: {
+                                      autocomplete_rb: true,
+                                    } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/support_tickets/local_authority_details.html.erb
+++ b/app/views/support_tickets/local_authority_details.html.erb
@@ -17,8 +17,11 @@
       </h1>
 
       <%= f.govuk_collection_select :local_authority_name, @form.local_authority_list, :name, :name,
-                                    label: {text: 'Local authority name', size: 's'},
-                                    options: { include_blank: true } %>
+                                    label: { text: 'Local authority name', size: 's' },
+                                    options: { include_blank: true },
+                                    data: {
+                                      autocomplete_rb: true,
+                                    } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -13,7 +13,11 @@ initAll();
 initWarnOnUnsavedChanges();
 
 initSelectAllNone();
-initResponsibleBodiesAutocomplete();
+initResponsibleBodiesAutocomplete(
+  {
+    input: "[data-autocomplete-rb]",
+  }
+);
 initSchoolAutocomplete(
   {
     input: "[data-autocomplete-school]",

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -16,32 +16,6 @@ initSelectAllNone();
 initResponsibleBodiesAutocomplete();
 initSchoolAutocomplete(
   {
-    input: "support-school-suggestion-form-name-or-urn-or-ukprn-field",
-    path: "/support/schools/results",
-    hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
-  }
-);
-
-initSchoolAutocomplete(
-  {
-    input: "support-school-suggestion-form-name-or-urn-or-ukprn-field-error",
-    path: "/support/schools/results",
-    hiddenFieldForURN: 'support_school_suggestion_form_school_urn'
-  }
-);
-
-initSchoolAutocomplete(
-  {
-    input: "school-search-form-name-or-identifier-field",
-    path: "/support/schools/results",
-    hiddenFieldForURN: 'school_search_form_identifier'
-  }
-);
-
-initSchoolAutocomplete(
-  {
-    input: "school-search-form-name-or-identifier-field-error",
-    path: "/support/schools/results",
-    hiddenFieldForURN: 'school_search_form_identifier'
+    input: "[data-autocomplete-school]",
   }
 );

--- a/app/webpacker/scripts/responsible-bodies-autocomplete.js
+++ b/app/webpacker/scripts/responsible-bodies-autocomplete.js
@@ -1,27 +1,16 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
-const initResponsibleBodiesAutocomplete = () => {
+const initResponsibleBodiesAutocomplete = ({input}) => {
   try {
-    const inputIds = [
-      "#support-user-responsible-body-form-responsible-body-id-field",
-      '#school-search-form-responsible-body-id-field',
-      '#support-ticket-academy-details-form-academy-name-field',
-      '#support-ticket-academy-details-form-academy-name-field-error',
-      '#support-ticket-local-authority-details-form-local-authority-name-field',
-      '#support-ticket-local-authority-details-form-local-authority-name-field-error'
-    ];
+    const responsibleBodiesSelect = document.querySelector(input);
+    if (!responsibleBodiesSelect) return;
 
-    inputIds.forEach(inputId => {
-      const responsibleBodiesSelect = document.querySelector(inputId);
-      if (!responsibleBodiesSelect) return;
-
-      accessibleAutocomplete.enhanceSelectElement({
-        selectElement: responsibleBodiesSelect,
-        showAllValues: true,
-        confirmOnBlur: false,
-        dropdownArrow: () => '',
-        displayMenu: 'overlay'
-      });
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: responsibleBodiesSelect,
+      showAllValues: true,
+      confirmOnBlur: false,
+      dropdownArrow: () => '',
+      displayMenu: 'overlay'
     });
   } catch (err) {
     console.error("Could not enhance responsible bodies select:", err);

--- a/app/webpacker/scripts/school-autocomplete.js
+++ b/app/webpacker/scripts/school-autocomplete.js
@@ -31,9 +31,14 @@ export const request = endpoint => {
   };
 };
 
-const initSchoolAutocomplete = ({input, path, hiddenFieldForURN}) => {
-  const $hiddenFieldForURN = document.getElementById(hiddenFieldForURN);
-  const $input = document.getElementById(input);
+const initSchoolAutocomplete = ({input}) => {
+  const $input = document.querySelector(input);
+
+  if ($input === null) {
+    return
+  }
+
+  const $hiddenFieldForURN = document.getElementById($input.dataset.autocompleteSchoolHiddenField);
   const inputValueTemplate = result => (typeof result === "string" ? result : result && result.name);
   const suggestionTemplate = result =>
     typeof result === "string" ? result : result && `${result.name} (${result.urn}, ${result.town}, ${result.postcode})`;
@@ -52,7 +57,7 @@ const initSchoolAutocomplete = ({input, path, hiddenFieldForURN}) => {
         name: $input.name,
         defaultValue: $input.value,
         minLength: 3,
-        source: request(path),
+        source: request($input.dataset.autocompleteSchoolPath),
         templates: {
           inputValue: inputValueTemplate,
           suggestion: suggestionTemplate


### PR DESCRIPTION
### Context

- https://trello.com/c/I5p4VO2m/1422-autocomplete-and-javascript-initialisers-should-be-thru-data-attributes-not-hardcoded-ids
- Autocomplete components were initialised via hard coded selectors within javascript

### Changes proposed in this pull request

- Autocomplete for schools and RBs are setup via data attributes
- Configuration of school autocomplete is now via data attributes
- This should make the autocomplete components a bit more reusable without having to modify the javascript

### Guidance to review

- Existing autocompletes on the site continue to work
  - Support user searching for an organisation
  - Support user searching for an schools via rb and state
  - Editing a user and changing schools
  - Editing a user and changing rbs
  - Create support ticket as LA
  - Create support ticket as an academy