### PR TITLE
Set cf health-check-invocation-timeout to default

### DIFF
--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 2G
     health-check-http-endpoint: /healthcheck.json
     health-check-type: http
-    health-check-invocation-timeout: 10
+    health-check-invocation-timeout: 60
     instances: 1
   - type: sidekiq
     disk_quota: 2G


### PR DESCRIPTION
### Context
The automated process to deploy the dev env to cf is reporting failures. All the failures that we have seen have been due to timeouts.

The dev env manifest had set the value of `health-check-invocation-timeout` to 10. The default is 60.

### Changes proposed in this pull request
The dev env manifest has set the value of `health-check-invocation-timeout` to the default of 60.

### Guidance to review
`health-check-invocation-timeout` = 60 for the dev cf env.

[health_check_timeout](https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#health_check_timeout)

