### PR TITLE
2404: rename args to PanelComponent and NotificationBannerComponent

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,7 +74,7 @@
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
         <% if impersonated_user %>
-          <%= render NotificationBannerComponent.new(title: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5') do |banner| %>
+          <%= render NotificationBannerComponent.new(title_text: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5') do |banner| %>
             <p class="govuk-notification-banner__heading">
               You are impersonating <%= link_to impersonated_user.full_name, support_user_path(impersonated_user) %> (<%= impersonated_user.email_address %>)
             </p>

--- a/app/views/support_tickets/thank_you.html.erb
+++ b/app/views/support_tickets/thank_you.html.erb
@@ -10,8 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full govuk-!-margin-bottom-5">
     <%= render GovukComponent::PanelComponent.new(
-      title: 'Support request sent',
-      body: "Your reference number #{session[:support_ticket_number]}")
+      title_text: 'Support request sent',
+      text: "Your reference number #{session[:support_ticket_number]}")
     %>
   </div>
 </div>


### PR DESCRIPTION
### Context
The new version of govuk-components has renamed a couple of args to initialize a PanelComponent. 
This is raising an exception on our code. See [sentry](https://sentry.io/organizations/dfe-get-help-with-tech/issues/2617817186/?project=5320558)
### Changes proposed in this pull request
Rename _:title_ and _:body_ params when initializing the *GovukComponent::PanelComponent* on *thank_you.html* view

### Guidance to review
See card [2404](https://trello.com/c/zqiEp5Sv)

