### PR TITLE
Provide value for `@responsible_body` for partial

### DIFF
--- a/app/controllers/school/devices_controller.rb
+++ b/app/controllers/school/devices_controller.rb
@@ -1,5 +1,7 @@
 class School::DevicesController < School::BaseController
   def order
+    @responsible_body = @school.responsible_body
+
     if @school.can_order_devices_right_now?
       if impersonated_or_current_user.has_an_active_techsource_account? && @school.can_order_for_specific_circumstances?
         render :can_order_for_specific_circumstances


### PR DESCRIPTION
### Context

Sentry: https://sentry.io/organizations/dfe-get-help-with-tech/issues/2445734273/?project=5320558&referrer=slack

### Changes proposed in this pull request

Provide value for `@responsible_body` for partial. This fixes two code paths. The three other routes to this partial seem to already be providing `@responsible_body` in their controllers

### Guidance to review

