### PR TITLE
[2085] Add more segmented device stats on the "service performance" dashboard

### DIFF
--- a/app/models/support/service_performance.rb
+++ b/app/models/support/service_performance.rb
@@ -72,6 +72,37 @@ class Support::ServicePerformance
     devolved + managed
   end
 
+  def segmented_device_counts
+    device_type = 'std_device'
+
+    [
+      Support::ServicePerformance::DeviceCounts.new(
+        key: :open_and_devolved_schools,
+        school_scope: School.gias_status_open,
+        device_type: device_type,
+        who_will_order_devices: 'school',
+      ),
+      Support::ServicePerformance::DeviceCounts.new(
+        key: :closed_and_devolved_schools,
+        school_scope: School.gias_status_closed,
+        device_type: device_type,
+        who_will_order_devices: 'school',
+      ),
+      Support::ServicePerformance::DeviceCounts.new(
+        key: :open_and_centrally_managed_schools,
+        school_scope: School.gias_status_open,
+        device_type: device_type,
+        who_will_order_devices: 'responsible_body',
+      ),
+      Support::ServicePerformance::DeviceCounts.new(
+        key: :closed_and_centrally_managed_schools,
+        school_scope: School.gias_status_closed,
+        device_type: device_type,
+        who_will_order_devices: 'responsible_body',
+      ),
+    ]
+  end
+
   #
   # devolved schools - devices
   #

--- a/app/models/support/service_performance/device_counts.rb
+++ b/app/models/support/service_performance/device_counts.rb
@@ -1,0 +1,70 @@
+class Support::ServicePerformance::DeviceCounts
+  OVER_ORDERED_ALLOCATION_QUERY = 'devices_ordered > 0 AND cap < devices_ordered'.freeze
+  NOT_OVER_ORDERED_ALLOCATION_QUERY = 'cap >= devices_ordered'.freeze
+
+  def self.sum_allocation(
+    school_scope:,
+    device_type:,
+    who_will_order_devices:,
+    sum_expression:,
+    scope_query: nil
+  )
+    SchoolDeviceAllocation
+      .where(device_type: device_type)
+      .where(scope_query)
+      .joins(school: :preorder_information)
+      .merge(school_scope)
+      .where(preorder_information: {
+        who_will_order_devices: who_will_order_devices,
+      })
+      .sum(sum_expression)
+  end
+
+  attr_reader :key
+
+  def initialize(
+    key:,
+    school_scope:,
+    device_type:,
+    who_will_order_devices:
+  )
+    @key = key
+    @school_scope = school_scope
+    @device_type = device_type
+    @who_will_order_devices = who_will_order_devices
+  end
+
+  def available
+    sum_allocation(sum_expression: 'cap')
+  end
+
+  def ordered
+    sum_allocation(sum_expression: 'devices_ordered')
+  end
+
+  def remaining_excl_over_ordered
+    sum_allocation(
+      scope_query: NOT_OVER_ORDERED_ALLOCATION_QUERY,
+      sum_expression: 'cap - devices_ordered',
+    )
+  end
+
+  def over_ordered
+    sum_allocation(
+      scope_query: OVER_ORDERED_ALLOCATION_QUERY,
+      sum_expression: 'devices_ordered - cap',
+    )
+  end
+
+private
+
+  def sum_allocation(sum_expression:, scope_query: nil)
+    self.class.sum_allocation(
+      school_scope: @school_scope,
+      device_type: @device_type,
+      who_will_order_devices: @who_will_order_devices,
+      sum_expression: sum_expression,
+      scope_query: scope_query,
+    )
+  end
+end

--- a/app/views/support/service_performance/_devices.html.erb
+++ b/app/views/support/service_performance/_devices.html.erb
@@ -23,6 +23,37 @@
   </div>
 </div>
 
+<% @stats.segmented_device_counts.each do |s| %>
+  <%= render GovukComponent::Details.new(summary: t(s.key, scope: i18n_scope), classes: ['govuk-!-margin-bottom-4']) do %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render Support::TileComponent.new(
+                  count: humanized_number(s.available),
+                  label: t(:devices_available, scope: i18n_scope),
+                  colour: :blue) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-third">
+        <%= render Support::TileComponent.new(
+                    count: humanized_number(s.ordered),
+                    label: t(:devices_ordered, scope: i18n_scope),
+                    colour: :green) %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render Support::TileComponent.new(
+                    count: humanized_number(s.remaining_excl_over_ordered),
+                    label: t(:devices_remaining_excl_over_ordered, scope: i18n_scope),
+                    colour: :orange) %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render Support::TileComponent.new(
+                    count: humanized_number(s.over_ordered),
+                    label: t(:devices_over_ordered, scope: i18n_scope),
+                    colour: :red) %>
+      </div>
+    </div>
+  <%- end -%>
+<%- end -%>
+
 <h3 class="govuk-heading-m govuk-!-margin-top-7">Devices remaining by day (last 7 days)</h3>
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,6 +446,14 @@ en:
       total_devices_available: total devices available
       total_devices_ordered: devices shipped
       total_devices_remaining: remaining
+      devices_available: devices available
+      devices_ordered: devices shipped
+      devices_remaining_excl_over_ordered: remaining (excl. over-ordered)
+      devices_over_ordered: over-ordered
+      open_and_devolved_schools: For open and devolved schools
+      closed_and_devolved_schools: For closed and devolved schools
+      open_and_centrally_managed_schools: For open and centrally managed schools
+      closed_and_centrally_managed_schools: For closed and centrally managed schools
       devolved_schools: devolved schools
       devolved_schools_that_have_fully_ordered_html: ordered their full allocation <br/>(%{amount} out of %{total})
       devolved_schools_that_have_partially_ordered_html: ordered but have devices left <br/>(%{amount} out of %{total})


### PR DESCRIPTION
<https://trello.com/c/sJVeOtqL/2085-performance-dashboard-improvements>

This adds new sections for open vs. closed and devolved vs. centrally managed schools. These sections show counts for:

- Devices available
- Devices shipped
- Devices remaining (excl. over-ordered)
- Devices over-ordered

---

<img width="770" alt="Screenshot 2021-06-14 at 15 24 25" src="https://user-images.githubusercontent.com/31973/121908558-08335d00-cd25-11eb-8b26-356191d3ff55.png">

---

<img width="753" alt="Screenshot 2021-06-14 at 15 27 06" src="https://user-images.githubusercontent.com/31973/121908564-09648a00-cd25-11eb-8e8a-077cb7af012c.png">

---

**TODO**

- [x] Consider copy additions/updates
- ~~Consider adding caching~~
- [x] Consider adding a test suite
