### PR TITLE
Change to return no assets instead of raising error

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -30,7 +30,7 @@ class Asset < ApplicationRecord
 
       where(department_sold_to_id: rb_cc_reference).or(where(location_cc_ship_to_account: self_managing_school_cc_references))
     else
-      raise 'unknown educational setting type'
+      Asset.none
     end
   }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -150,6 +150,10 @@ RSpec.describe Asset, type: :model do
 
       specify { expect(Asset.owned_by(rb)).to contain_exactly(rb_asset_1, rb_asset_2, rb_school_asset) }
     end
+
+    context 'neither RB nor school' do
+      specify { expect(Asset.owned_by(nil)).to eq(Asset.none) }
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
### Context

Was raising an error if user didn't represent a school or an RB. 

https://trello.com/c/QGIOpJhU

### Changes proposed in this pull request

Now it just returns the empty relation `Asset.none` to be safe.

### Guidance to review

