### PR TITLE
Stop showing "Check your details" to LA funded places

### DIFF
--- a/app/controllers/school/details_controller.rb
+++ b/app/controllers/school/details_controller.rb
@@ -1,3 +1,5 @@
 class School::DetailsController < School::BaseController
-  def show; end
+  def show
+    authorize @school, policy_class: School::DetailsPolicy
+  end
 end

--- a/app/policies/school/details_policy.rb
+++ b/app/policies/school/details_policy.rb
@@ -1,0 +1,5 @@
+class School::DetailsPolicy < School::BasePolicy
+  def show?
+    !record.la_funded_provision?
+  end
+end

--- a/app/views/school/home/show_la_funded_place.html.erb
+++ b/app/views/school/home/show_la_funded_place.html.erb
@@ -32,16 +32,6 @@
     <%= render 'shared/get_internet_access_section_description' %>
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to t('page_titles.iss.details'), details_school_path(@school) %>
-    </h2>
-
-    <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>review your allocation</li>
-      <li>change your Chromebook settings</li>
-    </ul>
-
-    <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.school_users'), school_users_path(@school) %>
     </h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,6 @@ en:
     iss:
       home: Get laptops and internet access
       order_devices: Get laptops
-      details: Check your details
       laptop_types: Find out what type of laptop pupils need
       chromebooks: Will your order include Google Chromebooks?
       will_need_chromebooks_error: Tell us if pupils will need Chromebooks

--- a/spec/policies/school/details_policy_spec.rb
+++ b/spec/policies/school/details_policy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe School::DetailsPolicy do
+  subject { described_class }
+
+  permissions :show? do
+    it { is_expected.to permit(build(:school_user), build(:school)) }
+    it { is_expected.not_to permit(build(:local_authority_user), build(:iss_provision)) }
+    it { is_expected.not_to permit(build(:local_authority_user), build(:scl_provision)) }
+  end
+end


### PR DESCRIPTION
### Context

It doesn't make sense to show the "Check your details" section for LA-funded places

https://trello.com/c/s5zR0VHK

### Changes proposed in this pull request

Stop showing this to those on the LA-funded route. Stop access to the controller action via Pundit authorisation.

### Guidance to review

