### PR TITLE
Use Sentry scopes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,17 +102,12 @@ private
       support_home_path
     else
       # this should not happen - so let's tell Sentry
-      Sentry.capture_message(
-        "couldn't figure out root_url_for user",
-        logger: 'logger',
-        extra: {
-          time_at: Time.zone.now,
-          user_id: user.id,
-        },
-        tags: {
-          env: Rails.env,
-        },
-      )
+      Sentry.configure_scope do |scope|
+        scope.set_context('ApplicationController#root_url_for', { user_id: user.id })
+
+        Sentry.capture_message("Couldn't figure out root_url_for user")
+      end
+
       '/'
     end
   end

--- a/spec/features/signing_in_as_different_types_of_user_spec.rb
+++ b/spec/features/signing_in_as_different_types_of_user_spec.rb
@@ -259,4 +259,16 @@ RSpec.feature 'Signing-in as different types of user', type: :feature do
       expect(page).to have_text 'TechSource'
     end
   end
+
+  context 'unable to determine where to redirect to for this user' do
+    let(:user) { create(:user) }
+
+    before { allow(Sentry).to receive(:capture_message) }
+
+    scenario 'it redirects to /' do
+      sign_in_as user
+      expect(page).to have_current_path('/')
+      expect(Sentry).to have_received(:capture_message).with("Couldn't figure out root_url_for user")
+    end
+  end
 end


### PR DESCRIPTION
This call to Sentry doesn't work as the update from Raven isn't backwards compatible with the params passed in.

Updated to use scope and also add test coverage.