### PR TITLE
Bulk updater should use raw devices ordered

### DIFF
--- a/app/jobs/allocation_job.rb
+++ b/app/jobs/allocation_job.rb
@@ -7,7 +7,7 @@ class AllocationJob < ApplicationJob
     current_allocation = school.std_device_allocation
 
     current_allocation_value = current_allocation&.raw_allocation || 0
-    devices_ordered = current_allocation&.devices_ordered || 0
+    devices_ordered = current_allocation&.raw_devices_ordered || 0
     new_allocation_value = [current_allocation_value + allocation_batch_job.allocation_delta, devices_ordered].max
 
     current_cap_value = current_allocation&.raw_cap || 0


### PR DESCRIPTION
### Context

Bulk updater was set to use devices_ordered as the lower bound, but it should use raw_devices_ordered

### Changes proposed in this pull request

Use raw_devices_ordered as the lower bound in the bulk updater

