### PR TITLE
Access to missing images in publis/devices return 404s

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 require Rails.root.join('lib/constraints/require_dfe_user_constraint')
 
 Rails.application.routes.draw do
+  # Stop missing images in `public/devices/` hitting a controller causing exceptions
+  scope format: true, constraints: { format: /jpg|png/ } do
+    get '/devices/*anything', to: 'errors#not_found'
+  end
+
   root 'pages#home_page'
 
   resource :notify_callbacks, only: [:create]
@@ -349,8 +354,8 @@ Rails.application.routes.draw do
 
   get '/techsource-start', to: 'techsource_launcher#start'
 
-  get '/403', to: 'errors#forbidden', via: :all
-  get '/404', to: 'errors#not_found', via: :all
-  get '/422', to: 'errors#unprocessable_entity', via: :all
-  get '/500', to: 'errors#internal_server_error', via: :all
+  match '/403', to: 'errors#forbidden', via: :all
+  match '/404', to: 'errors#not_found', via: :all
+  match '/422', to: 'errors#unprocessable_entity', via: :all
+  match '/500', to: 'errors#internal_server_error', via: :all
 end

--- a/spec/features/devices_guidance_spec.rb
+++ b/spec/features/devices_guidance_spec.rb
@@ -19,4 +19,10 @@ RSpec.feature 'Devices guidance pages', type: :feature do
 
     expect(page).to have_selector 'h1', text: 'Page not found'
   end
+
+  scenario 'Images that NO longer exist' do
+    visit '/devices/non-existent-image.png'
+
+    expect(page.status_code).to be(404)
+  end
 end


### PR DESCRIPTION
### Context

Access to missing image assets in `public/devices` hits the `DevicesGuidanceController` and bubbles up a `not_found` call, however since `png` is not a format with a template to render this causes an exception.

Given if an image were present it shouldn't hit the controller in the first place.

### Changes proposed in this pull request

At the top of the routes file, catch any png/jpg files to devices/ and forward to default Error controller to return a 404 and not raise a template exception

### Bonus

The last 4 GETs to should be `match`.

