### PR TITLE
2150 update guidance content device

### DIFF
--- a/app/views/devices_guidance/about_the_offer.md
+++ b/app/views/devices_guidance/about_the_offer.md
@@ -1,42 +1,34 @@
-## Ordering devices for schools, colleges, academy trusts and local authorities from September 2020
+## Devices for schools, colleges, academy trusts and local authorities from September 2020 to June 2021
 
-DfE is providing support to help disadvantaged children and young people who are otherwise unable to access remote education.
+DfE is provided support to help disadvantaged children and young people who were otherwise unable to access remote education.
 
 Examples of this include disadvantaged children:
 
 * with no digital devices in their household
-* whose only available device is a smartphone
-* with a single device in their household that’s being shared with more than one other family member
-* who do not have access to the internet at home
+* whose only available device was a smartphone
+* with a single device in their household that was shared with more than one other family member
+* who did not have access to the internet at home
 
-This offer applies to maintained schools, pupil referral units, academy trusts and hospital schools, as well as sixth-form colleges and further education institutions which have enrolled 14 to 16-year-olds. They’ll receive an allocation of laptops and tablets to be used to support disadvantaged children if they do not have access to a digital device through other means.
+This offer applied to maintained schools, pupil referral units, academy trusts and hospital schools, as well as sixth-form colleges and further education institutions which have enrolled 14 to 16-year-olds.
 
-They may also be eligible to get internet access for disadvantaged children through [increased mobile phone data allowances](/about-increasing-mobile-data) or [4G wireless routers](/how-to-request-4g-wireless-routers).
+They were also able to request internet access for disadvantaged children through [increased mobile phone data allowances](/about-increasing-mobile-data) or [4G wireless routers](/how-to-request-4g-wireless-routers).
 
-## Devices for disadvantaged pupils and students
+## Devices were available for disadvantaged pupils and students
 
-These are currently available for pupils and students:
+* in years 3 to 13 who did not have access to a device and whose face-to-face education was disrupted
+* aged 16 to 19 who received free meals in further education
+* over the age of 19 with an education, health and care plan (EHCP) who also received free meals
+* in any year group who had been [advised to shield](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19) because they (or someone they live with) arwase [clinically extremely vulnerable](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#cev)
+* in any year group, including those in 16 to 19 education, who attended a hospital school
+* in years 3 to 11 with [state-funded places in independent special schools or alternative provision](/devices/how-to-order-laptops-for-independent-special-schools), who were eligible for free school meals
 
-* in years 3 to 13 who do not have access to a device and whose face-to-face education is disrupted
-* aged 16 to 19 who receive free meals in further education
-* over the age of 19 with an education, health and care plan (EHCP) who also receive free meals 
-* in any year group who have been [advised to shield](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19) because they (or someone they live with) are [clinically extremely vulnerable](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#cev)
-* in any year group, including those in 16 to 19 education, attending a hospital school
-* in years 3 to 11 with [state-funded places in independent special schools or alternative provision](/devices/how-to-order-laptops-for-independent-special-schools), who are eligible for free school meals
-
-[Find out how we’ve calculated how many devices you can order](/devices/allocation-and-specification).
-
-[Find out how to order laptops and tablets](/devices/how-to-order) and [get the internet](/internet-access).
-
-## Devices for social care leavers
-
-Local authorities can [find out how to order laptops and get internet access for eligible care leavers](/devices/how-to-order-laptops-for-social-care-leavers).
+[Find out how we calculated how many devices could be ordered](/devices/allocation-and-specification).
 
 ## Laptops, tablets and 4G wireless routers provided during the 2020 summer term
 
 DfE provided [laptops, tablets and 4G wireless routers](https://www.gov.uk/guidance/laptops-tablets-and-4g-wireless-routers-provided-during-coronavirus-covid-19) to local authorities and academy trusts during the 2020 summer term. 
 
-These are being distributed to disadvantaged families, children and young adults who did not have access to them through another source, such as their school. 
+These were distributed to disadvantaged families, children and young adults who did not have access to them through another source, such as their school. 
 
 Laptops and tablets were provided for:
 
@@ -52,14 +44,9 @@ Laptops and tablets were provided for:
 
 A care leaver is someone aged 16 to 25 who was looked after by a local authority for at least 13 weeks (at least part of which was on or after their 16th birthday), but who is no longer looked after.
 
-These digital devices will help:
+These digital devices were provided to help:
 
 * social workers to provide virtual safeguarding and support to the children and families they work with via video conferences, for example 
 * children, young people, families and care leavers to access the online services they need to protect their wellbeing
 * families and care leavers to avoid social isolation
-* children and young people to access remote learning, including year 10 pupils in the 2019 to 2020 academic year
-
-## What to do if you cannot get laptops, tablets or internet access from DfE
-
-Parents, pupils, social care workers and schools that are not eligible for the Get help with technology programme can [find information about support available from other sources](/what-to-do-if-you-cannot-get-laptops-tablets-or-internet-access-from-dfe) in our guidance.
-
+* children and young people to access remote learning

--- a/app/views/devices_guidance/device_allocations.md
+++ b/app/views/devices_guidance/device_allocations.md
@@ -1,67 +1,32 @@
-## How devices are allocated
+## How devices were allocated for pupils and students from September 2020 to June 2021
 
-The number of devices we’ve made available for you to order through the service reflects the number of laptops and tablets we estimate are needed by your school, college or further education institution.
+The number of devices we made available to order through the service reflected the number of laptops and tablets we estimated your school, college or further education institution needed.
 
-This calculation is based on:
+This calculation was based on:
 
 * free school meals data
 * free meals data for further education institutions
-* an estimate of the number of devices a school or further education institution already has
+* an estimate of the number of devices a school or further education institution already had
 
-[Find out about allocations for care leavers](/devices/how-to-order-laptops-for-social-care-leavers)
+We also provided laptops and internet access to support disadvantaged pupils in years 3 to 11, who:
 
-[Find out about allocations for state-funded pupils in years 3 to 11 in independent special schools or alternative provision](devices/how-to-order-laptops-for-independent-special-schools)
+* had a funded place at an independent special school, or independent alternative provision
+* were eligible for free school meals
+* did not have access to a suitable device for remote education, and for use in face-to-face education
 
-## Providing internet connectivity
-
-Our guidance explains your options for [getting internet access](https://get-help-with-tech.education.gov.uk/internet-access) for disadvantaged children and young people. This could be through:
-
-* [increasing mobile data allowances](/about-increasing-mobile-data) for disadvantaged pupils in years 3 to 11 (not currently available to students in 16 to 19 further education)
-
-* [4G wireless routers](/how-to-request-4g-wireless-routers) for disadvantaged pupils in years 3 to 11, and disadvantaged and students in 16 to 19 further education 
-
-## How to request more devices
-
-You can see your current allocation by signing in to the [Get help with technology service](https://get-help-with-tech.education.gov.uk/sign-in).
-
-If you find that your allocation is substantially lower than your school needs, you can request more devices by [contacting us](https://get-help-with-tech.education.gov.uk/get-support). We cannot guarantee that we’ll be able to meet all requests, as we need to distribute devices among a large number of schools and colleges in England.
-
-Before requesting more laptops and tablets, you should make sure that pupils and students cannot access a device privately, or by being lent a device already owned by your school, college or further education institution.
-
-You’ll need to provide anonymised evidence that confirms:
-
-* the ages of the pupils and students for whom you are requesting additional devices
-* how you’ve identified that these pupils and students are disadvantaged (such as whether they get free meals)
-* how you know that the pupils and students do not have access to a private device (for example, through phone calls to families or a survey you’ve conducted about device ownership)
-* that all the devices your school or further education institution has already, have been distributed
-
-### If you’re applying for a local authority or academy trust, you need to tell us:
-
-* the LAESTAB number for a hospital school
-* the name of the school your query is for and the number of additional devices required. If you’re requesting additional devices for more than one school, you’ll need to provide the number of additional devices required for each school
-
-### If you’re applying for a school, college or further education institution, you need to tell us:
-
-* your unique reference number (URN), which is normally 6 digits. If you’re applying for a further education college, this will be your 8-digit UKPRN. If you don’t know your URN or UKPRN, you can find these on the [Get Information about Schools](https://get-information-schools.service.gov.uk/) site
-* the name of your school, college or further education institution
-* the number of additional devices required
-
-We’ll review your query and respond with a decision as soon as possible.
-
-## How to request devices for children and young people who are shielding or attending hospital school
-
-Devices can be requested at any time for disadvantaged pupils and students:
-
-* in any year group who have been advised to [shield](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19) because they (or someone they live with) are [clinically extremely vulnerable](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#cev)
-* in any year group, including 16 to 19 education, attending a hospital school
-
-[Contact us](https://get-help-with-tech.education.gov.uk/get-support) to make a request. 
-
-Do not submit any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask you to resend it.
-
+Allocations were based on the data each local authority submitted in the 2020 alternative provision census.
 
 ## Laptops, tablets and 4G wireless routers provided during the summer term 2020
 
 Over 220,000 laptops and tablets were made available to distribute as part of the [first phase of the Get help with technology programme](https://www.gov.uk/guidance/laptops-tablets-and-4g-wireless-routers-provided-during-coronavirus-covid-19). The most disadvantaged and vulnerable young people and children were prioritised to make sure they can access social care and remote education.
 
 The DfE considered all allocation queries raised by local authorities and academy trusts, and reviewed the submitted evidence against the initial allocation. DfE then compared those queries to similar requests received nationwide, and balanced these against the total number of devices available. More devices have been provided where there was an evidenced need to support eligible children.
+
+## How devices were allocated for care leavers in 2021
+
+DfE provided laptops and internet access to support care leavers who:
+
+* were aged between 16 and 25 years old
+* did not have access to a laptop or tablet from their LA, or any other source
+
+Allocation estimates were based on each local authority's share of the overall care leaver population.

--- a/app/views/devices_guidance/device_distribution_and_ownership.md
+++ b/app/views/devices_guidance/device_distribution_and_ownership.md
@@ -62,19 +62,6 @@ If an LA has given a child or young person a device and that person moves area, 
 * discuss transferring ownership of the device with the new LA, a relevant educational setting, or to the child or care leaver themself (if it’s safe and appropriate to do so)
 * asking the child or young person to return the device so that it can be redistributed within the LA
 
-## How to distribute devices
-
-Laptops, tablets and 4G wireless routers ordered from September 2020 will be delivered directly to schools, colleges, further education institutions or LAs named in the order. Read guidance on [how to order laptops and tablets](https://get-help-with-tech.education.gov.uk/devices/how-to-order) or [4G wireless routers](https://get-help-with-tech.education.gov.uk/how-to-request-4g-wireless-routers) for more information on the delivery process.
-
-Organisations are responsible for deciding how they deliver devices. For example, they can:
-
-* arrange for them to be collected
-* organise for them to be delivered to the homes of pupils, students and care leavers
-* arrange for schools, colleges and further education institutions to deliver them
-* use local organisations, such as those supporting care leavers
-
-All distribution and return of lent devices should be done in accordance with [social distancing guidelines relevant to your local area](https://www.gov.uk/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19).
-
 ### Deciding how to distribute devices
 
 LAs, trusts, schools, colleges and FE institutions can decide how best to meet the needs of vulnerable children and young people. We anticipate these organisations will safely distribute devices to people who need them as soon as possible.
@@ -85,13 +72,6 @@ Your organisation is best placed to review the needs of the people in your care.
 * only be used in supervised contexts (with a social worker, or support of an educational setting)
 * be managed by an educational setting
 * be used for other children or young people who would benefit from it, outside of eligible groups
-
-### Redistributing unused 4G wireless routers
-
-LAs, academy trusts, schools, colleges and further education institutions can use the [Support Portal](https://computacenterprod.service-now.com/dfe) to see how much data is being used by each router they are responsible for. If you identify routers that are not being used, you may wish to collect them and lend them to other children and young people who may have greater need.
-
-All SIM cards will remain active until 31 July 2021. Guidance will be made available explaining how to use routers with alternative data packages. 
-
 
 ## Loan agreements
 

--- a/app/views/devices_guidance/device_specification.md
+++ b/app/views/devices_guidance/device_specification.md
@@ -1,36 +1,18 @@
-You can find out which types of device are in stock by signing in to the TechSource ordering website. 
-
-## Before you order
-
-We may need some technical information from you before you can order, so we recommend choosing the types of devices and settings you want before you’re invited to order.
-
-### Pre-issued devices
-
-In addition to brand new devices, you may be able to order ‘pre-issued’ devices too. These have been distributed as part of the Get help with technology programme, and then returned. They may or may not be used. 
-
-Our delivery partner completes the following quality checks for each used device:
-
-* it’s visually inspected, and where possible any labels (such as asset tags) have been removed 
-* it switches on and powers up
-* the screen, CPU, RAM and HDD are tested
-* the device is reset
-
-These devices will meet the minimum technical specifications for remote education. They may have residual asset labels, external scratches, smart water application, etching or writing on the exterior of the device.
-
-If devices have a remaining manufacturer's warranty, it will be for less than a year. 
-
+<div class="govuk-inset-text">
+We’re now permanently out of stock of all laptops, tablets and routers.
+</div>
 
 ## Microsoft Windows laptops
 
-When you order you’ll be asked whether or not you want to have DfE settings installed.
+From September 2020, you were offered a choice of settings.
 
 #### Not having DfE settings installed
 
-These ‘DfE Standard’ Windows devices are provided with factory settings. Your school, trust or LA should configure them at your own cost before lending them to pupils. This means installing preferred safeguarding measures and bringing them into an existing device management framework.
+These ‘DfE Standard’ Windows devices were provided with factory settings. Your school, trust or LA should configure them at your own cost before lending them to pupils. This means installing preferred safeguarding measures and bringing them into an existing device management framework.
 
 #### DfE settings installed
 
-These ‘DfE Restricted’ Windows devices are set up with content filtering and MDM software before delivery. They’re not configurable, and there are limitations on downloading software and changing strict content filters that may prevent some browsers and conferencing tools from functioning. These settings expire on 30 September 2021. Read our guidance on [how to reset devices and apply your own security settings](/devices/guide-to-resetting-windows-laptops-and-tablets) to make them safe for pupils and students to use.
+These ‘DfE Restricted’ Windows devices were set up with content filtering and MDM software before delivery. They’re not configurable, and there are limitations on downloading software and changing strict content filters that may prevent some browsers and conferencing tools from functioning. These settings expire on 30 September 2021. Read our guidance on [how to reset devices and apply your own security settings](/devices/guide-to-resetting-windows-laptops-and-tablets) to make them safe for pupils and students to use.
 
 Read more information about [preparing Microsoft devices](/devices/preparing-microsoft-windows-laptops-and-tablets) for pupils, including how to access the local admin and BIOS passwords you’ll need to reset devices.
 
@@ -40,53 +22,30 @@ All devices provided before September 2020 were delivered with safeguarding and 
 
 ## Google Chromebooks
 
-A web-filtering solution called Cisco Umbrella is included free of charge until 30 September 2021, if you wish to use it. If you decide not to use Cisco Umbrella, or you continue using the Chromebooks once Cisco Umbrella has expired, DfE will no longer support these devices. It’s your responsibility to avoid risks to the online safety of the children and young people you’re providing devices to. [Find out more about Cisco Umbrella](https://get-help-with-tech.education.gov.uk/devices/preparing-chromebooks#securing-your-chromebooks) in our guidance.
+A web-filtering solution called Cisco Umbrella was included free of charge until 30 September 2021, if you wish to use it. If you decide not to use Cisco Umbrella, or you continue using the Chromebooks once Cisco Umbrella has expired, DfE will no longer support these devices. It’s your responsibility to avoid risks to the online safety of the children and young people you’re providing devices to. [Find out more about Cisco Umbrella](https://get-help-with-tech.education.gov.uk/devices/preparing-chromebooks#securing-your-chromebooks) in our guidance.
 
-### Ordering Chromebooks for state-funded schools, colleges or further education institutions
-
-You need to [sign in to the Get help with technology service](/sign-in) and give the following information before you can order Google Chromebooks:
-
-* the educational setting's Google domain for Google Workspace for Education Fundamentals (formerly G Suite for Education) - for example 'school.co.uk'
-* a recovery email address, which must be on a different domain to the educational setting's domain - for example, if the registered domain is ‘school.co.uk’, the recovery email cannot be ‘recovery@school.co.uk’
-
-If you’re not sure how to find this information, you should ask your IT support for help.
-
-If the school you’re ordering for does not currently use an education platform, you can [apply for DfE-funded support to get access to either Google Workspace for Education Fundamentals or Microsoft 365 Education](/digital-platforms).
-
-### Ordering Chromebooks for LA-funded pupils in independent special schools or alternative provision
-
-You’ll be asked if you want to order Google Chromebooks when you [sign in to the Get help with technology service](https://get-help-with-tech.education.gov.uk/sign-in). You should answer ‘Yes’.
-
-After you order you’ll get an email asking if you want us to supply Chrome Education Upgrades (Chromebook licenses). An educational setting will need a license to enrol the device in their Google Admin console. This gives them options to manage and secure the device.
-
-Reply to the email you receive to request licenses. You'll need to provide the following information for each pupil’s educational setting:
-
-* the educational setting's Google domain for Google Workspace for Education Fundamentals (formerly G Suite for Education) - for example 'school.co.uk'
-* a recovery email address, which must be on a different domain to the educational setting's domain - for example, if the registered domain is 'school.co.uk', the recovery email cannot be 'recovery@school.co.uk'
-
-The educational setting's IT support should be able to give you this.
-
-Alternatively, your LA can choose to [set up and manage a Google domain](https://get-help-with-tech.education.gov.uk/devices/google-domain-for-care-leavers-and-children-with-social-worker).
-
-If you do not request licenses, your Chromebooks will be delivered with factory settings. Cisco Umbrella web filtering will not be installed. Your LA, or the education setting you lend or give the devices to, will be responsible for [installing safeguarding and security settings](https://get-help-with-tech.education.gov.uk/devices/preparing-chromebooks#securing-your-chromebooks) before they’re distributed to pupils. 
-
-### Ordering Chromebooks for care leavers
-
-You’ll be asked if you want to order Google Chromebooks when you [sign in to the Get help with technology service](https://get-help-with-tech.education.gov.uk/sign-in). You should answer ‘Yes’. 
-
-If a care leaver is in education, their educational setting will need a Chrome Education Upgrade (Chromebook license) to enrol the device in their Google Admin console (if they have one). To request a license, follow the steps listed above for LA-funded pupils in independent special schools or alternative provision.
-
-If you’re ordering for a care leaver who is not in education, and you cannot provide Google Workspace for Education details for them, you can choose to:
-
-* order a Windows laptop instead
-* [set up and manage a Google domain](https://get-help-with-tech.education.gov.uk/devices/google-domain-for-care-leavers-and-children-with-social-worker)
-* distribute the device unsecured - [read our guidance on your safeguarding responsibilities before making this choice](https://get-help-with-tech.education.gov.uk/devices/safeguarding-for-device-users)
-
-Read more information about [preparing Google Chromebooks for pupils](/devices/preparing-chromebooks).
+A Chrome Education Upgrade (Chromebook license) was offered with every device.
 
 ## iPads and Windows tablets
 
-Apple iPads and Microsoft Windows tablets are now permanently out of stock. See our guide for information on [setting up and managing tablets you've already received](/devices/preparing-microsoft-windows-laptops-and-tablets).
+[Find out how to manage Microsoft Windows tablets.](https://get-help-with-tech.education.gov.uk/devices/preparing-microsoft-windows-laptops-and-tablets)
+
+[Find out how to manage Apple iPads.](https://docs.google.com/document/d/1ooCMW-deQm5djoyO_9g9ELYjSFv7ZA-_dMR4VwEXXUM/edit#heading=h.fm5jouy7e5fx)
+
+### Pre-issued devices
+
+In addition to brand new devices, we offered ‘pre-issued’ devices too. These had been distributed as part of the Get help with technology programme, and then returned. They may or may not have been used.
+
+Our delivery partner completed the following quality checks for each used device:
+
+* it was visually inspected, and where possible any labels (such as asset tags) were removed
+* it switched on and powered up
+* the screen, CPU, RAM and HDD were tested
+* the device was reset
+
+These devices met the minimum technical specifications for remote education. They may have residual asset labels, external scratches, smart water application, etching or writing on the exterior of the device.
+
+If devices came with any remaining manufacturer's warranty (this was less than a year).
 
 </div>
 

--- a/app/views/devices_guidance/index.html.erb
+++ b/app/views/devices_guidance/index.html.erb
@@ -13,37 +13,16 @@
     </h1>
 
     <p class="govuk-body">
-      How to choose, order, and safely set up laptops and tablets for pupils in <span class="app-no-wrap">years 3 to 13</span>,
+      Ordering is now closed for laptops and tablets.
+    </p>
+
+    <p class="govuk-body">
+      Find out how to safely set up laptops and tablets for pupils in <span class="app-no-wrap">years 3 to 13</span>,
       students in further education, and care leavers. You can also find out how to get help with faulty devices.
     </p>
 
     <h2 class="govuk-heading-m">
-      Before you order
-    </h2>
-
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-      <%= render partial: 'page_link_and_description', collection: @before_you_order_pages, as: :page %>
-    </ul>
-
-    <h2 class="govuk-heading-m">
-      How to order
-    </h2>
-
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-      <li>
-        <%= govuk_link_to 'How to order laptops and internet access for state schools, colleges and FE institutions', devices_how_to_order_path %>
-      </li>
-      <li>
-        <%= govuk_link_to 'How to get devices for state-funded pupils in independent special schools and alternative provision', devices_how_to_order_laptops_for_independent_special_schools_path %>
-      </li>
-      <li>
-        <%= govuk_link_to 'How to get devices for social care leavers', devices_how_to_order_laptops_for_social_care_leavers_path %>
-      </li>
-      <li><%= govuk_link_to "Sign in to order devices", sign_in_path, class: "app-emphasis-link" %></li>
-    </ul>
-
-    <h2 class="govuk-heading-m">
-      Once you’ve received your order
+      How to set up laptops and tablets
     </h2>
 
     <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
@@ -51,11 +30,19 @@
     </ul>
 
     <h2 class="govuk-heading-m">
-      Managing devices
+      Resetting devices, and resolving issues
     </h2>
 
     <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
       <%= render partial: 'page_link_and_description', collection: @manage_devices_pages, as: :page %>
+    </ul>
+
+    <h2 class="govuk-heading-m">
+      About the devices provided by DfE
+    </h2>
+
+    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
+      <%= render partial: 'page_link_and_description', collection: @before_you_order_pages, as: :page %>
     </ul>
   </div>
 </div>

--- a/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
+++ b/app/views/guide_to_collecting_mobile_information/_guide_contents.html.erb
@@ -3,7 +3,6 @@
 <%- content_for :before_content do %>
   <% breadcrumbs([{ "Home" => root_path },
                   { t('page_titles.internet_access') => connectivity_home_path },
-                  { t('page_titles.about_increasing_mobile_data_short') => about_increasing_mobile_data_path },
                   t('page_titles.guide_to_collecting_mobile_information'),
                  ]) %>
 <% end %>
@@ -12,19 +11,6 @@
   <%= t('page_titles.guide_to_collecting_mobile_information') %>
 </h1>
 
-<h2 class="govuk-heading-s">Contents</h2>
-<ol class="govuk-list govuk-list--number">
-  <% @contents.each do |item| %>
-    <li>
-      <% if item[:active] %>
-        <%= item[:text] %>
-      <% else %>
-        <%= govuk_link_to item[:text], item[:path] %>
-      <% end %>
-    </li>
-  <% end %>
-</ol>
-
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
-<h2 class="govuk-heading-l"><%= index %>. <%= @title %></h2>
+<h2 class="govuk-heading-l"><%= @title %></h2>

--- a/app/views/pages/internet_access.html.erb
+++ b/app/views/pages/internet_access.html.erb
@@ -12,38 +12,59 @@
     </h1>
 
     <p class="govuk-body">
-      How to request internet access for disadvantaged pupils in <span class="app-no-wrap">years 3 to 13</span>, students in further education, and care leavers.
+      Ordering is now closed for routers and extra mobile data.
     </p>
 
-<div class="govuk-inset-text">
+    <p class="govuk-body">
+      Find out when free data ends, and how to reset 4G wireless routers you’ve received.
+    </p>
+
+    <div class="govuk-inset-text">
       Young people and families on low incomes or certain benefits may be eligible for cheaper broadband tariffs. <%= govuk_link_to 'Find out who is eligible and which providers offer targeted tariffs', 'https://www.ofcom.org.uk/about-ofcom/latest/features-and-news/support-for-customers-during-pandemic' %>.
-</div>
-    
+    </div>
+
     <h2 class="govuk-heading-l">
-      Extra mobile data
+      4G wireless routers
     </h2>
 
+    <p class="govuk-body">
+      You can no longer request 4G wireless routers for children and young people.
+    </p>
+
     <p class="govuk-body govuk-!-margin-bottom-7">
-      This scheme temporarily increases data allowances for mobile phone users on certain networks,
-      if they do not have access to broadband at home. Extra data is available until the end of July 2021.
+      Router SIM cards you’ve received will remain active until the end of July 2021. To continue using your router after this date, you must reset it and replace the SIM card. The date you need to reset your router depends on the type of router you have.
     </p>
 
     <h3 class="govuk-heading-m">
-      Before you make a request
+      Manage 4G wireless routers
     </h3>
 
     <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
       <li>
-        <%= govuk_link_to 'Find out who can get extra mobile data and how to make a request', about_increasing_mobile_data_path %>
+        <%= govuk_link_to 'How to reset your wireless router', '/devices/reset-your-wireless-router' %>
+      </li>
+      <li>
+        <%= govuk_link_to 'Set up guide', '/devices/preparing-4g-wireless-routers' %>
+      </li>
+      <li>
+        <%= govuk_link_to 'Resolve issues with 4G wireless routers', '/devices/resolve-issues-with-4g-wireless-routers' %>
+      </li>
+      <li>
+        <%= govuk_link_to 'Guidance for children and young people', '/devices/4g-user-guidance' %>
       </li>
     </ul>
 
-    <h3 class="govuk-heading-m">
-      Request extra mobile data
-    </h3>
+    <h2 class="govuk-heading-l">
+      Extra mobile data
+    </h2>
+
+    <p class="govuk-body">
+      You can no longer request data increases for children and young people.
+    </p>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
-      <%= govuk_link_to "Sign in to make a request", sign_in_path, class: "app-emphasis-link" %>
+      Extra data will be provided to existing users until the end of July 2021. Mobile network providers will contact all users to let them know when their free data increase is ending.
+      <%= govuk_link_to 'View the privacy notice for this scheme.', '/guide-to-collecting-mobile-information/privacy' %>
     </p>
 
     <h3 class="govuk-heading-m">
@@ -53,51 +74,5 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       <%= govuk_link_to "Sign in to view your requests", sign_in_path, class: "app-emphasis-link" %>
     </p>
-
-    <h2 class="govuk-heading-l">
-      4G wireless routers
-    </h2>
-
-    <p class="govuk-body govuk-!-margin-bottom-7">
-      You can request a router for disadvantaged pupils and students who do not have broadband at home, and cannot get extra mobile data. 
-      Router SIM cards will remain active until the end of July 2021.
-    </p>
-
-    <h3 class="govuk-heading-m">
-      Before you make a request
-    </h3>
-
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-      <li>
-        <%= govuk_link_to 'Find out who can get a 4G wireless router and how to make a request', how_to_request_4g_wireless_routers_path %>
-      </li>
-    </ul>
-
-    <h3 class="govuk-heading-m">
-      Request 4G wireless routers
-    </h3>
-
-    <p class="govuk-body govuk-!-margin-bottom-7">
-      <%= govuk_link_to "Sign in to make a request", sign_in_path, class: "app-emphasis-link" %>
-    </p>
-
-    <h3 class="govuk-heading-m">
-      Manage 4G wireless routers
-    </h3>
-
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-      <li>
-        <%= govuk_link_to 'Set up guide', '/devices/preparing-4g-wireless-routers' %>
-      </li>
-      <li>
-        <%= govuk_link_to 'How to reset your wireless router', '/devices/reset-your-wireless-router' %>
-      </li>
-      <li>
-        <%= govuk_link_to 'Technical support', '/devices/resolve-issues-with-4g-wireless-routers' %>
-      </li>
-      <li>
-        <%= govuk_link_to 'Guidance for children and young people', '/devices/4g-user-guidance' %>
-      </li>
-    </ul>
   </div>
 </div>

--- a/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
+++ b/app/views/pages/what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe.html.erb
@@ -12,7 +12,7 @@
     </h1>
 
     <p class="govuk-body">
-      The Get help with technology programme provides support for disadvantaged pupils and students in years 3 to 13, or 16 to 19 education, in England. It can only be accessed by:
+      The Get help with technology programme provided support for disadvantaged pupils and students in years 3 to 13, or 16 to 19 education, in England. It could only be accessed by:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>state-funded schools</li>
@@ -21,22 +21,17 @@
       <li>local authorities</li>
     </ul>
 
+    <p class="govuk-body">
+      Ordering is now closed for devices and internet access. 
+    </p>
+
     <h2 class="govuk-heading-m">Get help for:</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <%= govuk_link_to 'parents, carers, pupils and students', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'parents-carers-pupils-students') %>
       </li>
       <li>
-        <%= govuk_link_to 'social care workers', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'social-care-workers') %>
-      </li>
-      <li>
-        <%= govuk_link_to 'nurseries and infant schools', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'nurseries-and-infant-schools') %>
-      </li>
-      <li>
-        <%= govuk_link_to 'independent schools', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'independent-schools') %>
-      </li>
-      <li>
-        <%= govuk_link_to 'schools, colleges and further education institutions in Northern Ireland, Scotland and Wales', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'schools-colleges-and-further-education-institutions-in-northern-ireland-scotland-and-wales') %>
+        <%= govuk_link_to 'educational settings', what_to_do_if_you_cannot_get_laptops_tablets_or_internet_access_from_dfe_path(anchor:'educational-settings') %>
       </li>
     </ul>
 
@@ -73,60 +68,19 @@
       If you need more help, contact the person who gave you your device.
     </p>
 
-    <h2 class="govuk-heading-l" id="social-care-workers">
-      Social care workers
+    <h2 class="govuk-heading-l" id="educational-settings">
+      Educational settings
     </h2>
     <p class="govuk-body">
-      <%= govuk_link_to 'Find out how local authorities can order laptops and get internet access for eligible care leavers', 'https://get-help-with-tech.education.gov.uk/devices/how-to-order-laptops-for-social-care-leavers' %>.
-    </p>
-    <p class="govuk-body">
-      <%= govuk_link_to 'You cannot request laptops, tablets or internet access for children and young people in social care. Find out which disadvantaged pupils and students are eligible for devices', 'https://get-help-with-tech.education.gov.uk/devices/about-the-offer#ordering-devices-for-schools-colleges-academy-trusts-and-local-authorities-from-september-2020' %> from their school, college or FE institution.
-    </p>
-    <p class="govuk-body">
-      <%= govuk_link_to 'Read about devices provided for social care in the 2020 summer term', 'https://www.gov.uk/guidance/laptops-tablets-and-4g-wireless-routers-provided-during-coronavirus-covid-19' %>.
-    </p>
-    <p class="govuk-body">
-      If you need help with a device you received from DfE, <%= govuk_link_to 'find out how to get support', 'https://get-help-with-tech.education.gov.uk/devices/' %>.
+      The <%= govuk_link_to 'BBC', 'https://www.bbc.co.uk/programmes/articles/5SqHJMTKZx5sYhlltXJvB1Q/give-a-laptop' %>
+      has a list of companies and charities involved in laptop donation schemes.
     </p>
 
-    <h2 class="govuk-heading-l" id="nurseries-and-infant-schools">
-      Nurseries and infant schools
-    </h2>
-    <p class="govuk-body">
-      Schools and nurseries can request a device or internet access for a disadvantaged child in any year group (including reception) if:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>they’ve been <%= govuk_link_to 'advised to shield', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19' %> because they (or someone they live with) are <%= govuk_link_to 'clinically extremely vulnerable', 'https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#cev' %></li>
-      <li>they’re attending a hospital school</li>
-    </ul>
-    <p class="govuk-body">
-      <%= govuk_link_to "Contact us to make a request", support_ticket_path %>. Do not submit any personally identifiable information about pupils that we do not need to process your support query. If we receive a request that contains such information, we’ll ask you to resend it.
-    </p>
-
-    <h2 class="govuk-heading-l" id="independent-schools">
-      Independent schools
-    </h2>
-    <p class="govuk-body">
-      Local authorities can <%= govuk_link_to 'find out how to order laptops and request internet access for state-funded pupils in years 3 to 11 in independent special schools or alternative provision', devices_how_to_order_laptops_for_independent_special_schools_path %>, who are eligible for free school meals.
-    </p>
-    <p class="govuk-body">
-      Pupils attending other independent schools are currently not able to access the Get help with technology programme.
-    </p>
-    <p class="govuk-body">
-      Parents or carers of pupils attending independent schools may be able to apply to the <%= govuk_link_to 'Family Fund', 'https://www.familyfund.org.uk/' %>, which provides some grants for devices and other support for children or young people who are disabled or seriously ill.
-    </p>
     <h2 class="govuk-heading-l" id="schools-colleges-and-further-education-institutions-in-northern-ireland-scotland-and-wales">
       Schools, colleges and further education institutions in <span class="app-no-wrap">Northern Ireland</span>, Scotland and Wales
     </h2>
     <p class="govuk-body">
-      The Get help with technology programme is only available in England. Contact your devolved administration to find out about similar support programmes. These may include:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= govuk_link_to 'Northern Ireland – Education Restart', 'https://www.education-ni.gov.uk/landing-pages/education-restart' %></li>
-      <li><%= govuk_link_to 'Scotland – Support for continuity in learning', 'https://www.gov.scot/publications/coronavirus-covid-19-support-for-continuity-in-learning/pages/related-guidance/' %>
-      <li><%= govuk_link_to 'Wales – Guidance for supporting vulnerable and disadvantaged learners', 'https://gov.wales/guidance-supporting-vulnerable-and-disadvantaged-learners' %></li>
-    </ul>
-
+      The Get help with technology programme is only available in England. Contact your devolved administration to find out about similar support programmes.
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,8 +289,8 @@ en:
       description: Find out who devices were provided for and why the DfE provided them.
       guidance_section: before_you_order_pages
     device_allocations:
-      title: How laptops and tablets were allocated
-      description: Find out how we estimated device requirements and how to query an allocation.
+      title: Device allocations
+      description: Find out how the Department for Education estimated requirements for disadvantaged children and young people.
       guidance_section: before_you_order_pages
     device_specification:
       title: Device types and IT settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,8 +285,8 @@ en:
     success: Your cookie preferences have been saved
   devices_guidance:
     about_the_offer:
-      title: Who could get laptops and tablets, and why DfE provided them
-      description: Find out who is eligible for devices and why the DfE is providing them.
+      title: About the offer
+      description: Find out who devices were provided for and why the DfE provided them.
       guidance_section: before_you_order_pages
     device_allocations:
       title: How laptops and tablets were allocated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,19 +285,19 @@ en:
     success: Your cookie preferences have been saved
   devices_guidance:
     about_the_offer:
-      title: Who can get laptops and tablets, and why DfE is providing them
+      title: Who could get laptops and tablets, and why DfE provided them
       description: Find out who is eligible for devices and why the DfE is providing them.
       guidance_section: before_you_order_pages
     device_allocations:
-      title: How laptops and tablets are allocated
+      title: How laptops and tablets were allocated
       description: Find out how we estimated device requirements and how to query an allocation.
       guidance_section: before_you_order_pages
     device_specification:
-      title: Choose the most suitable type of device and IT settings
+      title: Device types and IT settings
       description: Get the technical specifications of the laptops and tablets we offer. This information can help you and your IT support to make the right choice of device and settings for your needs.
       guidance_section: before_you_order_pages
     device_distribution_and_ownership:
-      title: Who owns the devices, and how to distribute them to children and young people
+      title: Who owns the devices
       description: Guidance on who owns devices, and information on insuring devices, asset management and loan agreements.
       guidance_section: before_you_order_pages
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,8 +293,8 @@ en:
       description: Find out how the Department for Education estimated requirements for disadvantaged children and young people.
       guidance_section: before_you_order_pages
     device_specification:
-      title: Device types and IT settings
-      description: Get the technical specifications of the laptops and tablets we offer. This information can help you and your IT support to make the right choice of device and settings for your needs.
+      title: Device options and specification
+      description: Get the technical specifications of the laptops and tablets provided by the Get help with technology programme.
       guidance_section: before_you_order_pages
     device_distribution_and_ownership:
       title: Who owns the devices


### PR DESCRIPTION
### Context

This is part of the overall service closure work for the 30th of June 2021.

The closure of the service creates the requirement for some content to be rephrased in the past tense and other sections to be completely removed.

### Changes proposed in this pull request

A high level Google Doc with links to amended pages can be found here: [Content updates for pausing ordering | June 2021](https://docs.google.com/document/d/1ulzlIfkfXiIgZSwemjmJa3uyfkJyhy8mf9QkaMe_2XA/edit#heading=h.91ktmv50h3uo)

### Guidance to review

https://get-help-with-tech.education.gov.uk/devices
should match
https://docs.google.com/document/d/138wfOMQx1mP1KLRgRz8Go7AN9VWfT349h02C0FtX5zg/edit?usp=sharing

https://get-help-with-tech.education.gov.uk/devices/about-the-offer
should match
https://docs.google.com/document/d/1I8c8JaUkI1E4velkJN3VVK6V_DLfRd93p0fZVnBltO4/edit?usp=sharing

https://get-help-with-tech.education.gov.uk/devices/device-allocations
should match
https://docs.google.com/document/d/12Ta2k4kSYVe3xu_J9hhLjv1TFQvPiV0zl64Ga9rDyb0/edit?usp=sharing

https://get-help-with-tech.education.gov.uk/devices/device-specification
should match
https://docs.google.com/document/d/1brvL_IjeOTn4UEakwBqYjO90POf2X2oAvMHQvvhwOjA/edit?usp=sharing

https://get-help-with-tech.education.gov.uk/devices/device-distribution-and-ownership
should match
https://docs.google.com/document/d/1s5EMRhXb1ocV52ietkucxbOHbpoRObB8hE7cmk0Bhmc/edit?usp=sharing

https://get-help-with-tech.education.gov.uk/what-to-do-if-you-cannot-get-laptops-tablets-or-internet-access-from-dfe
should match
https://docs.google.com/document/d/1lP6vAPkKoRoFIdXXnfB7EOBPMYIAEretTyEJa-iaKvI/edit?usp=sharing