### PR TITLE
Add rexml to Gemfile, Ruby 3 rexml is not default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem 'zendesk_api'
 # Validate and normalise phone numbers
 gem 'phonelib'
 
+# Required in Ruby 3 upgraded as it's no longer a default gem
+gem 'rexml'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,6 +562,7 @@ DEPENDENCIES
   rails-erd
   rails_semantic_logger
   redcarpet
+  rexml
   rspec-rails (~> 5.0.1)
   rubocop-govuk (~> 4.0.0.pre.1)
   rubyXL


### PR DESCRIPTION
rexml is a a bundled gem and not a default gem in Ruby 3

Can easily proved on a Rails console to quickly check...

If not added to Gemfile
```
> Hash.from_xml("<xml></xml>") 
You don't have rexml installed in your application. Please add it to your Gemfile and run bundle install
LoadError: cannot load such file -- rexml/document
from /usr/local/bundle/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:34:in `require'
```

Expected...
```
> Hash.from_xml("<xml></xml>")
=> {"xml"=>nil}
```