### PR TITLE
2315: change school responsible body

### DIFF
--- a/app/components/support/school_details_summary_list_component.rb
+++ b/app/components/support/school_details_summary_list_component.rb
@@ -1,6 +1,8 @@
 class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetailsSummaryListComponent
   def rows
     array = super
+
+    array.prepend responsible_body_row if SchoolPolicy.new(viewer, @school).update_responsible_body?
     array.prepend school_name_editable_row if SchoolPolicy.new(viewer, @school).update_name?
     array << headteacher_row if headteacher.present?
     array.map { |row| remove_change_links_if_read_only(row) }
@@ -15,6 +17,15 @@ class Support::SchoolDetailsSummaryListComponent < ResponsibleBody::SchoolDetail
   end
 
 private
+
+  def responsible_body_row
+    {
+      key: 'Responsible Body',
+      value: @school.responsible_body.name,
+      action_path: edit_support_school_responsible_body_path(@school),
+      action: 'Change <span class="govuk-visually-hidden">responsible body</span>'.html_safe,
+    }
+  end
 
   def sold_to_row
     {

--- a/app/controllers/support/schools/responsible_body_controller.rb
+++ b/app/controllers/support/schools/responsible_body_controller.rb
@@ -1,0 +1,61 @@
+class Support::Schools::ResponsibleBodyController < Support::BaseController
+  before_action :set_school
+  before_action :redirect_if_same_responsible_body, only: %i[update]
+
+  attr_reader :school
+
+  def edit
+    @responsible_body = @school.responsible_body
+    @form = Support::School::ChangeResponsibleBodyForm.new(school: school)
+  end
+
+  def update
+    if Support::School::ChangeResponsibleBodyForm.new(school: school, responsible_body_id: new_responsible_body_id).save
+      flash[:success] = success_message
+    else
+      flash[:warning] = error_message
+    end
+
+    redirect_to support_school_path(school)
+  end
+
+private
+
+  def error_message
+    "#{school.name} could not be associated with #{school.responsible_body_name}!"
+  end
+
+  def no_change_message
+    "Responsible body not changed for #{school.name}"
+  end
+
+  def new_responsible_body_id
+    responsible_body_params[:responsible_body_id]
+  end
+
+  def same_responsible_body?
+    new_responsible_body_id.to_s == school.responsible_body_id.to_s
+  end
+
+  def success_message
+    "#{school.name} is now associated with #{school.responsible_body_name}"
+  end
+
+  # Filters
+  def redirect_if_same_responsible_body
+    if same_responsible_body?
+      flash[:info] = no_change_message
+      redirect_to support_school_path(school)
+    end
+  end
+
+  def set_school
+    @school = School.gias_status_open.find_by_urn(params[:school_urn])
+    authorize school, :update_responsible_body?
+  end
+
+  # Params
+  def responsible_body_params
+    params.require(:support_school_change_responsible_body_form).permit(:responsible_body_id)
+  end
+end

--- a/app/form_objects/support/school/change_responsible_body_form.rb
+++ b/app/form_objects/support/school/change_responsible_body_form.rb
@@ -1,0 +1,33 @@
+class Support::School::ChangeResponsibleBodyForm
+  include ActiveModel::Model
+
+  attr_accessor :school
+  attr_writer :responsible_body_id, :responsible_body
+
+  validates :school, presence: true
+  validates :responsible_body, presence: true
+
+  def responsible_body_id
+    @responsible_body_id || school&.responsible_body_id
+  end
+
+  def responsible_body
+    @responsible_body ||= ResponsibleBody.find_by_id(responsible_body_id)
+  end
+
+  def responsible_body_options
+    @responsible_body_options ||= responsible_bodies.map do |id, name|
+      OpenStruct.new(id: id, name: name)
+    end
+  end
+
+  def save
+    valid? && ChangeSchoolResponsibleBodyService.new(school, responsible_body_id).call
+  end
+
+private
+
+  def responsible_bodies
+    ResponsibleBody.gias_status_open.order(type: :asc, name: :asc).pluck(:id, :name)
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -70,6 +70,8 @@ class School < ApplicationRecord
     gias_status_open.where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
   end
 
+  delegate :name, to: :responsible_body, prefix: true, allow_nil: true
+
   def ukprn_or_urn
     ukprn || urn
   end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -26,4 +26,8 @@ class SchoolPolicy < SupportPolicy
   def update_name?
     user.third_line_role?
   end
+
+  def update_responsible_body?
+    user.is_support? && user.third_line_role?
+  end
 end

--- a/app/services/change_school_responsible_body_service.rb
+++ b/app/services/change_school_responsible_body_service.rb
@@ -1,0 +1,44 @@
+class ChangeSchoolResponsibleBodyService
+  attr_reader :school, :new_responsible_body_id
+
+  COMPUTACENTER_CHANGE_STATUS = 'amended'.freeze
+
+  def initialize(school, new_responsible_body_id)
+    @school = school
+    @new_responsible_body_id = new_responsible_body_id
+  end
+
+  def call
+    change_responsible_body!
+    true
+  rescue StandardError => e
+    log_error(e)
+    false
+  end
+
+private
+
+  def change_responsible_body!
+    school.transaction do
+      update_school!
+      update_preorder_information!
+    end
+  end
+
+  def log_error(e)
+    school.errors.add(:base, e.message)
+    Rails.logger.error(e.message)
+    Sentry.capture_exception(e)
+  end
+
+  def update_preorder_information!
+    school.preorder_information.refresh_status!
+  end
+
+  def update_school!
+    school.update!(
+      responsible_body_id: new_responsible_body_id,
+      computacenter_change: COMPUTACENTER_CHANGE_STATUS,
+    )
+  end
+end

--- a/app/views/support/schools/responsible_body/edit.html.erb
+++ b/app/views/support/schools/responsible_body/edit.html.erb
@@ -1,0 +1,24 @@
+<%- title = t('page_titles.support.schools.responsible_body.edit') %>
+<% content_for :title, title %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_school_path(@school)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: support_school_responsible_body_path(@school), method: :patch do |f| %>
+      <%= f.govuk_collection_select(
+            :responsible_body_id,
+            @form.responsible_body_options,
+            :id,
+            :name,
+            label: { text: 'New responsible body' },
+            data: { autocomplete_rb: true }
+          ) %>
+      <%= f.govuk_submit 'Update' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,8 @@ en:
         home: Schools, colleges and FE institutions
         opt_outs:
           edit: Change communication preference
+        responsible_body:
+          edit: Update responsible body
       technical_support: Technical support
       feature_flags: Feature flags
       zendesk_statistics: Zendesk statistics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,6 +257,7 @@ Rails.application.routes.draw do
 
       scope module: 'schools' do
         resource :opt_out, only: %i[edit update], path: 'opt-out'
+        resource :responsible_body, only: %i[edit update], path: 'responsible-body', controller: :responsible_body
       end
 
       collection do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -17,6 +17,10 @@ describe Support::SchoolDetailsSummaryListComponent do
     expect(row_for_key(result, 'Name')).to be_nil
   end
 
+  it 'does not show school responsible body' do
+    expect(row_for_key(result, 'Responsible Body')).to be_nil
+  end
+
   context 'when third line support user' do
     let(:support_user) { build(:support_user, :third_line) }
 
@@ -26,6 +30,14 @@ describe Support::SchoolDetailsSummaryListComponent do
 
     it 'shows change link for school name' do
       expect(action_for_row(result, 'Name').text).to include('Change school name')
+    end
+
+    it 'shows school responsible body' do
+      expect(value_for_row(result, 'Responsible Body').text).to include(school.responsible_body_name)
+    end
+
+    it 'shows change link for school responsible body' do
+      expect(action_for_row(result, 'Responsible Body').text).to include('Change responsible body')
     end
   end
 

--- a/spec/controllers/support/schools/responsible_body_controller_spec.rb
+++ b/spec/controllers/support/schools/responsible_body_controller_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Support::Schools::ResponsibleBodyController, type: :controller do
+  let(:non_support_third_line_user) { create(:user, is_support: true, role: 'no') }
+  let(:support_third_line_user) { create(:support_user, :third_line) }
+  let!(:school) { create(:school) }
+
+  describe '#edit' do
+    context 'non support third line users' do
+      before { sign_in_as non_support_third_line_user }
+
+      specify do
+        expect { get :edit, params: { school_urn: school.urn } }.to be_forbidden_for(non_support_third_line_user)
+      end
+    end
+
+    context 'support third line users' do
+      before do
+        sign_in_as support_third_line_user
+        get :edit, params: { school_urn: school.urn }
+      end
+
+      specify { expect(response).to be_successful }
+
+      it 'exposes a form to change the responsible body of the school' do
+        expect(assigns(:form)).to be_a(Support::School::ChangeResponsibleBodyForm)
+        expect(assigns(:form).school).to eq(school)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:params) do
+      {
+        school_urn: school.urn,
+        support_school_change_responsible_body_form: {
+          responsible_body_id: responsible_body_id,
+        },
+      }
+    end
+
+    context 'non support third line users' do
+      let(:responsible_body_id) { school.responsible_body_id.next }
+
+      before { sign_in_as non_support_third_line_user }
+
+      specify do
+        expect { patch :update, params: params }.to be_forbidden_for(non_support_third_line_user)
+      end
+    end
+
+    context 'support third line users' do
+      context 'same responsible body' do
+        let(:responsible_body_id) { school.responsible_body_id }
+
+        before do
+          sign_in_as support_third_line_user
+          patch :update, params: params
+        end
+
+        it 'redirects back to school' do
+          expect(response).to redirect_to(support_school_path(school))
+        end
+
+        it 'inform the user about the school responsible body not changed' do
+          expect(flash[:info]).to eq("Responsible body not changed for #{school.name}")
+        end
+      end
+
+      context 'when the responsible body cannot be changed for some reason' do
+        let(:new_responsible_body) { create(:trust) }
+        let(:responsible_body_id) { new_responsible_body.id }
+
+        before do
+          sign_in_as support_third_line_user
+          patch :update, params: params
+        end
+
+        it 'redirects back to school' do
+          expect(response).to redirect_to(support_school_path(school))
+        end
+
+        it 'warns the user about the school responsible body not changed' do
+          expect(flash[:warning]).to eq("#{school.name} could not be associated with #{new_responsible_body.name}!")
+        end
+      end
+
+      context 'when the responsible body can be changed' do
+        let(:new_responsible_body) { create(:trust) }
+        let(:responsible_body_id) { new_responsible_body.id }
+
+        before do
+          create(:preorder_information, school: school)
+          sign_in_as support_third_line_user
+          patch :update, params: params
+        end
+
+        it 'redirects back to school' do
+          expect(response).to redirect_to(support_school_path(school))
+        end
+
+        it 'shows a successful change message to the user' do
+          expect(flash[:success]).to eq("#{school.name} is now associated with #{new_responsible_body.name}")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/schools/change_responsible_body_spec.rb
+++ b/spec/features/support/schools/change_responsible_body_spec.rb
@@ -53,21 +53,20 @@ private
   end
 
   def expect_responsible_body_change_failed_banner(school_name)
-    expect(page).to have_selector(
-      '.app-banner--warning',
-      text: "#{school_name} could not be associated with Lancashire!",
-    )
+    expect_school_page_with_banner(:warning, "#{school_name} could not be associated with Lancashire!")
   end
 
   def expect_responsible_body_changed_banner(school_name)
-    expect(page).to have_selector(
-      '.app-banner--success',
-      text: "#{school_name} is now associated with Lancashire",
-    )
+    expect_school_page_with_banner(:success, "#{school_name} is now associated with Lancashire")
   end
 
   def expect_responsible_body_not_changed_banner(school_name)
-    expect(page).to have_selector('.app-banner--info', text: "Responsible body not changed for #{school_name}")
+    expect_school_page_with_banner(:info, "Responsible body not changed for #{school_name}")
+  end
+
+  def expect_school_page_with_banner(type, text)
+    expect(school_page).to be_displayed
+    expect(page).to have_selector(".app-banner--#{type}", text: text)
   end
 
   def select_responsible_body(name)

--- a/spec/features/support/schools/change_responsible_body_spec.rb
+++ b/spec/features/support/schools/change_responsible_body_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Updating school responsible body' do
   let(:support_third_line_user) { create(:support_user, :third_line) }
   let(:school) { create(:school) }
   let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+  let(:edit_page) { PageObjects::Support::School::ResponsibleBody::EditPage.new }
 
   scenario 'non support third line users cant change a school responsible body' do
     sign_in_as non_support_third_line_user
@@ -17,6 +18,7 @@ RSpec.feature 'Updating school responsible body' do
     sign_in_as support_third_line_user
 
     visit support_school_path(school.urn)
+    go_to_edit_responsible_body(school)
     select_responsible_body(school.responsible_body_name)
 
     expect_responsible_body_not_changed_banner(school.name)
@@ -28,6 +30,7 @@ RSpec.feature 'Updating school responsible body' do
     sign_in_as support_third_line_user
 
     visit support_school_path(school.urn)
+    go_to_edit_responsible_body(school)
     select_responsible_body('Lancashire')
 
     expect_responsible_body_change_failed_banner(school.name)
@@ -40,6 +43,7 @@ RSpec.feature 'Updating school responsible body' do
     sign_in_as support_third_line_user
 
     visit support_school_path(school.urn)
+    go_to_edit_responsible_body(school)
     select_responsible_body('Lancashire')
 
     expect_responsible_body_changed_banner(school.name)
@@ -69,8 +73,17 @@ private
     expect(page).to have_selector(".app-banner--#{type}", text: text)
   end
 
-  def select_responsible_body(name)
+  def go_to_edit_responsible_body(school)
     school_page.school_details['Responsible Body'].follow_action_link
+    expect(edit_page).to be_displayed
+    expect(edit_page).to have_school_name_header(text: school.name)
+    expect(edit_page).to have_new_responsible_body_selector_label(text: 'New responsible body')
+    expect(edit_page).to have_new_responsible_body_selector
+    expect(edit_page.new_responsible_body_selector.value).to eq(school.responsible_body_id.to_s)
+    expect(edit_page).to have_submit(text: 'Update')
+  end
+
+  def select_responsible_body(name)
     select(name, from: 'support-school-change-responsible-body-form-responsible-body-id-field')
     click_on('Update')
   end

--- a/spec/features/support/schools/change_responsible_body_spec.rb
+++ b/spec/features/support/schools/change_responsible_body_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.feature 'Updating school responsible body' do
+  let(:non_support_third_line_user) { create(:support_user) }
+  let(:support_third_line_user) { create(:support_user, :third_line) }
+  let(:school) { create(:school) }
+  let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+
+  scenario 'non support third line users cant change a school responsible body' do
+    sign_in_as non_support_third_line_user
+
+    visit support_school_path(school.urn)
+    expect_no_responsible_body_row
+  end
+
+  scenario 'set same responsible body' do
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    select_responsible_body(school.responsible_body_name)
+
+    expect_responsible_body_not_changed_banner(school.name)
+  end
+
+  scenario 'failed to set a new responsible body' do
+    create(:trust, name: 'Lancashire')
+
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    select_responsible_body('Lancashire')
+
+    expect_responsible_body_change_failed_banner(school.name)
+  end
+
+  scenario 'successfully set a new responsible body' do
+    school = create(:school, :with_preorder_information)
+    create(:trust, name: 'Lancashire')
+
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    select_responsible_body('Lancashire')
+
+    expect_responsible_body_changed_banner(school.name)
+  end
+
+private
+
+  def expect_no_responsible_body_row
+    expect(school_page).to be_displayed
+    expect(school_page.school_details['Responsible Body']).to be_blank
+  end
+
+  def expect_responsible_body_change_failed_banner(school_name)
+    expect(page).to have_selector(
+      '.app-banner--warning',
+      text: "#{school_name} could not be associated with Lancashire!",
+    )
+  end
+
+  def expect_responsible_body_changed_banner(school_name)
+    expect(page).to have_selector(
+      '.app-banner--success',
+      text: "#{school_name} is now associated with Lancashire",
+    )
+  end
+
+  def expect_responsible_body_not_changed_banner(school_name)
+    expect(page).to have_selector('.app-banner--info', text: "Responsible body not changed for #{school_name}")
+  end
+
+  def select_responsible_body(name)
+    school_page.school_details['Responsible Body'].follow_action_link
+    select(name, from: 'support-school-change-responsible-body-form-responsible-body-id-field')
+    click_on('Update')
+  end
+end

--- a/spec/form_objects/support/school/change_responsible_body_form_spec.rb
+++ b/spec/form_objects/support/school/change_responsible_body_form_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
+  it { is_expected.to validate_presence_of(:school) }
+  it { is_expected.to validate_presence_of(:responsible_body) }
+
+  describe '#responsible_body_id' do
+    let(:school) { build_stubbed(:school) }
+    let(:responsible_body_id) { school.responsible_body_id.next }
+
+    context 'when a new responsible_body_id is given at initialization time' do
+      subject(:form) { described_class.new(school: school, responsible_body_id: responsible_body_id) }
+
+      it 'return the new responsible_body_id' do
+        expect(form.responsible_body_id).to eq(responsible_body_id)
+      end
+    end
+
+    context 'when a new responsible_body_id is not given at initialization time' do
+      subject(:form) { described_class.new(school: school) }
+
+      it 'return the given school responsible_body_id' do
+        expect(form.responsible_body_id).to eq(school.responsible_body_id)
+      end
+    end
+  end
+
+  describe '#responsible_body' do
+    let(:school) { create(:school) }
+
+    context 'when a new responsible_body_id is given at initialization time' do
+      let(:new_responsible_body) { create(:trust) }
+
+      subject(:form) { described_class.new(school: school, responsible_body_id: new_responsible_body.id) }
+
+      it 'return the new responsible_body' do
+        expect(form.responsible_body).to eq(new_responsible_body)
+      end
+    end
+
+    context 'when a new responsible_body_id is not given at initialization time' do
+      subject(:form) { described_class.new(school: school) }
+
+      it 'return the given school responsible_body' do
+        expect(form.responsible_body).to eq(school.responsible_body)
+      end
+    end
+  end
+
+  describe '#responsible_body_options' do
+    subject(:form) { described_class.new }
+
+    let!(:open_rbs) { create_list(:trust, 2) }
+
+    before do
+      create_list(:trust, 2, status: :closed)
+    end
+
+    it 'return a list of objects from the existing open responsible bodies including their id and name' do
+      expect(form.responsible_body_options.map(&:id)).to match_array(open_rbs.map(&:id))
+      expect(form.responsible_body_options.map(&:name)).to match_array(open_rbs.map(&:name))
+    end
+  end
+
+  describe '#save' do
+    context 'when the form is not valid' do
+      let(:school) { create(:school) }
+      let(:responsible_body_id) { school.responsible_body_id }
+
+      subject(:form) { described_class.new(school: school, responsible_body_id: responsible_body_id.next) }
+
+      it 'return false' do
+        expect(form.save).to be_falsey
+      end
+
+      it 'do not change the school responsible body' do
+        expect(school.reload.responsible_body_id).to eq(responsible_body_id)
+      end
+    end
+
+    context 'when the form is valid' do
+      let(:school) { create(:school, :with_preorder_information) }
+      let(:new_responsible_body_id) { create(:trust).id }
+
+      subject(:form) { described_class.new(school: school, responsible_body_id: new_responsible_body_id) }
+
+      it 'return true' do
+        expect(form.save).to be_truthy
+      end
+
+      it 'change the school responsible body' do
+        change_rb = instance_spy(ChangeSchoolResponsibleBodyService, call: true)
+        allow(ChangeSchoolResponsibleBodyService).to receive(:new).with(school, new_responsible_body_id) { change_rb }
+
+        expect(form.save).to be_truthy
+        expect(change_rb).to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/schools/responsible_body/edit_page.rb
+++ b/spec/page_objects/support/schools/responsible_body/edit_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Support
+    module School
+      module ResponsibleBody
+        class EditPage < PageObjects::BasePage
+          set_url '/support/schools/{urn}/responsible-body/edit'
+
+          element :school_name_header, 'h1.govuk-heading-xl span.govuk-caption-xl'
+
+          element :new_responsible_body_selector_label, 'form#new_support_school_change_responsible_body_form label[for=support-school-change-responsible-body-form-responsible-body-id-field]'
+          element :new_responsible_body_selector, 'select#support-school-change-responsible-body-form-responsible-body-id-field'
+
+          element :submit, 'button[type=submit]'
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -3,33 +3,53 @@ require 'rails_helper'
 describe SchoolPolicy do
   subject(:policy) { described_class }
 
+  let(:school) { build(:school) }
+  let(:computacenter_user) { build_stubbed(:computacenter_user) }
+  let(:support_user) { build_stubbed(:support_user) }
+  let(:non_support_user) { build_stubbed(:user, is_support: false) }
+  let(:third_line_user) { build_stubbed(:support_user, :third_line) }
+
   permissions :invite?, :confirm_invitation? do
     it 'grants access to support users' do
-      expect(policy).to permit(build(:support_user), :support)
+      expect(policy).to permit(support_user, school)
     end
 
     it 'blocks access to Computacenter users' do
-      expect(policy).not_to permit(build(:computacenter_user), :support)
+      expect(policy).not_to permit(computacenter_user, school)
     end
   end
 
   permissions :search?, :results? do
     it 'grants access to support users' do
-      expect(policy).to permit(build(:support_user), :support)
+      expect(policy).to permit(support_user, school)
     end
 
     it 'grants access to Computacenter users' do
-      expect(policy).to permit(build(:computacenter_user), :support)
+      expect(policy).to permit(computacenter_user, school)
     end
   end
 
   permissions :update_computacenter_reference? do
     it 'blocks access to support users' do
-      expect(policy).not_to permit(build(:support_user), :support)
+      expect(policy).not_to permit(support_user, school)
     end
 
     it 'grants access to Computacenter users' do
-      expect(policy).to permit(build(:computacenter_user), :support)
+      expect(policy).to permit(computacenter_user, school)
+    end
+  end
+
+  permissions :update_responsible_body? do
+    it 'block access to non support users' do
+      expect(policy).not_to permit(non_support_user, school)
+    end
+
+    it 'block access to non support third line users' do
+      expect(policy).not_to permit(support_user, school)
+    end
+
+    it 'grants access to support third line users' do
+      expect(policy).to permit(third_line_user, school)
     end
   end
 end

--- a/spec/services/change_school_responsible_body_service_spec.rb
+++ b/spec/services/change_school_responsible_body_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe ChangeSchoolResponsibleBodyService, type: :model do
+  let(:service) { described_class.new(school, new_responsible_body_id) }
+  let(:new_responsible_body_id) { create(:local_authority).id }
+
+  describe '#call' do
+    context 'when the school cannot be updated for some reason' do
+      let(:school) { create(:school, :with_preorder_information) }
+
+      it 'do not change the school responsible body' do
+        expect {
+          school.name = nil
+          service.call
+        }.not_to(change { school.reload.responsible_body_id })
+      end
+
+      it 'do not change the school preorder information' do
+        expect {
+          school.name = nil
+          service.call
+        }.not_to(change { school.reload.preorder_information })
+      end
+    end
+
+    context 'when the school preorder information cannot be refreshed for some reason' do
+      let(:school) { create(:school) }
+
+      it 'do not change the school responsible body' do
+        expect {
+          service.call
+        }.not_to(change { school.reload.responsible_body_id })
+      end
+
+      it 'do not change the school preorder information' do
+        expect {
+          service.call
+        }.not_to(change { school.reload.preorder_information })
+      end
+    end
+
+    context 'success' do
+      let(:school) { create(:school, :with_preorder_information) }
+
+      it 'update the school responsible body' do
+        expect {
+          service.call
+        }.to(change { school.reload.responsible_body_id })
+      end
+
+      it 'refresh the school preorder information' do
+        preorder_information = instance_spy(PreorderInformation, refresh_status!: true)
+        allow(school).to receive(:preorder_information).and_return(preorder_information)
+
+        service.call
+
+        expect(preorder_information).to have_received(:refresh_status!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Support third line users need to be able to manually move a school to a new Responsability Body. 

### Changes proposed in this pull request
Add a row in the school show details view displaying the school current responsability body and a cta to change it.

### Guidance to review 
User story: [GIAS - Move school to a new RB (RFQ-11)](https://trello.com/c/AyCdWd53)
