### PR TITLE
[1888] Make table cols equal width

### DIFF
--- a/app/views/devices_guidance/device_specification.md
+++ b/app/views/devices_guidance/device_specification.md
@@ -59,12 +59,12 @@ Read more information about <a class="govuk-link" href="/devices/preparing-chrom
     <caption class="govuk-table__caption govuk-visually-hidden">Minimum specification</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header app-schools-table__column-20"></th>
-        <th scope="col" class="govuk-table__header app-schools-table__column-20">Microsoft Windows laptop</th>
-        <th scope="col" class="govuk-table__header app-schools-table__column-20">Google Chromebook</th>
-        <th scope="col" class="govuk-table__header app-schools-table__column-20">Microsoft Windows tablet</th>
-        <th scope="col" class="govuk-table__header app-schools-table__column-20">Apple iPad</th>
-        <th scope="col" class="govuk-table__header app-schools-table__column-20">Dell Latitude 5300 series Microsoft Windows laptop</th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16"></th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16">Microsoft Windows laptop</th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16">Google Chromebook</th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16">Microsoft Windows tablet</th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16">Apple iPad</th>
+        <th scope="col" class="govuk-table__header app-schools-table__column-16">Dell Latitude 5300 series Microsoft Windows laptop</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -46,6 +46,10 @@ $govuk-image-url-function: frontend-image-url;
   width: 20%;
 }
 
+.app-schools-table__column-16 {
+  width: 16%;
+}
+
 .search-results {
   border-top: 1px solid $govuk-border-colour;
 

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -38,16 +38,12 @@ $govuk-image-url-function: frontend-image-url;
   border-bottom: 1px solid $govuk-border-colour;
 }
 
-.app-schools-table__column-40 {
-  width: 40%;
-}
+$sizes: 40, 20, 16;
 
-.app-schools-table__column-20 {
-  width: 20%;
-}
-
-.app-schools-table__column-16 {
-  width: 16%;
+@each $size in $sizes {
+  .app-schools-table__column-#{$size} {
+    width: $size + unquote('%');
+  }
 }
 
 .search-results {


### PR DESCRIPTION
### Context

- Fix table columns on guidance page for 6 columns 

### Changes proposed in this pull request

- Make each col span 16%

### Screenshots

![Screenshot 2021-04-22 at 14 01 47](https://user-images.githubusercontent.com/92580/115718782-5e160500-a373-11eb-9db5-d2ac9eac5d42.png)

### Guidance to review

- https://dfe-ghwt-pr-1597.herokuapp.com/devices/device-specification
- Spacing on table should be improved