### PR TITLE
Auto close trust from GIAS if trust has no schools

### DIFF
--- a/docs/support/sync_closed_trusts.md
+++ b/docs/support/sync_closed_trusts.md
@@ -1,0 +1,17 @@
+# Sync closed trusts from GIAS
+
+Previously only open trusts were updated so any trusts closed would remain open in our system.
+
+This has now been updated so any GIAS closed trusts are automatically closed if they don't contain any schools in our system.
+
+However previous to this automation we need to retroactively close trusts before the last time they updated.
+
+## Retroactively sync closed trusts in Rails console
+
+By calling the private function `close_trusts` and using a very old date we can sync it up.
+
+Any trusts that are skipped will be raised to Sentry with a list of failed trust ids that couldn't be closed for manualy investigation.
+
+```ruby
+TrustUpdateService.new.send(:close_trusts, 5.years.ago)
+```

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -50,6 +50,10 @@ FactoryBot.define do
     trait :multi_academy_trust do
       organisation_type           { :multi_academy_trust }
     end
+
+    trait :closed do
+      status { 'closed' }
+    end
   end
 
   factory :further_education_college, parent: :responsible_body, class: 'FurtherEducationCollege' do


### PR DESCRIPTION
PROPOSAL 2 - dealing with Trust closures

Initial naive proposal was https://github.com/DFE-Digital/get-help-with-tech/pull/1710 

- Auto close trusts if safe to do so
- `def close_trusts(last_update)` - This can be used directly in the console with a very old date in the past to retroactively close all Trusts that should be closed due to closed trusts not being synced.

TODO:
- ~~Tests~~
- ~~Sentry notification and logging~~

