### PR TITLE
[1909] Add SocialCareLeaversProvision

### DIFF
--- a/app/concerns/school_type.rb
+++ b/app/concerns/school_type.rb
@@ -18,6 +18,7 @@ module SchoolType
       special: 'special',
       other_type: 'other_type',
       la_funded_place: 'la_funded_place',
+      social_care_provision: 'social_care_provision',
     }, _suffix: true
 
     def human_for_school_type

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -17,6 +17,7 @@ class LocalAuthority < ResponsibleBody
   validates :organisation_type, presence: true
 
   has_one :la_funded_place, foreign_key: 'responsible_body_id'
+  has_one :social_care_provision, foreign_key: 'responsible_body_id'
 
   def create_la_funded_places!(urn:, device_allocation: 0, router_allocation: 0, extra_args: {})
     return la_funded_place if la_funded_place.present?
@@ -39,5 +40,28 @@ class LocalAuthority < ResponsibleBody
     funded_place.device_allocations.std_device.create!(allocation: device_allocation)
     funded_place.device_allocations.coms_device.create!(allocation: router_allocation)
     funded_place
+  end
+
+  def create_social_care_provision!(urn:, device_allocation: 0, router_allocation: 0, extra_args: {})
+    return social_care_provision if social_care_provision.present?
+
+    attrs = {
+      responsible_body: self,
+      urn: urn,
+      name: 'Care leavers',
+      establishment_type: 'social_care_provision',
+      address_1: address_1,
+      address_2: address_2,
+      address_3: address_3,
+      town: town,
+      county: county,
+      postcode: postcode,
+    }.reverse_merge(extra_args)
+
+    school = SocialCareProvision.create!(attrs)
+    school.create_preorder_information!(who_will_order_devices: 'school')
+    school.device_allocations.std_device.create!(allocation: device_allocation)
+    school.device_allocations.coms_device.create!(allocation: router_allocation)
+    school
   end
 end

--- a/app/models/social_care_provision.rb
+++ b/app/models/social_care_provision.rb
@@ -1,0 +1,9 @@
+class SocialCareProvision < CompulsorySchool
+  def institution_type
+    'local_authority'
+  end
+
+  def techsource_urn
+    "SCL_#{responsible_body.gias_id}"
+  end
+end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe LocalAuthority do
+  subject(:la) { create(:local_authority) }
+
+  describe '#create_social_care_provision!' do
+    it 'creates a new school record' do
+      expect {
+        la.create_social_care_provision!(urn: 123_456, device_allocation: 10, router_allocation: 20)
+      }.to change(School, :count).by(1)
+
+      record = la.reload.social_care_provision
+      expect(record.urn).to be(123_456)
+      expect(record.name).to eql('Care leavers')
+      expect(record.address_1).to eql(la.address_1)
+      expect(record.address_2).to eql(la.address_2)
+      expect(record.address_3).to eql(la.address_3)
+      expect(record.town).to eql(la.town)
+      expect(record.county).to eql(la.county)
+      expect(record.postcode).to eql(la.postcode)
+    end
+
+    it 'creates a preorder' do
+      expect {
+        la.create_social_care_provision!(urn: 123_456, device_allocation: 10, router_allocation: 20)
+      }.to change { PreorderInformation.count }.by(1)
+
+      record = PreorderInformation.last
+      expect(record.who_will_order_devices).to eql('school')
+    end
+
+    it 'creates a new device allocation' do
+      expect {
+        la.create_social_care_provision!(urn: 123_456, device_allocation: 10, router_allocation: 20)
+      }.to change { SchoolDeviceAllocation.std_device.count }.by(1)
+
+      record = SchoolDeviceAllocation.std_device.last
+      expect(record.allocation).to be(10)
+    end
+
+    it 'creates a new router allocation' do
+      expect {
+        la.create_social_care_provision!(urn: 123_456, device_allocation: 10, router_allocation: 20)
+      }.to change { SchoolDeviceAllocation.coms_device.count }.by(1)
+
+      record = SchoolDeviceAllocation.coms_device.last
+      expect(record.allocation).to be(20)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/PT2OlVWG/1909-add-social-care-leavers-school-type
- We need a start point to hook on behaviour for social care leavers provision

### Changes proposed in this pull request

- Add `SocialCareLeaversProvision`
- Add method at attach such a provision to an LA

### Guidance to review

- Should be able to attach an `SocialCareLeaversProvision` to an LA via the rails console