### PR TITLE
2109: add/remove school from rb pools when it changes responsible body

### DIFF
--- a/app/form_objects/support/school/change_responsible_body_form.rb
+++ b/app/form_objects/support/school/change_responsible_body_form.rb
@@ -22,7 +22,7 @@ class Support::School::ChangeResponsibleBodyForm
   end
 
   def save
-    valid? && ChangeSchoolResponsibleBodyService.new(school, responsible_body_id).call
+    valid? && ChangeSchoolResponsibleBodyService.new(school, responsible_body).call
   end
 
 private

--- a/app/models/preorder_information.rb
+++ b/app/models/preorder_information.rb
@@ -75,7 +75,7 @@ class PreorderInformation < ApplicationRecord
       self.who_will_order_devices = who
       self.status = infer_status
       save!
-      if school.responsible_body.can_school_be_added_to_virtual_cap_pools?(school)
+      if school.responsible_body.school_addable_to_virtual_cap_pools?(school)
         school.responsible_body.add_school_to_virtual_cap_pools!(school)
       end
       true

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -54,6 +54,15 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
+  def remove_school_from_virtual_cap_pools!(school)
+    raise(VirtualCapPoolError, 'Virtual cap feature flags not set') unless has_virtual_cap_feature_flags?
+
+    school.device_allocations.each do |allocation|
+      pool = virtual_cap_pools.send(allocation.device_type).first
+      pool&.remove_school!(school)
+    end
+  end
+
   def can_school_be_added_to_virtual_cap_pools?(school)
     has_virtual_cap_feature_flags? &&
       school.responsible_body_id == id &&
@@ -61,6 +70,14 @@ class ResponsibleBody < ApplicationRecord
       school.preorder_information&.responsible_body_will_order_devices? &&
       school.device_allocations.any? &&
       !has_school_in_virtual_cap_pools?(school)
+  end
+
+  def can_school_be_removed_from_virtual_cap_pools?(school)
+    has_virtual_cap_feature_flags? &&
+      school.responsible_body_id == id &&
+      school.preorder_information&.responsible_body_will_order_devices? &&
+      school.device_allocations.any? &&
+      has_school_in_virtual_cap_pools?(school)
   end
 
   def devices_available_to_order?

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -63,7 +63,7 @@ class ResponsibleBody < ApplicationRecord
     end
   end
 
-  def can_school_be_added_to_virtual_cap_pools?(school)
+  def school_addable_to_virtual_cap_pools?(school)
     has_virtual_cap_feature_flags? &&
       school.responsible_body_id == id &&
       !school.la_funded_provision? &&
@@ -72,7 +72,7 @@ class ResponsibleBody < ApplicationRecord
       !has_school_in_virtual_cap_pools?(school)
   end
 
-  def can_school_be_removed_from_virtual_cap_pools?(school)
+  def school_removable_from_virtual_cap_pools?(school)
     has_virtual_cap_feature_flags? &&
       school.responsible_body_id == id &&
       school.preorder_information&.responsible_body_will_order_devices? &&

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -5,9 +5,9 @@ class School < ApplicationRecord
 
   belongs_to :responsible_body
 
-  has_many   :device_allocations, class_name: 'SchoolDeviceAllocation'
-  has_one    :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
-  has_one    :coms_device_allocation, -> { where device_type: 'coms_device' }, class_name: 'SchoolDeviceAllocation'
+  has_many :device_allocations, class_name: 'SchoolDeviceAllocation'
+  has_one  :std_device_allocation, -> { where device_type: 'std_device' }, class_name: 'SchoolDeviceAllocation'
+  has_one  :coms_device_allocation, -> { where device_type: 'coms_device' }, class_name: 'SchoolDeviceAllocation'
 
   has_many :contacts, class_name: 'SchoolContact', inverse_of: :school
   has_many :user_schools

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -31,7 +31,7 @@ class VirtualCapPool < ApplicationRecord
 
   def add_school!(school)
     if school_can_be_added_to_pool?(school)
-      add_school_allocation(school.device_allocations.find_by(device_type: device_type))
+      add_school_allocation!(school.device_allocations.find_by(device_type: device_type))
     else
       raise VirtualCapPoolError, "Cannot add school to virtual pool #{school.urn} #{school.name}"
     end
@@ -39,7 +39,7 @@ class VirtualCapPool < ApplicationRecord
 
   def remove_school!(school)
     school_device_allocation = school.device_allocations.find_by(device_type: device_type)
-    remove_school_allocation(school_device_allocation) if school_device_allocation
+    remove_school_allocation!(school_device_allocation) if school_device_allocation
   end
 
   def has_school?(school)
@@ -55,12 +55,12 @@ private
       !school_virtual_caps.exists?(school_device_allocation: school.device_allocations.find_by(device_type: device_type))
   end
 
-  def add_school_allocation(device_allocation)
+  def add_school_allocation!(device_allocation)
     school_virtual_caps.create!(school_device_allocation: device_allocation)
     recalculate_caps!
   end
 
-  def remove_school_allocation(device_allocation)
+  def remove_school_allocation!(device_allocation)
     school_virtual_caps.find_by(school_device_allocation_id: device_allocation.id)&.destroy!
     recalculate_caps!
   end

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -37,6 +37,11 @@ class VirtualCapPool < ApplicationRecord
     end
   end
 
+  def remove_school!(school)
+    school_device_allocation = school.device_allocations.find_by(device_type: device_type)
+    remove_school_allocation(school_device_allocation) if school_device_allocation
+  end
+
   def has_school?(school)
     schools.exists?(school.id)
   end
@@ -52,6 +57,11 @@ private
 
   def add_school_allocation(device_allocation)
     school_virtual_caps.create!(school_device_allocation: device_allocation)
+    recalculate_caps!
+  end
+
+  def remove_school_allocation(device_allocation)
+    school_virtual_caps.find_by(school_device_allocation_id: device_allocation.id)&.destroy!
     recalculate_caps!
   end
 

--- a/app/services/change_school_responsible_body_service.rb
+++ b/app/services/change_school_responsible_body_service.rb
@@ -11,10 +11,10 @@ class ChangeSchoolResponsibleBodyService
 
   def call
     school.transaction do
-      remove_school_from_current_pool if school_can_be_removed?
+      remove_school_from_current_pool if school_removable?
       set_school_new_responsible_body
       update_preorder_information
-      add_school_to_new_pool if school_can_be_added?
+      add_school_to_new_pool if school_addable?
     end
     true
   rescue StandardError => e
@@ -38,12 +38,12 @@ private
     initial_responsible_body.remove_school_from_virtual_cap_pools!(school)
   end
 
-  def school_can_be_added?
-    new_responsible_body.can_school_be_added_to_virtual_cap_pools?(school)
+  def school_addable?
+    new_responsible_body.school_addable_to_virtual_cap_pools?(school)
   end
 
-  def school_can_be_removed?
-    initial_responsible_body&.can_school_be_removed_from_virtual_cap_pools?(school)
+  def school_removable?
+    initial_responsible_body&.school_removable_from_virtual_cap_pools?(school)
   end
 
   def set_school_new_responsible_body

--- a/app/services/change_school_responsible_body_service.rb
+++ b/app/services/change_school_responsible_body_service.rb
@@ -11,10 +11,10 @@ class ChangeSchoolResponsibleBodyService
 
   def call
     school.transaction do
-      remove_school_from_current_pool if school_removable?
-      set_school_new_responsible_body
-      update_preorder_information
-      add_school_to_new_pool if school_addable?
+      remove_school_from_current_pool! if school_removable?
+      set_school_new_responsible_body!
+      update_preorder_information!
+      add_school_to_new_pool! if school_addable?
     end
     true
   rescue StandardError => e
@@ -24,7 +24,7 @@ class ChangeSchoolResponsibleBodyService
 
 private
 
-  def add_school_to_new_pool
+  def add_school_to_new_pool!
     new_responsible_body.add_school_to_virtual_cap_pools!(school)
   end
 
@@ -34,7 +34,7 @@ private
     Sentry.capture_exception(e)
   end
 
-  def remove_school_from_current_pool
+  def remove_school_from_current_pool!
     initial_responsible_body.remove_school_from_virtual_cap_pools!(school)
   end
 
@@ -46,14 +46,14 @@ private
     initial_responsible_body&.school_removable_from_virtual_cap_pools?(school)
   end
 
-  def set_school_new_responsible_body
+  def set_school_new_responsible_body!
     school.update!(
       responsible_body_id: new_responsible_body.id,
       computacenter_change: COMPUTACENTER_CHANGE_STATUS,
     )
   end
 
-  def update_preorder_information
+  def update_preorder_information!
     school.preorder_information.refresh_status!
   end
 end

--- a/app/services/change_school_responsible_body_service.rb
+++ b/app/services/change_school_responsible_body_service.rb
@@ -1,15 +1,21 @@
 class ChangeSchoolResponsibleBodyService
-  attr_reader :school, :new_responsible_body_id
+  attr_reader :school, :initial_responsible_body, :new_responsible_body
 
   COMPUTACENTER_CHANGE_STATUS = 'amended'.freeze
 
-  def initialize(school, new_responsible_body_id)
+  def initialize(school, new_responsible_body)
     @school = school
-    @new_responsible_body_id = new_responsible_body_id
+    @initial_responsible_body = school.responsible_body
+    @new_responsible_body = new_responsible_body
   end
 
   def call
-    change_responsible_body!
+    school.transaction do
+      remove_school_from_current_pool if school_can_be_removed?
+      set_school_new_responsible_body
+      update_preorder_information
+      add_school_to_new_pool if school_can_be_added?
+    end
     true
   rescue StandardError => e
     log_error(e)
@@ -18,11 +24,8 @@ class ChangeSchoolResponsibleBodyService
 
 private
 
-  def change_responsible_body!
-    school.transaction do
-      update_school!
-      update_preorder_information!
-    end
+  def add_school_to_new_pool
+    new_responsible_body.add_school_to_virtual_cap_pools!(school)
   end
 
   def log_error(e)
@@ -31,14 +34,26 @@ private
     Sentry.capture_exception(e)
   end
 
-  def update_preorder_information!
-    school.preorder_information.refresh_status!
+  def remove_school_from_current_pool
+    initial_responsible_body.remove_school_from_virtual_cap_pools!(school)
   end
 
-  def update_school!
+  def school_can_be_added?
+    new_responsible_body.can_school_be_added_to_virtual_cap_pools?(school)
+  end
+
+  def school_can_be_removed?
+    initial_responsible_body&.can_school_be_removed_from_virtual_cap_pools?(school)
+  end
+
+  def set_school_new_responsible_body
     school.update!(
-      responsible_body_id: new_responsible_body_id,
+      responsible_body_id: new_responsible_body.id,
       computacenter_change: COMPUTACENTER_CHANGE_STATUS,
     )
+  end
+
+  def update_preorder_information
+    school.preorder_information.refresh_status!
   end
 end

--- a/app/services/timeline/school.rb
+++ b/app/services/timeline/school.rb
@@ -1,6 +1,6 @@
 module Timeline
   class School
-    FIELDS = %i[order_state status cap allocation devices_ordered].freeze
+    FIELDS = %i[order_state status cap allocation devices_ordered responsible_body_id].freeze
 
     attr_reader :school
 

--- a/spec/components/display_devices_ordered_component_spec.rb
+++ b/spec/components/display_devices_ordered_component_spec.rb
@@ -42,10 +42,4 @@ RSpec.describe DisplayDevicesOrderedComponent, type: :component do
       expect(rendered_component).to include('33&nbsp;routers')
     end
   end
-
-  def put_school_in_pool(responsible_body, pool_school)
-    pool_school.preorder_information.responsible_body_will_order_devices!
-    pool_school.can_order!
-    responsible_body.add_school_to_virtual_cap_pools!(pool_school)
-  end
 end

--- a/spec/form_objects/support/school/change_responsible_body_form_spec.rb
+++ b/spec/form_objects/support/school/change_responsible_body_form_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
     context 'when the form is valid' do
       let(:school) { create(:school, :with_preorder_information) }
-      let(:new_responsible_body_id) { create(:trust).id }
+      let(:new_responsible_body) { create(:trust) }
 
-      subject(:form) { described_class.new(school: school, responsible_body_id: new_responsible_body_id) }
+      subject(:form) { described_class.new(school: school, responsible_body_id: new_responsible_body.id) }
 
       it 'return true' do
         expect(form.save).to be_truthy
@@ -90,7 +90,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
       it 'change the school responsible body' do
         change_rb = instance_spy(ChangeSchoolResponsibleBodyService, call: true)
-        allow(ChangeSchoolResponsibleBodyService).to receive(:new).with(school, new_responsible_body_id) { change_rb }
+        allow(ChangeSchoolResponsibleBodyService).to receive(:new).with(school, new_responsible_body) { change_rb }
 
         expect(form.save).to be_truthy
         expect(change_rb).to have_received(:call)

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -18,6 +18,122 @@ RSpec.describe ResponsibleBody, type: :model do
     end
   end
 
+  describe '#can_school_be_added_to_virtual_cap_pools?' do
+    context 'when the responsible body has no virtual cap feature flag' do
+      subject(:responsible_body) { create(:trust, vcap_feature_flag: false) }
+
+      let(:school) { build(:school) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is associated to a different responsible body' do
+      let(:responsible_body) { create(:trust, vcap_feature_flag: true) }
+
+      let(:school) { create(:school, responsible_body: create(:trust)) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is of type LaFundedPlace' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { build_stubbed(:iss_provision, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school manages orders' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { build_stubbed(:school, :manages_orders, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school has no device_allocations' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { build_stubbed(:school, :centrally_managed, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is already included in any of the responsible body virtual cap pools' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { create_and_put_school_in_pool(responsible_body) }
+
+      before do
+        stub_computacenter_outgoing_api_calls
+      end
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is not included in any of the responsible body virtual cap pools' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { create(:school, :centrally_managed, :with_std_device_allocation, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_truthy }
+    end
+  end
+
+  describe '#can_school_be_removed_from_virtual_cap_pools?' do
+    context 'when the responsible body has no virtual cap feature flag' do
+      subject(:responsible_body) { create(:trust, vcap_feature_flag: false) }
+
+      let(:school) { build(:school) }
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is associated to a different responsible body' do
+      subject(:responsible_body) { create(:trust, vcap_feature_flag: true) }
+
+      let(:school) { create(:school, responsible_body: create(:trust)) }
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school manages orders' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { build_stubbed(:school, :manages_orders, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school has no device_allocations' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { build_stubbed(:school, :centrally_managed, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is not included in any of the responsible body virtual cap pools' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { create(:school, :centrally_managed, :with_std_device_allocation, responsible_body: responsible_body) }
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+    end
+
+    context 'when the school is included in any of the responsible body virtual cap pools' do
+      subject(:responsible_body) { create(:local_authority, vcap_feature_flag: true) }
+
+      let(:school) { create_and_put_school_in_pool(responsible_body) }
+
+      before do
+        stub_computacenter_outgoing_api_calls
+      end
+
+      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_truthy }
+    end
+  end
+
   describe '#next_school_sorted_ascending_by_name' do
     it 'allows navigating down a list of alphabetically-sorted schools' do
       zebra = create(:school, name: 'Zebra', responsible_body: responsible_body)
@@ -364,7 +480,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
   end
 
-  describe '#add_school_to_virtual_cap_pools' do
+  describe '#add_school_to_virtual_cap_pools!' do
     subject(:responsible_body) { create(:trust, :manages_centrally, vcap_feature_flag: true) }
 
     let(:schools) { create_list(:school, 3, :with_std_device_allocation, :with_coms_device_allocation, :with_preorder_information, :in_lockdown, responsible_body: responsible_body) }
@@ -392,6 +508,86 @@ RSpec.describe ResponsibleBody, type: :model do
     it 'creates the virtual pool for the device type if it does not exists' do
       expect { responsible_body.add_school_to_virtual_cap_pools!(schools.first) }.to change { VirtualCapPool.count }.by(2)
       expect { responsible_body.add_school_to_virtual_cap_pools!(schools.second) }.not_to(change { VirtualCapPool.count })
+    end
+  end
+
+  describe '#remove_school_from_virtual_cap_pools!' do
+    subject(:rb) { create(:trust, :manages_centrally, vcap_feature_flag: vcap_feature_flag) }
+
+    before do
+      stub_computacenter_outgoing_api_calls
+    end
+
+    context 'when the responsible body has no virtual_cap_feature_flag' do
+      let(:vcap_feature_flag) { false }
+
+      it 'raise an error' do
+        expect { rb.remove_school_from_virtual_cap_pools!(create(:school)) }
+          .to raise_exception(VirtualCapPoolError)
+      end
+    end
+
+    context 'when the responsible body has virtual_cap_feature_flag' do
+      let(:vcap_feature_flag) { true }
+
+      let(:rb_std_device_start_allocation) { [school_a, school_to_remove].map(&:std_device_allocation).sum(&:raw_allocation) }
+      let(:rb_std_device_end_allocation) { school_a.std_device_allocation.raw_allocation }
+      let(:rb_std_device_start_cap) { [school_a, school_to_remove].map(&:std_device_allocation).sum(&:raw_cap) }
+      let(:rb_std_device_end_cap) { school_a.std_device_allocation.raw_cap }
+      let(:rb_std_device_start_devices_ordered) { [school_a, school_to_remove].map(&:std_device_allocation).sum(&:raw_devices_ordered) }
+      let(:rb_std_device_end_devices_ordered) { school_a.std_device_allocation.raw_devices_ordered }
+
+      let(:rb_coms_device_start_allocation) { [school_a, school_to_remove].map(&:coms_device_allocation).sum(&:raw_allocation) }
+      let(:rb_coms_device_end_allocation) { school_a.coms_device_allocation.raw_allocation }
+      let(:rb_coms_device_start_cap) { [school_a, school_to_remove].map(&:coms_device_allocation).sum(&:raw_cap) }
+      let(:rb_coms_device_end_cap) { school_a.coms_device_allocation.raw_cap }
+      let(:rb_coms_device_start_devices_ordered) { [school_a, school_to_remove].map(&:coms_device_allocation).sum(&:raw_devices_ordered) }
+      let(:rb_coms_device_end_devices_ordered) { school_a.coms_device_allocation.raw_devices_ordered }
+
+      let!(:school_a) { create_and_put_school_in_pool(rb) }
+      let!(:school_to_remove) { create_and_put_school_in_pool(rb) }
+
+      it 'remove school std allocation from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.std_device.first.allocation }
+                .from(rb_std_device_start_allocation)
+                .to(rb_std_device_end_allocation)
+      end
+
+      it 'remove school std device caps from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.std_device.first.cap }
+                .from(rb_std_device_start_cap)
+                .to(rb_std_device_end_cap)
+      end
+
+      it 'remove school std devices_ordered from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.std_device.first.devices_ordered }
+                .from(rb_std_device_start_devices_ordered)
+                .to(rb_std_device_end_devices_ordered)
+      end
+
+      it 'remove school coms allocation from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.coms_device.first.allocation }
+                .from(rb_coms_device_start_allocation)
+                .to(rb_coms_device_end_allocation)
+      end
+
+      it 'remove school coms device caps from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.coms_device.first.cap }
+                .from(rb_coms_device_start_cap)
+                .to(rb_coms_device_end_cap)
+      end
+
+      it 'remove school coms devices_ordered from the responsible body pool' do
+        expect { rb.remove_school_from_virtual_cap_pools!(school_to_remove) }
+          .to change { rb.virtual_cap_pools.coms_device.first.devices_ordered }
+                .from(rb_coms_device_start_devices_ordered)
+                .to(rb_coms_device_end_devices_ordered)
+      end
     end
   end
 

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe ResponsibleBody, type: :model do
     end
   end
 
-  describe '#can_school_be_added_to_virtual_cap_pools?' do
+  describe '#school_addable_to_virtual_cap_pools?' do
     context 'when the responsible body has no virtual cap feature flag' do
       subject(:responsible_body) { create(:trust, vcap_feature_flag: false) }
 
       let(:school) { build(:school) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is associated to a different responsible body' do
@@ -32,7 +32,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { create(:school, responsible_body: create(:trust)) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is of type LaFundedPlace' do
@@ -40,7 +40,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { build_stubbed(:iss_provision, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school manages orders' do
@@ -48,7 +48,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { build_stubbed(:school, :manages_orders, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school has no device_allocations' do
@@ -56,7 +56,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { build_stubbed(:school, :centrally_managed, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is already included in any of the responsible body virtual cap pools' do
@@ -68,7 +68,7 @@ RSpec.describe ResponsibleBody, type: :model do
         stub_computacenter_outgoing_api_calls
       end
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is not included in any of the responsible body virtual cap pools' do
@@ -76,17 +76,17 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { create(:school, :centrally_managed, :with_std_device_allocation, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_added_to_virtual_cap_pools?(school)).to be_truthy }
+      specify { expect(responsible_body.school_addable_to_virtual_cap_pools?(school)).to be_truthy }
     end
   end
 
-  describe '#can_school_be_removed_from_virtual_cap_pools?' do
+  describe '#school_removable_from_virtual_cap_pools?' do
     context 'when the responsible body has no virtual cap feature flag' do
       subject(:responsible_body) { create(:trust, vcap_feature_flag: false) }
 
       let(:school) { build(:school) }
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is associated to a different responsible body' do
@@ -94,7 +94,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { create(:school, responsible_body: create(:trust)) }
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school manages orders' do
@@ -102,7 +102,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { build_stubbed(:school, :manages_orders, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school has no device_allocations' do
@@ -110,7 +110,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { build_stubbed(:school, :centrally_managed, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is not included in any of the responsible body virtual cap pools' do
@@ -118,7 +118,7 @@ RSpec.describe ResponsibleBody, type: :model do
 
       let(:school) { create(:school, :centrally_managed, :with_std_device_allocation, responsible_body: responsible_body) }
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_falsey }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_falsey }
     end
 
     context 'when the school is included in any of the responsible body virtual cap pools' do
@@ -130,7 +130,7 @@ RSpec.describe ResponsibleBody, type: :model do
         stub_computacenter_outgoing_api_calls
       end
 
-      specify { expect(responsible_body.can_school_be_removed_from_virtual_cap_pools?(school)).to be_truthy }
+      specify { expect(responsible_body.school_removable_from_virtual_cap_pools?(school)).to be_truthy }
     end
   end
 

--- a/spec/services/change_school_responsible_body_service_spec.rb
+++ b/spec/services/change_school_responsible_body_service_spec.rb
@@ -1,60 +1,182 @@
 require 'rails_helper'
 
 RSpec.describe ChangeSchoolResponsibleBodyService, type: :model do
-  let(:service) { described_class.new(school, new_responsible_body_id) }
-  let(:new_responsible_body_id) { create(:local_authority).id }
+  let(:service) { described_class.new(moving_school, new_rb) }
+  let(:new_rb) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
 
   describe '#call' do
     context 'when the school cannot be updated for some reason' do
-      let(:school) { create(:school, :with_preorder_information) }
+      let(:moving_school) { create(:school, :with_preorder_information) }
 
       it 'do not change the school responsible body' do
         expect {
-          school.name = nil
+          moving_school.name = nil
           service.call
-        }.not_to(change { school.reload.responsible_body_id })
+        }.not_to(change { moving_school.reload.responsible_body_id })
       end
 
       it 'do not change the school preorder information' do
         expect {
-          school.name = nil
+          moving_school.name = nil
           service.call
-        }.not_to(change { school.reload.preorder_information })
+        }.not_to(change { moving_school.reload.preorder_information })
       end
     end
 
     context 'when the school preorder information cannot be refreshed for some reason' do
-      let(:school) { create(:school) }
+      let(:moving_school) { create(:school) }
 
       it 'do not change the school responsible body' do
         expect {
           service.call
-        }.not_to(change { school.reload.responsible_body_id })
+        }.not_to(change { moving_school.reload.responsible_body_id })
       end
 
       it 'do not change the school preorder information' do
         expect {
           service.call
-        }.not_to(change { school.reload.preorder_information })
+        }.not_to(change { moving_school.reload.preorder_information })
       end
     end
 
     context 'success' do
-      let(:school) { create(:school, :with_preorder_information) }
+      let(:moving_school) { create(:school, :with_preorder_information) }
+      let(:initial_rb) { moving_school.responsible_body }
+
+      before do
+        stub_computacenter_outgoing_api_calls
+      end
 
       it 'update the school responsible body' do
         expect {
           service.call
-        }.to(change { school.reload.responsible_body_id })
+        }.to(change { moving_school.reload.responsible_body_id }.from(initial_rb.id).to(new_rb.id))
       end
 
       it 'refresh the school preorder information' do
         preorder_information = instance_spy(PreorderInformation, refresh_status!: true)
-        allow(school).to receive(:preorder_information).and_return(preorder_information)
+        allow(moving_school).to receive(:preorder_information).and_return(preorder_information)
 
         service.call
 
         expect(preorder_information).to have_received(:refresh_status!)
+      end
+
+      context 'when the school is centrally managed' do
+        let!(:initial_rb) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+        let!(:school_a) { create_and_put_school_in_pool(initial_rb) }
+        let!(:moving_school) { create_and_put_school_in_pool(initial_rb) }
+        let!(:school_b) { create_and_put_school_in_pool(new_rb) }
+
+        let(:initial_rb_std_device_start_allocation) { [school_a, moving_school].map(&:std_device_allocation).sum(&:raw_allocation) }
+        let(:initial_rb_std_device_end_allocation) { school_a.std_device_allocation.raw_allocation }
+        let(:new_rb_std_device_start_allocation) { school_b.std_device_allocation.raw_allocation }
+        let(:new_rb_std_device_end_allocation) { [school_b, moving_school].map(&:std_device_allocation).sum(&:raw_allocation) }
+        let(:initial_rb_std_device_start_cap) { [school_a, moving_school].map(&:std_device_allocation).sum(&:raw_cap) }
+        let(:initial_rb_std_device_end_cap) { school_a.std_device_allocation.raw_cap }
+        let(:new_rb_std_device_start_cap) { school_b.std_device_allocation.raw_cap }
+        let(:new_rb_std_device_end_cap) { [school_b, moving_school].map(&:std_device_allocation).sum(&:raw_cap) }
+        let(:initial_rb_std_device_start_devices_ordered) { [school_a, moving_school].map(&:std_device_allocation).sum(&:raw_devices_ordered) }
+        let(:initial_rb_std_device_end_devices_ordered) { school_a.std_device_allocation.raw_devices_ordered }
+        let(:new_rb_std_device_start_devices_ordered) { school_b.std_device_allocation.raw_devices_ordered }
+        let(:new_rb_std_device_end_devices_ordered) { [school_b, moving_school].map(&:std_device_allocation).sum(&:raw_devices_ordered) }
+
+        let(:initial_rb_coms_device_start_allocation) { [school_a, moving_school].map(&:coms_device_allocation).sum(&:raw_allocation) }
+        let(:initial_rb_coms_device_end_allocation) { school_a.coms_device_allocation.raw_allocation }
+        let(:new_rb_coms_device_start_allocation) { school_b.coms_device_allocation.raw_allocation }
+        let(:new_rb_coms_device_end_allocation) { [school_b, moving_school].map(&:coms_device_allocation).sum(&:raw_allocation) }
+        let(:initial_rb_coms_device_start_cap) { [school_a, moving_school].map(&:coms_device_allocation).sum(&:raw_cap) }
+        let(:initial_rb_coms_device_end_cap) { school_a.coms_device_allocation.raw_cap }
+        let(:new_rb_coms_device_start_cap) { school_b.coms_device_allocation.raw_cap }
+        let(:new_rb_coms_device_end_cap) { [school_b, moving_school].map(&:coms_device_allocation).sum(&:raw_cap) }
+        let(:initial_rb_coms_device_start_devices_ordered) { [school_a, moving_school].map(&:coms_device_allocation).sum(&:raw_devices_ordered) }
+        let(:initial_rb_coms_device_end_devices_ordered) { school_a.coms_device_allocation.raw_devices_ordered }
+        let(:new_rb_coms_device_start_devices_ordered) { school_b.coms_device_allocation.raw_devices_ordered }
+        let(:new_rb_coms_device_end_devices_ordered) { [school_b, moving_school].map(&:coms_device_allocation).sum(&:raw_devices_ordered) }
+
+        it 'remove school std allocation from the initial responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.std_device.first.allocation }
+                  .from(initial_rb_std_device_start_allocation)
+                  .to(initial_rb_std_device_end_allocation)
+        end
+
+        it 'remove school std device caps from the initial responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.std_device.first.cap }
+                  .from(initial_rb_std_device_start_cap)
+                  .to(initial_rb_std_device_end_cap)
+        end
+
+        it 'remove school std devices_ordered from the initial responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.std_device.first.devices_ordered }
+                  .from(initial_rb_std_device_start_devices_ordered)
+                  .to(initial_rb_std_device_end_devices_ordered)
+        end
+
+        it 'add school std allocation to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.std_device.first.allocation }
+                  .from(new_rb_std_device_start_allocation)
+                  .to(new_rb_std_device_end_allocation)
+        end
+
+        it 'add school std device cap to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.std_device.first.cap }
+                  .from(new_rb_std_device_start_cap)
+                  .to(new_rb_std_device_end_cap)
+        end
+
+        it 'add school std devices_ordered to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.std_device.first.devices_ordered }
+                  .from(new_rb_std_device_start_devices_ordered)
+                  .to(new_rb_std_device_end_devices_ordered)
+        end
+
+        it 'remove school coms allocation to the new responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.coms_device.first.allocation }
+                  .from(initial_rb_coms_device_start_allocation)
+                  .to(initial_rb_coms_device_end_allocation)
+        end
+
+        it 'remove school coms device cap from the initial responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.coms_device.first.cap }
+                  .from(initial_rb_coms_device_start_cap)
+                  .to(initial_rb_coms_device_end_cap)
+        end
+
+        it 'remove school coms devices_ordered from the initial responsible body' do
+          expect { service.call }
+            .to change { initial_rb.virtual_cap_pools.coms_device.first.devices_ordered }
+                  .from(initial_rb_coms_device_start_devices_ordered)
+                  .to(initial_rb_coms_device_end_devices_ordered)
+        end
+
+        it 'add school com allocation to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.coms_device.first.allocation }
+                  .from(new_rb_coms_device_start_allocation)
+                  .to(new_rb_coms_device_end_allocation)
+        end
+
+        it 'add school com device cap to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.coms_device.first.cap }
+                  .from(new_rb_coms_device_start_cap)
+                  .to(new_rb_coms_device_end_cap)
+        end
+
+        it 'add school com devices_ordered to the new responsible body' do
+          expect { service.call }
+            .to change { new_rb.virtual_cap_pools.coms_device.first.devices_ordered }
+                  .from(new_rb_coms_device_start_devices_ordered)
+                  .to(new_rb_coms_device_end_devices_ordered)
+        end
       end
     end
   end

--- a/spec/services/timeline/school_spec.rb
+++ b/spec/services/timeline/school_spec.rb
@@ -6,37 +6,27 @@ RSpec.describe Timeline::School, versioning: true do
   describe '#changesets' do
     subject(:timeline) { described_class.new(school: school) }
 
-    context 'when there are no changes' do
-      it 'returns empty collection' do
-        expect(timeline.changesets).to be_empty
-      end
-    end
-
     context 'when there are no relevant changes' do
-      before do
-        school.update!(address_1: 'new address line 1')
-      end
-
-      it 'returns empty collection' do
-        expect(timeline.changesets).to be_empty
+      it 'add no changes to the result' do
+        expect { school.update!(address_1: 'new address line 1') }
+          .not_to(change { described_class.new(school: school).changesets.map(&:changes) })
       end
     end
 
     context 'when there are relevant changes' do
-      before do
-        school.update!(status: 'closed')
-      end
-
-      it 'returns changesets' do
-        expect(timeline.changesets).not_to be_empty
+      it 'add a new changeset to the resulting collection' do
+        expect { school.update!(status: 'closed') }
+          .to(change { described_class.new(school: school).changesets.size }.from(1).to(2))
       end
 
       it 'returns Changeset populated correctly' do
-        changeset = timeline.changesets.first
+        school.update!(status: 'closed')
+        changeset = timeline.changesets.last
 
         expect(changeset).to be_a(Timeline::Changeset)
         expect(changeset.item).to eql(school)
         expect(changeset.updated_at).to be_within(10.seconds).of(school.updated_at)
+        expect(changeset.changes).to eq({ 'status' => %w[open closed] })
       end
     end
   end

--- a/spec/support/school_creator.rb
+++ b/spec/support/school_creator.rb
@@ -75,3 +75,17 @@ def create_schools_at_status(preorder_status:, count: 1, responsible_body: nil)
   end
   schools.count == 1 ? schools.first : schools
 end
+
+def create_and_put_school_in_pool(responsible_body)
+  create(:school, :centrally_managed, responsible_body: responsible_body).tap do |school|
+    create(:school_device_allocation, :with_std_allocation, school: school, allocation: rand(10..20), cap: rand(1..9), devices_ordered: rand(1..9))
+    create(:school_device_allocation, :with_coms_allocation, school: school, allocation: rand(10..10), cap: rand(1..9), devices_ordered: rand(1..9))
+    put_school_in_pool(responsible_body, school)
+  end
+end
+
+def put_school_in_pool(responsible_body, pool_school)
+  pool_school.preorder_information.responsible_body_will_order_devices!
+  pool_school.can_order!
+  responsible_body.add_school_to_virtual_cap_pools!(pool_school)
+end


### PR DESCRIPTION
### Context
See [card 2109: Totals wrong for responsible body virtual pool](https://trello.com/c/WBc27VQn)

### Changes proposed in this pull request
- Add tests to make sure recomputing pool allocations is done properly
- Remove school from pool when it leaves a responsible body. Recompute rb remaining allocations
- Add school to pool when it is moved to a different responsible body. Recompute rb new allocations

### Guidance to review

