### PR TITLE
adds homepage link to page not found

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -9,5 +9,8 @@
     <p class="govuk-body">
       If you pasted the web address, check you copied the entire address.
     </p>
+    <p class="govuk-body">
+      Go to the <%= govuk_link_to('Get help with technology homepage', root_path ) %> to see guidance or sign in.
+    </p>
   </div>
 </div>


### PR DESCRIPTION
### Context

https://trello.com/c/euhWUmqz

Because we have retired pages from the service, we anticipate a small bump in users hitting the 'page not found page'. Looking at it, we could make it more helpful by sign-posting the user to the homepage.

### Changes proposed in this pull request

Adds 'Go to the Get help with technology homepage to see guidance or sign in.' With a link to the homepage.

### Guidance to review

View a page that isn't there
