### PR TITLE
Make sign-in link feature an actual link

### DIFF
--- a/app/controllers/sign_in_tokens_controller.rb
+++ b/app/controllers/sign_in_tokens_controller.rb
@@ -49,7 +49,7 @@ class SignInTokensController < ApplicationController
       if FeatureFlag.active?(:display_sign_in_token_links)
         user = User.find_by(email_address: @sign_in_token_form.email_address)
         identifier = user.sign_in_identifier(user.sign_in_token)
-        flash[:success] = validate_sign_in_token_url(token: token, identifier: identifier)
+        flash[:sign_in_link] = "<a href='#{validate_sign_in_token_url(token: token, identifier: identifier)}'>Click to sign-in</a>"
       end
 
       redirect_to sent_token_path(token: token)

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -23,5 +23,13 @@
         </h2>
       </div>
     </div>
+  <% elsif flash[:sign_in_link] %>
+    <div class="app-banner app-banner--success" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1" role="alert">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="success-message">
+          <%= flash[:sign_in_link].html_safe %>
+        </h2>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
     visit sign_in_path
     fill_in('Email address', with: user.email_address)
     click_on 'Continue'
-    expect(page).to have_content('/token/validate?identifier=')
+    expect(page).to have_link('Click to sign-in')
   end
 
   context 'as a user who belongs to a responsible body' do


### PR DESCRIPTION
### Context
Make the sign-in link feature an actual clickable link

### Changes proposed in this pull request
Put the sign-in link into `flash[:sign_in_link]` instead of `flash[:success]` and handle as a special case to render the html link.

### Guidance to review
with `FEATURES_display_sign_in_token_links: active` when you sign in you will see a 'Click to sign-in` link instead of the URL in the flash message.
![image](https://user-images.githubusercontent.com/333931/115426821-cab8c480-a1f8-11eb-8d43-b018d35a7a12.png)
