### PR TITLE
2078 allocation job

### DIFF
--- a/app/jobs/allocation_job.rb
+++ b/app/jobs/allocation_job.rb
@@ -1,23 +1,68 @@
 class AllocationJob < ApplicationJob
   queue_as :default
 
-  def perform(allocation_batch_job)
+  def perform(allocation_batch_jobs)
+    allocation_batch_jobs.each do |allocation_batch_job|
+      # this definitely won't be idempotent if the same CSV is uploaded again
+      process_school_allocation_update(allocation_batch_job) unless allocation_batch_job.processed?
+    end
+  end
+
+private
+
+  def process_school_allocation_update(allocation_batch_job)
+    allocation_calculator = AllocationUpdateHelper.new(allocation_batch_job)
+
+    ActiveRecord::Base.transaction do
+      allocation_calculator.update_current_allocation!
+      allocation_calculator.call_school_order_state_and_cap_update_service
+      allocation_calculator.record_batch_job_processed_and_notify
+    end
+  end
+end
+
+# this class has too many responsibilities
+class AllocationUpdateHelper
+  def initialize(allocation_batch_job)
     set_instance_variables(allocation_batch_job)
     set_default_new_raw_allocation_value
     set_default_new_raw_cap_value
 
     # A negative delta must check against devices_available_to_order
     set_negative_allocation_and_cap_values if @allocation_delta.negative?
+  end
 
-    ActiveRecord::Base.transaction do
-      update_current_allocation!
-      call_school_order_state_and_cap_update_service
-      record_batch_job_processed_and_notify
+  def update_current_allocation!
+    if @allocation_delta.negative? && @new_raw_allocation_value < @current_allocation.raw_cap
+      # cap values are retrieved elsewhere in `SchoolOrderStateAndCapUpdateService` which is confusing
+      @current_allocation.update!(allocation: @new_raw_allocation_value, cap: @new_raw_cap_value)
+    else
+      @current_allocation.update!(allocation: @new_raw_allocation_value)
     end
+  end
+
+  def call_school_order_state_and_cap_update_service
+    service = SchoolOrderStateAndCapUpdateService.new(
+      school: @school.reload,
+      order_state: @order_state,
+      std_device_cap: @new_raw_cap_value,
+    )
+
+    service.disable_user_notifications! if @disable_user_notifications
+    service.call
+  end
+
+  def record_batch_job_processed_and_notify
+    if @disable_user_notifications
+      return @allocation_batch_job.update!(processed: true)
+    end
+
+    @allocation_batch_job.update!(processed: true, sent_notification: true)
   end
 
 private
 
+  # these instance variables might not be thread-safe
   def set_instance_variables(allocation_batch_job)
     @allocation_batch_job = allocation_batch_job
     @school = @allocation_batch_job.school
@@ -53,32 +98,5 @@ private
 
   def set_negative_new_raw_cap_value
     @new_raw_cap_value = [@current_raw_cap_value + @negative_allocation_delta, @new_raw_allocation_value].min
-  end
-
-  def update_current_allocation!
-    if @allocation_delta.negative? && @new_raw_allocation_value < @current_allocation.raw_cap
-      @current_allocation.update!(allocation: @new_raw_allocation_value, cap: @new_raw_cap_value)
-    else
-      @current_allocation.update!(allocation: @new_raw_allocation_value)
-    end
-  end
-
-  def call_school_order_state_and_cap_update_service
-    service = SchoolOrderStateAndCapUpdateService.new(
-      school: @school.reload,
-      order_state: @order_state,
-      std_device_cap: @new_raw_cap_value,
-    )
-
-    service.disable_user_notifications! if @disable_user_notifications
-    service.call
-  end
-
-  def record_batch_job_processed_and_notify
-    if @disable_user_notifications
-      return @allocation_batch_job.update!(processed: true)
-    end
-
-    @allocation_batch_job.update!(processed: true, sent_notification: true)
   end
 end

--- a/app/models/allocation_batch_job.rb
+++ b/app/models/allocation_batch_job.rb
@@ -1,3 +1,5 @@
+# this is not really a job, it just represents a school's allocation update,
+# so suggest renaming
 class AllocationBatchJob < ApplicationRecord
   def school
     @school ||= School.where_urn_or_ukprn_or_provision_urn(urn || ukprn).first!

--- a/app/services/importers/allocation_upload_csv.rb
+++ b/app/services/importers/allocation_upload_csv.rb
@@ -2,33 +2,21 @@ require 'csv'
 
 module Importers
   class AllocationUploadCsv
-    attr_reader :path, :send_notification
+    # really the `batch_id` is no longer needed but requires a large refactoring
+    attr_reader :batch_id
 
     def initialize(path_to_csv:, send_notification: true)
       @path = path_to_csv
       @send_notification = send_notification
+      @batch_id = SecureRandom.uuid
     end
-
-    # urn
-    # ukprn
-    # allocation_delta
-    # order_state # => ["can_order", "cannot_order"]
 
     def call
-      rows.each do |row|
-        job = AllocationBatchJob.create!(row.to_h.slice('urn', 'ukprn', 'allocation_delta', 'order_state').merge(batch_id: batch_id, send_notification: send_notification))
-        AllocationJob.perform_later(job)
-      end
-    end
-
-    def batch_id
-      @batch_id ||= SecureRandom.uuid
-    end
-
-  private
-
-    def rows
-      @rows ||= CSV.read(path, headers: true)
+      rows = CSV.read(@path, headers: true)
+      # creating the rows here outside of an `ActiveJob` means this could hang the browser
+      # but was necessary to avoid a larger redesign
+      allocation_batch_jobs = rows.collect { |row| AllocationBatchJob.create!(row.to_h.slice('urn', 'ukprn', 'allocation_delta', 'order_state').merge(batch_id: @batch_id)) }
+      AllocationJob.perform_later(allocation_batch_jobs, @send_notification)
     end
   end
 end

--- a/app/views/support/allocation_batch_jobs/show.html.erb
+++ b/app/views/support/allocation_batch_jobs/show.html.erb
@@ -19,7 +19,6 @@
       <th scope="col" class="govuk-table__header">UKPRN</th>
       <th scope="col" class="govuk-table__header">Allocation delta</th>
       <th scope="col" class="govuk-table__header">Order state</th>
-      <th scope="col" class="govuk-table__header">Send notification?</th>
       <th scope="col" class="govuk-table__header">Sent notification?</th>
       <th scope="col" class="govuk-table__header">Processed?</th>
     </tr>
@@ -32,7 +31,6 @@
         <td class="govuk-table__cell"><%= link_to_urn_or_ukprn_otherwise_identifier job.ukprn %></td>
         <td class="govuk-table__cell"><%= job.allocation_delta %></td>
         <td class="govuk-table__cell"><%= job.order_state %></td>
-        <td class="govuk-table__cell"><%= job.send_notification %></td>
         <td class="govuk-table__cell"><%= job.sent_notification %></td>
         <td class="govuk-table__cell"><%= job.processed %></td>
       </tr>

--- a/db/migrate/20210729105223_remove_send_notification_from_allocation_batch_job.rb
+++ b/db/migrate/20210729105223_remove_send_notification_from_allocation_batch_job.rb
@@ -1,0 +1,5 @@
+class RemoveSendNotificationFromAllocationBatchJob < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :allocation_batch_jobs, :send_notification, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_26_110031) do
+ActiveRecord::Schema.define(version: 2021_07_29_105223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,6 @@ ActiveRecord::Schema.define(version: 2021_07_26_110031) do
     t.integer "ukprn"
     t.integer "allocation_delta", null: false
     t.text "order_state"
-    t.boolean "send_notification", default: true, null: false
     t.boolean "sent_notification", default: false, null: false
     t.boolean "processed", default: false, null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/services/importers/allocation_upload_csv_spec.rb
+++ b/spec/services/importers/allocation_upload_csv_spec.rb
@@ -37,32 +37,8 @@ RSpec.describe Importers::AllocationUploadCsv do
       expect(record.order_state).to eql('can_order')
 
       expect(record.batch_id).to be_present
-      expect(record.send_notification).to be_truthy
       expect(record.sent_notification).to be_falsey
       expect(record.processed).to be_falsey
-    end
-
-    context 'when send_notification is false' do
-      subject(:service) do
-        described_class.new(path_to_csv: file.path, send_notification: false)
-      end
-
-      it 'sets send_notification to false' do
-        expect {
-          service.call
-        }.to change(AllocationBatchJob, :count).by(1)
-
-        record = AllocationBatchJob.last
-        expect(record.urn).to eql(school.urn)
-        expect(record.ukprn).to eql(school.ukprn)
-        expect(record.allocation_delta).to be(3)
-        expect(record.order_state).to eql('can_order')
-
-        expect(record.batch_id).to be_present
-        expect(record.send_notification).to be_falsey
-        expect(record.sent_notification).to be_falsey
-        expect(record.processed).to be_falsey
-      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/VJyULra4

Instead of creating an `ActiveJob` per school, creates one `ActiveJob` which will be easier to manage if there's a problem.

### Changes proposed in this pull request

Does the bare minimum, a much bigger refactoring or complete rewrite is probably needed.

### Guidance to review

