### PR TITLE
2309 record asset view

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -13,7 +13,9 @@ class AssetsController < ApplicationController
   end
 
   # GET /assets/1
-  def show; end
+  def show
+    @asset.update!(first_viewed_at: Time.zone.now) unless @asset.viewed?
+  end
 
 private
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,6 +34,10 @@ class Asset < ApplicationRecord
     end
   }
 
+  def viewed?
+    first_viewed_at.present?
+  end
+
   def ==(other)
     self.class == other.class && tag == other.tag && serial_number == other.serial_number
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -173,4 +173,20 @@ RSpec.describe Asset, type: :model do
       it { is_expected.not_to eq(other_asset) }
     end
   end
+
+  describe '#viewed?' do
+    let(:asset) { build(:asset) }
+
+    context 'viewed' do
+      before { asset.first_viewed_at = 1.day.ago }
+
+      specify { expect(asset).to be_viewed }
+    end
+
+    context 'never viewed' do
+      before { asset.first_viewed_at = nil }
+
+      specify { expect(asset).not_to be_viewed }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Records when an asset has first been shown (which acts a proxy for a DfE statistic.)

https://trello.com/c/01Tm1uXh

### Changes proposed in this pull request

Records first time an asset's `show` view has been called.

### Guidance to review

