### PR TITLE
Run jobs as one job in the queue

### DIFF
--- a/app/jobs/sequential_allocation_update_job.rb
+++ b/app/jobs/sequential_allocation_update_job.rb
@@ -1,0 +1,7 @@
+class SequentialAllocationUpdateJob < ApplicationJob
+  def perform(batch_id)
+    AllocationBatchJob.where(batch_id: batch_id).find_each do |allocation_batch_job|
+      AllocationJob.perform_now(allocation_batch_job)
+    end
+  end
+end

--- a/app/services/importers/allocation_upload_csv.rb
+++ b/app/services/importers/allocation_upload_csv.rb
@@ -16,9 +16,10 @@ module Importers
 
     def call
       rows.each do |row|
-        job = AllocationBatchJob.create!(row.to_h.slice('urn', 'ukprn', 'allocation_delta', 'order_state').merge(batch_id: batch_id, send_notification: send_notification))
-        AllocationJob.perform_later(job)
+        AllocationBatchJob.create!(row.to_h.slice('urn', 'ukprn', 'allocation_delta', 'order_state').merge(batch_id: batch_id, send_notification: send_notification))
       end
+
+      SequentialAllocationUpdateJob.perform_later(batch_id)
     end
 
     def batch_id


### PR DESCRIPTION
### Context

Simplest way of only generating one `ActiveJob`.

**There is no automated spec for this.**

https://trello.com/c/VJyULra4

### Changes proposed in this pull request

Put calls for individual school updates in a loop which calls `perform_now` so it bypasses the job queue.

### Guidance to review

