### PR TITLE
Add job for importing CC assets

### DIFF
--- a/app/jobs/computacenter_historical_asset_import_job.rb
+++ b/app/jobs/computacenter_historical_asset_import_job.rb
@@ -1,0 +1,65 @@
+# One-off import job to capture historical asset information from Computacenter
+class ComputacenterHistoricalAssetImportJob < ApplicationJob
+  queue_as :default
+
+  def perform(path_to_csv)
+    @path_to_csv = path_to_csv
+
+    File.open(@path_to_csv, 'r') do |file|
+      perform_on_file(file)
+    end
+  end
+
+  def perform_on_file(file)
+    job_class_name = self.class
+    progress_interval = 5_000
+    created_asset_count = 0
+
+    @asset_row_count = non_header_line_count_of_file
+
+    Rails.logger.info("Started #{job_class_name} for #{@path_to_csv} with #{@asset_row_count} asset(s)")
+
+    CSV.foreach(file, csv_options) do |row|
+      import_csv_row(row)
+      created_asset_count += 1
+      log_progress(created_asset_count) if (created_asset_count % progress_interval).zero?
+    end
+
+    Rails.logger.info("Finished #{job_class_name} for #{@path_to_csv} with #{created_asset_count} asset(s) imported")
+    Rails.logger.info("There are now #{Asset.count} total asset(s) in the database")
+  end
+
+  def unix_word_count_output
+    Open3.capture3('wc', '-l', @path_to_file).first
+  end
+
+private
+
+  # as a estimation of the number of assets in the CSV this could be wrong
+  # if there are blank lines in the file
+  def non_header_line_count_of_file
+    total_line_count = line_count_of_file
+    total_line_count.zero? ? 0 : total_line_count - 1
+  end
+
+  def line_count_of_file
+    console_output = unix_word_count_output
+    console_output.to_i
+  end
+
+  def csv_options
+    options_to_ignore_first_header_row_and_provide_encoding_to_stop_invalid_bytes_error
+  end
+
+  def options_to_ignore_first_header_row_and_provide_encoding_to_stop_invalid_bytes_error
+    { headers: true, encoding: 'ISO-8859-1' }
+  end
+
+  def import_csv_row(row)
+    Asset.create!(tag: row[1], serial_number: row[2], model: row[3], department: row[4], department_id: row[5], department_sold_to_id: row[6], location: row[7], location_id: row[8], location_cc_ship_to_account: row[9], bios_password: row[10], admin_password: row[11], hardware_hash: row[12], sys_created_at: row[13])
+  end
+
+  def log_progress(created_asset_count)
+    Rails.logger.info("This job has written #{created_asset_count} of #{@asset_row_count} assets(s) (#{number_to_percentage(created_asset_count / @asset_row_count.to_f)}) so far...")
+  end
+end

--- a/spec/jobs/computacenter_historical_asset_import_job_spec.rb
+++ b/spec/jobs/computacenter_historical_asset_import_job_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe ComputacenterHistoricalAssetImportJob, type: :job do
+  let(:sys_id_1) { '62c7' }
+  let(:asset_tag_1) { '30000000' }
+  let(:serial_number_1) { '1FFFFFF' }
+  let(:model_name_1) { 'Acme Laptop 1000' }
+  let(:department_name_1) { 'X ACADEMY TRUST' }
+  let(:department_id_1) { 't9000000' }
+  let(:sold_to_1) { '81000000' }
+  let(:location_name_1) { 'X Academy' }
+  let(:location_id_1) { 'L1' }
+  let(:ship_to_1) { '81000000' }
+  let(:bios_password_1) { 'secretbiospassword1' }
+  let(:admin_password_1) { 'secretadminpassword1' }
+  let(:hardware_hash_1) { 'secrethardwarehash1' }
+  let(:sys_created_on_1) { '2020-11-23 14:03:04' }
+
+  let(:sys_id_2) { '7bd4' }
+  let(:asset_tag_2) { '30000001' }
+  let(:serial_number_2) { '1FFFFF1' }
+  let(:model_name_2) { 'Acme Laptop 2000' }
+  let(:department_name_2) { 'Y ACADEMY TRUST' }
+  let(:department_id_2) { 't9000001' }
+  let(:sold_to_2) { '81000001' }
+  let(:location_name_2) { 'Y Academy' }
+  let(:location_id_2) { 'L2' }
+  let(:ship_to_2) { '81000001' }
+  let(:bios_password_2) { 'secretbiospassword2' }
+  let(:admin_password_2) { 'secretadminpassword2' }
+  let(:hardware_hash_2) { 'secrethardwarehash2' }
+  let(:sys_created_on_2) { '2020-12-24 18:03:04' }
+
+  let(:header_row) { ['sys_id', 'asset_tag', 'serial_number', 'model.display_name', 'department.name', 'department.id', 'department.u_sold_to_id', 'location.name', 'location.name.u_location_id', 'location.u_cc_ship_to_account', 'u_bios_password', 'u_admin_password', 'u_hardware_hash', 'sys_created_on'] }
+  let(:row_1) { [sys_id_1, asset_tag_1, serial_number_1, model_name_1, department_name_1, department_id_1, sold_to_1, location_name_1, location_id_1, ship_to_1, bios_password_1, admin_password_1, hardware_hash_1, sys_created_on_1] }
+  let(:row_2) { [sys_id_2, asset_tag_2, serial_number_2, model_name_2, department_name_2, department_id_2, sold_to_2, location_name_2, location_id_2, ship_to_2, bios_password_2, admin_password_2, hardware_hash_2, sys_created_on_2] }
+
+  let(:asset_csv_file_path) { 'assets.csv' }
+
+  describe '#perform' do
+    describe 'read file' do
+      before do
+        allow(File).to receive(:open)
+        described_class.perform_now(asset_csv_file_path)
+      end
+
+      specify { expect(File).to have_received(:open).with(asset_csv_file_path, 'r') }
+    end
+  end
+
+  describe '#perform_on_file' do
+    let(:test_io) { StringIO.new }
+    let(:job) { described_class.new }
+
+    before do
+      # behaves as CSV does when CSV options say file contains a header row
+      allow(CSV).to receive(:foreach).and_yield(row_1).and_yield(row_2)
+      allow(job).to receive(:unix_word_count_output).and_return("      3 #{asset_csv_file_path}\n")
+    end
+
+    describe 'record creation' do
+      it 'creates two records' do
+        expect { job.perform_on_file(test_io) }.to change { Asset.count }.from(0).to(2)
+        expect(Asset.first).to have_attributes(tag: asset_tag_1, serial_number: serial_number_1, model: model_name_1, department: department_name_1, department_id: department_id_1, department_sold_to_id: sold_to_1, location: location_name_1, location_id: location_id_1, location_cc_ship_to_account: ship_to_1, bios_password: bios_password_1, admin_password: admin_password_1, hardware_hash: hardware_hash_1, sys_created_at: Time.zone.parse(sys_created_on_1))
+        expect(Asset.second).to have_attributes(tag: asset_tag_2, serial_number: serial_number_2, model: model_name_2, department: department_name_2, department_id: department_id_2, department_sold_to_id: sold_to_2, location: location_name_2, location_id: location_id_2, location_cc_ship_to_account: ship_to_2, bios_password: bios_password_2, admin_password: admin_password_2, hardware_hash: hardware_hash_2, sys_created_at: Time.zone.parse(sys_created_on_2))
+      end
+    end
+
+    describe 'logging' do
+      let(:filename_regex_suitable_for_string_io_class) { /\.*/ }
+
+      before do
+        allow(Rails.logger).to receive(:info)
+        job.perform_on_file(test_io)
+      end
+
+      it 'logs' do
+        expect(Rails.logger).to have_received(:info).with(/Started ComputacenterHistoricalAssetImportJob for #{filename_regex_suitable_for_string_io_class.source} with 2 asset\(s\)/).ordered
+        expect(Rails.logger).to have_received(:info).with(/Finished ComputacenterHistoricalAssetImportJob for #{filename_regex_suitable_for_string_io_class.source} with 2 asset\(s\) imported/).ordered
+        expect(Rails.logger).to have_received(:info).with('There are now 2 total asset(s) in the database').ordered
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

`ActiveJob` to import a CSV file of assets. This uses an `ActiveJob` because of how long it takes to run. 

### Changes proposed in this pull request

### Guidance to review

