### PR TITLE
Expose techsource urn for funded places

### DIFF
--- a/app/components/computacenter/school_changes_details_component.rb
+++ b/app/components/computacenter/school_changes_details_component.rb
@@ -25,9 +25,10 @@ private
   end
 
   def school_rows
+    urn = school.la_funded_place? ? school.techsource_urn : school.urn
     [{
       key: 'School URN',
-      value: school.urn,
+      value: urn,
     },
      {
        key: 'School name',

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -4,6 +4,6 @@ class LaFundedPlace < CompulsorySchool
   end
 
   def techsource_urn
-    "iss-#{responsible_body.name}".parameterize
+    "ISS_#{responsible_body.gias_id}"
   end
 end

--- a/app/services/school_data_exporter.rb
+++ b/app/services/school_data_exporter.rb
@@ -56,7 +56,8 @@ private
   end
 
   def build_name_fields_for(school)
-    split_string("#{school.urn} #{school.name}", limit: 35)
+    urn = school.la_funded_place? ? school.techsource_urn : school.urn
+    split_string("#{urn} #{school.name}", limit: 35)
   end
 
   def schools

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= "#{@school.name} (#{@school.urn})" %></span>
+      <span class="govuk-caption-xl"><%= "#{@school.name} (#{@school.la_funded_place? ? @school.techsource_urn : @school.urn})" %></span>
       <%= title %>
     </h1>
 

--- a/app/views/computacenter/school_changes/index.html.erb
+++ b/app/views/computacenter/school_changes/index.html.erb
@@ -60,7 +60,7 @@
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= school.responsible_body.computacenter_identifier %></td>
                 <td class="govuk-table__cell"><%= school.responsible_body.computacenter_reference %></td>
-                <td class="govuk-table__cell"><%= school.urn %></td>
+                <td class="govuk-table__cell"><%= school.la_funded_place? ? school.techsource_urn : school.urn %></td>
                 <td class="govuk-table__cell"><%= school.name %></td>
                 <td class="govuk-table__cell"><%= school.address %></td>
                 <td class="govuk-table__cell"><%= school.computacenter_reference %></td>

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -70,4 +70,30 @@ RSpec.describe SchoolDataExporter, type: :model do
       expect(found).to be true
     end
   end
+
+  context 'when exporting LA funded places' do
+    let(:local_authority) { create(:local_authority) }
+    let!(:school) { create(:la_funded_place, responsible_body: local_authority) }
+
+    before do
+      exporter.export_schools
+    end
+
+    after do
+      remove_file(filename)
+    end
+
+    it 'uses the techsource urn' do
+      data = CSV.parse(File.read(filename), headers: true)
+      expect(data.count).to eq(School.count)
+
+      found = false
+      data.each do |row|
+        if row['School URN + School Name'].start_with?(school.techsource_urn)
+          found = true
+        end
+      end
+      expect(found).to be true
+    end
+  end
 end


### PR DESCRIPTION
### Context
Quick fix to enable us to expose the 2 manual LA funded places correctly to Computacenter.

### Changes proposed in this pull request
Correct format for URN as agreed with CC ('ISS_<3-digit lea code>')
Use `techsource_urn` in place of `urn` for LA funded places in the CC changes area.

### Guidance to review

