### PR TITLE
2055 refactor differing implementations for returning the number of devices available to order

### DIFF
--- a/app/components/device_count_component.rb
+++ b/app/components/device_count_component.rb
@@ -11,7 +11,7 @@ class DeviceCountComponent < ViewComponent::Base
   end
 
   def availability_string
-    if school.has_devices_available_to_order?
+    if school.devices_available_to_order?
       non_zero_allocations.map { |allocation|
         "#{allocation.devices_available_to_order} #{allocation.device_type_name.pluralize(allocation.devices_available_to_order)}"
       }.join(' and <br/>') + ' available' + availability_suffix

--- a/app/components/device_count_component.rb
+++ b/app/components/device_count_component.rb
@@ -13,7 +13,7 @@ class DeviceCountComponent < ViewComponent::Base
   def availability_string
     if school.has_devices_available_to_order?
       non_zero_allocations.map { |allocation|
-        "#{allocation.available_devices_count} #{allocation.device_type_name.pluralize(allocation.available_devices_count)}"
+        "#{allocation.devices_available_to_order} #{allocation.device_type_name.pluralize(allocation.devices_available_to_order)}"
       }.join(' and <br/>') + ' available' + availability_suffix
     else
       'All devices ordered'

--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -16,7 +16,7 @@ class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
   def availability_string
     if @responsible_body.has_devices_available_to_order?
       allocations.map { |allocation|
-        "#{allocation.available_devices_count} #{allocation.device_type_name.pluralize(allocation.available_devices_count)}"
+        "#{allocation.devices_available_to_order} #{allocation.device_type_name.pluralize(allocation.devices_available_to_order)}"
       }.join(' and <br/>') + ' available to order'
     else
       'No devices left to order'

--- a/app/components/responsible_body/pooled_device_count_component.rb
+++ b/app/components/responsible_body/pooled_device_count_component.rb
@@ -14,7 +14,7 @@ class ResponsibleBody::PooledDeviceCountComponent < ViewComponent::Base
   end
 
   def availability_string
-    if @responsible_body.has_devices_available_to_order?
+    if @responsible_body.devices_available_to_order?
       allocations.map { |allocation|
         "#{allocation.devices_available_to_order} #{allocation.device_type_name.pluralize(allocation.devices_available_to_order)}"
       }.join(' and <br/>') + ' available to order'

--- a/app/concerns/device_count.rb
+++ b/app/concerns/device_count.rb
@@ -2,7 +2,7 @@ module DeviceCount
   extend ActiveSupport::Concern
 
   included do
-    def has_devices_available_to_order?
+    def devices_available_to_order?
       devices_available_to_order.positive?
     end
 

--- a/app/concerns/device_count.rb
+++ b/app/concerns/device_count.rb
@@ -3,10 +3,10 @@ module DeviceCount
 
   included do
     def has_devices_available_to_order?
-      available_devices_count.positive?
+      devices_available_to_order.positive?
     end
 
-    def available_devices_count
+    def devices_available_to_order
       [0, (cap.to_i - devices_ordered.to_i)].max
     end
   end

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -13,7 +13,7 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::BaseControll
         if @responsible_body.has_virtual_cap_feature_flags? || @schools.can_order.count.positive?
 
           # There is no seperate 'cannot order anymore' page if we're not using virtual caps.
-          if !@responsible_body.has_virtual_cap_feature_flags? || @responsible_body.has_devices_available_to_order?
+          if !@responsible_body.has_virtual_cap_feature_flags? || @responsible_body.devices_available_to_order?
             render 'order_devices'
           else
             render 'cannot_order_anymore'

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -124,7 +124,7 @@ module ViewHelper
 
   def what_to_order_allocation_list(allocations:)
     allocations.map { |alloc|
-      "#{alloc.available_devices_count} #{alloc.device_type_name.pluralize(alloc.available_devices_count)}"
+      "#{alloc.devices_available_to_order} #{alloc.device_type_name.pluralize(alloc.devices_available_to_order)}"
     }.join(' and ')
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -131,7 +131,7 @@ module ViewHelper
   def what_to_order_availability(school:)
     suffix = (school.can_order_for_specific_circumstances? ? ' for specific circumstances' : nil)
 
-    if school.has_devices_available_to_order?
+    if school.devices_available_to_order?
       string = what_to_order_allocation_list(allocations: school.device_allocations)
 
       "Order #{string}#{suffix}"

--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -15,7 +15,7 @@ class Computacenter::API::CapUsageUpdate
   def apply!
     log_to_devices_ordered_updates
     CapMismatch.new(school, allocation).warn(cap_amount) if cap_amount != allocation.allocation
-    original_devices_ordered = allocation.devices_ordered
+    is_decreasing_cap = cap_used.to_i < allocation.devices_ordered
     begin
       allocation.update!(devices_ordered: cap_used)
     rescue Computacenter::OutgoingAPI::Error => e
@@ -24,7 +24,7 @@ class Computacenter::API::CapUsageUpdate
     end
     school.preorder_information&.refresh_status!
 
-    if cap_used.to_i < original_devices_ordered
+    if is_decreasing_cap && allocation.reload.has_devices_available_to_order?
       SchoolCanOrderDevicesNotifications.new(school: school).call
     end
 

--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -24,7 +24,7 @@ class Computacenter::API::CapUsageUpdate
     end
     school.preorder_information&.refresh_status!
 
-    if is_decreasing_cap && allocation.reload.has_devices_available_to_order?
+    if is_decreasing_cap && allocation.reload.devices_available_to_order?
       SchoolCanOrderDevicesNotifications.new(school: school).call
     end
 

--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -24,9 +24,7 @@ class Computacenter::API::CapUsageUpdate
     end
     school.preorder_information&.refresh_status!
 
-    if is_decreasing_cap && allocation.reload.devices_available_to_order?
-      SchoolCanOrderDevicesNotifications.new(school: school).call
-    end
+    SchoolCanOrderDevicesNotifications.new(school: school).call if is_decreasing_cap
 
     @status = 'succeeded'
   end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -63,8 +63,8 @@ class ResponsibleBody < ApplicationRecord
       !has_school_in_virtual_cap_pools?(school)
   end
 
-  def has_devices_available_to_order?
-    virtual_cap_pools.any?(&:has_devices_available_to_order?)
+  def devices_available_to_order?
+    virtual_cap_pools.any?(&:devices_available_to_order?)
   end
 
   def has_school_in_virtual_cap_pools?(school)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -131,15 +131,15 @@ class School < ApplicationRecord
   end
 
   def can_order_devices_right_now?
-    is_eligible_to_order? && has_devices_available_to_order?
+    is_eligible_to_order? && devices_available_to_order?
   end
 
   def can_order_routers_only_right_now?
-    is_eligible_to_order? && !std_device_allocation&.has_devices_available_to_order? && coms_device_allocation&.has_devices_available_to_order?
+    is_eligible_to_order? && !std_device_allocation&.devices_available_to_order? && coms_device_allocation&.devices_available_to_order?
   end
 
   def all_devices_ordered?
-    is_eligible_to_order? && !has_devices_available_to_order?
+    is_eligible_to_order? && !devices_available_to_order?
   end
 
   def has_std_device_allocation?
@@ -179,8 +179,8 @@ class School < ApplicationRecord
     end
   end
 
-  def has_devices_available_to_order?
-    device_allocations.any?(&:has_devices_available_to_order?)
+  def devices_available_to_order?
+    device_allocations.any?(&:devices_available_to_order?)
   end
 
   def in_virtual_cap_pool?

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -88,10 +88,6 @@ class SchoolDeviceAllocation < ApplicationRecord
     self[:allocation]
   end
 
-  def devices_available_to_order
-    cap - devices_ordered
-  end
-
   def is_in_virtual_cap_pool?
     school_virtual_cap.present?
   end

--- a/app/models/school_welcome_wizard.rb
+++ b/app/models/school_welcome_wizard.rb
@@ -25,7 +25,7 @@ class SchoolWelcomeWizard < ApplicationRecord
 
     case step
     when 'allocation'
-      if school&.std_device_allocation&.has_devices_available_to_order?
+      if school&.std_device_allocation&.devices_available_to_order?
         if user_orders_devices?
           techsource_account!
         else

--- a/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
+++ b/app/views/responsible_body/devices/orders/_place_order_for_virtual_pool.html.erb
@@ -33,7 +33,7 @@
     <p class="govuk-body">
       If you try to order more than <%= what_to_order_allocation_list(allocations: @responsible_body.virtual_cap_pools) %> the order will be cancelled.
     </p>
-    <% if @responsible_body&.std_device_pool&.available_devices_count > 149 %>
+    <% if @responsible_body&.std_device_pool&.devices_available_to_order > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
     <p class="govuk-body">

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -31,7 +31,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render ResponsibleBody::PooledDeviceCountComponent.new(
       responsible_body: @responsible_body,
-      show_action: @responsible_body.has_any_schools_that_can_order_now? && @responsible_body.has_devices_available_to_order?,
+      show_action: @responsible_body.has_any_schools_that_can_order_now? && @responsible_body.devices_available_to_order?,
       action: { 'Order devices' => responsible_body_devices_order_devices_path } ) %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/schools/order_devices.html.erb
+++ b/app/views/responsible_body/devices/schools/order_devices.html.erb
@@ -36,7 +36,7 @@
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
 
-    <% if @school&.std_device_allocation&.available_devices_count > 149 %>
+    <% if @school&.std_device_allocation&.devices_available_to_order > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
 

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -33,7 +33,7 @@
 
     <p class="govuk-body"><%= t('responsible_body.devices.delivery_timeline') %></p>
 
-    <% if @school&.std_device_allocation&.available_devices_count > 149 %>
+    <% if @school&.std_device_allocation&.devices_available_to_order > 149 %>
       <p class="govuk-body">For large orders (more than 150 devices), we’ll call your delivery contact to arrange delivery.</p>
     <% end %>
 

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature 'Ordering devices' do
   end
 
   def what_to_order_availability(school)
-    "Order #{school.std_device_allocation.available_devices_count} devices"
+    "Order #{school.std_device_allocation.devices_available_to_order} devices"
   end
 
   def what_to_order_state(school)

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
   end
 
-  describe '#has_devices_available_to_order?' do
+  describe '#devices_available_to_order?' do
     subject(:responsible_body) { create(:trust, :manages_centrally, vcap_feature_flag: true) }
 
     let(:schools) { create_list(:school, 2, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
@@ -467,7 +467,7 @@ RSpec.describe ResponsibleBody, type: :model do
       end
 
       it 'returns false' do
-        expect(responsible_body.has_devices_available_to_order?).to be false
+        expect(responsible_body.devices_available_to_order?).to be false
       end
     end
 
@@ -480,7 +480,7 @@ RSpec.describe ResponsibleBody, type: :model do
       end
 
       it 'returns true' do
-        expect(responsible_body.has_devices_available_to_order?).to be true
+        expect(responsible_body.devices_available_to_order?).to be true
       end
     end
 
@@ -493,7 +493,7 @@ RSpec.describe ResponsibleBody, type: :model do
       end
 
       it 'returns true' do
-        expect(responsible_body.has_devices_available_to_order?).to be true
+        expect(responsible_body.devices_available_to_order?).to be true
       end
     end
   end

--- a/spec/models/school_device_allocation_spec.rb
+++ b/spec/models/school_device_allocation_spec.rb
@@ -112,12 +112,12 @@ RSpec.describe SchoolDeviceAllocation, type: :model do
     end
   end
 
-  describe '#available_devices_count' do
+  describe '#devices_available_to_order' do
     subject(:allocation) { described_class.new(cap: 100, devices_ordered: 200) }
 
     context 'when negative' do
       it 'returns zero' do
-        expect(allocation.available_devices_count).to be_zero
+        expect(allocation.devices_available_to_order).to be_zero
       end
     end
   end

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -232,12 +232,12 @@ RSpec.describe VirtualCapPool, type: :model do
     end
   end
 
-  describe '#available_devices_count' do
+  describe '#devices_available_to_order' do
     subject(:allocation) { described_class.new(cap: 100, devices_ordered: 200) }
 
     context 'when negative' do
       it 'returns zero' do
-        expect(allocation.available_devices_count).to be_zero
+        expect(allocation.devices_available_to_order).to be_zero
       end
     end
   end

--- a/spec/models/virtual_cap_pool_spec.rb
+++ b/spec/models/virtual_cap_pool_spec.rb
@@ -242,12 +242,12 @@ RSpec.describe VirtualCapPool, type: :model do
     end
   end
 
-  describe '#has_devices_available_to_order?' do
+  describe '#devices_available_to_order?' do
     context 'when used full allocation' do
       let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 100) }
 
       it 'returns false' do
-        expect(allocation.has_devices_available_to_order?).to be false
+        expect(allocation.devices_available_to_order?).to be false
       end
     end
 
@@ -255,7 +255,7 @@ RSpec.describe VirtualCapPool, type: :model do
       let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 75) }
 
       it 'returns true' do
-        expect(allocation.has_devices_available_to_order?).to be true
+        expect(allocation.devices_available_to_order?).to be true
       end
     end
 
@@ -263,7 +263,7 @@ RSpec.describe VirtualCapPool, type: :model do
       let(:allocation) { described_class.new(cap: 100, allocation: 100, devices_ordered: 0) }
 
       it 'returns true' do
-        expect(allocation.has_devices_available_to_order?).to be true
+        expect(allocation.devices_available_to_order?).to be true
       end
     end
   end


### PR DESCRIPTION
### Context

`devices_available_to_order` and `available_devices_count` have the same intent, but different implementations.

`available_devices_count` has a minimum value of zero and so is the preferred implementation. However the name `devices_available_to_order` is more descriptive.

### Changes proposed in this pull request

1. Switch the single use of `devices_available_to_order` over to `available_devices_count`
2. Remove the `devices_available_to_order` method from the code-base
3. Rename `available_devices_count` to `devices_available_to_order`
4. Rename `has_devices_available_to_order?` to `devices_available_to_order?`

### Guidance to review

All specs should pass