### PR TITLE
Make factory sane

### DIFF
--- a/spec/factories/school_device_allocations.rb
+++ b/spec/factories/school_device_allocations.rb
@@ -1,42 +1,44 @@
 FactoryBot.define do
   factory :school_device_allocation do
+    std
     association :school
     association :created_by_user, factory: :dfe_user
     association :last_updated_by_user, factory: :dfe_user
-    device_type { SchoolDeviceAllocation.device_types.keys.sample }
+
+    trait :std do
+      device_type { 'std_device' }
+    end
+
+    trait :coms do
+      device_type { 'coms_device' }
+    end
 
     trait :with_std_allocation do
-      device_type { 'std_device' }
-      allocation { Faker::Number.within(range: 1..100) }
+      allocation { 1 }
+      cap { 0 }
+    end
+
+    trait :with_coms_allocation do
+      coms
+      allocation { 1 }
       cap { 0 }
     end
 
     trait :with_available_devices do
-      allocation { 100 }
-      cap { Faker::Number.within(range: 10..50) }
-    end
-
-    trait :with_coms_allocation do
-      device_type { 'coms_device' }
-      allocation { Faker::Number.within(range: 1..100) }
-      cap { 0 }
-    end
-
-    trait :with_orderable_devices do
-      allocation { 100 }
-      cap { Faker::Number.within(range: 20..80) }
+      allocation { 2 }
+      cap { 1 }
     end
 
     trait :fully_ordered do
-      allocation { 100 }
-      cap { 100 }
-      devices_ordered { 100 }
+      allocation { 1 }
+      cap { 1 }
+      devices_ordered { 1 }
     end
 
     trait :partially_ordered do
-      allocation { 100 }
-      cap { 100 }
-      devices_ordered { Faker::Number.within(range: 20..80) }
+      allocation { 2 }
+      cap { 2 }
+      devices_ordered { 1 }
     end
   end
 end

--- a/spec/features/computacenter/techsource_spec.rb
+++ b/spec/features/computacenter/techsource_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Computacenter confirming TechSource accounts' do
   end
 
   def given_rb_exists_that_can_order_devices
-    allocation = create(:school_device_allocation, :with_std_allocation, :with_orderable_devices)
+    allocation = create(:school_device_allocation, :with_std_allocation, :with_available_devices)
     preorder = create(:preorder_information, who_will_order_devices: 'responsible_body')
     @rb = create(:trust)
     @school = create(:school,
@@ -47,7 +47,7 @@ RSpec.describe 'Computacenter confirming TechSource accounts' do
   end
 
   def given_school_exists_that_can_order_devices
-    allocation = create(:school_device_allocation, :with_std_allocation, :with_orderable_devices)
+    allocation = create(:school_device_allocation, :with_std_allocation, :with_available_devices)
     preorder = create(:preorder_information, :does_not_need_chromebooks, who_will_order_devices: 'school', status: :school_can_order)
     @school = create(:school, preorder_information: preorder, order_state: :can_order, std_device_allocation: allocation)
     @school.users << create(:school_user)

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Ordering via a school' do
   let(:rb_user) { create(:local_authority_user, responsible_body: rb) }
   let(:preorder) { create(:preorder_information, :rb_will_order, :does_not_need_chromebooks, school_contact: school.contacts.first) }
   let(:another_preorder) { create(:preorder_information, :rb_will_order, :does_not_need_chromebooks, school_contact: school.contacts.first) }
-  let(:another_allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, devices_ordered: 3, cap: 12) }
+  let(:another_allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices, devices_ordered: 3, cap: 12) }
   let(:school) { create(:school, :with_headteacher_contact) }
 
   let(:school_page) { PageObjects::ResponsibleBody::SchoolPage.new }
@@ -31,7 +31,7 @@ RSpec.feature 'Ordering via a school' do
     end
 
     context 'when school has devices to order' do
-      let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, cap: 12, devices_ordered: 3) }
+      let(:allocation) { create(:school_device_allocation, allocation: 12, cap: 12, devices_ordered: 3) }
 
       before do
         school.update!(std_device_allocation: allocation, order_state: 'can_order')
@@ -71,7 +71,7 @@ RSpec.feature 'Ordering via a school' do
     end
 
     context 'when the school can order devices and has an allocation' do
-      let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices, allocation: 12, cap: 10, devices_ordered: 3) }
+      let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices, allocation: 12, cap: 10, devices_ordered: 3) }
 
       before do
         school.update!(std_device_allocation: allocation, order_state: 'can_order')

--- a/spec/models/preorder_information_spec.rb
+++ b/spec/models/preorder_information_spec.rb
@@ -201,14 +201,14 @@ RSpec.describe PreorderInformation, type: :model do
       end
 
       context 'when there are devices available to order' do
-        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_available_devices) }
 
         it { is_expected.to eq('rb_can_order') }
       end
 
       context 'when there are devices available to order but school cannot order' do
         let(:order_state) { 'cannot_order' }
-        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_available_devices) }
 
         it { is_expected.to eq('ready') }
       end
@@ -245,14 +245,14 @@ RSpec.describe PreorderInformation, type: :model do
       end
 
       context 'when there are devices available to order' do
-        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_available_devices) }
 
         it { is_expected.to eq('school_can_order') }
       end
 
       context 'when there are devices available to order but school cannot order' do
         let(:order_state) { 'cannot_order' }
-        let(:allocation) { create(:school_device_allocation, :with_orderable_devices) }
+        let(:allocation) { create(:school_device_allocation, :with_available_devices) }
 
         it { is_expected.to eq('school_ready') }
       end

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserCanOrderDevicesNotifications do
   end
 
   context 'when orders can be placed within a virtual cap' do
-    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
     let(:preorder) { create(:preorder_information, :school_will_order, status: :rb_can_order) }
     let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
     let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }
@@ -29,7 +29,7 @@ RSpec.describe UserCanOrderDevicesNotifications do
   end
 
   context 'when orders can be placed within a new FE college' do
-    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_orderable_devices) }
+    let(:allocation) { create(:school_device_allocation, :with_std_allocation, :with_available_devices) }
     let(:preorder) { create(:preorder_information, :school_will_order, status: :rb_can_order) }
     let(:responsible_body) { create(:further_education_college, :new_fe_wave) }
     let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }


### PR DESCRIPTION
### Context

Many of our flaky specs were due to the allocations factory having a random factor which:

* sometimes created a coms allocation, sometimes created a device allocation; and
* used random number generation which occasionally fell foul of cap and allocation constraints.

### Changes proposed in this pull request

* Remove random element
* Remove duplicate trait

### Guidance to review

