### PR TITLE
[2168] Archiving many *logged in* pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get '/privacy', to: 'pages#privacy'
   get '/privacy/dfe-windows-privacy-notice', to: 'pages#dfe_windows_privacy_notice'
   get '/privacy/general-privacy-notice', to: 'pages#general_privacy_notice'
-  get '/privacy/computers-for-kids-privacy-notice', to: 'pages#computers_for_kids_privacy_notice'
+  get '/privacy/computers-for-kids-privacy-notice', to: 'pages#computers_for_kids_privacy_notice', constraints: -> { false }
   get '/mobile-privacy', to: redirect('/increasing-mobile-data/privacy-notice')
   get '/request-a-change', to: 'pages#request_a_change'
   get '/how-to-request-4g-wireless-routers', to: redirect('/internet-access')
@@ -108,12 +108,12 @@ Rails.application.routes.draw do
     post '/privacy-notice', to: 'home#seen_privacy_notice'
 
     namespace :devices do
-      get '/', to: 'home#show'
+      get '/', to: 'home#show', constraints: -> { false }
       get '/tell-us', to: 'home#tell_us'
       get '/who-will-order', to: 'who_will_order#show'
       get '/who-will-order/edit', to: 'who_will_order#edit'
       patch '/who-will-order', to: 'who_will_order#update'
-      get 'order-devices', to: 'orders#show', as: :order_devices
+      get 'order-devices', to: 'orders#show', as: :order_devices, constraints: -> { false }
 
       resources :schools, only: %i[index show update], param: :urn do
         get '/who-to-contact', to: 'who_to_contact#new'
@@ -129,37 +129,37 @@ Rails.application.routes.draw do
     end
 
     namespace :donated_devices, path: '/donated-devices' do
-      get '/interest', to: 'interest#new'
-      post '/interest', to: 'interest#create'
+      get '/interest', to: 'interest#new', constraints: -> { false }
+      post '/interest', to: 'interest#create', constraints: -> { false }
 
       get '/about-devices', to: 'interest#about'
-      get '/queue', to: 'interest#queue'
-      get '/interest-confirmation', to: 'interest#interest_confirmation'
-      post '/interest-confirmation', to: 'interest#interest_confirmation'
-      get '/all-or-some-schools', to: 'interest#all_or_some_schools'
-      post '/all-or-some-schools', to: 'interest#all_or_some_schools'
-      get '/select-schools', to: 'interest#select_schools'
-      post '/select-schools', to: 'interest#select_schools'
+      get '/queue', to: 'interest#queue', constraints: -> { false }
+      get '/interest-confirmation', to: 'interest#interest_confirmation', constraints: -> { false }
+      post '/interest-confirmation', to: 'interest#interest_confirmation', constraints: -> { false }
+      get '/all-or-some-schools', to: 'interest#all_or_some_schools', constraints: -> { false }
+      post '/all-or-some-schools', to: 'interest#all_or_some_schools', constraints: -> { false }
+      get '/select-schools', to: 'interest#select_schools', constraints: -> { false }
+      post '/select-schools', to: 'interest#select_schools', constraints: -> { false }
 
       get '/what-devices-do-you-want', to: 'interest#device_types'
       post '/what-devices-do-you-want', to: 'interest#device_types'
-      get '/how-many-devices', to: 'interest#how_many_devices'
-      post '/how-many-devices', to: 'interest#how_many_devices'
-      get '/address', to: 'interest#address'
-      get '/disclaimer', to: 'interest#disclaimer'
-      get '/check-answers', to: 'interest#check_answers'
-      post '/check-answers', to: 'interest#check_answers'
-      get '/opted-in', to: 'interest#opted_in'
+      get '/how-many-devices', to: 'interest#how_many_devices', constraints: -> { false }
+      post '/how-many-devices', to: 'interest#how_many_devices', constraints: -> { false }
+      get '/address', to: 'interest#address', constraints: -> { false }
+      get '/disclaimer', to: 'interest#disclaimer', constraints: -> { false }
+      get '/check-answers', to: 'interest#check_answers', constraints: -> { false }
+      post '/check-answers', to: 'interest#check_answers', constraints: -> { false }
+      get '/opted-in', to: 'interest#opted_in', constraints: -> { false }
     end
 
     namespace :internet do
-      get '/', to: 'home#show'
+      get '/', to: 'home#show', constraints: -> { false }
 
       namespace :mobile, path: '/mobile' do
-        get '/', to: 'extra_data_requests#guidance', as: :extra_data_guidance
+        get '/', to: 'extra_data_requests#guidance', as: :extra_data_guidance, constraints: -> { false }
         get '/requests', to: 'extra_data_requests#index', as: :extra_data_requests
         get '/requests/:id', to: 'extra_data_requests#show', as: :extra_data_request
-        get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type
+        get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type, constraints: -> { false }
       end
     end
     resources :users
@@ -176,21 +176,21 @@ Rails.application.routes.draw do
       get '/', to: 'school/home#show', as: :home
       get '/before-you-can-order', to: 'school/before_can_order#edit'
       patch '/before-you-can-order', to: 'school/before_can_order#update'
-      get '/order-devices', to: 'school/devices#order'
-      get '/details', to: 'school/details#show', as: :details
-      get '/chromebooks/edit', to: 'school/chromebooks#edit'
+      get '/order-devices', to: 'school/devices#order', constraints: -> { false }
+      get '/details', to: 'school/details#show', as: :details, constraints: -> { false }
+      get '/chromebooks/edit', to: 'school/chromebooks#edit', constraints: -> { false }
       patch '/chromebooks', to: 'school/chromebooks#update'
       patch '/next(/:step)', to: 'school/welcome_wizard#next_step', as: :welcome_wizard
       patch '/prev', to: 'school/welcome_wizard#previous_step', as: :welcome_wizard_previous
       get '/get-laptops', to: 'school/la_funded_places#show', as: :get_laptops
       get '/order-laptops', to: 'school/la_funded_places#order', as: :order_laptops
       get '/funded-pupils-chromebooks/edit', to: 'school/la_funded_places_chromebooks#edit', as: :funded_chromebooks
-      patch '/funded-pupils-chromebooks', to: 'school/la_funded_places_chromebooks#update', as: :update_funded_chromebooks
-      get '/laptop-types', to: 'school/la_funded_places#laptop_types', as: :laptop_types
+      patch '/funded-pupils-chromebooks', to: 'school/la_funded_places_chromebooks#update', as: :update_funded_chromebooks, constraints: -> { false }
+      get '/laptop-types', to: 'school/la_funded_places#laptop_types', as: :laptop_types, constraints: -> { false }
       resources :users, as: 'school_users', only: %i[index new create edit update], module: 'school'
 
       scope module: :school do
-        namespace :donated_devices, path: '/donated-devices' do
+        namespace :donated_devices, path: '/donated-devices', constraints: -> { false } do
           get '/interest', to: 'interest#new'
           post '/interest', to: 'interest#create'
 
@@ -212,13 +212,13 @@ Rails.application.routes.draw do
         end
 
         namespace :internet do
-          get '/', to: 'home#show'
+          get '/', to: 'home#show', constraints: -> { false }
 
           namespace :mobile, path: '/mobile' do
-            get '/', to: 'extra_data_requests#guidance', as: :extra_data_guidance
+            get '/', to: 'extra_data_requests#guidance', as: :extra_data_guidance, constraints: -> { false }
             get '/requests', to: 'extra_data_requests#index', as: :extra_data_requests
             get '/requests/:id', to: 'extra_data_requests#show', as: :extra_data_request
-            get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type
+            get '/type', to: 'extra_data_requests#new', as: :extra_data_requests_type, constraints: -> { false }
           end
         end
       end

--- a/spec/features/huawei_password_spec.rb
+++ b/spec/features/huawei_password_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Huawei router password', type: :feature do
+RSpec.feature 'Huawei router password', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:school_with_router_allocation) { create(:school, :with_coms_device_allocation) }
   let(:iss_provision) { create(:iss_provision, :with_coms_device_allocation) }
   let(:user_for_organisation_without_router_allocation) { create(:school_user) }

--- a/spec/features/mno/extra_mobile_data_requests_spec.rb
+++ b/spec/features/mno/extra_mobile_data_requests_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'shared/expect_download'
 
-RSpec.feature 'MNO Requests view', type: :feature do
+RSpec.feature 'MNO Requests view', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:local_authority_user) { create(:local_authority_user) }
   let(:mno_user) { create(:mno_user) }
   let(:other_mno) { create(:mobile_network, brand: 'Other MNO') }

--- a/spec/features/ordering_for_la_funded_devices_spec.rb
+++ b/spec/features/ordering_for_la_funded_devices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Ordering for LA-funded devices', type: :feature do
+RSpec.feature 'Ordering for LA-funded devices', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   before do
     given_there_is_an_independent_settings_school
     given_i_am_signed_in_as_an_independent_settings_school_user

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Setting up the devices ordering' do
+RSpec.feature 'Setting up the devices ordering', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:responsible_body_schools_page) { PageObjects::ResponsibleBody::SchoolsPage.new }
   let(:responsible_body_school_page) { PageObjects::ResponsibleBody::SchoolPage.new }
 

--- a/spec/features/responsible_body/donated_devices_spec.rb
+++ b/spec/features/responsible_body/donated_devices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Accessing the donated devices area as an RB user', type: :feature, with_feature_flags: { donated_devices: 'active' } do
+RSpec.feature 'Accessing the donated devices area as an RB user', type: :feature, with_feature_flags: { donated_devices: 'active' }, skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:user) { create(:trust_user) }
   let(:responsible_body) { user.responsible_body }
   let(:school) { create(:school, :with_preorder_information, responsible_body: responsible_body) }

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Ordering devices within a virtual pool' do
+RSpec.feature 'Ordering devices within a virtual pool', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:responsible_body) { create(:trust, :manages_centrally) }
   let(:schools) { create_list(:school, 4, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body) }
   let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }

--- a/spec/features/responsible_body/ordering_devices_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Ordering devices' do
+RSpec.feature 'Ordering devices', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:responsible_body) { create(:local_authority) }
   let(:schools) { create_list(:school, 6, :with_preorder_information, :with_headteacher_contact, :with_std_device_allocation, responsible_body: responsible_body) }
   let!(:user) { create(:local_authority_user, responsible_body: responsible_body) }

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Viewing your schools' do
+RSpec.feature 'Viewing your schools', skip: 'Disabled for 30 Jun 2021 service closure' do
   include ActionView::Helpers::TextHelper
 
   let(:responsible_body) { create(:trust, :manages_centrally) }

--- a/spec/features/school/change_chromebook_information_spec.rb
+++ b/spec/features/school/change_chromebook_information_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Change school Chromebook information' do
+RSpec.feature 'Change school Chromebook information', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:school) { create(:school, :la_maintained) }
   let(:school_user) { create(:school_user, full_name: 'AAA Smith', school: school) }
 

--- a/spec/features/school/extra_mobile_data_requests_spec.rb
+++ b/spec/features/school/extra_mobile_data_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Accessing the extra mobile data requests area as a school user', type: :feature do
+RSpec.feature 'Accessing the extra mobile data requests area as a school user', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:user) { create(:school_user) }
   let(:school) { user.school }
   let(:my_requests_page) { PageObjects::School::Internet::YourRequestsPage.new }

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Order devices' do
+RSpec.feature 'Order devices', skip: 'Disabled for 30 Jun 2021 service closure' do
   include ViewHelper
 
   let(:school) { create(:school, :with_std_device_allocation) }

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'shared/filling_in_forms'
 require 'support/sidekiq'
 
-RSpec.feature 'Session behaviour', type: :feature do
+RSpec.feature 'Session behaviour', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   scenario 'new visitor has sign in link' do
     visit '/'
 

--- a/spec/features/techsource_availability_for_responsible_body_spec.rb
+++ b/spec/features/techsource_availability_for_responsible_body_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'TechSource availability for responsible body' do
+RSpec.feature 'TechSource availability for responsible body', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:local_authority) { create(:local_authority) }
   let(:la_user) { create(:local_authority_user, responsible_body: local_authority) }
   let(:school) { create(:school, :with_std_device_allocation, :with_preorder_information, responsible_body: local_authority) }

--- a/spec/features/techsource_availability_for_school_spec.rb
+++ b/spec/features/techsource_availability_for_school_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'TechSource availability for school' do
+RSpec.feature 'TechSource availability for school', skip: 'Disabled for 30 Jun 2021 service closure' do
   let(:school) { create(:school, :with_std_device_allocation) }
   let(:school_user) do
     create(:school_user,

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'View pages', type: :feature do
+RSpec.feature 'View pages', type: :feature, skip: 'Disabled for 30 Jun 2021 service closure' do
   scenario 'Root URL should be the guidance page' do
     visit '/'
     expect(page).to have_selector 'h1', text: I18n.t('service_name')


### PR DESCRIPTION
<https://trello.com/c/MOtq9f0w/2168-archive-pages>

Key assumption: this is different to the public pages archival work in that these are likely to come back – routes-wise – in it's current form. Thus, what I've done is:

- Marked each of these routes with a `constraints: -> { false }` to disable them
- This results in a 404 page for each of these routes (which I've tested manually)
- I've kept ALL underlying code…
- … and disabled _any_ test that fails as a result (but kept the code intact for these tests)

