### PR TITLE
Remove warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,3 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'simplecov'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# This is needed for review apps on Heroku to build
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,7 +515,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop
-  tzinfo-data
   web-console (>= 3.3.0)
   webdrivers (~> 4.6)
   webmock

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -29,6 +29,3 @@ end
 # Make Sidekiq admin panel share the same session as the Rails  app
 require 'sidekiq/web'
 require 'sidekiq-scheduler/web'
-
-Sidekiq::Web.set :sessions, false
-Sidekiq::Web.set :session_secret, Rails.application.credentials[:secret_key_base]


### PR DESCRIPTION
### Context

Seeing these errors in the output:

* `The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
* `WARNING: Sidekiq::Web.sessions= is no longer relevant and will be removed in Sidekiq 7.0. /Users/nigellowry/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/web.rb:75:in `set'`
* `WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /Users/nigellowry/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/web.rb:75:in `set'`

### Changes proposed in this pull request

Remove the Sidekiq configuration which the warning message says is no longer relevant and remove the dependency on the `tzinfo-data` gem (this means the app will no longer run on Windows)

### Guidance to review

https://github.com/tzinfo/tzinfo-data/issues/12