### PR TITLE
1841 multiple techsource outages

### DIFF
--- a/app/components/computacenter/tech_source_maintenance_banner_component.rb
+++ b/app/components/computacenter/tech_source_maintenance_banner_component.rb
@@ -1,14 +1,36 @@
 class Computacenter::TechSourceMaintenanceBannerComponent < ViewComponent::Base
-  MAINTENANCE_WINDOW = Computacenter::TechSource::MAINTENANCE_WINDOW
   DATE_TIME_FORMAT = '%A %-d %B %I:%M%P'.freeze
 
+  def initialize(techsource)
+    @techsource = techsource
+  end
+
   def message
-    "The TechSource website will be closed for maintenance on <span class=\"app-no-wrap\">#{MAINTENANCE_WINDOW.first.strftime(DATE_TIME_FORMAT)}.</span> You can order devices when it reopens on <span class=\"app-no-wrap\">#{MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)}.</span>".html_safe
+    maintenance_window = @techsource.current_maintenance_window
+
+    if maintenance_window
+      "The TechSource website will be closed for maintenance on <span class=\"app-no-wrap\">#{maintenance_window.first.strftime(DATE_TIME_FORMAT)}.</span> You can order devices when it reopens on <span class=\"app-no-wrap\">#{maintenance_window.last.strftime(DATE_TIME_FORMAT)}.</span>".html_safe
+    end
   end
 
   def render?
-    display_from = 2.days.before(MAINTENANCE_WINDOW.first.beginning_of_day)
-    display_until = MAINTENANCE_WINDOW.last
-    (display_from..display_until).cover? Time.zone.now
+    banner_periods = @techsource.maintenance_windows.collect { |maintenance_window| banner_period(maintenance_window) }
+    banner_periods.any? { |banner_period| banner_period.cover? current_time }
+  end
+
+private
+
+  def banner_period(maintenance_window)
+    period_from_start_of_two_days_before_window_to_end_of_window(maintenance_window)
+  end
+
+  def period_from_start_of_two_days_before_window_to_end_of_window(maintenance_window)
+    display_from = 2.days.before(maintenance_window.first.beginning_of_day)
+    display_until = maintenance_window.last
+    display_from..display_until
+  end
+
+  def current_time
+    Time.zone.now
   end
 end

--- a/app/controllers/techsource_launcher_controller.rb
+++ b/app/controllers/techsource_launcher_controller.rb
@@ -4,11 +4,11 @@ class TechsourceLauncherController < ApplicationController
   def start
     techsource = Computacenter::TechSource.new
 
-    if techsource.unavailable?
-      @available_at = Computacenter::TechSource::MAINTENANCE_WINDOW.last.strftime(DATE_TIME_FORMAT)
-      render 'unavailable'
-    else
+    if techsource.available?
       redirect_to URI.parse(techsource.url).to_s # The URI.parse is needed to appease Brakeman
+    else
+      @available_at = techsource.current_maintenance_window.last.strftime(DATE_TIME_FORMAT)
+      render 'unavailable'
     end
   end
 end

--- a/app/models/computacenter/tech_source.rb
+++ b/app/models/computacenter/tech_source.rb
@@ -1,11 +1,25 @@
 class Computacenter::TechSource
-  MAINTENANCE_WINDOW = (Time.zone.parse('26 Jun 2021 9:00am')..Time.zone.parse('26 Jun 2021 1:00pm'))
+  attr_reader :maintenance_windows
+
+  def initialize(maintenance_windows: [(Time.zone.parse('26 Jun 2021 9:00am')..Time.zone.parse('26 Jun 2021 1:00pm'))])
+    @maintenance_windows = maintenance_windows
+  end
 
   def url
     Settings.computacenter.techsource_url
   end
 
-  def unavailable?
-    MAINTENANCE_WINDOW.cover? Time.zone.now
+  def available?
+    current_maintenance_window.nil?
+  end
+
+  def current_maintenance_window
+    maintenance_windows.find { |maintenance_window| maintenance_window.cover? current_time }
+  end
+
+private
+
+  def current_time
+    Time.zone.now
   end
 end

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
@@ -1,60 +1,88 @@
 require 'rails_helper'
 
 RSpec.describe Computacenter::TechSourceMaintenanceBannerComponent, type: :component do
-  alias_method :component, :page
+  let(:techsource) { Computacenter::TechSource.new(maintenance_windows: maintenance_windows) }
+
+  subject(:banner) { described_class.new(techsource) }
 
   describe '#message' do
     context 'within window' do
-      before do
-        stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW',
-                   Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 22:00'))
-        Timecop.travel(Time.zone.parse('4 Jan 2021 15:00'))
-      end
+      let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 22:00')] }
 
-      specify { expect(described_class.new.message).to eq('The TechSource website will be closed for maintenance on <span class="app-no-wrap">Monday 4 January 09:00am.</span> You can order devices when it reopens on <span class="app-no-wrap">Monday 4 January 10:00pm.</span>') }
+      before { Timecop.travel(Time.zone.parse('4 Jan 2021 15:00')) }
+
+      specify { expect(banner.message).to eq('The TechSource website will be closed for maintenance on <span class="app-no-wrap">Monday 4 January 09:00am.</span> You can order devices when it reopens on <span class="app-no-wrap">Monday 4 January 10:00pm.</span>') }
     end
   end
 
   describe '#render?' do
-    before do
-      stub_const('Computacenter::TechSourceMaintenanceBannerComponent::MAINTENANCE_WINDOW',
-                 Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00'))
-    end
+    let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00')] }
 
     context 'one minute before midnight two days before' do
       before do
         Timecop.travel(Time.zone.parse('1 Jan 2021 23:59'))
-        render_inline(described_class.new)
+        render_inline(banner)
       end
 
-      specify { expect(component.text).not_to be_present }
+      specify { expect(rendered_component).to be_blank }
     end
 
     context 'one minute after midnight two days before' do
       before do
         Timecop.travel(Time.zone.parse('2 Jan 2021 00:01'))
-        render_inline(described_class.new)
+        render_inline(banner)
       end
 
-      specify { expect(component.text).to be_present }
+      specify { expect(rendered_component).to be_present }
     end
 
     context 'one minute before end of maintenance window' do
       before do
         Timecop.travel(Time.zone.parse('4 Jan 2021 09:59'))
-        render_inline(described_class.new)
+        render_inline(banner)
       end
 
-      specify { expect(component.text).to be_present }
+      specify { expect(rendered_component).to be_present }
     end
 
     context 'one minute after maintenance window' do
       before do
         Timecop.travel(Time.zone.parse('4 Jan 2021 10:01'))
-        render_inline(described_class.new)
+        render_inline(banner)
       end
 
-      specify { expect(component.text).not_to be_present }
+      specify { expect(rendered_component).to be_blank }
+    end
+
+    context 'two maintenance windows' do
+      let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00'), Time.zone.parse('1 Feb 2021 09:00')..Time.zone.parse('1 Feb 2021 10:00')] }
+
+      context 'within first maintenance banner window' do
+        before do
+          Timecop.travel(Time.zone.parse('4 Jan 2021 9:59'))
+          render_inline(banner)
+        end
+
+        specify { expect(rendered_component).to be_present }
+      end
+
+      context 'between maintenance banner windows' do
+        before do
+          Timecop.travel(Time.zone.parse('4 Jan 2021 10:01'))
+          render_inline(banner)
+        end
+
+        specify { expect(rendered_component).to be_blank }
+      end
+
+      context 'within second maintenance banner window' do
+        before do
+          Timecop.travel(Time.zone.parse('1 Feb 2021 9:01'))
+          render_inline(banner)
+        end
+
+        specify { expect(rendered_component).to be_present }
+      end
     end
   end
 end

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -2,55 +2,41 @@ require 'rails_helper'
 
 RSpec.describe TechsourceLauncherController, type: :controller do
   let(:user) { create(:local_authority_user) }
-  let(:techsource) { Computacenter::TechSource.new }
+  let(:maintenance_windows) { [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am'))] }
+  let(:techsource) { Computacenter::TechSource.new(maintenance_windows: maintenance_windows) }
 
   before do
-    stub_const('Computacenter::TechSource::NEXT_MAINTENANCE', {
-      window_start: Time.zone.local(2020, 11, 28, 7, 0, 0),
-      window_end: Time.zone.local(2020, 11, 28, 23, 0, 0),
-      maintenance_on_date: Date.new(2020, 11, 28),
-      reopened_on_date: Date.new(2020, 11, 29),
-    })
+    allow_any_instance_of(Computacenter::TechSource).to receive(:maintenance_windows).and_return(techsource.maintenance_windows) # rubocop:disable RSpec/AnyInstance
+    sign_in_as user
   end
 
   describe '#start' do
     context 'before techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 11, 27, 23, 0, 0))
-        sign_in_as user
+        Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am'))
+        get 'start'
       end
 
-      it 'redirects to techsource' do
-        get 'start'
-        expect(response).to redirect_to(techsource.url)
-      end
+      specify { expect(response).to redirect_to(techsource.url) }
     end
 
     context 'during techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 11, 28, 8, 0, 0))
-        sign_in_as user
+        Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am'))
+        get 'start'
       end
 
-      it 'renders the unavailable page' do
-        stub_const('Computacenter::TechSource::MAINTENANCE_WINDOW', Time.zone.local(2020, 11, 28, 7, 0, 0)..Time.zone.local(2020, 11, 28, 14, 0, 0))
-        get 'start'
-        expect(response).to render_template('unavailable')
-        expect(response).to have_http_status(:ok)
-        expect(assigns(:available_at)).to eq('Saturday 28 November 02:00pm')
-      end
+      specify { expect(response).to render_template('unavailable') }
+      specify { expect(assigns(:available_at)).to eq('Friday 1 January 10:00am') }
     end
 
     context 'after techsource maintenance window' do
       before do
-        Timecop.travel(Time.zone.local(2020, 11, 29, 3, 1, 0))
-        sign_in_as user
+        Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am'))
+        get 'start'
       end
 
-      it 'redirects to techsource' do
-        get 'start'
-        expect(response).to redirect_to(techsource.url)
-      end
+      specify { expect(response).to redirect_to(techsource.url) }
     end
   end
 end

--- a/spec/models/computacenter/tech_source_spec.rb
+++ b/spec/models/computacenter/tech_source_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::TechSource do
+  describe '#available?' do
+    context 'no maintenance windows' do
+      subject(:techsource) { described_class.new(maintenance_windows: []) }
+
+      specify { expect(techsource).to be_available }
+    end
+
+    context 'one maintenance window' do
+      subject(:techsource) { described_class.new(maintenance_windows: [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am'))]) }
+
+      context 'before window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+
+      context 'just at start of window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just before end of window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:59am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just after window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+    end
+
+    context 'two maintenance windows' do
+      subject(:techsource) { described_class.new(maintenance_windows: [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am')), (Time.zone.parse('1 Feb 2021 9:00am')..Time.zone.parse('1 Feb 2021 10:00am'))]) }
+
+      context 'before first window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+
+      context 'just at start of first window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just before end of first window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:59am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just after first window' do
+        before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+
+      context 'just before second window' do
+        before { Timecop.travel(Time.zone.parse('1 Feb 2021 8:59am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+
+      context 'just at start of second window' do
+        before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:01am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just before end of second window' do
+        before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:59am')) }
+
+        specify { expect(techsource).not_to be_available }
+      end
+
+      context 'just after second window' do
+        before { Timecop.travel(Time.zone.parse('1 Feb 2021 10:01am')) }
+
+        specify { expect(techsource).to be_available }
+      end
+    end
+  end
+
+  describe '#current_maintenance_window' do
+    let(:first_window) { Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am') }
+    let(:second_window) { Time.zone.parse('1 Feb 2021 9:00am')..Time.zone.parse('1 Feb 2021 10:00am') }
+
+    subject(:techsource) { described_class.new(maintenance_windows: [first_window, second_window]) }
+
+    context 'before first' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
+
+      specify { expect(techsource.current_maintenance_window).to be_nil }
+    end
+
+    context 'during first' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
+
+      specify { expect(techsource.current_maintenance_window).to eq(first_window) }
+    end
+
+    context 'between first and second' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
+
+      specify { expect(techsource.current_maintenance_window).to be_nil }
+    end
+
+    context 'during second' do
+      before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:01am')) }
+
+      specify { expect(techsource.current_maintenance_window).to eq(second_window) }
+    end
+
+    context 'after second' do
+      before { Timecop.travel(Time.zone.parse('1 Feb 2021 10:01am')) }
+
+      specify { expect(techsource.current_maintenance_window).to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/EpcohVyD

Allows multiple TechSource outages to be input at once, rather than having separate deployment cycle for each.

### Changes proposed in this pull request

Turn single value into array

### Guidance to review

