### PR TITLE
Remove `summer_ordering_pause` feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,7 +9,6 @@ class FeatureFlag
     half_term_delivery_suspension
     donated_devices
     rb_level_access_notification
-    summer_ordering_pause
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze


### PR DESCRIPTION
### Context

Remove feature flag because we've abandoned this approach

### Changes proposed in this pull request

Remove `summer_ordering_pause` feature flag

### Guidance to review

