### PR TITLE
[1955] fix Trusts with nil addresses

### DIFF
--- a/app/jobs/apply_staged_attribute_changes_to_trusts_job.rb
+++ b/app/jobs/apply_staged_attribute_changes_to_trusts_job.rb
@@ -1,0 +1,5 @@
+class ApplyStagedAttributeChangesToTrustsJob < ApplicationJob
+  def perform
+    TrustUpdateService.new.update_trusts
+  end
+end

--- a/app/services/trust_update_service.rb
+++ b/app/services/trust_update_service.rb
@@ -1,7 +1,7 @@
 class TrustUpdateService
-  def update_trusts
+  def update_trusts(last_update: nil)
     # look at the trusts that have changed since the last update
-    last_update = DataStage::DataUpdateRecord.last_update_for(:trusts)
+    last_update ||= DataStage::DataUpdateRecord.last_update_for(:trusts)
 
     # simple updates for trusts that are open
     DataStage::Trust.updated_since(last_update).gias_status_open.each do |staged_trust|

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,6 +17,10 @@
     cron: '30 5 * * * Europe/London' # every day at 5:30am
     queue: scheduler
     description: Stage GIAS trust data
+  ApplyStagedAttributeChangesToTrustsJob:
+    cron: '0 6 * * * Europe/London' # every day at 6:00am
+    queue: scheduler
+    description: Apply staged attribute changes to trusts
   NotifyMnosJob:
     cron: '0 8 * * 1-5 Europe/London'  # every weekday at 8:00am
     queue: scheduler

--- a/db/migrate/20210506113406_apply_staged_trust_attribute_changes.rb
+++ b/db/migrate/20210506113406_apply_staged_trust_attribute_changes.rb
@@ -1,0 +1,9 @@
+class ApplyStagedTrustAttributeChanges < ActiveRecord::Migration[6.1]
+  def up
+    TrustUpdateService.new.update_trusts(last_update: 10.years.ago)
+  end
+
+  def down
+    # no-op
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_150053) do
+ActiveRecord::Schema.define(version: 2021_05_06_113406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Context

Full context is on [Trello card 1955](https://trello.com/c/hfWrhp57/1955-82-new-trusts-exposed-without-addresses). A quick summary:

- We have lots of Trusts with no address.
- The addresses have been pulled through from GIAS and are present in the staged data, but have not been propagated to the actual Trust records
- The code to propagate the changes is already written, but has never been wired up to a job, so it has never been called. 

### Changes proposed in this pull request

Add migration to one-off-update all Trusts, and job to make sure future updates are propagated

### Guidance to review

First, stage the updates with `StageTrustDataJob.new.perform`
Check your local database count of `Trust.where(address_1: nil).count`
Run the migration
Check your local database count of `Trust.where(address_1: nil).count` again - it should have decreased (note: it's unlikely to decrease to zero, there are some Trusts which have no address in GIAS too )
