### PR TITLE
Add `SupplierOutage` model

### DIFF
--- a/app/components/computacenter/tech_source_maintenance_banner_component.rb
+++ b/app/components/computacenter/tech_source_maintenance_banner_component.rb
@@ -6,27 +6,27 @@ class Computacenter::TechSourceMaintenanceBannerComponent < ViewComponent::Base
   end
 
   def message
-    maintenance_window = @techsource.current_maintenance_window
+    supplier_outage = @techsource.current_supplier_outage
 
-    if maintenance_window
-      "The TechSource website will be closed for maintenance on <span class=\"app-no-wrap\">#{maintenance_window.first.strftime(DATE_TIME_FORMAT)}.</span> You can order devices when it reopens on <span class=\"app-no-wrap\">#{maintenance_window.last.strftime(DATE_TIME_FORMAT)}.</span>".html_safe
+    if supplier_outage
+      "The TechSource website will be closed for maintenance on <span class=\"app-no-wrap\">#{supplier_outage.start_at.strftime(DATE_TIME_FORMAT)}.</span> You can order devices when it reopens on <span class=\"app-no-wrap\">#{supplier_outage.end_at.strftime(DATE_TIME_FORMAT)}.</span>".html_safe
     end
   end
 
   def render?
-    banner_periods = @techsource.maintenance_windows.collect { |maintenance_window| banner_period(maintenance_window) }
+    banner_periods = @techsource.supplier_outages.collect { |supplier_outage| banner_period(supplier_outage) }
     banner_periods.any? { |banner_period| banner_period.cover? current_time }
   end
 
 private
 
-  def banner_period(maintenance_window)
-    period_from_start_of_two_days_before_window_to_end_of_window(maintenance_window)
+  def banner_period(supplier_outage)
+    period_from_start_of_two_days_before_supplier_outage_to_end_of_supplier_outage(supplier_outage)
   end
 
-  def period_from_start_of_two_days_before_window_to_end_of_window(maintenance_window)
-    display_from = 2.days.before(maintenance_window.first.beginning_of_day)
-    display_until = maintenance_window.last
+  def period_from_start_of_two_days_before_supplier_outage_to_end_of_supplier_outage(supplier_outage)
+    display_from = 2.days.before(supplier_outage.start_at.beginning_of_day)
+    display_until = supplier_outage.end_at
     display_from..display_until
   end
 

--- a/app/controllers/techsource_launcher_controller.rb
+++ b/app/controllers/techsource_launcher_controller.rb
@@ -7,7 +7,7 @@ class TechsourceLauncherController < ApplicationController
     if techsource.available?
       redirect_to URI.parse(techsource.url).to_s # The URI.parse is needed to appease Brakeman
     else
-      @available_at = techsource.current_maintenance_window.last.strftime(DATE_TIME_FORMAT)
+      @available_at = techsource.current_supplier_outage.end_at.strftime(DATE_TIME_FORMAT)
       render 'unavailable'
     end
   end

--- a/app/models/computacenter/tech_source.rb
+++ b/app/models/computacenter/tech_source.rb
@@ -1,8 +1,6 @@
 class Computacenter::TechSource
-  attr_reader :maintenance_windows
-
-  def initialize(maintenance_windows: [(Time.zone.parse('26 Jun 2021 9:00am')..Time.zone.parse('26 Jun 2021 1:00pm'))])
-    @maintenance_windows = maintenance_windows
+  def supplier_outages
+    SupplierOutage.all # for now Computacenter's TechSource is the only supplier
   end
 
   def url
@@ -10,16 +8,18 @@ class Computacenter::TechSource
   end
 
   def available?
-    current_maintenance_window.nil?
+    !SupplierOutage.current.exists?
   end
 
-  def current_maintenance_window
-    maintenance_windows.find { |maintenance_window| maintenance_window.cover? current_time }
+  def current_supplier_outage
+    outages = SupplierOutage.current
+    outages.none? ? nil : any_current_outage(outages)
   end
 
 private
 
-  def current_time
-    Time.zone.now
+  # we shouldn't really get overlapping outages
+  def any_current_outage(outages)
+    outages.first
   end
 end

--- a/app/models/supplier_outage.rb
+++ b/app/models/supplier_outage.rb
@@ -1,0 +1,22 @@
+class SupplierOutage < ApplicationRecord
+  validates :start_at, :end_at, presence: true
+  validate :end_at_cannot_be_in_the_past, on: :create # allows active outage to end early
+  validate :start_at_must_be_before_end_at
+
+  scope :current, lambda {
+    now = Time.zone.now
+    where('start_at < ? and end_at > ?', now, now)
+  }
+
+  def end_at_cannot_be_in_the_past
+    if end_at.present? && end_at.past?
+      errors.add(:end_at, "can't be in the past")
+    end
+  end
+
+  def start_at_must_be_before_end_at
+    if start_at.present? && end_at.present? && start_at >= end_at
+      errors.add(:start_at, 'must be before outage end')
+    end
+  end
+end

--- a/db/migrate/20210726110031_create_supplier_outages.rb
+++ b/db/migrate/20210726110031_create_supplier_outages.rb
@@ -1,0 +1,10 @@
+class CreateSupplierOutages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :supplier_outages do |t|
+      t.datetime :start_at
+      t.datetime :end_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_113406) do
+ActiveRecord::Schema.define(version: 2021_07_26_110031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -434,6 +434,13 @@ ActiveRecord::Schema.define(version: 2021_05_06_113406) do
     t.index ["gias_group_uid"], name: "index_staged_trusts_on_gias_group_uid", unique: true
     t.index ["name"], name: "index_staged_trusts_on_name"
     t.index ["status"], name: "index_staged_trusts_on_status"
+  end
+
+  create_table "supplier_outages", force: :cascade do |t|
+    t.datetime "start_at"
+    t.datetime "end_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "support_tickets", force: :cascade do |t|

--- a/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
+++ b/spec/components/previews/computacenter/tech_source_maintenance_banner_component_spec.rb
@@ -1,22 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Computacenter::TechSourceMaintenanceBannerComponent, type: :component do
-  let(:techsource) { Computacenter::TechSource.new(maintenance_windows: maintenance_windows) }
+  let(:techsource) { Computacenter::TechSource.new }
 
   subject(:banner) { described_class.new(techsource) }
 
   describe '#message' do
     context 'within window' do
-      let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 22:00')] }
-
-      before { Timecop.travel(Time.zone.parse('4 Jan 2021 15:00')) }
+      before do
+        Timecop.travel(Time.zone.parse('4 Jan 2021 15:00'))
+        create(:supplier_outage, start_at: Time.zone.parse('4 Jan 2021 09:00'), end_at: Time.zone.parse('4 Jan 2021 22:00'))
+      end
 
       specify { expect(banner.message).to eq('The TechSource website will be closed for maintenance on <span class="app-no-wrap">Monday 4 January 09:00am.</span> You can order devices when it reopens on <span class="app-no-wrap">Monday 4 January 10:00pm.</span>') }
     end
   end
 
   describe '#render?' do
-    let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00')] }
+    before do
+      Timecop.travel(Time.zone.parse('4 Jan 2021 08:00'))
+      create(:supplier_outage, start_at: Time.zone.parse('4 Jan 2021 09:00'), end_at: Time.zone.parse('4 Jan 2021 10:00'))
+    end
 
     context 'one minute before midnight two days before' do
       before do
@@ -55,7 +59,11 @@ RSpec.describe Computacenter::TechSourceMaintenanceBannerComponent, type: :compo
     end
 
     context 'two maintenance windows' do
-      let(:maintenance_windows) { [Time.zone.parse('4 Jan 2021 09:00')..Time.zone.parse('4 Jan 2021 10:00'), Time.zone.parse('1 Feb 2021 09:00')..Time.zone.parse('1 Feb 2021 10:00')] }
+      before do
+        Timecop.travel(Time.zone.parse('4 Jan 2021 8:00'))
+        create(:supplier_outage, start_at: Time.zone.parse('4 Jan 2021 09:00'), end_at: Time.zone.parse('4 Jan 2021 10:00'))
+        create(:supplier_outage, start_at: Time.zone.parse('1 Feb 2021 09:00'), end_at: Time.zone.parse('1 Feb 2021 10:00'))
+      end
 
       context 'within first maintenance banner window' do
         before do

--- a/spec/controllers/techsource_launcher_controller_spec.rb
+++ b/spec/controllers/techsource_launcher_controller_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe TechsourceLauncherController, type: :controller do
   let(:user) { create(:local_authority_user) }
-  let(:maintenance_windows) { [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am'))] }
-  let(:techsource) { Computacenter::TechSource.new(maintenance_windows: maintenance_windows) }
+  let(:techsource) { Computacenter::TechSource.new }
 
   before do
-    allow_any_instance_of(Computacenter::TechSource).to receive(:maintenance_windows).and_return(techsource.maintenance_windows) # rubocop:disable RSpec/AnyInstance
+    Timecop.travel(Time.zone.parse('1 Jan 2021 8:00am'))
+    create(:supplier_outage, start_at: Time.zone.parse('1 Jan 2021 9:00am'), end_at: Time.zone.parse('1 Jan 2021 10:00am'))
     sign_in_as user
   end
 

--- a/spec/factories/supplier_outages.rb
+++ b/spec/factories/supplier_outages.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :supplier_outage do
+    in_the_future
+  end
+
+  trait :in_the_future do
+    starts_in_the_future
+    end_at { 2.weeks.from_now }
+  end
+
+  trait :current do
+    starts_in_the_past
+    end_at { 2.weeks.from_now }
+  end
+
+  trait :starts_in_the_future do
+    start_at { 1.week.from_now }
+  end
+
+  trait :starts_in_the_past do
+    start_at { 1.week.ago }
+  end
+end

--- a/spec/models/computacenter/tech_source_spec.rb
+++ b/spec/models/computacenter/tech_source_spec.rb
@@ -1,87 +1,94 @@
 require 'rails_helper'
 
 RSpec.describe Computacenter::TechSource do
-  describe '#available?' do
-    context 'no maintenance windows' do
-      subject(:techsource) { described_class.new(maintenance_windows: []) }
+  subject(:techsource) { described_class.new }
 
+  describe '#available?' do
+    context 'no supplier outages' do
       specify { expect(techsource).to be_available }
     end
 
-    context 'one maintenance window' do
-      subject(:techsource) { described_class.new(maintenance_windows: [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am'))]) }
+    context 'one supplier outage' do
+      before do
+        Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am'))
+        create(:supplier_outage, start_at: Time.zone.parse('1 Jan 2021 9:00am'), end_at: Time.zone.parse('1 Jan 2021 10:00am'))
+      end
 
-      context 'before window' do
+      context 'before outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
 
         specify { expect(techsource).to be_available }
       end
 
-      context 'just at start of window' do
+      context 'just at start of outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just before end of window' do
+      context 'just before end of outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:59am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just after window' do
+      context 'just after outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
 
         specify { expect(techsource).to be_available }
       end
     end
 
-    context 'two maintenance windows' do
-      subject(:techsource) { described_class.new(maintenance_windows: [(Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am')), (Time.zone.parse('1 Feb 2021 9:00am')..Time.zone.parse('1 Feb 2021 10:00am'))]) }
+    context 'two supplier outages' do
+      before do
+        Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am'))
+        create(:supplier_outage, start_at: Time.zone.parse('1 Jan 2021 9:00am'), end_at: Time.zone.parse('1 Jan 2021 10:00am'))
+        create(:supplier_outage, start_at: Time.zone.parse('1 Feb 2021 9:00am'), end_at: Time.zone.parse('1 Feb 2021 10:00am'))
+      end
 
-      context 'before first window' do
+      context 'before first outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
 
         specify { expect(techsource).to be_available }
       end
 
-      context 'just at start of first window' do
+      context 'just at start of first outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just before end of first window' do
+      context 'just before end of first outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:59am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just after first window' do
+      context 'just after first outage' do
         before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
 
         specify { expect(techsource).to be_available }
       end
 
-      context 'just before second window' do
+      context 'just before second outage' do
         before { Timecop.travel(Time.zone.parse('1 Feb 2021 8:59am')) }
 
         specify { expect(techsource).to be_available }
       end
 
-      context 'just at start of second window' do
+      context 'just at start of second outage' do
         before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:01am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just before end of second window' do
+      context 'just before end of second outage' do
         before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:59am')) }
 
         specify { expect(techsource).not_to be_available }
       end
 
-      context 'just after second window' do
+      context 'just after second outage' do
         before { Timecop.travel(Time.zone.parse('1 Feb 2021 10:01am')) }
 
         specify { expect(techsource).to be_available }
@@ -89,40 +96,40 @@ RSpec.describe Computacenter::TechSource do
     end
   end
 
-  describe '#current_maintenance_window' do
-    let(:first_window) { Time.zone.parse('1 Jan 2021 9:00am')..Time.zone.parse('1 Jan 2021 10:00am') }
-    let(:second_window) { Time.zone.parse('1 Feb 2021 9:00am')..Time.zone.parse('1 Feb 2021 10:00am') }
+  describe '#current_supplier_outage' do
+    before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
 
-    subject(:techsource) { described_class.new(maintenance_windows: [first_window, second_window]) }
+    let!(:first_outage) { create(:supplier_outage, start_at: Time.zone.parse('1 Jan 2021 9:00am'), end_at: Time.zone.parse('1 Jan 2021 10:00am')) }
+    let!(:second_outage) { create(:supplier_outage, start_at: Time.zone.parse('1 Feb 2021 9:00am'), end_at: Time.zone.parse('1 Feb 2021 10:00am')) }
 
     context 'before first' do
       before { Timecop.travel(Time.zone.parse('1 Jan 2021 8:59am')) }
 
-      specify { expect(techsource.current_maintenance_window).to be_nil }
+      specify { expect(techsource.current_supplier_outage).to be_nil }
     end
 
     context 'during first' do
       before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:01am')) }
 
-      specify { expect(techsource.current_maintenance_window).to eq(first_window) }
+      specify { expect(techsource.current_supplier_outage).to eq(first_outage) }
     end
 
     context 'between first and second' do
       before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
 
-      specify { expect(techsource.current_maintenance_window).to be_nil }
+      specify { expect(techsource.current_supplier_outage).to be_nil }
     end
 
     context 'during second' do
       before { Timecop.travel(Time.zone.parse('1 Feb 2021 9:01am')) }
 
-      specify { expect(techsource.current_maintenance_window).to eq(second_window) }
+      specify { expect(techsource.current_supplier_outage).to eq(second_outage) }
     end
 
     context 'after second' do
       before { Timecop.travel(Time.zone.parse('1 Feb 2021 10:01am')) }
 
-      specify { expect(techsource.current_maintenance_window).to be_nil }
+      specify { expect(techsource.current_supplier_outage).to be_nil }
     end
   end
 end

--- a/spec/models/supplier_outage_spec.rb
+++ b/spec/models/supplier_outage_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe SupplierOutage, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:start_at) }
+    it { is_expected.to validate_presence_of(:end_at) }
+  end
+
+  describe 'time constraints' do
+    context 'create' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:00am')) }
+
+      context 'both start_at and end_at in the past' do
+        subject { described_class.new(start_at: '30 Dec 2020 9:00am', end_at: '31 Dec 2020 9:00am') }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'start_at in the past and end_at in the future' do
+        subject { described_class.new(start_at: '31 Dec 2020 9:00am', end_at: '2 Jan 2021 9:00am') }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'both start_at and end_at in the future' do
+        subject { described_class.new(start_at: '2 Jan 2021 9:00am', end_at: '3 Jan 2021 9:00am') }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'start_at before end_at' do
+        subject { described_class.new(start_at: '2 Jan 2021 9:00am', end_at: '4 Jan 2021 9:00am') }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'start_at and end_at at same time' do
+        subject { described_class.new(start_at: '2 Jan 2021 9:00am', end_at: '2 Jan 2021 9:00am') }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'end_at before start_at' do
+        subject { described_class.new(start_at: '3 Jan 2021 9:00am', end_at: '2 Jan 2021 9:00am') }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    context 'update' do
+      context 'future outage' do
+        subject(:outage) { build(:supplier_outage, :in_the_future) }
+
+        context 'moving into past' do
+          specify { expect { outage.update!(start_at: 2.hours.ago, end_at: 1.hour.ago) }.to raise_error /can't be in the past/ }
+        end
+      end
+
+      context 'current outage' do
+        subject(:outage) { create(:supplier_outage, :current) }
+
+        context 'end_at finished early' do
+          specify { expect { outage.update!(end_at: 1.minute.ago) }.not_to raise_error }
+        end
+      end
+    end
+  end
+
+  describe '.current' do
+    subject(:current_outage) { SupplierOutage.current }
+
+    before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:00am')) }
+
+    let!(:outage) { create(:supplier_outage, start_at: Time.zone.parse('1 Jan 2021 10:00am'), end_at: Time.zone.parse('1 Jan 2021 11:00am')) }
+
+    # overlapping?
+    context 'before outage' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 9:59am')) }
+
+      specify { expect(current_outage).to be_none }
+    end
+
+    context 'during outage' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 10:01am')) }
+
+      specify { expect(current_outage).to include(outage) }
+    end
+
+    context 'after outage' do
+      before { Timecop.travel(Time.zone.parse('1 Jan 2021 11:01am')) }
+
+      specify { expect(current_outage).to be_none }
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/b82716oi

Allow TechSource outages to be specified through database operations on the Rails production console. 

Currently there's only one supplier but in the future instead of a `SupplierOutage`, different suppliers could have many `Outage`s.

New outages can be managed in the database with:

```ruby
SupplierOutage.create!(start_at: Time.zone.parse('1 Jan 2021 10:00am'), end_at: Time.zone.parse('1 Jan 2021 11:00am'))
```

### Changes proposed in this pull request

Move outages to database model `SupplierOutage`

### Guidance to review

