### PR TITLE
Expose asset routes

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -6,7 +6,7 @@ class AssetsController < ApplicationController
     setting = if current_user.is_responsible_body_user?
                 current_user.responsible_body
               elsif current_user.is_school_user?
-                current_user.schools.first
+                current_user.school
               end
 
     @assets = Asset.owned_by(setting)
@@ -20,10 +20,5 @@ private
   # Use callbacks to share common setup or constraints between actions.
   def set_asset
     @asset = Asset.find(params[:id])
-  end
-
-  # Only allow a list of trusted parameters through.
-  def asset_params
-    params.require(:asset).permit(:tag, :serial_number, :model, :department, :department_id, :department_sold_to_id, :location, :location_id, :location_cc_ship_to_account, :encrypted_bios_password, :encrypted_admin_password, :encrypted_hardware_hash, :first_viewed_at)
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -3,6 +3,8 @@ require 'encryption_service'
 class Asset < ApplicationRecord
   validates :serial_number, :department_sold_to_id, presence: true
 
+  default_scope { order(:location) }
+
   def self.secure_attr_accessor(*attributes)
     attributes.each do |attribute|
       define_method(attribute) do

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,9 +1,9 @@
-<%- title = 'TODO title' %>
+<%- title = 'Assets' %>
 <% content_for :title, title %>
 <% content_for :browser_title, title %>
 
 <%- content_for :before_content do %>
-  <% breadcrumbs([{ "Home" => root_path },
+  <% breadcrumbs([{ 'Home' => root_path },
                   title,
                  ]) %>
 <% end %>
@@ -22,14 +22,14 @@
   </div>
 </div>
 
-<table id="<%= table_id %>" class="govuk-table">
+<table class="govuk-table">
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
     <th class="govuk-table__header app-schools-table__column-20">Serial/IMEI</th>
     <th class="govuk-table__header app-schools-table__column-20">Model</th>
-    <th class="govuk-table__header app-schools-table__column-20">LA</th>
-    <th class="govuk-table__header app-schools-table__column-20">School/college</th>
-    <th class="govuk-table__header app-schools-table__column-20">View your BIOS and admin passwords and hardware hash</th>
+    <th class="govuk-table__header app-schools-table__column-20">Local Authority/Academy Trust</th>
+    <th class="govuk-table__header app-schools-table__column-20">School/College</th>
+    <th class="govuk-table__header app-schools-table__column-20">View your BIOS/admin passwords and hardware hash</th>
   </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/views/assets/show.html.erb
+++ b/app/views/assets/show.html.erb
@@ -1,8 +1,11 @@
-<%- title = 'TODO' -%>
+<%- title = 'Asset BIOS/Admin Password and Hardware Hash' -%>
 <%- content_for :title, title %>
-<%#- content_for :before_content do %>
-  <%#- school_breadcrumbs items: title, school: @school, user: impersonated_or_current_user %>
-<%# end %>
+<%- content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => root_path },
+                  { 'Assets' => assets_path },
+                  title,
+                 ]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,10 +14,9 @@
     </h1>
 
     <div>
-      <h2 class="govuk-heading-l">Asset</h2>
       <div>
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><%= @asset.serial_number %></h3>
-        <%= render SummaryListComponent.new(rows: { bios_password: @asset.bios_password, admin_password: @asset.admin_password, hardware_hash: @asset.hardware_hash } ) %>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Asset <%= @asset.serial_number %></h2>
+        <%= render SummaryListComponent.new(rows: { 'Asset Tag' => @asset.tag, 'Serial/IMEI' => @asset.serial_number, 'BIOS Password' => @asset.bios_password, 'Admin Password' => @asset.admin_password, 'Hardware Hash' => @asset.hardware_hash } ) %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,7 @@ Rails.application.routes.draw do
   get '/cookie-preferences', to: 'cookie_preferences#new', as: 'cookie_preferences'
   post '/cookie-preferences', to: 'cookie_preferences#create', as: 'create_cookie_preferences'
 
-  # reinstate later
-  # resources :assets, only: %i[show index]
+  resources :assets, only: %i[show index]
 
   resources :sessions, only: %i[create destroy]
 

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -1,32 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe AssetsController do
-  xdescribe '#index' do
+  describe '#index' do
+    before { allow(Asset).to receive(:owned_by) }
+
     context 'school A' do
       let(:school_a) { create(:school) }
-      let(:school_b) { create(:school) }
       let(:school_a_user) { create(:school_user, schools: [school_a]) }
-      let(:school_a_asset1) { create(:asset, location_id: school_a.id) }
-      let(:school_a_asset2) { create(:asset, location_id: school_a.id) }
-      let(:school_b_asset) { create(:asset, location_id: school_b.id) }
 
       before { sign_in_as school_a_user }
 
       it 'shows index of assets belonging to that school' do
         get :index
         expect(response).to be_successful
-        expect(assigns(:assets)).to contain_exactly(school_a_asset1, school_a_asset2)
-        expect(assigns(:assets)).not_to include(school_b_asset)
+        expect(Asset).to have_received(:owned_by).with(school_a)
+        expect(response).to render_template(:index)
       end
     end
 
     context 'RB A' do
       let(:rb_a) { create(:local_authority) }
-      let(:rb_b) { create(:local_authority) }
       let(:rb_a_user) { create(:local_authority_user) }
-      let(:rb_a_asset1) { create(:asset, department_sold_to_id: rb_a.id) }
-      let(:rb_a_asset2) { create(:asset, department_sold_to_id: rb_a.id) }
-      let(:rb_b_asset) { create(:asset, department_sold_to_id: rb_b.id) }
 
       before do
         rb_a.users = [rb_a_user]
@@ -36,13 +30,13 @@ RSpec.describe AssetsController do
       it 'shows index of assets belonging to that RB' do
         get :index
         expect(response).to be_successful
-        expect(assigns(:assets)).to contain_exactly(rb_a_asset1, rb_a_asset2)
-        expect(assigns(:assets)).not_to include(rb_b_asset)
+        expect(Asset).to have_received(:owned_by).with(rb_a)
+        expect(response).to render_template(:index)
       end
     end
   end
 
-  xdescribe '#show' do
+  describe '#show' do
     let(:asset) { create(:asset) }
 
     before { get :show, params: { id: asset.id } }


### PR DESCRIPTION
### Context

Expose `Asset` `index` and `show` views so they can be tested on `staging` and potentially `prod`.

### Changes proposed in this pull request

Some specs for the controller were already out of date, and are already covered by the specs for `Asset.owned_by`, so I changed them just to check it calls `Asset.owned_by`.

### Guidance to review

