### PR TITLE
add redis status to the healthcheck JSON

### DIFF
--- a/app/services/healthcheck_service.rb
+++ b/app/services/healthcheck_service.rb
@@ -1,5 +1,5 @@
 class HealthcheckService
-  SERVICES = %i[db].freeze
+  SERVICES = %i[db redis].freeze
 
   def self.run
     all_services_status = services_status
@@ -39,6 +39,7 @@ class HealthcheckService
   def self.status_of(service)
     case service
     when :db then db_status
+    when :redis then redis_status
     end
   rescue StandardError
     'DOWN'
@@ -46,6 +47,11 @@ class HealthcheckService
 
   def self.db_status
     ExtraMobileDataRequest.maximum(:created_at)
+    'UP'
+  end
+
+  def self.redis_status
+    Sidekiq.redis_info['redis_version']
     'UP'
   end
 end


### PR DESCRIPTION
### Context

The `/healthcheck.json` endpoint only shows the status of the database service, and does not include redis

### Changes proposed in this pull request

Add a redis status check

### Guidance to review

Hit '/healthcheck.json` - you should see something like this:

![Screenshot from 2021-05-06 14-48-37](https://user-images.githubusercontent.com/134501/117309310-35fdca00-ae7a-11eb-9e67-f8e196f0a8ec.png)

(screenshot from localhost - if you're on a deployed container, the git variables will also be populated)
