### PR TITLE
Skip invite if user already belongs to the school

### DIFF
--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -45,7 +45,8 @@ class CreateUserService
   def self.invite_to_additional_school!(user_params)
     user = User.find_by_email_address(user_params[:email_address])
     school = School.find(user_params[:school_id])
-    if user.schools << school
+    unless user.school_ids.include?(user_params[:school_id])
+      user.schools << school
       AddAdditionalSchoolToExistingUserMailer.with(user: user, school: school).additional_school_email.deliver_later
       school.preorder_information&.refresh_status!
       user.update!(user_params.select { |key, _value| user.send(key).blank? }.merge(deleted_at: nil))

--- a/spec/services/create_user_service_spec.rb
+++ b/spec/services/create_user_service_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe CreateUserService do
       end
       let(:result) { CreateUserService.invite_school_user(params) }
 
+      context 'user already a user on this school and belongs to a responsible body' do
+        let!(:existing_user) { create(:school_user, email_address: 'existing@user.com', school: school, responsible_body_id: school.responsible_body_id) }
+
+        it 'does not create a user with the given params' do
+          expect { result }.not_to change(User, :count)
+        end
+
+        it 'does not send any email' do
+          expect { perform_enqueued_jobs { result } }.not_to change(ActionMailer::Base.deliveries, :size)
+        end
+
+        it 'returns the existing user' do
+          expect(result).to be_a(User)
+          expect(result).to eq(existing_user)
+        end
+      end
+
       context 'on the given school' do
         before { create(:school_user, email_address: 'existing@user.com', school: school) }
 


### PR DESCRIPTION
The shovel `<<` throws a PG index duplicate entry error, so we should check before shovelling a school in.