### PR TITLE
Responsible body updates for iss

### DIFF
--- a/app/components/computacenter/school_changes_details_component.rb
+++ b/app/components/computacenter/school_changes_details_component.rb
@@ -25,10 +25,9 @@ private
   end
 
   def school_rows
-    urn = school.la_funded_place? ? school.techsource_urn : school.urn
     [{
       key: 'School URN',
-      value: urn,
+      value: school.urn,
     },
      {
        key: 'School name',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,7 +131,8 @@ private
   def school_root_url_for(user)
     if user.schools.size == 1
       if user.school.preorder_information&.school_will_order_devices? &&
-          user.school.preorder_information&.chromebook_info_still_needed?
+          user.school.preorder_information&.chromebook_info_still_needed? &&
+          !user.school.la_funded_provision?
         before_you_can_order_school_path(user.school)
       else
         home_school_path(user.schools.first)

--- a/app/controllers/computacenter/school_changes_controller.rb
+++ b/app/controllers/computacenter/school_changes_controller.rb
@@ -36,7 +36,7 @@ class Computacenter::SchoolChangesController < Computacenter::BaseController
 private
 
   def set_school
-    @school = School.gias_status_open.where_urn_or_ukprn(params[:id]).first!
+    @school = School.gias_status_open.where_urn_or_ukprn_or_provision_urn(params[:id]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -12,7 +12,7 @@ private
   end
 
   def set_school
-    @school = impersonated_or_current_user.schools.where_urn_or_ukprn(params[:urn].to_i).first!
+    @school = impersonated_or_current_user.schools.where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
   end
 
   def require_completed_welcome_wizard!

--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -4,7 +4,7 @@ class School::DevicesController < School::BaseController
       if impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
         render :can_order_for_specific_circumstances
       elsif impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order?
-        if @school.la_funded_place?
+        if @school.la_funded_provision?
           redirect_to get_laptops_school_path(@school)
         else
           render :can_order

--- a/app/controllers/school/home_controller.rb
+++ b/app/controllers/school/home_controller.rb
@@ -1,7 +1,7 @@
 class School::HomeController < School::BaseController
   def show
     @allocation = @school.std_device_allocation&.allocation || 0
-    if @school.la_funded_place?
+    if @school.la_funded_provision?
       render 'show_la_funded_place'
     else
       render

--- a/app/form_objects/chromebook_information_form.rb
+++ b/app/form_objects/chromebook_information_form.rb
@@ -39,7 +39,7 @@ class ChromebookInformationForm
   end
 
   def will_need_chromebooks_and_is_not_a_la_funded_school?
-    will_need_chromebooks? && !school.la_funded_place?
+    will_need_chromebooks? && !school.la_funded_provision?
   end
 
   def will_need_chromebooks_message

--- a/app/models/la_funded_place.rb
+++ b/app/models/la_funded_place.rb
@@ -1,9 +1,20 @@
-class LaFundedPlace < CompulsorySchool
-  def institution_type
-    'local_authority'
+class LaFundedPlace < School
+  validates :provision_urn, presence: true
+
+  enum provision_type: {
+    iss: 'iss',
+    scl: 'scl',
+  }, _suffix: 'provision'
+
+  def urn
+    provision_urn
   end
 
-  def techsource_urn
-    "ISS_#{responsible_body.gias_id}"
+  def to_param
+    provision_urn
+  end
+
+  def institution_type
+    'local_authority'
   end
 end

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -116,7 +116,7 @@ class PreorderInformation < ApplicationRecord
   def chromebook_information_complete?
     # if we remove the '&' it breaks 400+ specs as this is called by infer_status
     # via callbacks
-    return true if school&.la_funded_place_establishment_type?
+    return true if school&.la_funded_provision?
 
     if will_need_chromebooks == 'yes'
       school_or_rb_domain.present? && recovery_email_address.present?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -45,8 +45,12 @@ class School < ApplicationRecord
   }, _prefix: true
 
   scope :where_urn_or_ukprn, ->(identifier) { where('urn = ? OR ukprn = ?', identifier, identifier) }
+  scope :where_urn_or_ukprn_or_provision_urn, ->(identifier) { where('urn = ? OR ukprn = ? OR provision_urn = ?', identifier.to_i, identifier.to_i, identifier) }
   scope :further_education, -> { where(type: 'FurtherEducationSchool') }
-  scope :la_funded_place, -> { where(type: 'LaFundedPlace') }
+  scope :la_funded_provision, -> { where(type: 'LaFundedPlace') }
+  scope :iss_provision, -> { where(type: 'LaFundedPlace', provision_type: 'iss') }
+  scope :scl_provision, -> { where(type: 'LaFundedPlace', provision_type: 'scl') }
+  scope :excluding_la_funded_provisions, -> { where.not(type: 'LaFundedPlace') }
 
   after_update :maybe_generate_user_changes
 
@@ -74,7 +78,7 @@ class School < ApplicationRecord
     type == 'FurtherEducationSchool'
   end
 
-  def la_funded_place?
+  def la_funded_provision?
     type == 'LaFundedPlace'
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
   end
 
   def la_funded_user?
-    schools.la_funded_place.any?
+    schools.la_funded_provision.any?
   end
 
   def has_multiple_schools?
@@ -198,7 +198,7 @@ class User < ApplicationRecord
     wizard = school_welcome_wizards.find_by_school_id(school.id)
     return wizard if wizard
 
-    if school.la_funded_place?
+    if school.la_funded_provision?
       school_welcome_wizards.create!(school: school, step: 'complete')
     else
       school_welcome_wizards.create!(school: school)

--- a/app/services/interstitial_picker.rb
+++ b/app/services/interstitial_picker.rb
@@ -6,12 +6,12 @@ class InterstitialPicker
   end
 
   def call
-    @call ||= if user.la_funded_user? && user.is_responsible_body_user? && user.responsible_body.la_funded_place&.device_allocations&.can_order_std_devices_now.present?
+    @call ||= if user.la_funded_user? && user.is_responsible_body_user? && user.responsible_body.iss_provision&.device_allocations&.can_order_std_devices_now.present?
                 OpenStruct.new(
                   title: 'Laptops and internet access for state-funded pupils in independent settings',
                   partial: 'interstitials/la_funded_rb_user',
                 )
-              elsif user.la_funded_user? && user.schools.la_funded_place.first&.device_allocations&.can_order_std_devices_now.present?
+              elsif user.la_funded_user? && user.schools.iss_provision.first&.device_allocations&.can_order_std_devices_now.present?
                 OpenStruct.new(
                   title: 'Get laptops for state-funded pupils at independent settings',
                   partial: 'interstitials/la_funded_user',

--- a/app/services/personas/la_funded_place.rb
+++ b/app/services/personas/la_funded_place.rb
@@ -10,15 +10,12 @@ class Personas::LaFundedPlace
 private
 
   def la_funded_place
-    @la_funded_place ||= la.la_funded_place || la.create_la_funded_place!(name: 'LA funded place') do |s|
-      s.urn = (School.maximum(:urn) || 800_000) + 1
-      s.address_1 = '14 High Street'
-      s.town = 'Cambridge'
-      s.county = 'Cambridgeshire'
-      s.postcode = 'CB1 0BE'
-    end
-
-    @la_funded_place.preorder_information || @la_funded_place.build_preorder_information(who_will_order_devices: 'school').save!
+    @la_funded_place ||= la.la_funded_provision || la.create_iss_provision!(extra_args: {
+      address_1: '14 High Street',
+      town: 'Cambridge',
+      county: 'Cambridgeshire',
+      postcode: 'CB1 0BE',
+    })
 
     @la_funded_place
   end
@@ -38,6 +35,7 @@ private
     @la ||= LocalAuthority.find_or_create_by!(name: 'Cambridgeshire') do |rb|
       rb.organisation_type = 'county'
       rb.who_will_order_devices = 'responsible_body'
+      rb.gias_id = '873'
     end
   end
 

--- a/app/services/school_data_exporter.rb
+++ b/app/services/school_data_exporter.rb
@@ -56,11 +56,10 @@ private
   end
 
   def build_name_fields_for(school)
-    urn = school.la_funded_place? ? school.techsource_urn : school.urn
-    split_string("#{urn} #{school.name}", limit: 35)
+    split_string("#{school.urn} #{school.name}", limit: 35)
   end
 
   def schools
-    School.all.includes(:responsible_body).order(urn: :asc)
+    School.all.includes(:responsible_body).order(urn: :asc, ukprn: :asc, provision_urn: :asc)
   end
 end

--- a/app/views/computacenter/school_changes/edit.html.erb
+++ b/app/views/computacenter/school_changes/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= "#{@school.name} (#{@school.la_funded_place? ? @school.techsource_urn : @school.urn})" %></span>
+      <span class="govuk-caption-xl"><%= "#{@school.name} (#{@school.urn})" %></span>
       <%= title %>
     </h1>
 

--- a/app/views/computacenter/school_changes/index.html.erb
+++ b/app/views/computacenter/school_changes/index.html.erb
@@ -60,7 +60,7 @@
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= school.responsible_body.computacenter_identifier %></td>
                 <td class="govuk-table__cell"><%= school.responsible_body.computacenter_reference %></td>
-                <td class="govuk-table__cell"><%= school.la_funded_place? ? school.techsource_urn : school.urn %></td>
+                <td class="govuk-table__cell"><%= school.urn %></td>
                 <td class="govuk-table__cell"><%= school.name %></td>
                 <td class="govuk-table__cell"><%= school.address %></td>
                 <td class="govuk-table__cell"><%= school.computacenter_reference %></td>

--- a/app/views/school/la_funded_places/order.html.erb
+++ b/app/views/school/la_funded_places/order.html.erb
@@ -79,7 +79,9 @@
 
     <h2 class="govuk-heading-m">Your laptops will be delivered to:</h2>
     <p class="govuk-body">
-      <%= @school.address_components.join('<br>').html_safe %>
+      <% @school.address_components.each do |address_line| %>
+        <%= address_line %><br/>
+      <% end -%>
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'Contact us to change your delivery address.', support_ticket_path %>
@@ -90,7 +92,7 @@
       You’ll place your order on a website called TechSource.
     </p>
     <p class="govuk-body">
-      When you’re asked for a URN, use ‘<strong><%= @school.techsource_urn %></strong>’.
+      When you’re asked for a URN, use ‘<strong><%= @school.urn %></strong>’.
     </p>
     <p class="govuk-body">
     <% devices_available = @school.std_device_allocation.devices_available_to_order %>

--- a/db/migrate/20210426150053_add_la_funded_place_urn_to_schools.rb
+++ b/db/migrate/20210426150053_add_la_funded_place_urn_to_schools.rb
@@ -1,0 +1,7 @@
+class AddLaFundedPlaceUrnToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :provision_urn, :string
+    add_column :schools, :provision_type, :string
+    add_index :schools, :provision_urn, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_132319) do
+ActiveRecord::Schema.define(version: 2021_04_26_150053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -369,8 +369,11 @@ ActiveRecord::Schema.define(version: 2021_04_16_132319) do
     t.text "fe_type"
     t.boolean "hide_mno", default: false
     t.datetime "opted_out_of_comms_at"
+    t.string "provision_urn"
+    t.string "provision_type"
     t.index ["computacenter_change"], name: "index_schools_on_computacenter_change"
     t.index ["name"], name: "index_schools_on_name"
+    t.index ["provision_urn"], name: "index_schools_on_provision_urn", unique: true
     t.index ["responsible_body_id"], name: "index_schools_on_responsible_body_id"
     t.index ["type", "id"], name: "index_schools_on_type_and_id"
     t.index ["type"], name: "index_schools_on_type"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -6,9 +6,20 @@ FactoryBot.define do
       urn { nil }
     end
 
-    factory :la_funded_place, class: 'LaFundedPlace' do
+    factory :iss_provision, class: 'LaFundedPlace' do
       association :responsible_body, factory: :local_authority
       establishment_type { 'la_funded_place' }
+      name { 'State-funded pupils in independent special schools and alternative provision' }
+      provision_type { 'iss' }
+      provision_urn { "ISS#{responsible_body.gias_id}" }
+    end
+
+    factory :scl_provision, class: 'LaFundedPlace' do
+      association :responsible_body, factory: :local_authority
+      establishment_type { 'la_funded_place' }
+      name { 'Care leavers' }
+      provision_type { 'scl' }
+      provision_urn { "SCL#{responsible_body.gias_id}" }
     end
 
     association :responsible_body, factory: %i[local_authority trust].sample

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
 
     factory :la_funded_place_user do
       transient do
-        school { build(:la_funded_place) }
+        school { build(:iss_provision) }
       end
       after(:build) do |user, evaluator|
         user.schools << evaluator.school if user.schools.empty? && evaluator.school.present?

--- a/spec/features/ordering_for_la_funded_devices_spec.rb
+++ b/spec/features/ordering_for_la_funded_devices_spec.rb
@@ -82,8 +82,8 @@ RSpec.feature 'Ordering for LA-funded devices', type: :feature do
   end
 
   def given_there_is_an_independent_settings_school
-    @school = create(:la_funded_place, :can_order, :with_preorder_information)
-    @school.preorder_information.update!(who_will_order_devices: 'responsible_body')
+    @school = create(:iss_provision, :can_order, :with_preorder_information)
+    @school.preorder_information.update!(who_will_order_devices: 'school')
   end
 
   def given_i_am_signed_in_as_an_independent_settings_school_user

--- a/spec/features/school/navigate_school_welcome_wizard_spec.rb
+++ b/spec/features/school/navigate_school_welcome_wizard_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Navigate school welcome wizard' do
   end
 
   def as_a_new_la_funded_user
-    @school = create(:la_funded_place, std_device_allocation: available_allocation)
+    @school = create(:iss_provision, std_device_allocation: available_allocation)
     @user = create(:la_funded_place_user, :new_visitor, :has_not_seen_privacy_notice, school: @school)
   end
 

--- a/spec/form_objects/chromebook_information_form_spec.rb
+++ b/spec/form_objects/chromebook_information_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChromebookInformationForm do
   let(:school) do
     instance_double(CompulsorySchool,
                     institution_type: 'Educational foundation',
-                    la_funded_place?: false)
+                    la_funded_provision?: false)
   end
   let(:form) do
     described_class.new(school: school,
@@ -62,7 +62,7 @@ RSpec.describe ChromebookInformationForm do
   end
 
   context 'LA school' do
-    let(:school) { create(:la_funded_place) }
+    let(:school) { create(:iss_provision) }
 
     let(:form) do
       described_class.new(school: school,

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe LocalAuthority, type: :model do
+  subject(:local_authority) { create(:local_authority, address_1: 'Big Office', address_2: 'High St.', town: 'Little Hampton', postcode: 'LH1 2PE') }
+
+  describe '#create_iss_provision!' do
+    context 'when a iss provision does not already exist for the LA' do
+      it 'adds an iss funded place' do
+        expect { local_authority.create_iss_provision! }.to change { LaFundedPlace.count }.by(1)
+      end
+
+      it 'creates a provision_urn in the correct format' do
+        provision = local_authority.create_iss_provision!
+        expect(provision.provision_urn).to eq("ISS#{local_authority.gias_id}")
+      end
+
+      it 'populates the address from the local authority' do
+        provision = local_authority.create_iss_provision!
+        expect(provision.address_1).to eq(local_authority.address_1)
+        expect(provision.address_2).to eq(local_authority.address_2)
+        expect(provision.town).to eq(local_authority.town)
+        expect(provision.postcode).to eq(local_authority.postcode)
+      end
+
+      it 'adds preorder information to the provision' do
+        provision = local_authority.create_iss_provision!
+        expect(provision.preorder_information).to be_present
+        expect(provision.preorder_information.who_will_order_devices).to eq('school')
+      end
+
+      it 'adds a default device and router allocation' do
+        provision = local_authority.create_iss_provision!
+        expect(provision.std_device_allocation.allocation).to eq(0)
+        expect(provision.coms_device_allocation.allocation).to eq(0)
+      end
+
+      it 'sets the device and router allocations to the optional supplied values' do
+        provision = local_authority.create_iss_provision!(device_allocation: 50, router_allocation: 5)
+        expect(provision.std_device_allocation.allocation).to eq(50)
+        expect(provision.coms_device_allocation.allocation).to eq(5)
+      end
+    end
+
+    context 'when a iss provision already exists for the LA' do
+      let!(:existing_provision) { create(:iss_provision, responsible_body: local_authority) }
+
+      it 'returns the existing provision' do
+        provision = local_authority.create_iss_provision!
+        expect(provision).to eq(existing_provision)
+      end
+    end
+  end
+
+  describe '#create_scl_provision!' do
+    context 'when a scl provision does not already exist for the LA' do
+      it 'adds an scl funded place' do
+        expect { local_authority.create_scl_provision! }.to change { LaFundedPlace.count }.by(1)
+      end
+
+      it 'creates a provision_urn in the correct format' do
+        provision = local_authority.create_scl_provision!
+        expect(provision.provision_urn).to eq("SCL#{local_authority.gias_id}")
+      end
+
+      it 'populates the address from the local authority' do
+        provision = local_authority.create_scl_provision!
+        expect(provision.address_1).to eq(local_authority.address_1)
+        expect(provision.address_2).to eq(local_authority.address_2)
+        expect(provision.town).to eq(local_authority.town)
+        expect(provision.postcode).to eq(local_authority.postcode)
+      end
+
+      it 'adds preorder information to the provision' do
+        provision = local_authority.create_scl_provision!
+        expect(provision.preorder_information).to be_present
+        expect(provision.preorder_information.who_will_order_devices).to eq('school')
+      end
+
+      it 'adds a default device and router allocation' do
+        provision = local_authority.create_scl_provision!
+        expect(provision.std_device_allocation.allocation).to eq(0)
+        expect(provision.coms_device_allocation.allocation).to eq(0)
+      end
+
+      it 'sets the device and router allocations to the optional supplied values' do
+        provision = local_authority.create_scl_provision!(device_allocation: 50, router_allocation: 5)
+        expect(provision.std_device_allocation.allocation).to eq(50)
+        expect(provision.coms_device_allocation.allocation).to eq(5)
+      end
+    end
+
+    context 'when a scl provision already exists for the LA' do
+      let!(:existing_provision) { create(:scl_provision, responsible_body: local_authority) }
+
+      it 'returns the existing provision' do
+        provision = local_authority.create_scl_provision!
+        expect(provision).to eq(existing_provision)
+      end
+    end
+  end
+end

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe PreorderInformation, type: :model do
   describe '#chromebook_information_complete?' do
     context 'la funded places' do
       let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: true) }
-      let(:school) { create(:la_funded_place, :centrally_managed, responsible_body: local_authority) }
+      let(:school) { create(:iss_provision, :centrally_managed, responsible_body: local_authority) }
 
       subject(:preorder_info) { school.preorder_information }
 

--- a/spec/services/interstitial_picker_spec.rb
+++ b/spec/services/interstitial_picker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe InterstitialPicker do
   describe '#call' do
     context 'when LA user + LA funded place user' do
-      let(:school) { create :la_funded_place, std_device_allocation: allocation }
+      let(:school) { create :iss_provision, std_device_allocation: allocation }
       let(:user) { create :user, schools: [school], responsible_body: la }
       let(:service) { described_class.new(user: user) }
       let(:la) { school.responsible_body }
@@ -26,7 +26,7 @@ RSpec.describe InterstitialPicker do
     end
 
     context 'when LA funded place user' do
-      let(:school) { create :la_funded_place, std_device_allocation: allocation }
+      let(:school) { create :iss_provision, std_device_allocation: allocation }
       let(:user) { create :user, schools: [school] }
       let(:service) { described_class.new(user: user) }
 

--- a/spec/services/school_data_exporter_spec.rb
+++ b/spec/services/school_data_exporter_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SchoolDataExporter, type: :model do
 
   context 'when exporting LA funded places' do
     let(:local_authority) { create(:local_authority) }
-    let!(:school) { create(:la_funded_place, responsible_body: local_authority) }
+    let!(:school) { create(:iss_provision, responsible_body: local_authority) }
 
     before do
       exporter.export_schools
@@ -83,13 +83,13 @@ RSpec.describe SchoolDataExporter, type: :model do
       remove_file(filename)
     end
 
-    it 'uses the techsource urn' do
+    it 'uses the LA funded place urn' do
       data = CSV.parse(File.read(filename), headers: true)
       expect(data.count).to eq(School.count)
 
       found = false
       data.each do |row|
-        if row['School URN + School Name'].start_with?(school.techsource_urn)
+        if row['School URN + School Name'].start_with?(school.provision_urn)
           found = true
         end
       end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/EINnKlVj/1905-iss-add-maidenhead-la-and-cornwall-la-schools) - when adding these initial independent special school provisions for manual processing we identified extra functionality that wasn't in place yet that was needed and also confirmed the URN format and added provision for Social care

### Changes proposed in this pull request
Add creation of ISS and SCL provision methods to the `LocalAuthority` model.
Adds `provision_urn` and `provision_type` to school DB schema
Prevents `LaFundedPlace` schools from appearing in the responsible bodies list of schools
Uses `provision_urn` in place of `urn` where applicable

### Guidance to review
Add ISS or SCL provisions via the `LocalAuthority#create_iss_provision!` or `LocalAuthority#create_scl_provision!`. This will add a `LaFundedPlace` with the `provision_type` set to `iss` or `scl`.
A RB user should not see either of these in their list of schools and colleges.
