### PR TITLE
Add performance profiling tools for dev and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,16 @@ group :development do
   # Gives a better error view with a web console
   gem 'better_errors'
   gem 'binding_of_caller'
+
+  # performance profiling
+  gem 'rack-mini-profiler'
+
+  # For memory profiling add ?pp=profile-memory to the URL of any request
+  gem 'memory_profiler'
+
+  # For call-stack profiling flamegraphs add ?pp=flamegraph to the URL of any request
+  gem 'flamegraph'
+  gem 'stackprof'
 end
 
 group :test do
@@ -157,6 +167,7 @@ end
 
 group :development, :test do
   gem 'brakeman'
+  gem 'bullet'
   gem 'bundle-audit'
   gem 'factory_bot_rails'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
       msgpack (~> 1.0)
     brakeman (5.0.0)
     builder (3.2.4)
+    bullet (6.1.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bundle-audit (0.1.0)
       bundler-audit
     bundler-audit (0.7.0.1)
@@ -157,6 +160,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flamegraph (0.9.5)
     foreman (0.87.2)
     fugit (1.3.9)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -210,6 +214,7 @@ GEM
       activesupport (>= 5.2.4.3)
       notifications-ruby-client (~> 5.1)
       rack (>= 2.1.4)
+    memory_profiler (0.9.14)
     method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -252,6 +257,8 @@ GEM
     raabro (1.3.3)
     racc (1.5.2)
     rack (2.2.3)
+    rack-mini-profiler (1.0.2)
+      rack (>= 1.2.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -403,6 +410,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
+    stackprof (0.2.12)
     thor (1.1.0)
     thwait (0.2.0)
       e2mmap
@@ -414,6 +422,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    uniform_notifier (1.14.1)
     view_component (2.30.0)
       activesupport (>= 5.0.0, < 7.0)
     web-console (4.1.0)
@@ -459,6 +468,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   brakeman
+  bullet
   bundle-audit
   byebug
   canonical-rails!
@@ -472,6 +482,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fakeredis
+  flamegraph
   foreman
   govuk-components (>= 1.1.5)
   govuk_design_system_formbuilder
@@ -481,6 +492,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.6)
   logstash-logger (~> 0.26.1)
   mail-notify
+  memory_profiler
   nokogiri
   notifications-ruby-client
   pagy
@@ -493,6 +505,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.2)
   pundit
+  rack-mini-profiler
   rack-throttle
   rails-controller-testing
   rails-erd
@@ -514,6 +527,7 @@ DEPENDENCIES
   site_prism
   spring
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   timecop
   tzinfo-data
   web-console (>= 3.3.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,14 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,12 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = false
+    Bullet.bullet_logger = true
+    Bullet.raise         = false # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,6 +16,9 @@ Rails.application.config.content_security_policy do |policy|
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"
+
+  # Workaround for rack mini profiler CSP error in development
+  policy.script_src :self, :https, :unsafe_eval if Rails.env.development?
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
### Context

To investigate potential performance improvements we can use these tools in development and test environments.

### Changes proposed in this pull request

Add the following gems:

Development:

- rack-mini-profiler
- memory_profiler
- flamegraph
- stackprof

Development and test:

- bullet

### Guidance to review

Start in the development environment locally and there will be a floating widget at the top left of the browser page.

<img width="709" alt="image" src="https://user-images.githubusercontent.com/420873/115919903-be8f6a00-a479-11eb-8b66-71b597bea9f2.png">

Check log/bullet.log for N+1 queries.