### PR TITLE
Add 2 min timeout for dev env deployment

### DIFF
--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -8,6 +8,7 @@ applications:
     health-check-type: http
     health-check-invocation-timeout: 60
     instances: 1
+    timeout: 120
   - type: sidekiq
     disk_quota: 2G
     health-check-type: process


### PR DESCRIPTION
### Context

The automated process to deploy the dev env to cf is reporting failures. All the failures that we have seen have been due to timeouts.

The dev env manifest had not set the value of timeout for the web app.

### Changes proposed in this pull request

The dev env manifest has set the value of timeout to 120 for the web app.

### Guidance to review

timeout = 120 for the web app in dev cf env.

[app-manifest-specification](https://v3-apidocs.cloudfoundry.org/version/3.76.0/index.html#the-app-manifest-specification)