### PR TITLE
Show the school's URN (or equivalent) on the support page

### DIFF
--- a/app/views/support/schools/show.html.erb
+++ b/app/views/support/schools/show.html.erb
@@ -13,6 +13,7 @@
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @school.responsible_body.name %></span>
       <%= @school.name %>
+      (<%= @school.urn %>)
     </h1>
   </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/PJkbX8Ow/1227-show-the-urn-on-the-school-page-in-support

### Context

The school's page on the support portal does not currently show the URN (or equivalent) for that school.

### Changes proposed in this pull request

Show the URN (or equivalent) next to the school's name, just like on the list of schools on the responsible body page.

![Screenshot 2021-05-27 at 12 22 01](https://user-images.githubusercontent.com/31973/119830209-f0ba3e80-bef3-11eb-87dc-37af354e2937.png)


![Screenshot 2021-05-27 at 12 22 20](https://user-images.githubusercontent.com/31973/119830216-f1eb6b80-bef3-11eb-862b-5094ac2af213.png)

### Guidance to review

Check that the URN is being shown for schools when you click through to the school's page on the support portal.

