### PR TITLE
Remove not ordered blurb, add missing tests for 4G blurb

### DIFF
--- a/app/views/responsible_body/home/_closed_banner.html.erb
+++ b/app/views/responsible_body/home/_closed_banner.html.erb
@@ -5,10 +5,6 @@
 
   <% if @has_ordered || @has_completed_extra_mobile_data_requests %>
     <%= render partial: 'closed_banner_multiple' %>
-  <% else %>
-    <p class="govuk-body">
-      Schools and colleges in your <%= @responsible_body.humanized_type -%> did not order any laptops, tablets or routers from <span class="app-no-wrap">September 2020</span> to <span class="app-no-wrap">July 2021</span>.
-    </p>
   <% end %>
   <p class="govuk-body">
     <span class="app-no-wrap">4G wireless routers</span> are available to order until <span class="app-no-wrap">31 July</span>.

--- a/app/views/school/home/_closed_banner.html.erb
+++ b/app/views/school/home/_closed_banner.html.erb
@@ -9,16 +9,6 @@
     <% else %>
       <%= render partial: 'closed_banner_multiple' %>
     <% end %>
-  <% else %>
-    <% if @in_vcap_pool %>
-      <p class="govuk-body">
-        Schools and colleges in your <%= @school.responsible_body.humanized_type -%> did not order any laptops, tablets or routers from <span class="app-no-wrap">September 2020</span> to <span class="app-no-wrap">July 2021</span>.
-      </p>
-    <% else %>
-      <p class="govuk-body">
-        Your <%= @school.institution_type -%> did not order any laptops, tablets or routers from <span class="app-no-wrap">September 2020</span> to <span class="app-no-wrap">July 2021</span>.
-      </p>
-    <% end %>
   <% end %>
   <p class="govuk-body">
     <span class="app-no-wrap">4G wireless routers</span> are available to order until <span class="app-no-wrap">31 July</span>.

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -65,20 +65,10 @@ RSpec.feature ResponsibleBody do
           create_list(:school, 4, :centrally_managed, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body)
         end
 
-        context 'local authority' do
-          let(:responsible_body) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
+        let(:responsible_body) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
 
-          it 'says local authority did not order anything' do
-            expect(page).to have_content('Schools and colleges in your local authority did not order any laptops, tablets or routers from September 2020 to July 2021')
-          end
-        end
-
-        context 'trust' do
-          let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
-
-          it 'says trust did not order anything' do
-            expect(page).to have_content('Schools and colleges in your trust did not order any laptops, tablets or routers from September 2020 to July 2021')
-          end
+        it 'says 4G routers are available to order till 31 July' do
+          expect(page).to have_content('4G wireless routers are available to order until 31 July.')
         end
       end
 
@@ -134,8 +124,8 @@ RSpec.feature ResponsibleBody do
       context 'has NOT ordered anything' do
         before { sign_in_as rb_user }
 
-        it 'says school did not order anything' do
-          expect(page).to have_content('Schools and colleges in your local authority did not order any laptops, tablets or routers from September 2020 to July 2021.')
+        it 'says 4G routers are available to order till 31 July' do
+          expect(page).to have_content('4G wireless routers are available to order until 31 July.')
         end
       end
 

--- a/spec/features/school/view_school_details_spec.rb
+++ b/spec/features/school/view_school_details_spec.rb
@@ -47,20 +47,10 @@ RSpec.feature 'View school details' do
           create_list(:school, 4, :centrally_managed, :with_std_device_allocation, :with_coms_device_allocation, responsible_body: responsible_body)
         end
 
-        context 'local authority' do
-          let(:responsible_body) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
+        let(:responsible_body) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
 
-          it 'says local authority did not order anything' do
-            expect(page).to have_content('Schools and colleges in your local authority did not order any laptops, tablets or routers from September 2020 to July 2021')
-          end
-        end
-
-        context 'trust' do
-          let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
-
-          it 'says trust did not order anything' do
-            expect(page).to have_content('Schools and colleges in your trust did not order any laptops, tablets or routers from September 2020 to July 2021')
-          end
+        it 'says 4G routers are available to order till 31 July' do
+          expect(page).to have_content('4G wireless routers are available to order until 31 July.')
         end
       end
 
@@ -116,8 +106,8 @@ RSpec.feature 'View school details' do
       before { sign_in_as user }
 
       context 'has NOT ordered anything' do
-        it 'says school did not order anything' do
-          expect(page).to have_content('Your school did not order any laptops, tablets or routers from September 2020 to July 2021')
+        it 'says 4G routers are available to order till 31 July' do
+          expect(page).to have_content('4G wireless routers are available to order until 31 July.')
         end
       end
 


### PR DESCRIPTION
No need to remind users that they haven't ordered.

