### PR TITLE
Tactical fix to allow allocations to be decreased

### DIFF
--- a/app/form_objects/support/allocation_form.rb
+++ b/app/form_objects/support/allocation_form.rb
@@ -1,18 +1,42 @@
 class Support::AllocationForm
   include ActiveModel::Model
 
-  attr_accessor :allocation, :current_allocation, :school_allocation
+  attr_reader :allocation
+  attr_accessor :current_allocation, :school_allocation
 
-  delegate :cap, :devices_ordered, to: :school_allocation
+  delegate :cap, :raw_devices_ordered, :is_in_virtual_cap_pool?, to: :school_allocation
 
-  validates :allocation, numericality: { only_integer: true, greater_than: -1 }
+  validate :check_decrease_allowed
+  validate :check_minimum
 
   def initialize(params = {})
     super(params)
     @current_allocation = @school_allocation.dup
   end
 
+  def allocation=(value)
+    @allocation = value.to_i
+  end
+
   def order_state
     school_allocation&.school&.order_state
+  end
+
+private
+
+  def decreasing?
+    allocation < current_allocation.raw_allocation
+  end
+
+  def check_decrease_allowed
+    return unless decreasing?
+
+    errors.add(:allocation, :decreasing_in_virtual_cap_pool) if is_in_virtual_cap_pool?
+  end
+
+  def check_minimum
+    if allocation < raw_devices_ordered
+      errors.add(:allocation, :gte_devices_ordered, devices_ordered: raw_devices_ordered)
+    end
   end
 end

--- a/app/services/allocation_updater.rb
+++ b/app/services/allocation_updater.rb
@@ -6,7 +6,14 @@ class AllocationUpdater
   end
 
   def call
-    allocation.update!(allocation: value)
+    # HACK: this is a tactical fix to allow allocations to be decreased - we need to attempt to
+    # update the cap to keep the allocation record valid when persisting the change.
+    # We want to still keep the previous behaviour for increases.
+    if decreasing?
+      allocation.update!(allocation: value, cap: adjusted_cap_when_decreasing)
+    else
+      allocation.update!(allocation: value)
+    end
 
     if cap_will_change?
       cap_service.update!
@@ -19,6 +26,25 @@ private
 
   def allocation
     @allocation ||= SchoolDeviceAllocation.find_or_initialize_by(school: school, device_type: device_type)
+  end
+
+  def decreasing?
+    value < allocation.raw_allocation
+  end
+
+  def adjusted_cap_when_decreasing
+    # This mirrors the logic in the `SchoolAllocationDevice#cap_implied_by_order_state` method,
+    # which is used in the cap_service below.
+    # We can't call that method directly as it relies on the internal state of the allocation
+    # object which won't have been updated just yet (chicken and egg!)
+    case school.order_state.to_sym
+    when :cannot_order
+      allocation.raw_devices_ordered.to_i
+    when :can_order
+      value
+    else
+      allocation.raw_cap
+    end
   end
 
   def cap_will_change?

--- a/app/views/support/schools/devices/allocation/edit.html.erb
+++ b/app/views/support/schools/devices/allocation/edit.html.erb
@@ -18,11 +18,19 @@
         <%= t(@form.order_state, scope: %i[support allocation edit order_states], cap: @form.current_allocation.cap, allocation: @form.current_allocation.allocation) %>
       </p>
 
+     <% if @form.is_in_virtual_cap_pool? %>
+      <%= render GovukComponent::Warning.new(text: t(:is_in_virtual_cap_pool, scope: %i[support allocation edit])) %>
+     <% end %>
+
       <%= f.govuk_number_field :allocation,
                               only_integer: true,
                               label: {text: 'New allocation'},
                               width: 3,
-                              value: @form.current_allocation.raw_allocation %>
+                              value: @form.current_allocation.raw_allocation,
+                              min: @form.raw_devices_ordered,
+                              hint: {
+                                text: t(:allocation_input_hint, scope: %i[support allocation edit], devices_ordered: @form.raw_devices_ordered)
+                              } %>
 
       <%= f.govuk_submit 'Save' %>
     <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,6 +417,8 @@ en:
           cannot_order: They cannot place orders yet. When they can, their total allocation is %{allocation} devices.
           can_order_for_specific_circumstances: They can place orders for specific circumstances, up to %{cap} devices from their total allocation of %{allocation}.
           can_order: They can order their full allocation of %{allocation} because a closure or group of self-isolating children has been reported.
+        is_in_virtual_cap_pool: Note that you currently won't be able to decrease the allocation for this school as it is in a virtual cap pool - contact the dev team to do this manually for now
+        allocation_input_hint: Must be at least %{devices_ordered} (current devices ordered)
       update:
         success: We’ve saved the new allocation
     service_performance:
@@ -628,10 +630,9 @@ en:
               gte_devices_ordered: Cap cannot be less than the number they have already ordered (%{devices_ordered})
         support/allocation_form:
           attributes:
-            cap:
-              lte_allocation: Enter an allocation that’s greater than, or the same as, the current cap
             allocation:
-              greater_than: Enter an allocation that’s non-negative
+              decreasing_in_virtual_cap_pool: Decreasing an allocation for a school in a virtual cap pool is currently not possible - contact the dev team to do this manually for now
+              gte_devices_ordered: Allocation cannot be less than the number they have already ordered (%{devices_ordered})
         support/school_suggestion_form:
           attributes:
             name_or_urn_or_ukprn:

--- a/spec/features/support/adjusting_a_schools_allocation_spec.rb
+++ b/spec/features/support/adjusting_a_schools_allocation_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Adjusting a schools allocation' do
   let(:enable_orders_confirm_page) { PageObjects::Support::Schools::Devices::EnableOrdersConfirmPage.new }
 
   before do
-    create(:school_device_allocation, :with_std_allocation, allocation: 50, school: school)
+    create(:school_device_allocation, :with_std_allocation, allocation: 50, devices_ordered: 10, school: school)
     sign_in_as support_user
   end
 
@@ -32,17 +32,17 @@ RSpec.feature 'Adjusting a schools allocation' do
 
       context 'filling in an invalid value and clicking Save' do
         before do
-          fill_in 'New allocation', with: '-1'
+          fill_in 'New allocation', with: '9'
           click_on 'Save'
         end
 
         it 'shows me an error' do
           expect(page).to have_http_status(:unprocessable_entity)
-          expect(page).to have_text('Enter an allocation that’s non-negative')
+          expect(page).to have_text('Allocation cannot be less than the number they have already ordered')
         end
       end
 
-      context 'filling in an valid value and clicking Save' do
+      context 'filling in a valid increased value and clicking Save' do
         before do
           fill_in 'New allocation', with: '51'
           click_on 'Save'
@@ -53,6 +53,20 @@ RSpec.feature 'Adjusting a schools allocation' do
           expect(page).to have_http_status(:ok)
           expect(page).to have_text('We’ve saved the new allocation')
           expect(school_details_page.school_details_rows[2]).to have_text(51)
+        end
+      end
+
+      context 'filling in a valid decreased value and clicking Save' do
+        before do
+          fill_in 'New allocation', with: '40'
+          click_on 'Save'
+        end
+
+        it 'takes me back to the school details page' do
+          expect(page).to have_current_path(support_school_path(school.urn))
+          expect(page).to have_http_status(:ok)
+          expect(page).to have_text('We’ve saved the new allocation')
+          expect(school_details_page.school_details_rows[2]).to have_text(40)
         end
       end
     end

--- a/spec/form_objects/support/allocation_form_spec.rb
+++ b/spec/form_objects/support/allocation_form_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Support::AllocationForm do
+  describe 'validations' do
+    context 'when in a virtual cap pool' do
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+      let :school do
+        create(:school, :with_preorder_information, :in_lockdown, responsible_body: responsible_body)
+      end
+      let! :school_device_allocation do
+        create(:school_device_allocation, school: school, allocation: initial_value)
+      end
+
+      subject :form do
+        described_class.new(allocation: updated_value, school_allocation: school_device_allocation)
+      end
+
+      before do
+        # Properly associate things with a virtual cap pool.
+        school.preorder_information.responsible_body_will_order_devices!
+        responsible_body.add_school_to_virtual_cap_pools!(school)
+        school_device_allocation.reload
+      end
+
+      # Precondition
+      context 'precondition' do
+        let(:initial_value) { 1 }
+        let(:updated_value) { 2 }
+
+        it 'school_device_allocation#is_in_virtual_cap_pool? is true' do
+          expect(school_device_allocation.is_in_virtual_cap_pool?).to be true
+        end
+      end
+
+      context 'when increasing the allocation' do
+        let(:initial_value) { 1 }
+        let(:updated_value) { 2 }
+
+        it 'is valid' do
+          expect(form).to be_valid
+        end
+      end
+
+      context 'when decreasing the allocation' do
+        let(:initial_value) { 2 }
+        let(:updated_value) { 1 }
+
+        it 'has errors' do
+          expect(form).to be_invalid
+          expect(form.errors[:allocation]).to be_present
+          expect(form.errors[:allocation].first).to include('Decreasing an allocation for a school in a virtual cap pool is currently not possible')
+        end
+      end
+    end
+
+    context 'compared with raw_devices_ordered' do
+      let(:school_device_allocation) { create(:school_device_allocation, allocation: 3, devices_ordered: 2) }
+
+      context 'when allocation is above raw_devices_ordered' do
+        subject(:form) { described_class.new(allocation: 4, school_allocation: school_device_allocation) }
+
+        it 'is valid' do
+          expect(form).to be_valid
+        end
+      end
+
+      context 'when allocation is below raw_devices_ordered' do
+        subject(:form) { described_class.new(allocation: 1, school_allocation: school_device_allocation) }
+
+        it 'has errors' do
+          expect(form).to be_invalid
+          expect(form.errors[:allocation]).to be_present
+          expect(form.errors[:allocation].first).to include('Allocation cannot be less than the number they have already ordered')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
… for schools that are not in a virtual cap pool.

https://trello.com/c/LcUxgM3W/1967-reducing-allocation-for-a-single-school-is-rejected

### Context

Before these changes, reducing allocations could cause an error due to the underlying `cap` value not being adjusted to match, in time for the model validation to hit.

### Changes proposed in this pull request

Note: I've gone for a "light touch" fix here that doesn't attempt to change too much – there's a longer term piece required for refactoring + code consolidation + potential fixes, later on, after we figure out / confirm what the intended product design for allocations and vcap pools is moving forward.

Changes here:

- Allow allocations to be decreased, but only for schools that are not in a virtual cap pool.
- For schools that are in a virtual cap pool, we a) show a warning message in the UI that decreasing is not allowed, and b) have a validation (at the form model layer) to prevent decreasing.
- The allocation now has a minimum, set to the current `SchoolDeviceAllocation#raw_devices_ordered`, via a validation in the form model. The UI has also been updated to show a hint.
  - Note: this validation is only on the form model layer as we only want to enforce it for the support user flow. See <https://trello.com/c/FxejJUlY/716-remove-the-validation-that-devicesordered-cannot-be-greater-than-cap> for context on why this is not a model validation.
- Updated existing specs + new specs for the `AllocationForm` model.

Note an edge case here: because the main change here mirrors the cap adjustment logic in `SchoolAllocationDevice#cap_implied_by_order_state`, the cap is not adjusted for schools that have an order state of `can_order_for_specific_circumstances`, which could result in the same HTTP 422 error bug hitting if an allocation is decreased below the cap for a school with this order state.

## Screenshots

![Screenshot 2021-05-25 at 16 48 21](https://user-images.githubusercontent.com/31973/119644247-90a09b00-be14-11eb-9b13-4c0f1f339c30.png)

![Screenshot 2021-05-25 at 16 52 18](https://user-images.githubusercontent.com/31973/119644262-96967c00-be14-11eb-8de8-e5749ba70b83.png)

![Screenshot 2021-05-25 at 15 42 07](https://user-images.githubusercontent.com/31973/119644296-9dbd8a00-be14-11eb-83c9-e94e1a376169.png)

![Screenshot 2021-05-25 at 15 53 49](https://user-images.githubusercontent.com/31973/119644325-a3b36b00-be14-11eb-8885-8dcf2f151fd3.png)

### Guidance to review

- Allocations can always be **increased**.
- Allocations can be **decreased** for schools not in a virtual cap pool.
- Allocations cannot be **decreased** for schools in a virtual cap pool.
- When decreasing an allocation, it cannot go below the current devices ordered.

