### PR TITLE
Add feature flag for 30 Jun order closing

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,6 +9,7 @@ class FeatureFlag
     half_term_delivery_suspension
     donated_devices
     rb_level_access_notification
+    summer_ordering_pause
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze


### PR DESCRIPTION
### Context

Need feature flag for 30 Jun service changes. Content designers will need to check this flag to switch between the different behaviours when the service is closed for ordering.

### Changes proposed in this pull request

Add feature flag called `summer_ordering_pause`

### Guidance to review

