### PR TITLE
Remove hard-coded date string

### DIFF
--- a/app/controllers/techsource_launcher_controller.rb
+++ b/app/controllers/techsource_launcher_controller.rb
@@ -1,7 +1,11 @@
 class TechsourceLauncherController < ApplicationController
+  DATE_TIME_FORMAT = Computacenter::TechSourceMaintenanceBannerComponent::DATE_TIME_FORMAT
+
   def start
     techsource = Computacenter::TechSource.new
+
     if techsource.unavailable?
+      @available_at = Computacenter::TechSource::MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)
       render 'unavailable'
     else
       redirect_to URI.parse(techsource.url).to_s # The URI.parse is needed to appease Brakeman

--- a/app/views/techsource_launcher/unavailable.html.erb
+++ b/app/views/techsource_launcher/unavailable.html.erb
@@ -8,6 +8,6 @@
     </h1>
 
     <p class="govuk-body">The TechSource website is closed for maintenance.</p>
-    <p class="govuk-body">You will be able to order devices when it reopens on Sunday 29 November.</p>
+    <p class="govuk-body">You will be able to order devices when it reopens on <%= @available_at %>.</p>
   </div>
 </div>

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe TechsourceLauncherController, type: :controller do
         get 'start'
         expect(response).to render_template('unavailable')
         expect(response).to have_http_status(:ok)
+        expect(assigns(:available_at)).to eq('Saturday 28 November 02:00pm')
       end
     end
 


### PR DESCRIPTION
### Context

When a TechSource maintenance period was active we were displaying the hardcoded string that `You will be able to order devices when it reopens on Saturday 28 November` which is wrong.

https://trello.com/c/d7XZ7U4y

### Changes proposed in this pull request

Dynamically set the end of the maintenance period (and include the time)

### Guidance to review

