### PR TITLE
Export CSV of assets first viewed during date range

### DIFF
--- a/app/concerns/csv_value_sanitiser.rb
+++ b/app/concerns/csv_value_sanitiser.rb
@@ -5,7 +5,8 @@ class CsvValueSanitiser
   end
 
   def safe?
-    @value =~ /\A[^=+\-@\t\r]/
+    string_value = @value.to_s
+    string_value.blank? ? true : string_value =~ /\A[^=+\-@\t\r]/
   end
 
   def sanitise

--- a/app/controllers/viewed_assets_controller.rb
+++ b/app/controllers/viewed_assets_controller.rb
@@ -1,0 +1,29 @@
+require 'datetime_period'
+
+class ViewedAssetsController < ApplicationController
+  before_action :require_sign_in!
+
+  def new
+    @title = 'Viewed devices CSV download'
+    @datetime_period = DatetimePeriod.new
+  end
+
+  def index
+    @datetime_period = DatetimePeriod.new(params[:datetime_period])
+
+    if @datetime_period.valid?
+      @filename = filename(@datetime_period)
+      @viewed_assets = policy_scope(Asset).first_viewed_during_period(@datetime_period.range)
+
+      respond_to do |format|
+        format.csv { send_data @viewed_assets.to_viewed_csv, filename: @filename }
+      end
+    end
+  end
+
+private
+
+  def filename(period)
+    "assets_first_viewed_during_#{period}.csv"
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -48,6 +48,16 @@ class Asset < ApplicationRecord
     to_csv
   end
 
+  def self.to_viewed_csv
+    class << self
+      def exportable_attributes # rubocop:disable Lint/DuplicateMethods
+        { serial_number: 'serial_number', first_viewed_at: 'first_viewed_at' }
+      end
+    end
+
+    to_csv
+  end
+
   def self.secure_attr_accessor(*attributes)
     attributes.each do |attribute|
       define_method(attribute) do
@@ -78,6 +88,8 @@ class Asset < ApplicationRecord
   }
 
   scope :search_by_serial_numbers, ->(serial_numbers) { where(serial_number: serial_numbers) }
+
+  scope :first_viewed_during_period, ->(period) { where(first_viewed_at: period) }
 
   def bios_unlockable?
     model.match?(UNLOCKABLE_MODEL_PATTERN)

--- a/app/views/viewed_assets/new.html.erb
+++ b/app/views/viewed_assets/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, @title %>
+<% content_for :browser_title, @title %>
+
+<% content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => root_path },
+                  @title,
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      Enter time period for devices which were first viewed.
+      Acceptable date formats can be found
+      <%= govuk_link_to 'here', 'https://github.com/mojombo/chronic#examples' %>
+    </p>
+
+    <%= form_with model: [@datetime_period], url: viewed_assets_path(format: 'csv'), method: :get do |f| %>
+      <%= f.govuk_text_field :start_at_string, label: { text: 'Start of period', size: 'm' } %>
+      <%= f.govuk_text_field :end_at_string, label: { text: 'End of period', size: 'm' } %>
+      <%= f.govuk_submit 'Export to CSV' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :viewed_assets, only: %i[new index]
+
   resources :sessions, only: %i[create destroy]
 
   namespace :support_ticket, path: '/get-support' do

--- a/lib/datetime_period.rb
+++ b/lib/datetime_period.rb
@@ -1,0 +1,56 @@
+class DatetimePeriod
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
+  attr_accessor :start_at_string, :end_at_string
+
+  validates :start_at_string, :end_at_string, presence: true
+  validate :parseable_strings, :start_at_must_be_before_end_at
+
+  def initialize(attributes = {})
+    attributes.each do |name, value|
+      send("#{name}=", value)
+    end
+  end
+
+  def persisted?
+    false
+  end
+
+  def to_s
+    "#{human_readable_datetime(range.first)}--#{human_readable_datetime(range.last)}"
+  end
+
+  def range
+    start_at..end_at
+  end
+
+private
+
+  def parseable_strings
+    errors.add(:start_at_string) if start_at.nil?
+    errors.add(:end_at_string) if end_at.nil?
+  end
+
+  def start_at_must_be_before_end_at
+    errors.add(:start_at_string) unless start_at&.before?(end_at)
+  end
+
+  def start_at
+    defined?(@start_at) ? @start_at : @start_at = parse_datetime_string_or_nil(start_at_string)
+  end
+
+  def end_at
+    defined?(@end_at) ? @end_at : @end_at = parse_datetime_string_or_nil(end_at_string)
+  end
+
+  def parse_datetime_string_or_nil(string)
+    Chronic.time_class = Time.zone
+    Chronic.parse(string)
+  end
+
+  def human_readable_datetime(datetime)
+    datetime.strftime('%FT%R')
+  end
+end

--- a/spec/concerns/csv_value_sanitiser_spec.rb
+++ b/spec/concerns/csv_value_sanitiser_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe CsvValueSanitiser do
   describe '#safe?' do
     let(:good_value) { 'foo' }
+    let(:date_value_str) { '2021-09-15 12:52:00 +0100' }
+    let(:date_value) { Time.zone.parse(date_value_str) }
 
     let(:begins_with_equals) { '=foo' }
     let(:begins_with_plus) { '+foo' }
@@ -11,14 +13,19 @@ RSpec.describe CsvValueSanitiser do
     let(:begins_with_tab) { "\tfoo" }
     let(:begins_with_carriage_return) { "\rfoo" }
 
-    specify { expect(CsvValueSanitiser.new(good_value)).to be_safe }
+    specify { expect(described_class.new(good_value)).to be_safe }
+    specify { expect(described_class.new(date_value_str)).to be_safe }
+    specify { expect(described_class.new(date_value)).to be_safe }
 
-    specify { expect(CsvValueSanitiser.new(begins_with_equals)).not_to be_safe }
-    specify { expect(CsvValueSanitiser.new(begins_with_plus)).not_to be_safe }
-    specify { expect(CsvValueSanitiser.new(begins_with_minus)).not_to be_safe }
-    specify { expect(CsvValueSanitiser.new(begins_with_at)).not_to be_safe }
-    specify { expect(CsvValueSanitiser.new(begins_with_tab)).not_to be_safe }
-    specify { expect(CsvValueSanitiser.new(begins_with_carriage_return)).not_to be_safe }
+    specify { expect(described_class.new(nil)).to be_safe }
+    specify { expect(described_class.new('')).to be_safe }
+
+    specify { expect(described_class.new(begins_with_equals)).not_to be_safe }
+    specify { expect(described_class.new(begins_with_plus)).not_to be_safe }
+    specify { expect(described_class.new(begins_with_minus)).not_to be_safe }
+    specify { expect(described_class.new(begins_with_at)).not_to be_safe }
+    specify { expect(described_class.new(begins_with_tab)).not_to be_safe }
+    specify { expect(described_class.new(begins_with_carriage_return)).not_to be_safe }
   end
 
   describe '#sanitise' do
@@ -30,9 +37,9 @@ RSpec.describe CsvValueSanitiser do
     let(:bad_input_2) { %q(=1+2'" ;,=1+2) }
     let(:escaped_output_2) { %q("'=1+2'"" ;,=1+2") }
 
-    specify { expect(CsvValueSanitiser.new(good_input).sanitise).to eq(good_input) }
+    specify { expect(described_class.new(good_input).sanitise).to eq(good_input) }
 
-    specify { expect(CsvValueSanitiser.new(bad_input_1).sanitise).to eq(escaped_output_1) }
-    specify { expect(CsvValueSanitiser.new(bad_input_2).sanitise).to eq(escaped_output_2) }
+    specify { expect(described_class.new(bad_input_1).sanitise).to eq(escaped_output_1) }
+    specify { expect(described_class.new(bad_input_2).sanitise).to eq(escaped_output_2) }
   end
 end

--- a/spec/controllers/viewed_assets_controller_spec.rb
+++ b/spec/controllers/viewed_assets_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe ViewedAssetsController, type: :controller do
+  let(:support_user) { create(:support_user) }
+
+  describe '#new' do
+    before do
+      sign_in_as support_user
+      get :new
+    end
+
+    specify { expect(assigns(:title)).to eq('Viewed devices CSV download') }
+  end
+
+  describe '#index' do
+    context 'not logged in' do
+      it 'redirects to log in' do
+        get :index, format: :csv
+        expect(response).not_to be_successful
+      end
+    end
+
+    context 'logged in' do
+      context 'start before end' do
+        let(:start_period_string) { '20 September 2020 09:00' }
+        let(:end_period_string) { '20 September 2020 10:00' }
+        let!(:first_viewed_during) { create(:asset, first_viewed_at: Time.zone.parse('20 September 2020 09:01"')) }
+
+        before do
+          create(:asset, first_viewed_at: Time.zone.parse('20 September 2020 08:59'))
+          create(:asset, first_viewed_at: Time.zone.parse('20 September 2020 10:01'))
+
+          sign_in_as support_user
+          get :index, params: { datetime_period: { start_at_string: start_period_string, end_at_string: end_period_string } }, format: :csv
+        end
+
+        specify { expect(assigns(:filename)).to eq('assets_first_viewed_during_2020-09-20T09:00--2020-09-20T10:00.csv') }
+        specify { expect(assigns(:viewed_assets)).to contain_exactly(first_viewed_during) }
+      end
+
+      context 'end before start' do
+        let(:start_period_string) { '20 September 2020 10:00' }
+        let(:end_period_string) { '20 September 2020 09:00' }
+
+        before do
+          sign_in_as support_user
+          get :index, params: { datetime_period: { start_at_string: start_period_string, end_at_string: end_period_string } }, format: :csv
+        end
+
+        specify { expect(assigns(:period)).to be_nil }
+      end
+
+      context 'zero period' do
+        let(:datetime_string) { '20 September 2020 10:00' }
+
+        before do
+          sign_in_as support_user
+          get :index, params: { datetime_period: { start_at_string: datetime_string, end_at_string: datetime_string } }, format: :csv
+        end
+
+        specify { expect(assigns(:period)).to be_nil }
+      end
+    end
+  end
+end

--- a/spec/lib/datetime_period_spec.rb
+++ b/spec/lib/datetime_period_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'datetime_period'
+
+RSpec.describe DatetimePeriod, type: :model do
+  describe 'validations' do
+    let(:monday_string) { '20 September 2021 09:00' }
+    let(:tuesday_string) { '21 September 2021 09:00' }
+
+    it { is_expected.to validate_presence_of(:start_at_string) }
+    it { is_expected.to validate_presence_of(:end_at_string) }
+
+    it { is_expected.not_to allow_values('blah').for(:start_at_string) }
+    it { is_expected.not_to allow_values('blah').for(:end_at_string) }
+
+    context 'start before end' do
+      subject { described_class.new(start_at_string: monday_string, end_at_string: tuesday_string) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'end before start' do
+      subject { described_class.new(start_at_string: tuesday_string, end_at_string: monday_string) }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'same end and start' do
+      subject { described_class.new(start_at_string: monday_string, end_at_string: monday_string) }
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  describe '#to_s' do
+    let(:start_at_string) { '1 Jan 2021 09:00' }
+    let(:end_at_string) { '2 Jan 2021 10:00' }
+    let(:period) { described_class.new(start_at_string: start_at_string, end_at_string: end_at_string) }
+
+    specify { expect(period.to_s).to eq('2021-01-01T09:00--2021-01-02T10:00') }
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/7nZxVgYn

### Changes proposed in this pull request

Unfortunately I couldn't find a way to print the error messages if the date range is wrong because of redirect errors, etc. Freddie's said this is acceptable. The UX is that if there's something wrong with the date range, the CSV download button just does nothing. 

Rather than leave the error messaging half-finished, it makes no attempt to print the error messages *at all*.

### Guidance to review

