### PR TITLE
2208: add trusts when importing them from GIAS

### DIFF
--- a/app/services/stage_trust_data.rb
+++ b/app/services/stage_trust_data.rb
@@ -7,15 +7,7 @@ class StageTrustData
 
   def import_trusts
     datasource.trusts do |trust_data|
-      trust = DataStage::Trust.find_by(companies_house_number: trust_data[:companies_house_number])
-
-      if trust
-        trust.update!(trust_data)
-      else
-        DataStage::Trust.create!(trust_data)
-      end
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error(e.message)
+      TrustUpsertService.new(trust_data).call
     end
     DataStage::DataUpdateRecord.staged!(:trusts)
   end

--- a/app/services/trust_upsert_service.rb
+++ b/app/services/trust_upsert_service.rb
@@ -1,0 +1,28 @@
+class TrustUpsertService
+  ID_KEY = :companies_house_number
+
+  attr_reader :attributes
+
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      upsert!(DataStage::Trust)
+      upsert!(Trust)
+    end
+  rescue StandardError => e
+    Rails.logger.error(e.message)
+  end
+
+private
+
+  def identification
+    { ID_KEY => attributes[ID_KEY] }
+  end
+
+  def upsert!(model)
+    model.find_or_initialize_by(identification).update!(attributes)
+  end
+end

--- a/spec/services/stage_trust_data_spec.rb
+++ b/spec/services/stage_trust_data_spec.rb
@@ -3,93 +3,31 @@ require 'rails_helper'
 RSpec.describe StageTrustData, type: :model do
   describe 'importing trusts' do
     let(:filename) { Rails.root.join('tmp/trust_test_data.csv') }
+    let(:now) { Time.zone.now }
+    let(:number_of_rows) { rand(1..5) }
+    let(:attrs) { attributes_for_list(:staged_trust, number_of_rows) }
+    let(:service) { described_class.new(TrustDataFile.new(filename)) }
+    let(:trust_upsert_service) { instance_double(TrustUpsertService, call: true) }
+    let(:trust_data_update_record) { DataStage::DataUpdateRecord.trusts.last }
 
-    context 'when a trust does not already exist' do
-      let(:attrs) do
-        {
-          gias_group_uid: '4001',
-          companies_house_number: '09933123',
-          name: 'Callio Forsythe Academy',
-          address_1: 'Big Academy',
-          address_2: 'Strange Lane',
-          town: 'Easttown',
-          postcode: 'EW1 1AA',
-          status: 'Closed',
-          organisation_type: 'Single-academy trust',
-        }
-      end
-
-      before do
-        create_trust_csv_file(filename, [attrs])
-        @service = described_class.new(TrustDataFile.new(filename))
-      end
-
-      after do
-        remove_file(filename)
-      end
-
-      it 'creates a new trust record' do
-        expect {
-          @service.import_trusts
-        }.to change { DataStage::Trust.count }.by(1)
-      end
-
-      it 'sets the correct values on the Trust record' do
-        @service.import_trusts
-        expect(DataStage::Trust.last).to have_attributes(
-          gias_group_uid: '4001',
-          companies_house_number: '09933123',
-          name: 'Callio Forsythe Academy',
-          address_1: 'Big Academy',
-          address_2: 'Strange Lane',
-          town: 'Easttown',
-          postcode: 'EW1 1AA',
-          status: 'closed',
-          organisation_type: 'single_academy_trust',
-        )
-      end
+    before do
+      create_trust_csv_file(filename, attrs)
+      class_spy(TrustUpsertService, new: trust_upsert_service).as_stubbed_const
+      Timecop.freeze(now)
+      service.import_trusts
     end
 
-    context 'when a trust already exists' do
-      let!(:trust) { create(:staged_trust, companies_house_number: '09933123') }
+    after do
+      Timecop.return
+      remove_file(filename)
+    end
 
-      let(:attrs) do
-        {
-          gias_group_uid: '4001',
-          companies_house_number: '09933123',
-          name: 'Academy of Wigtown',
-          address_1: 'Academy Campus',
-          address_2: 'Wigtown Lane',
-          town: 'Wigtown',
-          postcode: 'W1G 1AA',
-          status: 'Open',
-          organisation_type: 'Multi-academy trust',
-        }
-      end
+    it 'upserts records for the trusts imported' do
+      expect(trust_upsert_service).to have_received(:call).exactly(number_of_rows).times
+    end
 
-      before do
-        create_trust_csv_file(filename, [attrs])
-        @service = described_class.new(TrustDataFile.new(filename))
-      end
-
-      after do
-        remove_file(filename)
-      end
-
-      it 'updates the existing trust record' do
-        @service.import_trusts
-        expect(trust.reload).to have_attributes(
-          gias_group_uid: '4001',
-          companies_house_number: '09933123',
-          name: 'Academy of Wigtown',
-          address_1: 'Academy Campus',
-          address_2: 'Wigtown Lane',
-          town: 'Wigtown',
-          postcode: 'W1G 1AA',
-          status: 'open',
-          organisation_type: 'multi_academy_trust',
-        )
-      end
+    it 'updates trusts staging time' do
+      expect(trust_data_update_record.staged_at.to_i).to eq(now.to_i)
     end
   end
 end

--- a/spec/services/stage_trust_data_spec.rb
+++ b/spec/services/stage_trust_data_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StageTrustData, type: :model do
   describe 'importing trusts' do
     let(:filename) { Rails.root.join('tmp/trust_test_data.csv') }
     let(:now) { Time.zone.now }
-    let(:number_of_rows) { rand(1..5) }
+    let(:number_of_rows) { 3 }
     let(:attrs) { attributes_for_list(:staged_trust, number_of_rows) }
     let(:service) { described_class.new(TrustDataFile.new(filename)) }
     let(:trust_upsert_service) { instance_double(TrustUpsertService, call: true) }

--- a/spec/services/trust_upsert_service_spec.rb
+++ b/spec/services/trust_upsert_service_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe TrustUpsertService, type: :model do
+  let(:service) { described_class.new(attrs) }
+
+  describe 'importing trusts' do
+    let(:attrs) do
+      {
+        gias_group_uid: '4001',
+        companies_house_number: '09933123',
+        name: 'Callio Forsythe Academy',
+        address_1: 'Big Academy',
+        address_2: 'Strange Lane',
+        town: 'Easttown',
+        postcode: 'EW1 1AA',
+        status: 'closed',
+        organisation_type: 'single_academy_trust',
+      }
+    end
+
+    [DataStage::Trust, Trust].each do |model|
+      context "when an associated #{model} does not exist" do
+        it 'creates a new record' do
+          expect { service.call }.to change { model.count }.by(1)
+        end
+
+        it 'sets the correct values on the new record' do
+          service.call
+          expect(model.last).to have_attributes(attrs)
+        end
+      end
+    end
+
+    %i[staged_trust trust].each do |factory_name|
+      context "when an associated #{factory_name} exists already" do
+        let!(:existing) { create(factory_name, companies_house_number: '09933123') }
+        let(:organisation_type) { existing.organisation_type }
+        let(:attrs) do
+          {
+            gias_group_uid: '4001',
+            companies_house_number: '09933123',
+            name: 'Academy of Wigtown',
+            address_1: 'Academy Campus',
+            address_2: 'Wigtown Lane',
+            town: 'Wigtown',
+            postcode: 'W1G 1AA',
+            status: 'open',
+            organisation_type: organisation_type,
+          }
+        end
+
+        before do
+          service.call
+        end
+
+        it 'updates the existing record' do
+          expect(existing.reload).to have_attributes(attrs)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
On the periodic import of GIAS trusts csv file sometimes new trusts are coming. Even though we are currently staging them, we are not creating the Trust entries associated.

### Changes proposed in this pull request
Create/update our Trust entries with any trust coming from GIAS on csv import.

### Guidance to review
- New service _TrustUpsertService_ created to mirror any GIAS trust into our own Trust table.
- I think the new service above also covers the job done by _ApplyStagedAttributeChangesToTrustsJob_. Thoughts?
- Tests on _stage_trust_data.rb_ updated accordingly and partially moved to the new service tests suite.