### PR TITLE
Update README to say how to run spec files or spec directories in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ You can then login with your new support user, check the rails logs for the magi
 ## Running specs
 ```
 bundle exec rake parallel:setup
-bundle exec rake # runs rspec and other code checks
+bundle exec parallel_rspec spec/models # to run spec directories (or individual spec files) in parallel
+bundle exec rake # runs rspec (in parallel) and other code checks
 ```
 
 ## Linting


### PR DESCRIPTION
### Context

`README.md` was missing instructions on how to run RSpec in parallel without running entire suite

### Changes proposed in this pull request

Add instructions to run RSpec in parallel on spec directories or individual spec files

### Guidance to review

