### PR TITLE
Makes the journey for users who have a router allocation and want to …

### DIFF
--- a/app/views/devices_guidance/how_to_order.html.erb
+++ b/app/views/devices_guidance/how_to_order.html.erb
@@ -3,7 +3,8 @@
 
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => root_path },
-                  "Get laptops",
+                  { "Laptops and tablets" => devices_guidance_index_path },
+                  t('page_titles.devices_guidance_how_to_order'),
                  ]) %>
 <% end %>
 

--- a/app/views/devices_guidance/how_to_order_laptops_for_independent_special_schools.html.erb
+++ b/app/views/devices_guidance/how_to_order_laptops_for_independent_special_schools.html.erb
@@ -3,7 +3,8 @@
 
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => root_path },
-                  "Get laptops",
+                  { "Laptops and tablets" => devices_guidance_index_path },
+                  "Order laptops and get internet access for state-funded pupils in independent special schools and alternative provision",
                  ]) %>
 <% end %>
 

--- a/app/views/devices_guidance/how_to_order_laptops_for_social_care_leavers.html.erb
+++ b/app/views/devices_guidance/how_to_order_laptops_for_social_care_leavers.html.erb
@@ -3,7 +3,8 @@
 
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => root_path },
-                  "Get laptops",
+                  { "Laptops and tablets" => devices_guidance_index_path },
+                  "Order laptops and get internet access for care leavers",
                  ]) %>
 <% end %>
 

--- a/app/views/responsible_body/devices/home/show.html.erb
+++ b/app/views/responsible_body/devices/home/show.html.erb
@@ -30,7 +30,7 @@
 
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>place orders</li>
+        <li>order laptops<% if @responsible_body.coms_device_pool&.devices_available_to_order %> and routers<% end %></li>
         <li>access the Computacenter TechSource website</li>
       </ul>
 

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-      <%= govuk_link_to 'Get laptops and tablets', responsible_body_devices_path %>
+      <%= govuk_link_to t('page_titles.responsible_body_devices_home'), responsible_body_devices_path %>
     </h2>
 
     <p class="govuk-body">Use this section to:</p>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -21,7 +21,7 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <% if @school.coms_device_allocation&.allocation.positive? %>
+      <% if @school.coms_device_allocation&.allocation&.positive? %>
         <li>order laptops and 4G routers</li>
       <% else %>
         <li>order laptops</li>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -21,7 +21,11 @@
 
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>place orders</li>
+      <% if @school.coms_device_allocation&.allocation.positive? %>
+        <li>order laptops and 4G routers</li>
+      <% else %>
+        <li>order laptops</li>
+      <% end %>
       <li>access the Computacenter TechSource website to order devices</li>
     </ul>
 

--- a/app/views/shared/_how_to_order_routers.html.erb
+++ b/app/views/shared/_how_to_order_routers.html.erb
@@ -1,0 +1,13 @@
+<h3 class="govuk-heading-s">How to order 4G routers in Techsource</h3>
+
+<ol class="govuk-list govuk-list--number">
+  <li>
+    Click on the magnifying glass icon in the top right corner of the screen.
+  </li>
+  <li>
+    Type ‘4G wireless routers’ into the search box and press ‘enter’ on your keyboard.
+  </li>
+  <li>
+    Enter the number of routers you want to order and click ‘Add to basket’.
+  </li>
+</ol>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -1,17 +1,33 @@
 <h3 class="govuk-heading-s">Using TechSource for the first time</h3>
 
 <p class="govuk-body">Use these details to sign in:</p>
-<ul class="govuk-list govuk-list--bullet<% unless local_assigns[:school_urn] %> govuk-!-margin-bottom-7<% end %>">
+<ul class="govuk-list govuk-list--bullet">
   <li>User ID: <%= local_assigns[:email_address] %></li>
   <li>Password: Use the ‘Forgotten password?’ link to set a password the first time you sign in</li>
 </ul>
 
 <% if local_assigns[:school_urn] %>
-<p class="govuk-body govuk-!-margin-bottom-7">
+<p class="govuk-body">
   When you place an order you’ll need the unique reference number (URN) for <%= @school.name %>. It is: <%= local_assigns[:school_urn] %>
 </p>
 <% end %>
 
-<%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3', target: '_blank') -%>
+<% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? &&@school.coms_device_allocation&.devices_available_to_order?) %>
+  <h3 class="govuk-heading-s">How to order 4G routers in Techsource</h3>
+
+  <ol class="govuk-list govuk-list--number">
+    <li>
+      Click on the magnifying glass icon in the top right corner of the screen.
+    </li>
+    <li>
+      Type ‘4G wireless routers’ into the search box and press ‘enter’ on your keyboard.
+    </li>
+    <li>
+      Enter the number of routers you want to order (up to <%if current_user.is_responsible_body_user? %><%= @responsible_body.coms_device_pool&.devices_available_to_order %><% else %><%= @school.coms_device_allocation&.allocation %><% end %>) and click ‘Add to basket’.
+    </li>
+  </ol>
+<% end %>
+
+<%= govuk_start_button_link_to('Start now', techsource_start_path, class: 'govuk-!-margin-bottom-3, govuk-!-margin-top-7', target: '_blank') -%>
 
 <p class="govuk-body-s">on TechSource in a new window</p>

--- a/app/views/shared/_start_ordering_on_techsource.html.erb
+++ b/app/views/shared/_start_ordering_on_techsource.html.erb
@@ -12,7 +12,7 @@
 </p>
 <% end %>
 
-<% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? &&@school.coms_device_allocation&.devices_available_to_order?) %>
+<% if (current_user.is_responsible_body_user? && @responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? && @school.coms_device_allocation&.devices_available_to_order?) %>
   <h3 class="govuk-heading-s">How to order 4G routers in Techsource</h3>
 
   <ol class="govuk-list govuk-list--number">

--- a/app/views/shared/internet/_home.html.erb
+++ b/app/views/shared/internet/_home.html.erb
@@ -1,9 +1,11 @@
 <%- if is_rb %>
   <%- path_request_extra_mobile_data = responsible_body_internet_mobile_extra_data_guidance_path %>
   <%- path_view_extra_mobile_date = responsible_body_internet_mobile_extra_data_requests_path %>
+  <%- path_place_order = responsible_body_devices_order_devices_path %>
 <%- else %>
   <%- path_request_extra_mobile_data = extra_data_guidance_internet_mobile_school_path(@school)  %>
   <%- path_view_extra_mobile_date = extra_data_requests_internet_mobile_school_path(@school) %>
+  <%- path_place_order = order_devices_school_path(@school) %>
 <%- end %>
 
 <div class="govuk-grid-row">
@@ -20,6 +22,9 @@
 
     <p class="govuk-body">
       This scheme temporarily increases data allowances for mobile phone users on certain networks, if they do not have access to broadband at home.
+    </p>
+    <p class="govuk-body">
+       Extra mobile data will end on <span class="app-no-wrap">31 July 2021</span>.
     </p>
 
     <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
@@ -38,26 +43,36 @@
       You can request a router for disadvantaged pupils and students who do not
       have access to the internet at home, and cannot get a mobile data increase.
     </p>
+    <p class="govuk-body">
+      Data provided by DfE will end on <span class="app-no-wrap">31 July 2021</span>, but the routers will work with other data plans if they’re reset. Huawei routers need to be reset before <span class="app-no-wrap">16 July 2021</span>.
+    </p>
     <ul class="govuk-list govuk-list--spaced">
       <li>
-        <%= govuk_link_to 'What you need to know to request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
+        <%= govuk_link_to 'How to request 4G wireless routers', how_to_request_4g_wireless_routers_path %>
       </li>
       <li>
-        <%= govuk_link_to 'Request a 4G wireless router', 'https://forms.gle/LE1hi2FAKdedUvCz6' %>
+        <%= govuk_link_to 'Request 4G wireless routers from DfE', 'https://forms.gle/LE1hi2FAKdedUvCz6' %>
+      </li>
+      <% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? &&@school.coms_device_allocation&.devices_available_to_order?) %>
+      <li>
+        <%= govuk_link_to ('Get your 4G wireless routers'), path_place_order %>
       </li>
       <li>
         <%= govuk_link_to 'How to reset your router', '/devices/reset_your_wireless_router' %>
       </li>
+      <% end %>
     </ul>
-    <h3 class="govuk-heading-s">
-      Reset your Huawei router
-    </h3>
-    <p class="govuk-body">
-      If you do not reset your Huawei router before 16 July 2021, you will not be able
-      to use it after 31 July 2021.
-    </p>
-    <p class="govuk-body">
-      <%= govuk_link_to 'See your Huawei router password', huawei_router_password_path %>
-    </p>
+    <% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.allocation.positive?) || (current_user.is_school_user? &&@school.coms_device_allocation&.allocation.positive?) %>
+      <h3 class="govuk-heading-s">
+        Reset your Huawei router
+      </h3>
+      <p class="govuk-body">
+        If you do not reset your Huawei router before <span class="app-no-wrap">16 July 2021</span>, you will not be able to use it after <span class="app-no-wrap">31 July 2021</span>.
+      </p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'See your Huawei router password', huawei_router_password_path %>
+      </p>
+    <% end %>
   </div>
 </div>
+

--- a/app/views/shared/internet/_home.html.erb
+++ b/app/views/shared/internet/_home.html.erb
@@ -53,7 +53,7 @@
       <li>
         <%= govuk_link_to 'Request 4G wireless routers from DfE', 'https://forms.gle/LE1hi2FAKdedUvCz6' %>
       </li>
-      <% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? &&@school.coms_device_allocation&.devices_available_to_order?) %>
+      <% if (current_user.is_responsible_body_user? && @responsible_body.coms_device_pool&.devices_available_to_order?) || (current_user.is_school_user? && @school.coms_device_allocation&.devices_available_to_order?) %>
       <li>
         <%= govuk_link_to ('Get your 4G wireless routers'), path_place_order %>
       </li>
@@ -62,7 +62,7 @@
       </li>
       <% end %>
     </ul>
-    <% if (current_user.is_responsible_body_user? &&@responsible_body.coms_device_pool&.allocation.positive?) || (current_user.is_school_user? &&@school.coms_device_allocation&.allocation.positive?) %>
+    <% if (current_user.is_responsible_body_user? && @responsible_body.coms_device_pool&.allocation&.positive?) || (current_user.is_school_user? && @school.coms_device_allocation&.allocation&.positive?) %>
       <h3 class="govuk-heading-s">
         Reset your Huawei router
       </h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,9 +26,9 @@ en:
     error_prefix: "Error: "
     responsible_body:
       devices:
-        order_devices: Order devices now
+        order_devices: Get devices now
     responsible_body_home: Get help with technology
-    responsible_body_devices_home: Get laptops
+    responsible_body_devices_home: Get devices
     responsible_body_devices_tell_us: Tell us who will order laptops
     responsible_body_users_index: Manage %{rb_type} users
     responsible_body_trust_users_index: Manage trust administrators
@@ -49,7 +49,7 @@ en:
     guide_to_resetting_windows_laptops_and_tablets: Guide to resetting Windows laptops and tablets
     start: Get help with technology
     internet_access: Internet access
-    signed_in_internet_access: Get internet access
+    signed_in_internet_access: Request internet access
     who_needs_the_data: Who needs the extra mobile data?
     report_a_problem: Report a problem
     devices_guidance_how_to_order: "How and when to order DfE laptops during coronavirus (COVID-19)"
@@ -66,7 +66,7 @@ en:
     how_to_access_the_get_help_with_technology_service: How to access the Get help with technology service
     iss:
       home: Get laptops and internet access
-      order_devices: Get laptops
+      order_devices: Order devices
       laptop_types: Find out what type of laptop pupils need
       chromebooks: Will your order include Google Chromebooks?
       will_need_chromebooks_error: Tell us if pupils will need Chromebooks

--- a/spec/features/huawei_password_spec.rb
+++ b/spec/features/huawei_password_spec.rb
@@ -39,13 +39,13 @@ RSpec.feature 'Huawei router password', type: :feature do
 private
 
   def go_to_huawei_password
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'See your Huawei router password'
   end
 
   def expect_password_and_breadcrumb
     expect(page).to have_text 'Password:'
-    expect(page).to have_link('Get internet access')
+    expect(page).to have_link('Request internet access')
   end
 
   def expect_login_screen

--- a/spec/features/ordering_for_la_funded_devices_spec.rb
+++ b/spec/features/ordering_for_la_funded_devices_spec.rb
@@ -160,7 +160,7 @@ RSpec.feature 'Ordering for LA-funded devices', type: :feature do
   end
 
   def when_i_click_on_get_laptops
-    click_on 'Get laptops'
+    click_on 'Order devices'
   end
 
   def then_i_see_i_have_laptops_remaining

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -190,7 +190,7 @@ RSpec.feature 'Setting up the devices ordering' do
   end
 
   def when_i_follow_the_get_devices_link
-    click_on 'Get laptops and tablets'
+    click_on 'Get devices'
   end
 
   def and_i_follow_the_your_schools_link

--- a/spec/features/responsible_body/donated_devices_spec.rb
+++ b/spec/features/responsible_body/donated_devices_spec.rb
@@ -68,7 +68,7 @@ private
 
   def and_i_navigate_to_the_devices_page
     visit responsible_body_home_path
-    click_on 'Get laptops and tablets'
+    click_on 'Get devices'
   end
 
   def and_i_click_the_donated_devices_link

--- a/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
+++ b/spec/features/responsible_body/extra_mobile_data_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
   end
 
   scenario 'the user can navigate to the manual request form from the responsible body home page' do
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'Request extra data for mobile devices'
 
     expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
@@ -26,7 +26,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a responsible bo
   end
 
   scenario 'the user can navigate to the bulk upload form from the responsible body home page' do
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'Request extra data for mobile devices'
 
     expect(page).to have_css('h1', text: 'Request extra data for mobile devices')

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature ResponsibleBody do
 
       expect(responsible_body_home_page).to be_displayed
       expect(page.status_code).to eq 200
-      expect(page).to have_link('Get laptops and tablets')
+      expect(page).to have_link('Get devices')
     end
 
     context 'with a responsible body managing at least 1 school centrally' do
@@ -52,7 +52,7 @@ RSpec.feature ResponsibleBody do
 
       it 'shows link to get extra data' do
         visit responsible_body_home_path
-        expect(page).to have_link('Get internet access')
+        expect(page).to have_link('Request internet access')
       end
     end
 
@@ -61,14 +61,14 @@ RSpec.feature ResponsibleBody do
 
       it 'does not show link to get extra data' do
         visit responsible_body_home_path
-        expect(page).not_to have_link('Get internet access')
+        expect(page).not_to have_link('Request internet access')
       end
     end
 
     context 'with a local authority devolved to all schools' do
       it 'shows link to get extra data' do
         visit responsible_body_home_path
-        expect(page).to have_link('Get internet access')
+        expect(page).to have_link('Request internet access')
       end
     end
 

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -123,11 +123,11 @@ RSpec.feature 'Ordering devices within a virtual pool' do
   end
 
   def and_i_follow_the_get_laptops_and_tablets_link
-    click_link 'Get laptops and tablets'
+    click_link 'Get devices'
   end
 
   def then_i_see_the_get_laptops_and_tablets_page
-    expect(page).to have_css('h1', text: 'Get laptops')
+    expect(page).to have_css('h1', text: 'Get devices')
     expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
   end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -88,11 +88,11 @@ RSpec.feature 'Ordering devices' do
   end
 
   def and_i_follow_the_get_laptops_and_tablets_link
-    click_link 'Order devices'
+    click_link 'Get devices'
   end
 
   def then_i_see_the_get_laptops_and_tablets_page
-    expect(page).to have_css('h1', text: 'Order devices')
+    expect(page).to have_css('h1', text: 'Get devices')
     expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
   end

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -88,11 +88,11 @@ RSpec.feature 'Ordering devices' do
   end
 
   def and_i_follow_the_get_laptops_and_tablets_link
-    click_link 'Get laptops'
+    click_link 'Order devices'
   end
 
   def then_i_see_the_get_laptops_and_tablets_page
-    expect(page).to have_css('h1', text: 'Get laptops')
+    expect(page).to have_css('h1', text: 'Order devices')
     expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
   end

--- a/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
+++ b/spec/features/responsible_body/submitting_an_extra_mobile_data_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Submitting an extra mobile data request', type: :feature do
 
     scenario 'Navigating to the form' do
       visit responsible_body_home_path
-      click_on('Get internet access')
+      click_on('Request internet access')
       click_on('Request extra data for mobile devices')
       click_on('New request')
       expect(page).to have_text('How would you like to submit information?')

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature 'Viewing your schools' do
   end
 
   def then_i_see_the_get_laptops_and_tablets_page
-    expect(page).to have_css('h1', text: 'Order devices')
+    expect(page).to have_css('h1', text: 'Get devices')
     expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
   end

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature 'Viewing your schools' do
   end
 
   def and_i_follow_the_get_laptops_and_tablets_link
-    click_link 'Get laptops and tablets'
+    click_link 'Get devices'
   end
 
   def when_i_follow_the_your_schools_link
@@ -159,7 +159,7 @@ RSpec.feature 'Viewing your schools' do
   end
 
   def then_i_see_the_get_laptops_and_tablets_page
-    expect(page).to have_css('h1', text: 'Get laptops')
+    expect(page).to have_css('h1', text: 'Order devices')
     expect(page).to have_link('Your schools')
     expect(page).to have_link('Order devices')
   end

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
   end
 
   scenario 'the user can navigate to the manual request form from the home page' do
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'Request extra data for mobile devices'
 
     expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
@@ -29,7 +29,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     end
 
     scenario 'do not show FE excluded MNOs' do
-      click_on 'Get internet access'
+      click_on 'Request internet access'
       click_on 'Request extra data for mobile devices'
       click_on 'New request'
       choose 'One at a time, using a form'
@@ -39,7 +39,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
   end
 
   scenario 'the user can navigate to the bulk upload form from the home page' do
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'Request extra data for mobile devices'
 
     expect(page).to have_css('h1', text: 'Request extra data for mobile devices')
@@ -60,7 +60,7 @@ RSpec.feature 'Accessing the extra mobile data requests area as a school user', 
     end
 
     scenario 'the user can navigate to their previous requests from the home page' do
-      click_on 'Get internet access'
+      click_on 'Request internet access'
       click_on 'Request extra data for mobile devices'
 
       expect(page).to have_css('h1', text: 'Request extra data for mobile devices')

--- a/spec/features/school/wireless_router_requests_spec.rb
+++ b/spec/features/school/wireless_router_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Accessing the 4G wireless routers requests area as a school user'
   end
 
   scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
-    click_on 'Get internet access'
+    click_on 'Request internet access'
     click_on 'What you need to know to request 4G wireless routers'
 
     expect(page).to have_css('h1', text: 'How to request 4G wireless routers')

--- a/spec/features/school/wireless_router_requests_spec.rb
+++ b/spec/features/school/wireless_router_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Accessing the 4G wireless routers requests area as a school user'
 
   scenario 'the user can navigate to the request 4G wireless routers page from the home page' do
     click_on 'Request internet access'
-    click_on 'What you need to know to request 4G wireless routers'
+    click_on 'How to request 4G wireless routers'
 
     expect(page).to have_css('h1', text: 'How to request 4G wireless routers')
     expect(page).to have_http_status(:ok)

--- a/spec/views/school/home/show.html.erb_spec.rb
+++ b/spec/views/school/home/show.html.erb_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'school/home/show.html.erb' do
     assign(:current_user, user)
   end
 
-  it 'always shows the Get internet access section' do
+  it 'always shows the Request internet access section' do
     render template: template, locals: { impersonated_or_current_user: user }
-    expect(rendered).to include('Get internet access')
+    expect(rendered).to include('Request internet access')
   end
 end


### PR DESCRIPTION
### Context

From ticket (Review 4G router ordering journey for users (particularly ISS and SC) -are they blocked?)[https://trello.com/c/AZvS4Eku/2046-review-4g-router-ordering-journey-for-users-particularly-iss-and-sc-are-they-blocked]:

Anya reported that an LA user could not find how to order the 4G routers allocated to her. We had a call to discuss the journey and agreed that it needs a review.

### Changes proposed in this pull request

- reword 'Get laptops' pages to 'Get devices'
- show users links to these pages allow them to order routers (when they have been allocated routers)
- add a link to order routers from the 'Request internet access' page
- give guidance on how to add routers to your order in techsource

We're also updating emails sent to users when their router request is approved to give guidance on how to order and the imminent end of the data we provide for those routers. 

I've also made the router password conditional on the user’s organisation having been allocated some routers.

#### School only changes:

![localhost_3000_schools_135086](https://user-images.githubusercontent.com/8417288/120801220-ce01d880-c538-11eb-8765-bdebcc46d819.png)

#### RB only changes:

![localhost_3000_responsible-body (4)](https://user-images.githubusercontent.com/8417288/120801273-df4ae500-c538-11eb-9434-33a0d621f770.png)

#### RB and school changes:

![localhost_3000_schools_135086_internet](https://user-images.githubusercontent.com/8417288/120801362-f984c300-c538-11eb-8375-a3012b7e597b.png)

![localhost_3000_schools_135086_order-devices](https://user-images.githubusercontent.com/8417288/120801369-fc7fb380-c538-11eb-88ff-43567b8c3953.png)

### Guidance to review

Your organisation needs to have a router allocation to see the changes.