### PR TITLE
Handle negative values in the bulk allocation update

### DIFF
--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -32,5 +32,11 @@ FactoryBot.define do
       cap { 100 }
       devices_ordered { 100 }
     end
+
+    trait :partially_ordered do
+      allocation { 100 }
+      cap { 100 }
+      devices_ordered { Faker::Number.within(range: 20..80) }
+    end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -74,6 +74,14 @@ FactoryBot.define do
       std_device_allocation { association :school_device_allocation, :with_std_allocation, school: instance }
     end
 
+    trait :with_std_device_allocation_fully_ordered do
+      std_device_allocation { association :school_device_allocation, :with_std_allocation, :fully_ordered, school: instance }
+    end
+
+    trait :with_std_device_allocation_partially_ordered do
+      std_device_allocation { association :school_device_allocation, :with_std_allocation, :partially_ordered, school: instance }
+    end
+
     trait :with_coms_device_allocation do
       coms_device_allocation { association :school_device_allocation, :with_coms_allocation, school: instance }
     end

--- a/spec/jobs/allocation_job_spec.rb
+++ b/spec/jobs/allocation_job_spec.rb
@@ -135,6 +135,27 @@ RSpec.describe AllocationJob do
           }.to change { school.std_device_allocation.reload.allocation }.by(-1)
         end
       end
+
+      context 'maintain part of allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-100', order_state: 'cannot_order') }
+
+        it 'reduces allocation to match ordered' do
+          described_class.perform_now(batch_job)
+          expect(school.std_device_allocation.reload.allocation).to eq(school.std_device_allocation.devices_ordered)
+        end
+      end
+
+      context 'maintain allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_fully_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
+
+        it 'does not update the allocation' do
+          expect {
+            described_class.perform_now(batch_job)
+          }.not_to change(school.std_device_allocation.reload, :allocation)
+        end
+      end
     end
 
     context 'for school that can order' do
@@ -193,6 +214,27 @@ RSpec.describe AllocationJob do
           }.to change { school.std_device_allocation.reload.allocation }.by(-1)
         end
       end
+
+      context 'maintain part of allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-100', order_state: 'cannot_order') }
+
+        it 'reduces allocation to match ordered' do
+          described_class.perform_now(batch_job)
+          expect(school.std_device_allocation.reload.allocation).to eq(school.std_device_allocation.devices_ordered)
+        end
+      end
+
+      context 'maintain allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_fully_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
+
+        it 'does not update the allocation' do
+          expect {
+            described_class.perform_now(batch_job)
+          }.not_to change(school.std_device_allocation.reload, :allocation)
+        end
+      end
     end
 
     context 'when school is part of virtual cap pool' do
@@ -244,6 +286,27 @@ RSpec.describe AllocationJob do
           expect {
             described_class.perform_now(batch_job)
           }.to change { school1.std_device_allocation.reload.raw_allocation }.by(-1)
+        end
+      end
+
+      context 'maintain part of allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-100', order_state: 'cannot_order') }
+
+        it 'reduces allocation to match ordered' do
+          described_class.perform_now(batch_job)
+          expect(school.std_device_allocation.reload.allocation).to eq(school.std_device_allocation.devices_ordered)
+        end
+      end
+
+      context 'maintain allocation if already ordered' do
+        let!(:school) { create(:school, :with_std_device_allocation_fully_ordered) }
+        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
+
+        it 'does not update the allocation' do
+          expect {
+            described_class.perform_now(batch_job)
+          }.not_to change(school.std_device_allocation.reload, :allocation)
         end
       end
     end


### PR DESCRIPTION
### Context

Negative values in bulk allocation should not reduce allocation below devices_ordered or zero.

### Changes proposed in this pull request

When negative delta values are passed allocations will be reduce to the max of new_allocation, devices_ordered or zero.

### Guidance to review

Using the bulk updater add negative values that will reduce the allocation below devices_ordered. The allocation will be equal to devices_ordered.
