### PR TITLE
Add next TechSource outage window

### DIFF
--- a/app/models/computacenter/tech_source.rb
+++ b/app/models/computacenter/tech_source.rb
@@ -1,5 +1,5 @@
 class Computacenter::TechSource
-  MAINTENANCE_WINDOW = (Time.zone.parse('29 May 2021 09:00am')..Time.zone.parse('29 May 2021 12:00pm'))
+  MAINTENANCE_WINDOW = (Time.zone.parse('11 Jun 2021 6:00pm')..Time.zone.parse('13 Jun 2021 8:00pm'))
 
   def url
     Settings.computacenter.techsource_url


### PR DESCRIPTION
### Context

Adds next TechSource outage window for banner

https://trello.com/c/p4mnd1ng

### Changes proposed in this pull request

Add outage period for between 6pm on Friday 11 June and 8pm on Sunday 13 June.

### Guidance to review

