### PR TITLE
[1937] LA funded place shows school name

### DIFF
--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -18,9 +18,11 @@
     <h2 class="govuk-heading-m">
       Before you order
     </h2>
+
     <p class="govuk-body">
       Make sure you’re certain of what devices you need, as amending or cancelling an order will cause delays.
     </p>
+
     <p class="govuk-body">
       You can <%= govuk_link_to 'give someone else access so they can place orders', school_users_path %>.
     </p>

--- a/app/views/school/home/show_la_funded_place.html.erb
+++ b/app/views/school/home/show_la_funded_place.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
-    <span class="govuk-caption-xl">State-funded pupils in independent schools and  alternative provision</span>
+    <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl">
       <%= title %>
     </h1>

--- a/spec/features/ordering_for_la_funded_devices_spec.rb
+++ b/spec/features/ordering_for_la_funded_devices_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Ordering for LA-funded devices', type: :feature do
   end
 
   def given_i_am_on_the_independent_settings_school_page
-    expect(page).to have_selector('.govuk-caption-xl', text: 'State-funded pupils in independent schools and alternative provision')
+    expect(page).to have_selector('.govuk-caption-xl', text: 'State-funded pupils in independent special schools and alternative provision')
     expect(page).to have_selector('h1', text: 'Get laptops and internet access')
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/1bXvq7Wn/1937-scl-incorrect-homepage
- Incorrect school name for SCL homepage

### Changes proposed in this pull request

- This allows for ISS and SCL to use LA funded homepage

### Screenshots

ISS homepage
![image](https://user-images.githubusercontent.com/92580/116719356-e2e7cb00-a9d2-11eb-88a1-fe5a4727a63a.png)

SCL homepage
![image](https://user-images.githubusercontent.com/92580/116719224-bb90fe00-a9d2-11eb-98b4-acaab9e3a392.png)

### Guidance to review

- Sign in as ISS user
- homepage should show correct school name
- Sign in as SCL user
- homepage should show correct school name