### PR TITLE
Hard delete users without TS confirmed account

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -73,7 +73,7 @@ class Support::UsersController < Support::BaseController
   def confirm_destroy; end
 
   def destroy
-    @user.update!(deleted_at: Time.zone.now, orders_devices: false)
+    DeleteUserService.delete!(@user)
 
     flash[:success] = 'You have deleted this user'
 

--- a/app/services/delete_user_service.rb
+++ b/app/services/delete_user_service.rb
@@ -1,0 +1,17 @@
+class DeleteUserService
+  # Due CC needing to sync "Removed" users, just soft-delete accounts with
+  # `techsource_account_confirmed_at` to keep a record of TS accounts as a precaution.
+  # We can probably hard-delete in future them as "Removal" is recorded
+  # in `Computacenter::UserChange`
+
+  # Retroactively hard destroy already soft-deleted accounts, run in console:
+  # User.deleted.where(techsource_account_confirmed_at: nil).each { |u| u.destroy! }
+
+  def self.delete!(user)
+    if user.techsource_account_confirmed_at
+      user.update!(deleted_at: Time.zone.now, orders_devices: false)
+    else
+      user.destroy!
+    end
+  end
+end

--- a/spec/services/delete_user_service_spec.rb
+++ b/spec/services/delete_user_service_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DeleteUserService do
+  describe '#delete!' do
+    before do
+      described_class.delete!(user)
+    end
+
+    context 'techsource_account_confirmed_at set' do
+      let(:user) { create(:local_authority_user, :with_a_confirmed_techsource_account) }
+
+      it 'soft deletes the user' do
+        expect(user.reload.deleted_at).to be_present
+      end
+    end
+
+    context 'techsource_account_confirmed_at NOT set' do
+      let(:user) { create(:local_authority_user) }
+
+      it 'hard deletes the user' do
+        expect(User.find_by(id: user.id)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Reduce the number of soft-deleted users in the system.

### Changes proposed in this pull request

When deleting users check if they have a TS account confirmed, if not hard-delete otherwise soft-delete as a precaution for now.

### Guidance to review

- Added a service just for deletion, everything else kept the same
- Removed dependency of extra mobile requests to be deleted as they should be retained

