### PR TITLE
2210: update school headteacher

### DIFF
--- a/app/controllers/support/schools/headteacher_controller.rb
+++ b/app/controllers/support/schools/headteacher_controller.rb
@@ -1,0 +1,54 @@
+class Support::Schools::HeadteacherController < Support::BaseController
+  before_action :set_school
+
+  attr_reader :form, :school
+
+  def edit
+    @form = Support::School::ChangeHeadteacherForm.new(school: school, **contact_details)
+  end
+
+  def update
+    @form = Support::School::ChangeHeadteacherForm.new(school: school, **headteacher_params)
+    if form.save
+      flash[:success] = success_message
+      redirect_to support_school_path(school)
+    else
+      render(:edit)
+    end
+  end
+
+private
+
+  def contact_details
+    contact = school.headteacher_contact || school.contacts.first
+    {
+      email_address: contact&.email_address,
+      full_name: contact&.full_name,
+      id: contact&.id,
+      phone_number: contact&.phone_number,
+      role: contact&.role,
+      title: contact&.title,
+    }
+  end
+
+  def success_message
+    "#{school.name}'s headteacher details updated"
+  end
+
+  # Filters
+  def set_school
+    @school = School.gias_status_open.find_by_urn(params[:school_urn])
+    authorize school, :update_headteacher?
+  end
+
+  # Params
+  def headteacher_params
+    @headteacher_params ||= params.require(:support_school_change_headteacher_form).permit(
+      :email_address,
+      :full_name,
+      :id,
+      :phone_number,
+      :title,
+    ).to_h
+  end
+end

--- a/app/form_objects/support/school/change_headteacher_form.rb
+++ b/app/form_objects/support/school/change_headteacher_form.rb
@@ -1,0 +1,34 @@
+class Support::School::ChangeHeadteacherForm
+  include ActiveModel::Model
+
+  attr_accessor :email_address, :full_name, :id, :phone_number, :role, :school, :title
+
+  def headteacher?
+    role == 'headteacher'
+  end
+
+  def save
+    updated_headteacher.errors.empty? || save_error
+  end
+
+private
+
+  def updated_headteacher
+    @headteacher ||= ChangeSchoolHeadteacherService.new(school, **headteacher_details).call
+  end
+
+  def headteacher_details
+    {
+      email_address: email_address,
+      full_name: full_name,
+      id: id.presence,
+      phone_number: phone_number.presence,
+      title: title.presence,
+    }.compact
+  end
+
+  def save_error
+    errors.copy!(updated_headteacher.errors)
+    false
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -153,7 +153,7 @@ class School < ApplicationRecord
   end
 
   def headteacher_contact
-    contacts.find_by(role: :headteacher)
+    contacts.headteacher.first
   end
 
   def current_contact

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -9,25 +9,21 @@ class SchoolPolicy < SupportPolicy
     end
   end
 
+  def support_third_line_editable?
+    user.is_support? && user.third_line_role?
+  end
+
   alias_method :search?, :readable?
   alias_method :results?, :readable?
   alias_method :invite?, :editable?
   alias_method :confirm_invitation?, :editable?
   alias_method :history?, :editable?
+  alias_method :update_address?, :support_third_line_editable?
+  alias_method :update_headteacher?, :support_third_line_editable?
+  alias_method :update_name?, :support_third_line_editable?
+  alias_method :update_responsible_body?, :support_third_line_editable?
 
   def update_computacenter_reference?
     user.is_computacenter?
-  end
-
-  def update_address?
-    user.third_line_role?
-  end
-
-  def update_name?
-    user.third_line_role?
-  end
-
-  def update_responsible_body?
-    user.is_support? && user.third_line_role?
   end
 end

--- a/app/services/change_school_headteacher_service.rb
+++ b/app/services/change_school_headteacher_service.rb
@@ -1,0 +1,22 @@
+class ChangeSchoolHeadteacherService
+  attr_reader :school, :details
+
+  def initialize(school, **details)
+    @school = school
+    @details = details
+  end
+
+  def call
+    attributes = details.except(:id).merge!(role: :headteacher)
+    headteacher_id = details[:id] if valid_id?
+    SchoolContact.find_or_initialize_by(school_id: school.id, id: headteacher_id).tap do |headteacher|
+      headteacher.update(attributes)
+    end
+  end
+
+private
+
+  def valid_id?
+    school.contacts.exists?(id: details[:id])
+  end
+end

--- a/app/views/support/schools/headteacher/edit.html.erb
+++ b/app/views/support/schools/headteacher/edit.html.erb
@@ -1,0 +1,33 @@
+<%- title = t('page_titles.support.schools.headteacher.edit') %>
+<% content_for :title, title %>
+<%- content_for :before_content, govuk_back_link(text: 'Back', href: support_school_path(@school)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <%= title %>
+    </h1>
+
+    <%= form_for @form, url: support_school_headteacher_path(@school), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.hidden_field :id %>
+
+      <%= f.govuk_text_field :title,
+        label: { text: 'Title', size: 's' } %>
+
+      <%= f.govuk_text_field :full_name,
+        label: { text: 'Full name', size: 's' } %>
+
+      <%= f.govuk_email_field :email_address,
+        label: { text: 'Email address', size: 's' } %>
+
+      <%= f.govuk_text_field :phone_number,
+        width: 10,
+        label: { text: 'Telephone number', size: 's' } %>
+
+      <%= f.govuk_submit @form.headteacher? ? 'Update' : 'Set as headteacher', warning: true %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,8 @@ en:
         home: Schools, colleges and FE institutions
         opt_outs:
           edit: Change communication preference
+        headteacher:
+          edit: Update headteacher
         responsible_body:
           edit: Update responsible body
       technical_support: Technical support
@@ -637,6 +639,15 @@ en:
           attributes:
             name_or_urn_or_ukprn:
               too_short: Enter a school name that is at least %{count} characters
+        support/school/change_headteacher_form:
+          attributes:
+            email_address:
+              blank: Enter an email address in the correct format, like name@example.com
+              taken: Email address has already been used
+              invalid: Enter an email address in the correct format, like name@example.com
+            full_name:
+              blank: Enter the headteacher’s full name
+              length: Enter a name that is between 2 and 1024 characters
         school_search_form:
           attributes:
             search_type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Rails.application.routes.draw do
       scope module: 'schools' do
         resource :opt_out, only: %i[edit update], path: 'opt-out'
         resource :responsible_body, only: %i[edit update], path: 'responsible-body', controller: :responsible_body
+        resource :headteacher, only: %i[edit update], controller: :headteacher
       end
 
       collection do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -21,6 +21,10 @@ describe Support::SchoolDetailsSummaryListComponent do
     expect(row_for_key(result, 'Responsible Body')).to be_nil
   end
 
+  it 'does not show change link for headteacher' do
+    expect(action_for_row(result, 'Headteacher')).to be_nil
+  end
+
   context 'when third line support user' do
     let(:support_user) { build(:support_user, :third_line) }
 
@@ -38,6 +42,10 @@ describe Support::SchoolDetailsSummaryListComponent do
 
     it 'shows change link for school responsible body' do
       expect(action_for_row(result, 'Responsible Body').text).to include('Change responsible body')
+    end
+
+    it 'shows change link for headteacher' do
+      expect(action_for_row(result, 'Headteacher').text).to include('Change headteacher')
     end
   end
 
@@ -161,10 +169,10 @@ describe Support::SchoolDetailsSummaryListComponent do
       expect(value_for_row(result, 'Headteacher').text).to include('12345')
     end
 
-    it 'hides the headteacher details if none are available' do
+    it 'displays Not Set if none are available' do
       school.contacts.destroy_all
 
-      expect(result.css('.govuk-summary-list__row').text).not_to include('Headteacher')
+      expect(value_for_row(result, 'Headteacher').text).to include('Not set')
     end
   end
 

--- a/spec/controllers/support/schools/headteacher_controller_spec.rb
+++ b/spec/controllers/support/schools/headteacher_controller_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe Support::Schools::HeadteacherController, type: :controller do
+  let(:non_support_third_line_user) { create(:user, is_support: true, role: 'no') }
+  let(:support_third_line_user) { create(:support_user, :third_line) }
+  let!(:school) { create(:school) }
+
+  describe '#edit' do
+    context 'non support third line users' do
+      before { sign_in_as non_support_third_line_user }
+
+      specify do
+        expect { get :edit, params: { school_urn: school.urn } }.to be_forbidden_for(non_support_third_line_user)
+      end
+    end
+
+    context 'support third line users' do
+      before do
+        sign_in_as support_third_line_user
+      end
+
+      context 'when the school has no contacts at all' do
+        before { get :edit, params: { school_urn: school.urn } }
+
+        specify { expect(response).to be_successful }
+
+        it 'exposes a blank form to create the headteacher contact of the school' do
+          expect(assigns(:form)).to be_a(Support::School::ChangeHeadteacherForm)
+          expect(assigns(:form).school).to eq(school)
+          expect(assigns(:form).email_address).to be_nil
+          expect(assigns(:form).full_name).to be_nil
+          expect(assigns(:form).id).to be_nil
+          expect(assigns(:form).phone_number).to be_nil
+          expect(assigns(:form).role).to be_nil
+          expect(assigns(:form).title).to be_nil
+        end
+      end
+
+      context 'when the school has a non-headteacher contact' do
+        let!(:contact) { create(:school_contact, :contact, school: school) }
+
+        before { get :edit, params: { school_urn: school.urn } }
+
+        specify { expect(response).to be_successful }
+
+        it 'exposes a form initialized to set the contact as the headteacher of the school' do
+          expect(assigns(:form).school).to eq(school)
+          expect(assigns(:form).email_address).to eq(contact.email_address)
+          expect(assigns(:form).full_name).to eq(contact.full_name)
+          expect(assigns(:form).id).to eq(contact.id)
+          expect(assigns(:form).phone_number).to eq(contact.phone_number)
+          expect(assigns(:form).role).to eq(contact.role)
+          expect(assigns(:form).title).to eq(contact.title)
+        end
+      end
+
+      context 'when the school has a headteacher contact' do
+        let!(:headteacher) { create(:school_contact, :headteacher, school: school) }
+
+        before { get :edit, params: { school_urn: school.urn } }
+
+        specify { expect(response).to be_successful }
+
+        it 'exposes a form initialized to update the details of the headteacher of the school' do
+          expect(assigns(:form).school).to eq(school)
+          expect(assigns(:form).email_address).to eq(headteacher.email_address)
+          expect(assigns(:form).full_name).to eq(headteacher.full_name)
+          expect(assigns(:form).id).to eq(headteacher.id)
+          expect(assigns(:form).phone_number).to eq(headteacher.phone_number)
+          expect(assigns(:form).role).to eq(headteacher.role)
+          expect(assigns(:form).title).to eq(headteacher.title)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:full_name) { Faker::Name.unique.name }
+    let(:email_address) { Faker::Internet.unique.email }
+    let(:id) { Faker::Number.unique.between(from: 1000, to: 100_000) }
+    let(:phone_number) { Faker::PhoneNumber.phone_number }
+    let(:title) { Faker::Lorem.sentence }
+    let(:params) do
+      {
+        school_urn: school.urn,
+        support_school_change_headteacher_form: {
+          email_address: email_address,
+          full_name: full_name,
+          id: id,
+          phone_number: phone_number,
+          title: title,
+        },
+      }
+    end
+
+    context 'non support third line users' do
+      before { sign_in_as non_support_third_line_user }
+
+      specify do
+        expect { patch :update, params: params }.to be_forbidden_for(non_support_third_line_user)
+      end
+    end
+
+    context 'support third line users' do
+      before do
+        sign_in_as support_third_line_user
+        patch :update, params: params
+      end
+
+      context 'when the headteacher can be updated' do
+        it 'redirects back to school' do
+          expect(response).to redirect_to(support_school_path(school))
+        end
+
+        it 'shows a successful change message to the user' do
+          expect(flash[:success]).to eq("#{school.name}'s headteacher details updated")
+        end
+      end
+
+      context 'when the headteacher cannot be updated for some reason' do
+        let(:email_address) {}
+
+        it 'display again the form with some errors' do
+          expect(assigns(:form).errors).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/schools/change_headteacher_spec.rb
+++ b/spec/features/support/schools/change_headteacher_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.feature 'Updating school headteacher details' do
+  let(:non_support_third_line_user) { create(:support_user) }
+  let(:support_third_line_user) { create(:support_user, :third_line) }
+  let(:school) { create(:school) }
+  let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }
+  let(:edit_page) { PageObjects::Support::School::Headteacher::EditPage.new }
+
+  scenario 'non support third line users cant change a school headteacher details' do
+    sign_in_as non_support_third_line_user
+
+    visit support_school_path(school.urn)
+    expect_no_headteacher_change_link
+  end
+
+  scenario 'headteacher with invalid details' do
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    go_to_edit_headteacher(school.name)
+
+    expect(edit_page.email_address_field.value).to be_blank
+
+    click_on('Set as headteacher')
+    expect_email_invalid_error(school.name)
+  end
+
+  scenario 'modify details of an existing headteacher' do
+    school = create(:school, :with_headteacher_contact)
+    headteacher = school.headteacher_contact
+    new_email = 'headteacher@example.com'
+
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    go_to_edit_headteacher(school.name)
+
+    expect(edit_page.title_field.value).to eq(headteacher.title)
+    expect(edit_page.full_name_field.value).to eq(headteacher.full_name)
+    expect(edit_page.email_address_field.value).to eq(headteacher.email_address)
+    expect(edit_page.phone_number_field.value).to eq(headteacher.phone_number)
+    expect(edit_page.submit_button.text).to eq('Update')
+
+    fill_in('Email address', with: new_email)
+    click_on('Update')
+
+    expect_headteacher_changed_banner(school.name)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: new_email)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: headteacher.full_name)
+    expect(school_page.school_details['Headteacher']).to have_action_element(text: 'Change headteacher')
+  end
+
+  scenario 'set existing contact as headteacher' do
+    school = create(:school)
+    contact = create(:school_contact, :contact, school: school)
+    new_email = 'headteacher@example.com'
+
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    go_to_edit_headteacher(school.name)
+
+    expect(edit_page.title_field.value).to eq(contact.title)
+    expect(edit_page.full_name_field.value).to eq(contact.full_name)
+    expect(edit_page.email_address_field.value).to eq(contact.email_address)
+    expect(edit_page.phone_number_field.value).to eq(contact.phone_number)
+    expect(edit_page.submit_button.text).to eq('Set as headteacher')
+
+    fill_in('Email address', with: 'headteacher@example.com')
+    click_on('Set as headteacher')
+
+    expect_headteacher_changed_banner(school.name)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: new_email)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: contact.full_name)
+    expect(school_page.school_details['Headteacher']).to have_action_element(text: 'Change headteacher')
+  end
+
+  scenario 'create a new headteacher contact' do
+    title = 'Mr.'
+    full_name = 'New Headteacher Name'
+    email = 'headteacher@example.com'
+    phone_number = '07759337788'
+
+    sign_in_as support_third_line_user
+
+    visit support_school_path(school.urn)
+    go_to_edit_headteacher(school.name)
+
+    expect(edit_page.title_field.value).to be_blank
+    expect(edit_page.full_name_field.value).to be_blank
+    expect(edit_page.email_address_field.value).to be_blank
+    expect(edit_page.phone_number_field.value).to be_blank
+    expect(edit_page.submit_button.text).to eq('Set as headteacher')
+
+    fill_in('Title', with: title)
+    fill_in('Full name', with: full_name)
+    fill_in('Email address', with: email)
+    fill_in('Telephone number', with: phone_number)
+    click_on('Set as headteacher')
+
+    expect_headteacher_changed_banner(school.name)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: title)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: full_name)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: email)
+    expect(school_page.school_details['Headteacher']).to have_value_element(text: phone_number)
+    expect(school_page.school_details['Headteacher']).to have_action_element(text: 'Change headteacher')
+  end
+
+private
+
+  def expect_no_headteacher_change_link
+    expect(school_page).to be_displayed
+    expect(school_page.school_details['Headteacher']).to have_no_action_element
+  end
+
+  def expect_email_invalid_error(school_name)
+    error_message = 'Enter an email address in the correct format, like name@example.com'
+    expect(edit_page).to be_displayed
+    expect(edit_page).to have_school_name_header(text: school_name)
+    expect(edit_page).to have_error_summary(text: 'There is a problem')
+    expect(edit_page).to have_no_email_address_field
+    expect(edit_page).to have_email_address_error_message(text: error_message)
+    expect(edit_page).to have_email_address_error_field
+  end
+
+  def expect_headteacher_changed_banner(school_name)
+    expect_school_page_with_banner(:success, "#{school_name}'s headteacher details updated")
+  end
+
+  def expect_school_page_with_banner(type, text)
+    expect(school_page).to be_displayed
+    expect(page).to have_selector(".app-banner--#{type}", text: text)
+  end
+
+  def go_to_edit_headteacher(school_name)
+    school_page.school_details['Headteacher'].follow_action_link
+    expect(edit_page).to be_displayed
+    expect(edit_page).to have_school_name_header(text: school_name)
+    expect(edit_page).to have_title_label(text: 'Title')
+    expect(edit_page).to have_title_field
+    expect(edit_page).to have_full_name_label(text: 'Full name')
+    expect(edit_page).to have_full_name_field
+    expect(edit_page).to have_email_address_label(text: 'Email address')
+    expect(edit_page).to have_email_address_field
+    expect(edit_page).to have_phone_number_label(text: 'Telephone number')
+    expect(edit_page).to have_phone_number_field
+  end
+end

--- a/spec/form_objects/support/school/change_headteacher_form_spec.rb
+++ b/spec/form_objects/support/school/change_headteacher_form_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Support::School::ChangeHeadteacherForm, type: :model do
+  describe '#headteacher?' do
+    let(:school) { build_stubbed(:school) }
+
+    subject(:form) { described_class.new(school: school, role: role) }
+
+    context 'when the role of the form contact is :headteacher' do
+      let(:role) { 'headteacher' }
+
+      it 'return true' do
+        expect(form.headteacher?).to be_truthy
+      end
+    end
+
+    context 'when the role of the form contact is other than :headteacher' do
+      let(:role) {}
+
+      it 'return false' do
+        expect(form.headteacher?).to be_falsey
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:school) { create(:school, :with_headteacher_contact) }
+    let(:headteacher_id) { school.headteacher_contact.id }
+
+    context 'when the new headteacher details cannot be set' do
+      let(:new_email_address) { 'invalid_email_address' }
+
+      subject(:form) { described_class.new(school: school, id: headteacher_id, email_address: new_email_address) }
+
+      it 'return false' do
+        expect(form.save).to be_falsey
+      end
+
+      it 'do not change the school headteacher' do
+        expect { form.save }.not_to change(school.reload, :headteacher_contact)
+      end
+
+      it 'add errors to the form object' do
+        expect(form.save).to be_falsey
+        expect(form.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'when the new headteacher details can be set' do
+      let(:new_email_address) { Faker::Internet.email }
+
+      subject(:form) { described_class.new(school: school, id: headteacher_id, email_address: new_email_address) }
+
+      it 'return true' do
+        expect(form.save).to be_truthy
+      end
+
+      it 'change the school headteacher details' do
+        expect(form.save).to be_truthy
+        expect(school.reload.headteacher_contact.email_address).to eq(new_email_address)
+      end
+
+      it 'do not add errors to the form object' do
+        expect(form.save).to be_truthy
+        expect(form.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/page_objects/support/schools/headteacher/edit_page.rb
+++ b/spec/page_objects/support/schools/headteacher/edit_page.rb
@@ -1,0 +1,31 @@
+module PageObjects
+  module Support
+    module School
+      module Headteacher
+        class EditPage < PageObjects::BasePage
+          set_url_matcher /\/support\/schools\/\d+\/headteacher(\/edit)?/
+
+          element :error_summary, '.govuk-error-summary'
+
+          element :school_name_header, 'h1.govuk-heading-xl span.govuk-caption-xl'
+
+          element :title_label, 'form label[for=support-school-change-headteacher-form-title-field]'
+          element :title_field, 'input#support-school-change-headteacher-form-title-field'
+
+          element :full_name_label, 'form label[for=support-school-change-headteacher-form-full-name-field]'
+          element :full_name_field, 'input#support-school-change-headteacher-form-full-name-field'
+
+          element :email_address_label, 'form label[for=support-school-change-headteacher-form-email-address-field]'
+          element :email_address_error_message, '#support-school-change-headteacher-form-email-address-error'
+          element :email_address_field, 'input#support-school-change-headteacher-form-email-address-field[type=email]'
+          element :email_address_error_field, 'input#support-school-change-headteacher-form-email-address-field-error[type=email]'
+
+          element :phone_number_label, 'form label[for=support-school-change-headteacher-form-phone-number-field]'
+          element :phone_number_field, 'input#support-school-change-headteacher-form-phone-number-field'
+
+          element :submit_button, 'form button.govuk-button[type=submit]'
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -39,7 +39,7 @@ describe SchoolPolicy do
     end
   end
 
-  permissions :update_responsible_body? do
+  permissions(*%i[update_address? update_headteacher? update_name? update_responsible_body?]) do
     it 'block access to non support users' do
       expect(policy).not_to permit(non_support_user, school)
     end

--- a/spec/services/change_school_headteacher_service_spec.rb
+++ b/spec/services/change_school_headteacher_service_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe ChangeSchoolHeadteacherService, type: :model do
+  let(:service) { described_class.new(school, **details) }
+  let(:email_address) { Faker::Internet.email }
+  let(:full_name) { Faker::Name.name }
+  let(:details) do
+    {
+      email_address: email_address,
+      full_name: full_name,
+      id: headteacher_id,
+    }
+  end
+
+  describe '#call' do
+    context 'when the school have already a headteacher contact set' do
+      let(:school) { create(:school, :with_headteacher_contact) }
+      let(:headteacher_id) { school.headteacher_contact.id }
+
+      let!(:result) { service.call }
+
+      it 'update their details' do
+        headteacher = school.reload.headteacher_contact
+        expect(headteacher.email_address).to eq(details[:email_address])
+        expect(headteacher.full_name).to eq(details[:full_name])
+        expect(headteacher.id).to eq(headteacher_id)
+      end
+
+      it 'return the headteacher contact with no errors' do
+        expect(result).to be_a(SchoolContact)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when the school have a non-headteacher contact' do
+      let(:school) { create(:school) }
+      let(:headteacher_id) { create(:school_contact, :contact, school: school).id }
+
+      let!(:result) { service.call }
+
+      it 'set it as headteacher' do
+        headteacher = school.reload.headteacher_contact
+        expect(headteacher.email_address).to eq(details[:email_address])
+        expect(headteacher.full_name).to eq(details[:full_name])
+        expect(headteacher.id).to eq(headteacher_id)
+      end
+
+      it 'return true' do
+        expect(result).to be_a(SchoolContact)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when the school have no contacts' do
+      let(:school) { create(:school) }
+      let(:headteacher_id) { school.contacts.first&.id }
+
+      let!(:result) { service.call }
+
+      it 'create a new headteacher contact' do
+        headteacher = school.reload.headteacher_contact
+        expect(headteacher.email_address).to eq(details[:email_address])
+        expect(headteacher.full_name).to eq(details[:full_name])
+        expect(headteacher.id).not_to eq(headteacher_id)
+      end
+
+      it 'return true' do
+        expect(result).to be_a(SchoolContact)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when the new headteacher details are not valid' do
+      let(:school) { create(:school) }
+      let(:email_address) {}
+      let(:headteacher_id) {}
+
+      it 'do not change the school headteacher details' do
+        expect {
+          service.call
+        }.not_to(change { school.reload.headteacher_contact })
+      end
+
+      it 'return false' do
+        result = service.call
+        expect(result).to be_a(SchoolContact)
+        expect(result.errors).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Headteacher details of a school can't be changed

### Changes proposed in this pull request
- Add link to change headteacher details to the headteacher row when displaying details of a school in support area.
- Allow third line users to edit a school headteacher details

### Guidance to review
- When the school has no SchoolContacts are all, display a form to create a new headteacher contact
- When the school has a non-headteacher contact associated, display a form filled with their data to set it as headteacher
- When the school already has a headteacher associated, display a form pre-filled with their data to allow details changes.
- The form shows errors when new details don´t  pass validations.

See card [GIAS - Ability to update Headteacher details in /support](https://trello.com/c/lNUYeULi)
