### PR TITLE
Update build-push-and-deploy-container.yml

### DIFF
--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - docker-build-push-action-v2
 
 jobs:
   build-and-push-container:

--- a/.github/workflows/build-push-and-deploy-container.yml
+++ b/.github/workflows/build-push-and-deploy-container.yml
@@ -25,7 +25,7 @@ jobs:
       # Github actions. Helpfully, there's an off-the-shelf 'official' docker
       # action that does it for us
       - name: Build and push Docker image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           build_args: GIT_COMMIT_SHA=${{ steps.vars.outputs.sha_short }},GIT_BRANCH=${{ steps.vars.outputs.branch }}
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
### Context

The github action build-and-push-container has the following warning:
Input 'repository' has been deprecated with message: v2 is now available through docker/build-push-action@v2

### Changes proposed in this pull request

We can use build-push-action v2

### Guidance to review

Confirm successful build and push of container to heroku
