### PR TITLE
Nullify invited_user_id from the SchoolWelcomeWizard when destroying a user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :extra_mobile_data_requests, foreign_key: :created_by_user_id, inverse_of: :created_by_user
   has_many :api_tokens, dependent: :destroy
   has_many :school_welcome_wizards, dependent: :destroy
+  has_many :invited_to_school_welcome_wizards, class_name: 'SchoolWelcomeWizard', foreign_key: 'invited_user_id', dependent: :nullify
   has_many :email_audits, dependent: :destroy
 
   belongs_to :mobile_network, optional: true

--- a/spec/services/delete_user_service_spec.rb
+++ b/spec/services/delete_user_service_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe DeleteUserService do
   describe '#delete!' do
-    before do
-      described_class.delete!(user)
-    end
-
     context 'techsource_account_confirmed_at set' do
       let(:user) { create(:local_authority_user, :with_a_confirmed_techsource_account) }
+
+      before do
+        described_class.delete!(user)
+      end
 
       it 'soft deletes the user' do
         expect(user.reload.deleted_at).to be_present
@@ -16,9 +16,21 @@ RSpec.describe DeleteUserService do
 
     context 'techsource_account_confirmed_at NOT set' do
       let(:user) { create(:local_authority_user) }
+      let(:school_user) { create(:school_user) }
+
+      before do
+        @wizard = school_user.school_welcome_wizards.first
+        @wizard.update!(invited_user_id: user.id)
+
+        described_class.delete!(user)
+      end
 
       it 'hard deletes the user' do
         expect(User.find_by(id: user.id)).to be_nil
+      end
+
+      it 'nullifies the welcome wizard invite_user_id' do
+        expect(@wizard.reload.invited_user_id).to be_nil
       end
     end
   end


### PR DESCRIPTION
Issue: Can cause a foreign key error if a user is invited and destroyed.

Solution: Nullify the invited user but keep the wizard as it belongs to another user.