### PR TITLE
2190: upgrade accordion section arg names

### DIFF
--- a/app/views/guide_to_resetting_windows_laptops_and_tablets/reset_the_bios_password.html.erb
+++ b/app/views/guide_to_resetting_windows_laptops_and_tablets/reset_the_bios_password.html.erb
@@ -17,7 +17,7 @@
     </p>
 
     <%= render GovukComponent::AccordionComponent.new do |component| %>
-      <%= component.section(title: "Acer (all models)") do %>
+      <%= component.section(heading_text: "Acer (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -51,7 +51,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "ASUS (all models)") do %>
+      <%= component.section(heading_text: "ASUS (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -85,7 +85,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Dell (all models)") do %>
+      <%= component.section(heading_text: "Dell (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -121,7 +121,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Dynabook (A30)") do %>
+      <%= component.section(heading_text: "Dynabook (A30)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -156,7 +156,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Dynabook (R50)") do %>
+      <%= component.section(heading_text: "Dynabook (R50)") do %>
         <%- begin %>
           <p class="govuk-body">
             A ‘BIOS Unlock’ app is required for Dynabook R50 laptops. To download this executable file, log in to
@@ -175,7 +175,7 @@
           </p>
         <%- end %>
       <% end %>
-      <%= component.section(title: "Dynabook (other models)") do %>
+      <%= component.section(heading_text: "Dynabook (other models)") do %>
         <%- begin %>
           <h4 class="govuk-heading-s">
             Access BIOS
@@ -206,7 +206,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Geobook (all models)") do %>
+      <%= component.section(heading_text: "Geobook (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -241,7 +241,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "HP (all models)") do %>
+      <%= component.section(heading_text: "HP (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -281,7 +281,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Lenovo (all models)") do %>
+      <%= component.section(heading_text: "Lenovo (all models)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">
@@ -315,7 +315,7 @@
 
         <%- end %>
       <% end %>
-      <%= component.section(title: "Microsoft (Surface Go)") do %>
+      <%= component.section(heading_text: "Microsoft (Surface Go)") do %>
         <%- begin %>
 
           <h4 class="govuk-heading-s">


### PR DESCRIPTION
### Context
Exception raised in Sentry. [see here](https://sentry.io/organizations/dfe-get-help-with-tech/issues/2608380031/?project=5320558&referrer=slack)
Version 2.x of govuk-components has renamed some of the keyword args in AccordionComponent and _:title_ (the one causing this error) is one of them. [See this PR](https://github.com/DFE-Digital/govuk-components/commit/043afc2ec5ed3dbd8b5883b65d5f646655c7248d#)
### Changes proposed in this pull request
Rename _:title_ argument to its new name _: heading_text_
### Guidance to review
[2190: View Component deprecation warnings](https://trello.com/c/2pqveqrU)
