### PR TITLE
add docker to dependabot manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
   - dependency-name: core-js
     versions:
     - 3.10.2
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
### Context

- To keep docker manifest up-to-date

### Changes proposed in this pull request

- Add docker to dependabot manifest

### Guidance to review

- Dependabot manifest should be valid