### PR TITLE
Set node use to v12 for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">12.0"
+    "node": "12.x"
   },
   "dependencies": {
     "@rails/webpacker": ">=5.2.1",


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
For our review apps, we had the node engine version set to `>12.0`.
This meant that up until recently our review apps were using a newer nodejs
version compared to our local dev setup. We only spotted this issues today
after v16 of nodejs was released yesterday and Heroku tried to use that
but all our review apps started failing as a result of our dependency not
being compatible with v16.

For the time being we will stay on v12 but we should look to update to
latest LTS version which at the time is v14. This is a bigger task because
we need to ensure our docker image is pulling in the correct version of node
and some other checking is required.

### Guidance to review
- Review apps are deployed successfully
- v.12 is being used on heroku

Heroku logs found below for the review app generated from this PR.
```
-----> Building on the Heroku-18 stack
-----> Using buildpacks:
       1. heroku/nodejs
       2. heroku/ruby
-----> Node.js app detected
       
-----> Creating runtime environment
       
       NPM_CONFIG_LOGLEVEL=error
       YARN_CACHE=true
       USE_YARN_CACHE=true
       NODE_ENV=production
       NODE_MODULES_CACHE=true
       NODE_VERBOSE=false
       
-----> Installing binaries
       engines.node (package.json):  12.x
       engines.npm (package.json):   unspecified (use default)
       engines.yarn (package.json):  unspecified (use default)
       
       Resolving node version 12.x...
       Downloading and installing node 12.22.1...
       Using default npm version: 6.14.12
       Resolving yarn version 1.22.x...
       Downloading and installing yarn (1.22.10)
       Installed yarn 1.22.10
       
-----> Restoring cache
       - yarn cache
       
       ```