### PR TITLE
Bugfix: Soft-deleted users only visible to support section only

### DIFF
--- a/app/components/support/user_preview_summary_list_component.rb
+++ b/app/components/support/user_preview_summary_list_component.rb
@@ -6,7 +6,7 @@ class Support::UserPreviewSummaryListComponent < ViewComponent::Base
   end
 
   def rows
-    [
+    r = [
       {
         key: 'Email address',
         value: @user.email_address,
@@ -32,6 +32,9 @@ class Support::UserPreviewSummaryListComponent < ViewComponent::Base
         value: can_order_devices_label,
       },
     ]
+
+    r << { key: 'Deleted', value: 'Yes' } if @user.soft_deleted?
+    r
   end
 
 private

--- a/app/controllers/responsible_body/users_controller.rb
+++ b/app/controllers/responsible_body/users_controller.rb
@@ -1,12 +1,12 @@
 class ResponsibleBody::UsersController < ResponsibleBody::BaseController
   def index
-    @users = @responsible_body.users.order(:full_name)
+    @users = @responsible_body.users.not_deleted.order(:full_name)
   end
 
   def show; end
 
   def new
-    @rb_user = @responsible_body.users.build
+    @rb_user = @responsible_body.users.not_deleted.build
   end
 
   def create
@@ -27,11 +27,11 @@ class ResponsibleBody::UsersController < ResponsibleBody::BaseController
   end
 
   def edit
-    @rb_user = @responsible_body.users.find(params[:id])
+    @rb_user = @responsible_body.users.not_deleted.find(params[:id])
   end
 
   def update
-    @rb_user = @responsible_body.users.find(params[:id])
+    @rb_user = @responsible_body.users.not_deleted.find(params[:id])
 
     authorize @rb_user, policy_class: ResponsibleBody::BasePolicy
 

--- a/app/controllers/school/users_controller.rb
+++ b/app/controllers/school/users_controller.rb
@@ -1,6 +1,6 @@
 class School::UsersController < School::BaseController
   def index
-    @users = @school.users.order(:full_name)
+    @users = @school.users.not_deleted.order(:full_name)
   end
 
   def new
@@ -21,11 +21,11 @@ class School::UsersController < School::BaseController
   end
 
   def edit
-    @user = present(@school.users.find(params[:id]))
+    @user = present(@school.users.not_deleted.find(params[:id]))
   end
 
   def update
-    @user = @school.users.find(params[:id])
+    @user = @school.users.not_deleted.find(params[:id])
 
     authorize @user, policy_class: School::BasePolicy
 

--- a/app/controllers/support/responsible_bodies_controller.rb
+++ b/app/controllers/support/responsible_bodies_controller.rb
@@ -14,7 +14,7 @@ class Support::ResponsibleBodiesController < Support::BaseController
   def show
     @responsible_body = ResponsibleBody.find(params[:id])
     @virtual_cap_pools = @responsible_body.virtual_cap_pools.with_std_device_first
-    @users = policy_scope(@responsible_body.users).not_deleted.order('last_signed_in_at desc nulls last, updated_at desc')
+    @users = policy_scope(@responsible_body.users).order('last_signed_in_at desc nulls last, updated_at desc')
     @schools = @responsible_body
       .schools
       .gias_status_open

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -32,7 +32,7 @@ class Support::SchoolsController < Support::BaseController
 
   def show
     @school = School.includes(:responsible_body).where_urn_or_ukprn_or_provision_urn(params[:urn]).first!
-    @users = policy_scope(@school.users).not_deleted
+    @users = policy_scope(@school.users)
     @email_audits = @school.email_audits.order(created_at: :desc)
     @timeline = Timeline::School.new(school: @school)
   end

--- a/spec/components/support/user_preview_summary_list_component_spec.rb
+++ b/spec/components/support/user_preview_summary_list_component_spec.rb
@@ -19,6 +19,10 @@ describe Support::UserPreviewSummaryListComponent do
     expect(result.css('.govuk-summary-list__row')[2].text).to include(user.privacy_notice_seen_at.strftime('%d'))
   end
 
+  it 'does NOT display the Deleted row' do
+    expect(result.css('.govuk-summary-list__row')[6]).to be_nil
+  end
+
   context 'when privacy notice has not been seen' do
     let(:user) do
       build(:school_user, :has_not_seen_privacy_notice, telephone: '12345')
@@ -78,6 +82,17 @@ describe Support::UserPreviewSummaryListComponent do
 
     it 'displays the when the TechSource account was confirmed' do
       expect(result.css('.govuk-summary-list__row')[5].text).to include(user.techsource_account_confirmed_at.strftime('%d'))
+    end
+  end
+
+  context 'soft-deleted user' do
+    let(:user) do
+      build(:school_user, :has_seen_privacy_notice, telephone: '12345', deleted_at: Time.zone.now)
+    end
+
+    it 'displays the user is deleted' do
+      expect(result.css('.govuk-summary-list__row')[6].text).to include('Deleted')
+      expect(result.css('.govuk-summary-list__row')[6].text).to include('Yes')
     end
   end
 end

--- a/spec/features/responsible_body/manage_users_spec.rb
+++ b/spec/features/responsible_body/manage_users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Managing ResponsibleBody users' do
   let!(:rb_user) { create(:local_authority_user, full_name: 'AAA Smith') }
   let!(:rb_user_2) { create(:local_authority_user, full_name: 'ZZZ Jones', responsible_body: rb_user.responsible_body) }
+  let!(:rb_user_3_deleted) { create(:local_authority_user, :deleted, full_name: 'John Doe', responsible_body: rb_user.responsible_body) }
   let(:user_from_other_rb) { create(:trust_user) }
   let(:rb_users_index_page) { PageObjects::ResponsibleBody::UsersPage.new }
   let(:new_rb_user_form) { PageObjects::ResponsibleBody::NewUserPage.new }
@@ -24,6 +25,8 @@ RSpec.feature 'Managing ResponsibleBody users' do
     expect(rb_users_index_page.user_rows.size).to eq(2)
     expect(rb_users_index_page.user_rows[0]).to have_content(rb_user.full_name)
     expect(rb_users_index_page.user_rows[1]).to have_content(rb_user_2.full_name)
+
+    expect(rb_users_index_page).not_to have_content(rb_user_3_deleted.full_name)
   end
 
   it 'shows a link to Invite a new user' do

--- a/spec/features/school/manage_users_spec.rb
+++ b/spec/features/school/manage_users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Manage school users' do
   let(:school_user) { create(:school_user, full_name: 'AAA Smith') }
   let(:user_from_same_school) { create(:school_user, full_name: 'ZZZ Jones', school: school_user.school) }
+  let(:user_from_same_school_deleted) { create(:school_user, :deleted, full_name: 'John Doe', school: school_user.school) }
   let(:new_school_user) { build(:school_user, full_name: 'BBB Brown', school: school_user.school) }
   let(:user_from_other_school) { create(:school_user) }
   let(:school_users_page) { PageObjects::School::UsersPage.new }
@@ -13,6 +14,7 @@ RSpec.feature 'Manage school users' do
     allow(Settings.computacenter.service_now_user_import_api).to receive(:endpoint).and_return(nil)
     user_from_same_school
     user_from_other_school
+    user_from_same_school_deleted
 
     sign_in_as school_user
   end
@@ -75,6 +77,8 @@ RSpec.feature 'Manage school users' do
   def then_i_see_a_list_of_users_for_my_school
     expect(school_users_page.user_rows[0]).to have_content('AAA Smith')
     expect(school_users_page.user_rows[1]).to have_content('ZZZ Jones')
+
+    expect(page).not_to have_content(user_from_same_school_deleted.full_name)
   end
 
   def and_i_dont_see_users_from_other_schools
@@ -145,6 +149,8 @@ RSpec.feature 'Manage school users' do
     expect(school_users_page.user_rows[0]).to have_content('AAA Smith')
     expect(school_users_page.user_rows[1]).to have_content('BBB Brown')
     expect(school_users_page.user_rows[2]).to have_content('ZZZ Jones')
+
+    expect(page).not_to have_content(user_from_same_school_deleted.full_name)
   end
 
   def then_i_see_the_updated_details_for_the_user

--- a/spec/features/support/managing_schools_spec.rb
+++ b/spec/features/support/managing_schools_spec.rb
@@ -125,6 +125,7 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
                     responsible_body: local_authority)
     create(:school_user, school: school, full_name: 'James P. Sullivan', email_address: 'sully@alpha.sch.uk')
     create(:school_user, school: school, full_name: 'Mike Wazowski', email_address: 'mike@alpha.sch.uk', privacy_notice_seen_at: nil)
+    create(:school_user, :deleted, school: school, full_name: 'John Doe', email_address: 'john.doe@alpha.sch.uk')
   end
 
   def and_the_school_is_closed
@@ -181,6 +182,9 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
 
     expect(page).to have_text('Mike Wazowski')
     expect(page).to have_text('mike@alpha.sch.uk')
+
+    expect(page).to have_text('John Doe')
+    expect(page).to have_text('john.doe@alpha.sch.uk')
   end
 
   def then_i_see_that_the_school_is_permanently_closed
@@ -190,6 +194,9 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
   def then_i_see_the_school_users_who_have_seen_the_privacy_policy
     expect(page).to have_text('James P. Sullivan')
     expect(page).to have_text('sully@alpha.sch.uk')
+
+    expect(page).to have_text('John Doe')
+    expect(page).to have_text('john.doe@alpha.sch.uk')
   end
 
   def and_i_dont_see_the_school_users_who_have_not_seen_the_privacy_policy
@@ -227,6 +234,9 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
 
     expect(page).to have_text('Michael Wazowski')
     expect(page).to have_text('mwazowski@alpha.sch.uk')
+
+    expect(page).to have_text('John Doe')
+    expect(page).to have_text('john.doe@alpha.sch.uk')
   end
 
   def then_i_see_error_messages

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -115,6 +115,15 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
            last_signed_in_at: Date.new(2020, 7, 1),
            privacy_notice_seen_at: Date.new(2020, 7, 1),
            responsible_body: local_authority)
+
+    create(:user,
+           :deleted,
+           full_name: 'John Doe',
+           email_address: 'john.doe@coventry.gov.uk',
+           sign_in_count: 1,
+           last_signed_in_at: Date.new(2020, 5, 1),
+           privacy_notice_seen_at: Date.new(2020, 5, 1),
+           responsible_body: local_authority)
   end
 
   def given_a_centrally_managed_responsible_body_with_users
@@ -132,6 +141,15 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
            sign_in_count: 2,
            last_signed_in_at: Date.new(2020, 7, 1),
            privacy_notice_seen_at: Date.new(2020, 7, 1),
+           responsible_body: local_authority_managing_centrally)
+
+    create(:user,
+           :deleted,
+           full_name: 'John Doe',
+           email_address: 'john.doe@coventry.gov.uk',
+           sign_in_count: 1,
+           last_signed_in_at: Date.new(2020, 5, 1),
+           privacy_notice_seen_at: Date.new(2020, 5, 1),
            responsible_body: local_authority_managing_centrally)
   end
 
@@ -304,7 +322,7 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
   end
 
   def then_i_can_see_the_users_assigned_to_that_responsible_body
-    expect(responsible_body_page.users.size).to eq(2)
+    expect(responsible_body_page.users.size).to eq(3)
 
     first_user = responsible_body_page.users[0]
     expect(first_user).to have_text('Zeta Zane')
@@ -313,20 +331,32 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     expect(first_user).to have_text('01 Jul 00:00')
 
     second_user = responsible_body_page.users[1]
-    expect(second_user).to have_text('Amy Adams')
-    expect(second_user).to have_text('amy.adams@coventry.gov.uk')
-    expect(second_user).to have_text('0') # sign-ins
-    expect(second_user).to have_text('Never')
+    expect(second_user).to have_text('John Doe')
+    expect(second_user).to have_text('john.doe@coventry.gov.uk')
+    expect(second_user).to have_text('1') # sign-ins
+    expect(second_user).to have_text('01 May 00:00')
+
+    third_user = responsible_body_page.users[2]
+    expect(third_user).to have_text('Amy Adams')
+    expect(third_user).to have_text('amy.adams@coventry.gov.uk')
+    expect(third_user).to have_text('0') # sign-ins
+    expect(third_user).to have_text('Never')
   end
 
   def then_i_only_see_the_users_assigned_to_that_responsible_body_who_have_seen_the_privacy_notice
-    expect(responsible_body_page.users.size).to eq(1)
+    expect(responsible_body_page.users.size).to eq(2)
 
     first_user = responsible_body_page.users[0]
     expect(first_user).to have_text('Zeta Zane')
     expect(first_user).to have_text('zeta.zane@coventry.gov.uk')
     expect(first_user).to have_text('2') # sign-ins
     expect(first_user).to have_text('01 Jul 00:00')
+
+    first_user = responsible_body_page.users[1]
+    expect(first_user).to have_text('John Doe')
+    expect(first_user).to have_text('john.doe@coventry.gov.uk')
+    expect(first_user).to have_text('1') # sign-ins
+    expect(first_user).to have_text('01 May 00:00')
 
     expect(responsible_body_page).not_to have_text('Amy Adams')
   end

--- a/spec/features/support/viewing_service_performance_spec.rb
+++ b/spec/features/support/viewing_service_performance_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
   end
 
   scenario 'DfE users can query for completions between given dates' do
+    Timecop.freeze
     given_there_are_some_completion_events
 
     when_i_sign_in_as_a_dfe_user
@@ -53,6 +54,7 @@ RSpec.feature 'Viewing service performance', type: :feature do
     and_click_calculate
     then_i_see_the_correct_number
     and_i_see_the_dates_i_entered_in_govuk_format
+    Timecop.return
   end
 
   scenario 'DfE users see service stats about routers' do


### PR DESCRIPTION
Deleted users should only be visible to support section only, normal users shouldn't see any soft-deleted users.

* In support - added extra "Deleted: Yes" row to indicate deleted users for support reasons.


