### PR TITLE
[1712] Support interface to add support users

### DIFF
--- a/app/controllers/support/privileged_users_controller.rb
+++ b/app/controllers/support/privileged_users_controller.rb
@@ -1,0 +1,47 @@
+class Support::PrivilegedUsersController < Support::BaseController
+  before_action { authorize :PrivilegedUser }
+
+  def index
+    @computacenter_users = User.where(is_computacenter: true)
+    @support_users = User.where(is_support: true)
+    @mno_users = User.where('mobile_network_id IS NOT NULL')
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+
+    if @user.update(is_support: false, role: 'no', is_computacenter: false, mobile_network_id: nil)
+      flash[:success] = "Privileges for #{@user.email_address} have been removed"
+      redirect_to support_privileged_users_path
+    else
+      flash[:warning] = 'Privileges could not be removed'
+      render :show
+    end
+  end
+
+  def new
+    @form_object = Support::PrivilegedUserForm.new
+  end
+
+  def create
+    @form_object = Support::PrivilegedUserForm.new(form_params)
+
+    if @form_object.valid?
+      @form_object.create_user!
+      flash[:success] = 'User has been added'
+      redirect_to support_privileged_users_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def form_params
+    params.require(:support_privileged_user_form).permit(:full_name, :email_address, privileges: [])
+  end
+end

--- a/app/form_objects/support/privileged_user_form.rb
+++ b/app/form_objects/support/privileged_user_form.rb
@@ -1,0 +1,45 @@
+class Support::PrivilegedUserForm
+  include ActiveModel::Model
+
+  attr_accessor :full_name, :email_address, :privileges
+
+  validates :full_name, presence: { message: 'Enter the name of the user' }
+  validates :email_address, presence: { message: 'Enter the email address of the user' },
+                            format: { with: /\A.*@computacenter.com|.*@digital.education.gov.uk|.*@education.gov.uk\z/,
+                                      message: 'Email address must be end with @computacenter.com, @digital.education.gov.uk or @education.gov.uk' }
+  validate :validate_email_not_taken
+  validate :validate_atleast_one_privilege
+  validate :validate_acceptable_privileges
+
+  def create_user!
+    User.create!(full_name: full_name, email_address: email_address, is_support: is_support?, is_computacenter: is_computacenter?)
+  end
+
+private
+
+  def is_support?
+    privileges.include?('support')
+  end
+
+  def is_computacenter?
+    privileges.include?('computacenter')
+  end
+
+  def validate_acceptable_privileges
+    if privileges.union(['', 'support', 'computacenter']).size > 3
+      errors.add :privileges, :inclusion, message: 'Only select from available privileges'
+    end
+  end
+
+  def validate_atleast_one_privilege
+    if privileges.reject(&:blank?).empty?
+      errors.add :privileges, :at_least_one, message: 'Select at least one privilege to apply'
+    end
+  end
+
+  def validate_email_not_taken
+    if User.exists?(['lower(email_address) = ?', email_address.downcase])
+      errors.add :email_address, :duplicate, message: 'This email adddress has already been taken'
+    end
+  end
+end

--- a/app/form_objects/support/privileged_user_form.rb
+++ b/app/form_objects/support/privileged_user_form.rb
@@ -8,7 +8,7 @@ class Support::PrivilegedUserForm
                             format: { with: /\A.*@computacenter.com|.*@digital.education.gov.uk|.*@education.gov.uk\z/,
                                       message: 'Email address must be end with @computacenter.com, @digital.education.gov.uk or @education.gov.uk' }
   validate :validate_email_not_taken
-  validate :validate_atleast_one_privilege
+  validate :validate_at_least_one_privilege
   validate :validate_acceptable_privileges
 
   def create_user!
@@ -31,7 +31,7 @@ private
     end
   end
 
-  def validate_atleast_one_privilege
+  def validate_at_least_one_privilege
     if privileges.reject(&:blank?).empty?
       errors.add :privileges, :at_least_one, message: 'Select at least one privilege to apply'
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,6 +236,17 @@ class User < ApplicationRecord
     scope
   end
 
+  def privileges
+    array = []
+
+    array << :support_user if is_support?
+    array << :third_line_support_user if third_line_role?
+    array << :computacenter_user if is_computacenter?
+    array << :mno_user if is_mno_user?
+
+    array
+  end
+
 private
 
   def cleansed_full_name

--- a/app/policies/privileged_user_policy.rb
+++ b/app/policies/privileged_user_policy.rb
@@ -1,0 +1,21 @@
+class PrivilegedUserPolicy < SupportPolicy
+  def index?
+    user.third_line_role?
+  end
+
+  def new?
+    user.third_line_role?
+  end
+
+  def create?
+    user.third_line_role?
+  end
+
+  def destroy?
+    user.third_line_role?
+  end
+
+  def show?
+    user.third_line_role?
+  end
+end

--- a/app/views/support/home/show.html.erb
+++ b/app/views/support/home/show.html.erb
@@ -62,6 +62,18 @@
       </ul>
     <% end %>
 
+    <% if policy(:PrivilegedUser).index? %>
+      <h2 class="govuk-heading-l govuk-!-font-size-27">
+        <%= govuk_link_to 'Privileged users', support_privileged_users_path %>
+      </h2>
+
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>see privileged users</li>
+        <li>add or remove privileged users</li>
+      </ul>
+    <% end %>
+
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to 'Email audits', support_email_audits_path %>
     </h2>

--- a/app/views/support/privileged_users/index.html.erb
+++ b/app/views/support/privileged_users/index.html.erb
@@ -1,0 +1,81 @@
+<%- title = t('page_titles.support.privileged_users.index') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_back_link(text: 'Back', href: support_home_path) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%= govuk_link_to('Add privileged user', new_support_privileged_user_path, button: true) %>
+
+    <h2 class="govuk-heading-l">
+      Support users
+    </h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Email</th>
+          <th scope="col" class="govuk-table__header">Last sign in</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @support_users.each do |user| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= link_to user.email_address, support_privileged_user_path(user) %></th>
+            <td class="govuk-table__cell"><%= user.last_signed_in_at&.to_s(:govuk_date_short) || 'Never' %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l">
+      Computacenter users
+    </h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Email</th>
+          <th scope="col" class="govuk-table__header">Last sign in</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @computacenter_users.each do |user| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= link_to user.email_address, support_privileged_user_path(user) %></th>
+            <td class="govuk-table__cell"><%= user.last_signed_in_at&.to_s(:govuk_date_short) || 'Never' %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l">
+      MNO users
+    </h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Email</th>
+          <th scope="col" class="govuk-table__header">Last sign in</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @mno_users.each do |user| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= link_to user.email_address, support_privileged_user_path(user) %></th>
+            <td class="govuk-table__cell"><%= user.last_signed_in_at&.to_s(:govuk_date_short) || 'Never' %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support/privileged_users/new.html.erb
+++ b/app/views/support/privileged_users/new.html.erb
@@ -1,0 +1,29 @@
+<% title = t('page_titles.support.privileged_users.new') %>
+<% content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_back_link(text: 'Back', href: support_privileged_users_path) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%= form_with model: @form_object, url: support_privileged_users_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :full_name, required: true, label: { text: 'Full name', size: 'm' } %>
+      <%= f.govuk_email_field :email_address, required: true, label: { text: 'Email address', size: 'm' } %>
+
+      <% privileges = [
+        OpenStruct.new(id: 'support', name: 'Support'),
+        OpenStruct.new(id: 'computacenter', name: 'Computacenter'),
+      ] %>
+
+      <%= f.govuk_collection_check_boxes :privileges, privileges, :id, :name, legend: { text: "Which privileges should be granted?" } %>
+
+      <%= f.govuk_submit 'Create account' %>
+    <%- end %>
+  </div>
+</div>

--- a/app/views/support/privileged_users/show.html.erb
+++ b/app/views/support/privileged_users/show.html.erb
@@ -1,0 +1,37 @@
+<%- title = t('page_titles.support.privileged_users.show') %>
+<%- content_for :title, title %>
+<%- content_for :before_content do %>
+  <%= govuk_back_link(text: 'Back', href: support_privileged_users_path) %>
+<%- end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+
+    <%=
+      render GovukComponent::SummaryList.new do |component|
+        component.slot(
+          :row,
+          key: 'Email',
+          value: @user.email_address,
+        )
+
+        component.slot(
+          :row,
+          key: 'Last sign in',
+          value: @user.last_signed_in_at&.to_s(:govuk_date_short) || 'Never'
+        )
+
+        component.slot(
+          :row,
+          key: 'Privileges',
+          value: @user.privileges.map{|p| p.to_s.humanize}.join('<br>').html_safe
+        )
+      end
+    %>
+
+    <%= govuk_button_to 'Revoke all privileges', support_privileged_user_path(@user), class: 'govuk-button--warning', method: :delete %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,10 @@ en:
 
     support:
       home: Support
+      privileged_users:
+        index: Privileged users
+        show: Edit privileged user
+        new: Add privileged user
       allocation_batch_jobs:
         index: Bulk allocation update jobs
         show: Bulk allocation update job

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,7 @@ Rails.application.routes.draw do
 
   namespace :support do
     get '/', to: 'home#show', as: :home
+    resources :privileged_users, only: %i[index show destroy new create], path: 'privileged-users'
     get '/schools', to: 'home#schools'
     get '/technical', to: 'home#technical_support', as: :technical_support
     get '/feature-flags', to: 'home#feature_flags', as: :feature_flags

--- a/spec/controllers/support/privileged_users_controller_spec.rb
+++ b/spec/controllers/support/privileged_users_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Support::PrivilegedUsersController do
+  let(:support_user) { create(:support_user, role: 'third_line') }
+
+  before do
+    sign_in_as support_user
+  end
+
+  describe '#index' do
+    context 'when support user' do
+      let(:support_user) { create(:support_user) }
+
+      it 'is not successful' do
+        get :index
+        expect(response).not_to be_successful
+      end
+    end
+
+    context 'when third line support user' do
+      it 'is successful' do
+        get :index
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'creates privileged user' do
+      expect {
+        post :create, params: {
+          support_privileged_user_form: {
+            full_name: 'John Doe',
+            email_address: 'john.doe@digital.education.gov.uk',
+            privileges: %w[support],
+          },
+        }
+      }.to change(User, :count).by(1)
+
+      record = User.last
+
+      expect(record.full_name).to eql('John Doe')
+      expect(record.email_address).to eql('john.doe@digital.education.gov.uk')
+      expect(record.is_support).to be_truthy
+      expect(record.is_computacenter).to be_falsey
+    end
+  end
+
+  describe '#destroy' do
+    let!(:other_support_user) { create(:support_user) }
+
+    it 'removes privileges from user' do
+      expect {
+        delete :destroy, params: { id: other_support_user.id }
+      }.to change { other_support_user.reload.is_support }.from(true).to(false)
+    end
+  end
+
+  describe '#new' do
+    it 'is successful' do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#show' do
+    let!(:other_support_user) { create(:support_user) }
+
+    it 'is successful' do
+      get :show, params: { id: other_support_user.id }
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/form_objects/support/privileged_user_form_spec.rb
+++ b/spec/form_objects/support/privileged_user_form_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Support::PrivilegedUserForm do
+  describe 'validations' do
+    before do
+      form.valid?
+    end
+
+    context 'when full_name is blank' do
+      subject(:form) { described_class.new(email_address: '', privileges: []) }
+
+      it 'has errors' do
+        expect(form.errors[:full_name]).to be_present
+      end
+    end
+
+    context 'when email_address is blank' do
+      subject(:form) { described_class.new(email_address: '', privileges: []) }
+
+      it 'has errors' do
+        expect(form.errors[:email_address]).to be_present
+      end
+    end
+
+    context 'when email_address is not from valid domain' do
+      subject(:form) { described_class.new(email_address: 'user@example.com', privileges: []) }
+
+      it 'has errors' do
+        expect(form.errors[:email_address]).to be_present
+      end
+    end
+
+    context 'when email_address is from valid domain' do
+      ['user@computacenter.com',
+       'user@digital.education.gov.uk',
+       'user@education.gov.uk'].each do |email|
+        subject(:form) { described_class.new(email_address: email, privileges: []) }
+
+        it "does not have errors for #{email}" do
+          expect(form.errors[:email_address]).not_to be_present
+        end
+      end
+    end
+
+    context 'when email is taken' do
+      let!(:existing_user) { create(:support_user) }
+
+      subject(:form) { described_class.new(email_address: existing_user.email_address, privileges: []) }
+
+      it 'has errors' do
+        expect(form.errors[:email_address]).to be_present
+      end
+    end
+
+    context 'when no privileges selected' do
+      subject(:form) { described_class.new(email_address: '', privileges: []) }
+
+      it 'has errors' do
+        expect(form.errors[:privileges]).to be_present
+      end
+    end
+
+    context 'when injecting custom privilege' do
+      subject(:form) { described_class.new(email_address: '', privileges: %w[foo]) }
+
+      it 'has errors' do
+        expect(form.errors[:privileges]).to be_present
+      end
+    end
+  end
+
+  describe '#create_user!' do
+    subject(:form) { described_class.new(full_name: 'some body', email_address: 'user@digital.education.gov.uk', privileges: %w[support computacenter]) }
+
+    it 'sets up privileges' do
+      expect {
+        form.create_user!
+      }.to change(User, :count).by(1)
+
+      user = User.last
+
+      expect(user.is_support?).to be_truthy
+      expect(user.is_computacenter?).to be_truthy
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1180,4 +1180,22 @@ RSpec.describe User, type: :model do
       expect(User.from_responsible_body_or_schools).to be_empty
     end
   end
+
+  describe '#privileges' do
+    subject(:model) do
+      User.new(
+        is_support: true,
+        role: 'third_line',
+        is_computacenter: true,
+        mobile_network: build(:mobile_network),
+      )
+    end
+
+    it 'returns correct privileges' do
+      expect(model.privileges).to include(:support_user)
+      expect(model.privileges).to include(:third_line_support_user)
+      expect(model.privileges).to include(:computacenter_user)
+      expect(model.privileges).to include(:mno_user)
+    end
+  end
 end

--- a/spec/views/support/home/show.html.erb_spec.rb
+++ b/spec/views/support/home/show.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'support/home/show.html.erb' do
+  context 'when support user' do
+    let(:support_user) { build(:support_user) }
+
+    before do
+      enable_pundit(view, support_user)
+    end
+
+    it 'does not display privileged users section' do
+      render
+      expect(rendered).not_to include('Privileged users')
+    end
+  end
+
+  context 'when third line support user' do
+    let(:support_user) { build(:support_user, role: 'third_line') }
+
+    before do
+      enable_pundit(view, support_user)
+    end
+
+    it 'displays privileged users section' do
+      render
+      expect(rendered).to include('Privileged users')
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/lkhFVwWu/1712-third-line-support-can-add-other-support-users
- Save the need for a developer to onboard additional support users

### Changes proposed in this pull request

- Third line support users can:
  - view privileged users: support users, computacenter users and mno users
  - can also add other support users - these are restricted to certain domains for the email addresses
  - revoke all privileges of one of these users

### Screenshots

New section on support homepage 
![image](https://user-images.githubusercontent.com/92580/116055080-4214ab00-a674-11eb-83a3-0b367a2a72ff.png)

Index view
![image](https://user-images.githubusercontent.com/92580/116055246-67a1b480-a674-11eb-92ac-dffc5401e3c8.png)

Adding another user
![image](https://user-images.githubusercontent.com/92580/116055295-76886700-a674-11eb-91f9-ecfaae0ebb21.png)

### Guidance to review

- Sign in as non third line support
- Cannot see or access this areas
- Sign in as third line support
- Should be able to see and access new area
- Can see existing privileged users
- Can add privileged users
- Can remove privileges of users