### PR TITLE
Always Access Support Portal section even when not ordered

### DIFF
--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -16,9 +16,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <%= render partial: 'closed_banner' %>
+    <%= render partial: 'summary_access_to_support_portal' %>
 
     <% if @has_ordered %>
-      <%= render partial: 'summary_access_to_support_portal' %>
       <%= render partial: 'summary_reset_devices' %>
       <%= render partial: 'summary_order_history' %>
     <% end %>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -16,9 +16,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
     <%= render partial: 'closed_banner' %>
+    <%= render partial: 'summary_access_to_support_portal' %>
 
     <% if @has_ordered %>
-      <%= render partial: 'summary_access_to_support_portal' %>
       <%= render partial: 'summary_reset_devices' %>
       <%= render partial: 'summary_order_history' %>
     <% end %>

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -192,8 +192,22 @@ RSpec.feature ResponsibleBody do
       context 'has NOT ordered anything' do
         before { sign_in_as rb_user }
 
-        it 'does not show this section' do
-          expect(page).not_to have_content('Access the Support Portal')
+        it 'shows the title' do
+          expect(page).to have_content('Access the Support Portal')
+        end
+
+        context 'when a local authority' do
+          it 'show a link to manage users' do
+            expect(page).to have_link('Manage local authority users')
+          end
+        end
+
+        context 'when a trust' do
+          let(:responsible_body) { create(:trust) }
+
+          it 'show a link to manage trust administrators' do
+            expect(page).to have_link('Manage trust administrators')
+          end
         end
       end
 

--- a/spec/features/school/view_school_details_spec.rb
+++ b/spec/features/school/view_school_details_spec.rb
@@ -164,8 +164,12 @@ RSpec.feature 'View school details' do
     before { sign_in_as user }
 
     context 'has NOT ordered anything' do
-      it 'does not show this section' do
-        expect(page).not_to have_content('Access the Support Portal')
+      it 'shows the title' do
+        expect(page).to have_content('Access the Support Portal')
+      end
+
+      it 'show a link to manage users' do
+        expect(page).to have_link('Manage who can access the Support Portal')
       end
     end
 


### PR DESCRIPTION
Even if the RB/School has not ordered show the option to manage users.

