### PR TITLE
New section in /computacenter for ISS/SCL Chromebook domains

### DIFF
--- a/app/controllers/computacenter/multi_domain_chromebooks_iss_scl_controller.rb
+++ b/app/controllers/computacenter/multi_domain_chromebooks_iss_scl_controller.rb
@@ -1,0 +1,44 @@
+require 'csv'
+
+class Computacenter::MultiDomainChromebooksIssSclController < Computacenter::BaseController
+  def index
+    @schools = School
+      .includes(:responsible_body)
+      .joins(:preorder_information)
+      .gias_status_open
+      .la_funded_provision
+      .where({
+        provision_type: %w[iss scl],
+        preorder_information: {
+          will_need_chromebooks: %w[yes i_dont_know],
+        },
+      })
+      .sort_by { |s| s.responsible_body.name }
+
+    respond_to do |format|
+      format.html { @show_download_link = @schools.any? }
+      format.csv { send_data csv_generator, filename: make_filename }
+    end
+  end
+
+private
+
+  def make_filename
+    "multi-chromebook-domain-responsible-bodies-iss-scl-#{Time.zone.now.strftime('%Y%m%d')}.csv"
+  end
+
+  def csv_generator
+    CSV.generate(headers: true) do |csv|
+      csv << ['RB Type', 'RB Name', 'RB URN', 'School URN', 'Sold To']
+      @schools.each do |s|
+        csv << [
+          s.responsible_body.humanized_type,
+          s.responsible_body.computacenter_name,
+          s.responsible_body.computacenter_identifier,
+          s.urn,
+          s.responsible_body.computacenter_reference,
+        ]
+      end
+    end
+  end
+end

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -199,7 +199,7 @@ class ResponsibleBody < ApplicationRecord
           (SELECT rb_id FROM
             (SELECT DISTINCT s.responsible_body_id AS rb_id, p.school_or_rb_domain
               FROM schools s JOIN preorder_information p ON (p.school_id = s.id)
-              WHERE s.status='open'
+              WHERE s.status = 'open'
               AND p.who_will_order_devices='responsible_body'
               AND NOT (p.school_or_rb_domain = '' OR p.school_or_rb_domain IS NULL)
               AND s.type <> 'LaFundedPlace'

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -38,7 +38,13 @@
       <%= govuk_link_to 'Responsible bodies managing multiple Chromebook domains', computacenter_multi_domain_chromebooks_path %>
     </h2>
 
-    <p class="govuk-body">View details of responsible bodies that manage schools with mutliple Chromebook domains.</p>
+    <p class="govuk-body">View details of responsible bodies that manage schools with multiple Chromebook domains.</p>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to 'ISS or Social Care LAs managing multiple Chromebook domains', computacenter_multi_domain_chromebooks_iss_scl_path %>
+    </h2>
+
+    <p class="govuk-body">View details of a ISS or Social care account that manage schools with multiple Chromebook domains.</p>
 
     <h2 class="govuk-heading-m">
       <%= govuk_link_to 'Download donated device requests', computacenter_donated_device_requests_path(format: :csv) %>

--- a/app/views/computacenter/multi_domain_chromebooks_iss_scl/index.html.erb
+++ b/app/views/computacenter/multi_domain_chromebooks_iss_scl/index.html.erb
@@ -1,0 +1,52 @@
+<% title = t('page_titles.computacenter.multi_domain_chromebooks_iss_scl') %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_back_link(text: 'Back', href: computacenter_home_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= title %>
+    </h1>
+  </div>
+</div>
+
+<% if @show_download_link %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-body">
+      <%= govuk_link_to 'Download as a CSV file', computacenter_multi_domain_chromebooks_iss_scl_path(format: :csv) %>
+    </div>
+  </div>
+</div>
+<%- end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table" id="closed-schools">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">RB Type</th>
+          <th scope="col" class="govuk-table__header">RB Name</th>
+          <th scope="col" class="govuk-table__header">RB URN</th>
+          <th scope="col" class="govuk-table__header">School URN</th>
+          <th scope="col" class="govuk-table__header">Sold To</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @schools.each do |s| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= s.responsible_body.humanized_type %></td>
+            <td class="govuk-table__cell"><%= s.responsible_body.computacenter_name %></td>
+            <td class="govuk-table__cell"><%= s.responsible_body.computacenter_identifier %></td>
+            <td class="govuk-table__cell"><%= s.urn %></td>
+            <td class="govuk-table__cell"><%= s.responsible_body.computacenter_reference %></td>
+          </tr>
+        <%- end %>
+      </tbody>
+    </table>
+    <div class="govuk-body">
+      <%- item_count = @schools.count %>
+      <%= "#{item_count} #{'record'.pluralize(item_count)} found" -%>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
       responsible_body_changes: Changes to responsible bodies
       responsible_body_changes_edit: Verify the responsible body details
       multi_domain_chromebooks: Responsible bodies managing multiple Chromebook domains
+      multi_domain_chromebooks_iss_scl: ISS or Social Care LAs managing multiple Chromebook domains
     who_will_order: Who will place orders for laptops?
     who_will_order_show:
       school: Each school or college will place their own orders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,6 +326,7 @@ Rails.application.routes.draw do
     get '/techsource', to: 'techsource#new'
     post '/techsource', to: 'techsource#create'
     get '/multi-domain-chromebooks', to: 'multi_domain_chromebooks#index', as: :multi_domain_chromebooks
+    get '/multi-domain-chromebooks-iss-scl', to: 'multi_domain_chromebooks_iss_scl#index', as: :multi_domain_chromebooks_iss_scl
     resources :api_tokens, path: '/api-tokens'
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
       preorder_information { association :preorder_information, school: instance }
     end
 
+    trait :with_preorder_information_chromebooks do
+      preorder_information { association :preorder_information, :needs_chromebooks, school: instance }
+    end
+
     trait :manages_orders do
       preorder_information { association :preorder_information, :school_will_order, school: instance }
     end

--- a/spec/features/computacenter/chromebook_domains_iss_scl.rb
+++ b/spec/features/computacenter/chromebook_domains_iss_scl.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require 'shared/expect_download'
+
+RSpec.feature 'ISS or Social Care LAs managing multiple Chromebook domains' do
+  let(:user) { create(:computacenter_user) }
+
+  context 'signed in as a Computacenter user' do
+    let(:user) { create(:computacenter_user) }
+    let!(:school) { create(:iss_provision, :with_preorder_information) }
+    let!(:school_iss) { create(:iss_provision, :with_preorder_information_chromebooks) }
+    let!(:school_scl) { create(:scl_provision, :with_preorder_information_chromebooks) }
+
+    before do
+      sign_in_as user
+    end
+
+    it 'shows me a ISS or Social Care LAs managing multiple Chromebook domains link' do
+      expect(page).to have_link('ISS or Social Care LAs managing multiple Chromebook domains')
+    end
+
+    scenario 'navigate to manage iss scl chromebooks page' do
+      when_i_visit_manage_iss_scl_chromebooks_page
+      then_i_see_the_list_of_all_iss_scl_responsible_bodies_with_possible_multiple_domains
+      and_i_see_csv_download_link
+    end
+
+    scenario 'download csv' do
+      when_i_visit_manage_iss_scl_chromebooks_page
+      and_i_click_the_download_csv_link
+      then_it_downloads_the_list_as_a_csv_file
+    end
+
+    def when_i_visit_manage_iss_scl_chromebooks_page
+      visit computacenter_multi_domain_chromebooks_iss_scl_path
+    end
+
+    def then_i_see_the_list_of_all_iss_scl_responsible_bodies_with_possible_multiple_domains
+      has_scl_iss_schools
+      not_have_non_lafunded_schools
+    end
+
+    def and_i_see_csv_download_link
+      expect(page).to have_text('Download as a CSV file')
+    end
+
+    def and_i_click_the_download_csv_link
+      click_on 'Download as a CSV file'
+    end
+
+    def then_it_downloads_the_list_as_a_csv_file
+      expect_download(content_type: 'text/csv')
+
+      has_scl_iss_schools
+      not_have_non_lafunded_schools
+    end
+
+    def has_scl_iss_schools
+      [school_iss, school_scl].each do |s|
+        expect(page).to have_text(s.responsible_body.humanized_type)
+        expect(page).to have_text(s.responsible_body.computacenter_name)
+        expect(page).to have_text(s.responsible_body.computacenter_identifier)
+        expect(page).to have_text(s.urn)
+        expect(page).to have_text(s.responsible_body.computacenter_reference)
+      end
+    end
+
+    def not_have_non_lafunded_schools
+      expect(page).not_to have_text(school.responsible_body.computacenter_name)
+      expect(page).not_to have_text(school.responsible_body.computacenter_identifier)
+      expect(page).not_to have_text(school.urn)
+      expect(page).not_to have_text(school.responsible_body.computacenter_reference)
+    end
+  end
+end

--- a/spec/features/computacenter/download_csv_files_spec.rb
+++ b/spec/features/computacenter/download_csv_files_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Download CSV files' do
       expect(page).to have_link('Download Chromebook details')
     end
 
-    it 'shows me a Download donated device reuqests link' do
+    it 'shows me a Download donated device requests link' do
       expect(page).to have_link('Download donated device requests')
     end
 


### PR DESCRIPTION
Add a new section to list ISS and SCL provisions and their respective Responsible Bodies that needs to highlight the possibility that multiple chromebook domains are required.

Any ISS or SCL that has said `yes` or `i_dont_know` for Chromebooks is listed essentially.

