### PR TITLE
[1932] Prevent errors when using ISS and SCL 'urns' in support area

### DIFF
--- a/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
+++ b/app/controllers/responsible_body/devices/change_who_will_order_controller.rb
@@ -34,7 +34,7 @@ private
   end
 
   def set_school
-    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = @responsible_body.schools.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
   end
 
   def who_will_order

--- a/app/controllers/responsible_body/devices/chromebook_information_controller.rb
+++ b/app/controllers/responsible_body/devices/chromebook_information_controller.rb
@@ -30,7 +30,7 @@ class ResponsibleBody::Devices::ChromebookInformationController < ResponsibleBod
 private
 
   def find_school!
-    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = @responsible_body.schools.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
   end
 
   def chromebook_params

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -4,7 +4,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
   def index; end
 
   def show
-    @school = @responsible_body.schools.where_urn_or_ukprn(params[:urn]).first!
+    @school = @responsible_body.schools.where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
     if @school.preorder_information.needs_contact?
       redirect_to responsible_body_devices_school_who_to_contact_path(@school.urn)
     elsif @school.preorder_information.orders_managed_centrally?
@@ -13,7 +13,7 @@ class ResponsibleBody::Devices::SchoolsController < ResponsibleBody::BaseControl
   end
 
   def order_devices
-    @school = @responsible_body.schools.where_urn_or_ukprn(params[:urn]).first!
+    @school = @responsible_body.schools.where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
   end
 
 private

--- a/app/controllers/responsible_body/devices/who_to_contact_controller.rb
+++ b/app/controllers/responsible_body/devices/who_to_contact_controller.rb
@@ -48,7 +48,7 @@ private
   end
 
   def find_school!
-    @school = @responsible_body.schools.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = @responsible_body.schools.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
   end
 
   def who_to_contact_form_params

--- a/app/controllers/support/addresses_controller.rb
+++ b/app/controllers/support/addresses_controller.rb
@@ -2,13 +2,13 @@ class Support::AddressesController < Support::BaseController
   before_action { authorize School }
 
   def edit
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
 
     authorize @school, :update_address?
   end
 
   def update
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
 
     authorize @school, :update_address?
 

--- a/app/controllers/support/schools/devices/allocation_controller.rb
+++ b/app/controllers/support/schools/devices/allocation_controller.rb
@@ -28,7 +28,7 @@ private
   helper_method :device_type
 
   def set_school_and_allocation
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     authorize @school, :show?
     @allocation = SchoolDeviceAllocation.find_or_initialize_by(school: @school, device_type: device_type)
     authorize @allocation

--- a/app/controllers/support/schools/devices/change_who_will_order_controller.rb
+++ b/app/controllers/support/schools/devices/change_who_will_order_controller.rb
@@ -33,7 +33,7 @@ private
   end
 
   def set_school
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
   end
 
   def who_will_order

--- a/app/controllers/support/schools/devices/chromebooks_controller.rb
+++ b/app/controllers/support/schools/devices/chromebooks_controller.rb
@@ -28,7 +28,7 @@ class Support::Schools::Devices::ChromebooksController < Support::BaseController
 private
 
   def set_school
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/support/schools/devices/order_status_controller.rb
+++ b/app/controllers/support/schools/devices/order_status_controller.rb
@@ -69,7 +69,7 @@ class Support::Schools::Devices::OrderStatusController < Support::BaseController
 private
 
   def set_school
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     authorize @school, :show?
   end
 

--- a/app/controllers/support/schools/opt_outs_controller.rb
+++ b/app/controllers/support/schools/opt_outs_controller.rb
@@ -19,7 +19,7 @@ class Support::Schools::OptOutsController < Support::BaseController
 private
 
   def set_school
-    @school ||= School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school ||= School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
   end
 
   def form_params

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -31,14 +31,14 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def show
-    @school = School.includes(:responsible_body).where_urn_or_ukprn(params[:urn]).first!
+    @school = School.includes(:responsible_body).where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
     @users = policy_scope(@school.users).not_deleted
     @email_audits = @school.email_audits.order(created_at: :desc)
     @timeline = Timeline::School.new(school: @school)
   end
 
   def confirm_invitation
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     @school_contact = @school.preorder_information&.school_contact
     if @school_contact.nil?
       flash[:warning] = I18n.t('support.schools.invite.no_school_contact', name: @school.name)
@@ -47,7 +47,7 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def invite
-    school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     success = school.invite_school_contact
     if success
       flash[:success] = I18n.t('support.schools.invite.success', name: school.name)
@@ -58,20 +58,20 @@ class Support::SchoolsController < Support::BaseController
   end
 
   def history
-    @school = School.where_urn_or_ukprn(params[:school_urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
     @history_object = object_for_view_mode
   end
 
   def edit
     authorize School, :update_name?
 
-    @school = School.where_urn_or_ukprn(params[:urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
   end
 
   def update
     authorize School, :update_name?
 
-    @school = School.where_urn_or_ukprn(params[:urn]).first!
+    @school = School.where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
 
     if @school.update(school_params)
       flash[:success] = 'School has been updated'

--- a/app/controllers/support/users/schools_controller.rb
+++ b/app/controllers/support/users/schools_controller.rb
@@ -58,7 +58,7 @@ private
   end
 
   def set_school
-    @school = @user.schools.where_urn_or_ukprn(params[:urn]).first || School.gias_status_open.where_urn_or_ukprn(params[:urn]).first
+    @school = @user.schools.where_urn_or_ukprn_or_provision_urn(params[:urn]).first || School.gias_status_open.where_urn_or_ukprn_or_provision_urn(params[:urn]).first
   end
 
   def update_schools_params

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -114,7 +114,7 @@ private
 
   def set_school_if_present
     if params[:school_urn]
-      @school = School.gias_status_open.where_urn_or_ukprn(params[:school_urn]).first!
+      @school = School.gias_status_open.where_urn_or_ukprn_or_provision_urn(params[:school_urn]).first!
       authorize @school, :show?
     end
   end

--- a/app/form_objects/school_search_form.rb
+++ b/app/form_objects/school_search_form.rb
@@ -29,7 +29,7 @@ class SchoolSearchForm
     school_records = School.includes(:responsible_body, :std_device_allocation)
 
     if search_type == 'single'
-      school_records = school_records.matching_name_or_urn_or_ukprn(identifier.presence || name_or_identifier)
+      school_records = school_records.matching_name_or_urn_or_ukprn_or_provision_urn(identifier.presence || name_or_identifier)
     elsif search_type == 'multiple'
       school_records = school_records.where('urn IN (?) OR ukprn in (?)', array_of_identifiers, array_of_identifiers) if array_of_identifiers.present?
     elsif search_type == 'responsible_body_or_order_state'

--- a/app/form_objects/support/school_suggestion_form.rb
+++ b/app/form_objects/support/school_suggestion_form.rb
@@ -46,7 +46,7 @@ private
 
   def schools_by_name_or_urn_or_ukprn
     School
-      .matching_name_or_urn_or_ukprn(@name_or_urn_or_ukprn)
+      .matching_name_or_urn_or_ukprn_or_provision_urn(@name_or_urn_or_ukprn)
       .includes(:responsible_body)
       .order(:name)
       .limit(MAX_NUMBER_OF_SUGGESTED_SCHOOLS)

--- a/app/models/allocation_batch_job.rb
+++ b/app/models/allocation_batch_job.rb
@@ -1,5 +1,5 @@
 class AllocationBatchJob < ApplicationRecord
   def school
-    @school ||= School.where_urn_or_ukprn(urn || ukprn).first!
+    @school ||= School.where_urn_or_ukprn_or_provision_urn(urn || ukprn).first!
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -22,7 +22,7 @@ class School < ApplicationRecord
 
   validates :name, presence: true
 
-  pg_search_scope :matching_name_or_urn_or_ukprn, against: %i[name urn ukprn], using: { tsearch: { prefix: true } }
+  pg_search_scope :matching_name_or_urn_or_ukprn_or_provision_urn, against: %i[name urn ukprn provision_urn], using: { tsearch: { prefix: true } }
 
   before_create :set_computacenter_change
 
@@ -45,7 +45,7 @@ class School < ApplicationRecord
   }, _prefix: true
 
   scope :where_urn_or_ukprn, ->(identifier) { where('urn = ? OR ukprn = ?', identifier, identifier) }
-  scope :where_urn_or_ukprn_or_provision_urn, ->(identifier) { where('urn = ? OR ukprn = ? OR provision_urn = ?', identifier.to_i, identifier.to_i, identifier) }
+  scope :where_urn_or_ukprn_or_provision_urn, ->(identifier) { where('urn = ? OR ukprn = ? OR provision_urn = ?', identifier.to_i, identifier.to_i, identifier.to_s) }
   scope :further_education, -> { where(type: 'FurtherEducationSchool') }
   scope :la_funded_provision, -> { where(type: 'LaFundedPlace') }
   scope :iss_provision, -> { where(type: 'LaFundedPlace', provision_type: 'iss') }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -356,12 +356,12 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe '#matching_name_or_urn_or_ukprn' do
+  describe '#matching_name_or_urn_or_ukprn_or_provision_urn' do
     it 'returns schools with the provided URN' do
       matched_school = create(:school, urn: 123_456)
       create(:school, urn: 123_458) # non-matching school
 
-      expect(School.matching_name_or_urn_or_ukprn(123_456)).to eq([matched_school])
+      expect(School.matching_name_or_urn_or_ukprn_or_provision_urn(123_456)).to eq([matched_school])
     end
 
     it 'returns schools which match the name partially or exactly' do
@@ -369,7 +369,14 @@ RSpec.describe School, type: :model do
       matched_school2 = create(:school, name: 'Southside Primary')
       create(:school, name: 'Northside') # non-matching school
 
-      expect(School.matching_name_or_urn_or_ukprn('Southside')).to contain_exactly(matched_school1, matched_school2)
+      expect(School.matching_name_or_urn_or_ukprn_or_provision_urn('Southside')).to contain_exactly(matched_school1, matched_school2)
+    end
+
+    it 'returns LaFundedPlaces matching the provided URN' do
+      matched_school = create(:iss_provision, provision_urn: 'ISS999')
+      create(:school, urn: 123_458) # non-matching school
+
+      expect(School.matching_name_or_urn_or_ukprn_or_provision_urn('ISS999')).to eq([matched_school])
     end
   end
 


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/PmWLwSX0/1932-iss-school-show-page-displays-an-error-in-production)
Errors in production search from support area.

### Changes proposed in this pull request
Use the scopes that include handling `provision_urn` for school searches
This does not include the multi-URN search from the support area and that is a much more complex change and probably not required for these specialised school instances.

### Guidance to review
Should be able to search for a ISSnnn style URN from support area.
