### PR TITLE
Update specs for allocation job and refactor job

### DIFF
--- a/app/jobs/allocation_job.rb
+++ b/app/jobs/allocation_job.rb
@@ -2,38 +2,89 @@ class AllocationJob < ApplicationJob
   queue_as :default
 
   def perform(allocation_batch_job)
-    school = allocation_batch_job.school
-    order_state = allocation_batch_job.order_state
-    current_allocation = school.std_device_allocation
+    set_instance_variables(allocation_batch_job)
+    set_default_new_raw_allocation_value
+    set_default_new_raw_cap_value
 
-    current_allocation_value = current_allocation&.raw_allocation || 0
-    devices_ordered = current_allocation&.raw_devices_ordered || 0
-    new_allocation_value = [current_allocation_value + allocation_batch_job.allocation_delta, devices_ordered].max
-
-    current_cap_value = current_allocation&.raw_cap || 0
-    new_cap_value = [current_cap_value + allocation_batch_job.allocation_delta, devices_ordered].max
-
-    disable_user_notifications = !allocation_batch_job.send_notification
-
-    allocation = SchoolDeviceAllocation.find_or_initialize_by(school: school, device_type: 'std_device')
+    # A negative delta must check against devices_available_to_order
+    set_negative_allocation_and_cap_values if @allocation_delta.negative?
 
     ActiveRecord::Base.transaction do
-      allocation.update!(allocation: new_allocation_value, cap: new_cap_value)
-
-      service = SchoolOrderStateAndCapUpdateService.new(
-        school: school,
-        order_state: order_state,
-        std_device_cap: new_cap_value,
-      )
-
-      service.disable_user_notifications! if disable_user_notifications
-      service.call
-
-      if disable_user_notifications
-        allocation_batch_job.update!(processed: true)
-      else
-        allocation_batch_job.update!(processed: true, sent_notification: true)
-      end
+      update_current_allocation!
+      call_school_order_state_and_cap_update_service
+      record_batch_job_processed_and_notify
     end
+  end
+
+private
+
+  def set_allocation_batch_job
+    @allocation_batch_job = allocation_batch_job
+  end
+
+  def set_instance_variables(allocation_batch_job)
+    @allocation_batch_job = allocation_batch_job
+    @school = @allocation_batch_job.school
+    @order_state = @allocation_batch_job.order_state
+    @allocation_delta = @allocation_batch_job.allocation_delta.to_i
+    @disable_user_notifications = !@allocation_batch_job.send_notification
+    @current_allocation = SchoolDeviceAllocation.find_or_initialize_by(school: @school, device_type: 'std_device')
+  end
+
+  def set_default_new_raw_allocation_value
+    @current_raw_allocation_value = @current_allocation&.raw_allocation || 0
+    @new_raw_allocation_value = @current_raw_allocation_value + @allocation_delta
+  end
+
+  def set_default_new_raw_cap_value
+    @current_raw_cap_value = @current_allocation&.raw_cap || 0
+    @new_raw_cap_value = @current_raw_cap_value + @allocation_delta
+  end
+
+  def set_negative_allocation_and_cap_values
+    set_negative_allocation_delta
+    set_negative_new_raw_allocation_value
+    set_negative_new_raw_cap_value
+  end
+
+  def set_negative_allocation_delta
+    @negative_allocation_delta = [-@current_allocation.devices_available_to_order, @allocation_delta].max
+  end
+
+  def set_negative_new_raw_allocation_value
+    @new_raw_allocation_value = @current_raw_allocation_value + @negative_allocation_delta
+  end
+
+  def set_negative_new_raw_cap_value
+    @new_raw_cap_value = [@current_raw_cap_value + @negative_allocation_delta, @new_raw_allocation_value].min
+  end
+
+  def update_current_allocation!
+    if @allocation_delta.negative?
+      return unless @current_allocation.devices_available_to_order.positive? # Don't update the allocation, but allow order_state to be updated
+
+      @current_allocation.update!(allocation: @new_raw_allocation_value, cap: @new_raw_cap_value)
+    else
+      @current_allocation.update!(allocation: @new_raw_allocation_value)
+    end
+  end
+
+  def call_school_order_state_and_cap_update_service
+    service = SchoolOrderStateAndCapUpdateService.new(
+      school: @school.reload,
+      order_state: @order_state,
+      std_device_cap: @new_raw_cap_value,
+    )
+
+    service.disable_user_notifications! if @disable_user_notifications
+    service.call
+  end
+
+  def record_batch_job_processed_and_notify
+    if @disable_user_notifications
+      return @allocation_batch_job.update!(processed: true)
+    end
+
+    @allocation_batch_job.update!(processed: true, sent_notification: true)
   end
 end

--- a/app/jobs/allocation_job.rb
+++ b/app/jobs/allocation_job.rb
@@ -18,10 +18,6 @@ class AllocationJob < ApplicationJob
 
 private
 
-  def set_allocation_batch_job
-    @allocation_batch_job = allocation_batch_job
-  end
-
   def set_instance_variables(allocation_batch_job)
     @allocation_batch_job = allocation_batch_job
     @school = @allocation_batch_job.school
@@ -60,9 +56,7 @@ private
   end
 
   def update_current_allocation!
-    if @allocation_delta.negative?
-      return unless @current_allocation.devices_available_to_order.positive? # Don't update the allocation, but allow order_state to be updated
-
+    if @allocation_delta.negative? && @new_raw_allocation_value < @current_allocation.raw_cap
       @current_allocation.update!(allocation: @new_raw_allocation_value, cap: @new_raw_cap_value)
     else
       @current_allocation.update!(allocation: @new_raw_allocation_value)

--- a/spec/jobs/allocation_job_spec.rb
+++ b/spec/jobs/allocation_job_spec.rb
@@ -130,9 +130,7 @@ RSpec.describe AllocationJob do
         let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
 
         it 'does not reduce allocation' do
-          expect {
-            described_class.perform_now(batch_job)
-          }.to change { school.std_device_allocation.reload.allocation }.by(0)
+          expect { described_class.perform_now(batch_job) }.not_to(change { school.std_device_allocation.reload.allocation })
         end
       end
 
@@ -223,9 +221,7 @@ RSpec.describe AllocationJob do
           let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '0', order_state: 'cannot_order') }
 
           it 'does not change the allocation' do
-            expect {
-              described_class.perform_now(batch_job)
-            }.to change { school.std_device_allocation.reload.allocation }.by(0)
+            expect { described_class.perform_now(batch_job) }.not_to(change { school.std_device_allocation.reload.allocation })
           end
 
           it 'changes the cap to equal raw_devices_ordered' do
@@ -364,23 +360,13 @@ RSpec.describe AllocationJob do
         end
 
         it 'does not change the allocation' do
-          expect {
-            described_class.perform_now(batch_allocation_job1)
-          }.to change { school1.std_device_allocation.reload.allocation }.by(0)
-
-          expect {
-            described_class.perform_now(batch_allocation_job2)
-          }.to change { school2.std_device_allocation.reload.allocation }.by(0)
+          expect { described_class.perform_now(batch_allocation_job1) }.not_to(change { school1.std_device_allocation.reload.allocation })
+          expect { described_class.perform_now(batch_allocation_job2) }.not_to(change { school2.std_device_allocation.reload.allocation })
         end
 
         it 'does not change the raw_allocation' do
-          expect {
-            described_class.perform_now(batch_allocation_job1)
-          }.to change { school1.std_device_allocation.reload.raw_allocation }.by(0)
-
-          expect {
-            described_class.perform_now(batch_allocation_job2)
-          }.to change { school2.std_device_allocation.reload.raw_allocation }.by(0)
+          expect { described_class.perform_now(batch_allocation_job1) }.not_to(change { school1.std_device_allocation.reload.raw_allocation })
+          expect { described_class.perform_now(batch_allocation_job2) }.not_to(change { school2.std_device_allocation.reload.raw_allocation })
         end
 
         it 'updates the raw_cap to match raw_devices_ordered' do

--- a/spec/jobs/allocation_job_spec.rb
+++ b/spec/jobs/allocation_job_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe AllocationJob do
       context 'reducing allocation' do
         let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
 
-        it 'reduces allocation' do
+        it 'does not reduce allocation' do
           expect {
             described_class.perform_now(batch_job)
-          }.to change { school.std_device_allocation.reload.allocation }.by(-1)
+          }.to change { school.std_device_allocation.reload.allocation }.by(0)
         end
       end
 
@@ -192,10 +192,47 @@ RSpec.describe AllocationJob do
           }.to change { school.std_device_allocation.reload.allocation }.by(3)
         end
 
-        it 'zeros the cap' do
+        it 'changes the cap to equal raw_devices_ordered when raw_devices_ordered is zero' do
           described_class.perform_now(batch_job)
 
-          expect(school.std_device_allocation.reload.cap).to be(0)
+          expect(school.std_device_allocation.reload.cap).to be(school.std_device_allocation.reload.raw_devices_ordered)
+        end
+
+        context 'when partially_ordered' do
+          let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
+
+          it 'changes the cap to equal raw_devices_ordered' do
+            described_class.perform_now(batch_job)
+
+            expect(school.std_device_allocation.reload.cap).to be(school.std_device_allocation.reload.raw_devices_ordered)
+          end
+        end
+
+        context 'when fully_ordered' do
+          let!(:school) { create(:school, :with_std_device_allocation_fully_ordered) }
+
+          it 'changes the cap to equal raw_devices_ordered' do
+            described_class.perform_now(batch_job)
+
+            expect(school.std_device_allocation.reload.cap).to be(school.std_device_allocation.reload.raw_devices_ordered)
+          end
+        end
+
+        context 'when school partially_ordered with a zero delta' do
+          let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
+          let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '0', order_state: 'cannot_order') }
+
+          it 'does not change the allocation' do
+            expect {
+              described_class.perform_now(batch_job)
+            }.to change { school.std_device_allocation.reload.allocation }.by(0)
+          end
+
+          it 'changes the cap to equal raw_devices_ordered' do
+            described_class.perform_now(batch_job)
+
+            expect(school.std_device_allocation.reload.cap).to be(school.std_device_allocation.reload.raw_devices_ordered)
+          end
         end
 
         it 'marks job as processed' do
@@ -206,6 +243,7 @@ RSpec.describe AllocationJob do
       end
 
       context 'reducing allocation' do
+        let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
         let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
 
         it 'reduces allocation' do
@@ -247,15 +285,20 @@ RSpec.describe AllocationJob do
       end
 
       let(:school1) { rb.schools.first }
+      let(:school1_allocation) { school1.std_device_allocation.reload.allocation }
+      let(:school1_devices_available_to_order) { school1.std_device_allocation.reload.devices_available_to_order }
+
       let(:school2) { rb.schools.last }
+      let(:school2_allocation) { school2.std_device_allocation.reload.allocation }
+      let(:school2_devices_available_to_order) { school2.std_device_allocation.reload.devices_available_to_order }
 
       before do
         create_list(:school, 2,
                     :centrally_managed,
                     responsible_body: rb)
 
-        create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, school: school1)
-        create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, school: school2)
+        create(:school_device_allocation, :with_std_allocation, :partially_ordered, school: school1)
+        create(:school_device_allocation, :with_std_allocation, :partially_ordered, school: school2)
 
         rb.add_school_to_virtual_cap_pools!(school1)
         rb.add_school_to_virtual_cap_pools!(school2)
@@ -269,7 +312,23 @@ RSpec.describe AllocationJob do
         }.to change { school1.std_device_allocation.reload.raw_allocation }.by(3)
       end
 
-      it 'updates the cap to match allocation' do
+      context 'increasing the allocation for multiple schools in the same pool' do
+        let(:batch_allocation_job1) do
+          create(:allocation_batch_job, urn: school1.urn, allocation_delta: '100', order_state: 'can_order')
+        end
+        let(:batch_allocation_job2) do
+          create(:allocation_batch_job, urn: school2.urn, allocation_delta: '100', order_state: 'can_order')
+        end
+
+        it 'increases the allocation of the pool' do
+          expect {
+            described_class.perform_now(batch_allocation_job1)
+            described_class.perform_now(batch_allocation_job2)
+          }.to change { school1.std_device_allocation.reload.allocation }.by(200)
+        end
+      end
+
+      it 'updates the cap to match allocation when order_status is can_order' do
         described_class.perform_now(batch_job)
 
         sum = school1.std_device_allocation.reload.raw_cap + school2.std_device_allocation.reload.raw_cap
@@ -279,33 +338,102 @@ RSpec.describe AllocationJob do
         expect(school1.std_device_allocation.raw_cap).to eql(school1.std_device_allocation.raw_allocation)
       end
 
+      context 'updating to cannot_order' do
+        let(:batch_allocation_job1) do
+          create(:allocation_batch_job, urn: school1.urn, allocation_delta: '100', order_state: 'cannot_order')
+        end
+        let(:batch_allocation_job2) do
+          create(:allocation_batch_job, urn: school2.urn, allocation_delta: '100', order_state: 'cannot_order')
+        end
+
+        it 'updates the raw_cap to match raw_devices_ordered' do
+          described_class.perform_now(batch_allocation_job1)
+          described_class.perform_now(batch_allocation_job2)
+
+          expect(school1.std_device_allocation.raw_cap).to eql(school1.std_device_allocation.raw_devices_ordered)
+          expect(school2.std_device_allocation.raw_cap).to eql(school2.std_device_allocation.raw_devices_ordered)
+        end
+      end
+
+      context 'updating to cannot_order with a zero delta' do
+        let(:batch_allocation_job1) do
+          create(:allocation_batch_job, urn: school1.urn, allocation_delta: '0', order_state: 'cannot_order')
+        end
+        let(:batch_allocation_job2) do
+          create(:allocation_batch_job, urn: school2.urn, allocation_delta: '0', order_state: 'cannot_order')
+        end
+
+        it 'does not change the allocation' do
+          expect {
+            described_class.perform_now(batch_allocation_job1)
+          }.to change { school1.std_device_allocation.reload.allocation }.by(0)
+
+          expect {
+            described_class.perform_now(batch_allocation_job2)
+          }.to change { school2.std_device_allocation.reload.allocation }.by(0)
+        end
+
+        it 'does not change the raw_allocation' do
+          expect {
+            described_class.perform_now(batch_allocation_job1)
+          }.to change { school1.std_device_allocation.reload.raw_allocation }.by(0)
+
+          expect {
+            described_class.perform_now(batch_allocation_job2)
+          }.to change { school2.std_device_allocation.reload.raw_allocation }.by(0)
+        end
+
+        it 'updates the raw_cap to match raw_devices_ordered' do
+          described_class.perform_now(batch_allocation_job1)
+          described_class.perform_now(batch_allocation_job2)
+
+          expect(school1.std_device_allocation.raw_cap).to eql(school1.std_device_allocation.raw_devices_ordered)
+          expect(school2.std_device_allocation.raw_cap).to eql(school2.std_device_allocation.raw_devices_ordered)
+        end
+
+        it 'returns false for devices_available_to_order?' do
+          described_class.perform_now(batch_allocation_job1)
+          described_class.perform_now(batch_allocation_job2)
+
+          expect(school1.std_device_allocation.reload.devices_available_to_order?).to be(false)
+          expect(school2.std_device_allocation.reload.devices_available_to_order?).to be(false)
+        end
+      end
+
       context 'reducing allocation' do
-        let(:batch_job) { create(:allocation_batch_job, urn: school1.urn, allocation_delta: '-1', order_state: 'can_order') }
+        let(:batch_deallocation_job) { create(:allocation_batch_job, urn: school1.urn, allocation_delta: '-1', order_state: 'can_order') }
 
         it 'reduces allocation' do
           expect {
-            described_class.perform_now(batch_job)
+            described_class.perform_now(batch_deallocation_job)
           }.to change { school1.std_device_allocation.reload.raw_allocation }.by(-1)
         end
       end
 
-      context 'maintain part of allocation if already ordered' do
-        let!(:school) { create(:school, :with_std_device_allocation_partially_ordered) }
-        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-100', order_state: 'cannot_order') }
+      context 'reduce and maintain part of allocation if already ordered' do
+        let!(:devices_available_to_deallocate) { [school1_devices_available_to_order, 198].min }
+        let(:batch_deallocation_job1) do
+          create(:allocation_batch_job, urn: school1.urn, allocation_delta: '-99', order_state: 'can_order')
+        end
+        let(:batch_deallocation_job2) do
+          create(:allocation_batch_job, urn: school2.urn, allocation_delta: '-99', order_state: 'can_order')
+        end
 
         it 'reduces allocation to match ordered' do
-          described_class.perform_now(batch_job)
-          expect(school.std_device_allocation.reload.allocation).to eq(school.std_device_allocation.devices_ordered)
+          expect {
+            described_class.perform_now(batch_deallocation_job1)
+            described_class.perform_now(batch_deallocation_job2)
+          }.to change { school1.std_device_allocation.reload.allocation }.by(-devices_available_to_deallocate)
         end
       end
 
-      context 'maintain allocation if already ordered' do
+      context 'reduce and maintain all of allocation if already fully ordered' do
         let!(:school) { create(:school, :with_std_device_allocation_fully_ordered) }
-        let(:batch_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'cannot_order') }
+        let(:batch_deallocation_job) { create(:allocation_batch_job, urn: school.urn, allocation_delta: '-1', order_state: 'can_order') }
 
         it 'does not update the allocation' do
           expect {
-            described_class.perform_now(batch_job)
+            described_class.perform_now(batch_deallocation_job)
           }.not_to change(school.std_device_allocation.reload, :allocation)
         end
       end


### PR DESCRIPTION
### Context

Negative deltas were not considered at all in the project from the beginning. We have an urgent need to reduce allocations across thousands of objects.

### Changes proposed in this pull request

Expand the scope of the `AllocationJob` specs to cover more complex cases.

Refactoring of the AllocationJob to show the intent more clearly.

### Guidance to review

Focus on the correctness of the `AllocationJob` specs. The specs should be refactored in a subsequent PR. This could not be done for this PR because of time pressure.

The immediate use case will be to pass a zero delta and `order_state` = `cannot_order` to thousands of `School` objects today.

