### PR TITLE
Order devices page for a school

### DIFF
--- a/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
+++ b/app/views/responsible_body/devices/orders/cannot_order_anymore.html.erb
@@ -8,7 +8,7 @@
     </h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
   </div>
 </div>
 

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -7,7 +7,7 @@
     </h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
   </div>
 </div>

--- a/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
+++ b/app/views/responsible_body/devices/orders/specific_circumstances.html.erb
@@ -8,7 +8,7 @@
     </h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
 
     <p class="govuk-body">Now you’ve contacted us to request devices for specific circumstances, you can go ahead with your order.</p>
 

--- a/app/views/school/devices/can_order.html.erb
+++ b/app/views/school/devices/can_order.html.erb
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
 
     <%= render DeviceCountComponent.new(school: @school) %>

--- a/app/views/school/devices/can_order_awaiting_techsource.html.erb
+++ b/app/views/school/devices/can_order_awaiting_techsource.html.erb
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
 
     <p class="govuk-body">You’ll be able to order <%= what_to_order_allocation_list(allocations: @school.device_allocations) %> soon.</p>
 

--- a/app/views/school/devices/can_order_for_specific_circumstances.html.erb
+++ b/app/views/school/devices/can_order_for_specific_circumstances.html.erb
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
 
     <%= render DeviceCountComponent.new(school: @school) %>
 

--- a/app/views/school/devices/school_can_order_user_cannot.html.erb
+++ b/app/views/school/devices/school_can_order_user_cannot.html.erb
@@ -10,7 +10,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
 
     <%= render DeviceCountComponent.new(school: @school) %>
 

--- a/app/views/school/la_funded_places/order.html.erb
+++ b/app/views/school/la_funded_places/order.html.erb
@@ -11,7 +11,7 @@
     </h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
 
     <%= render partial: 'shared/stock_levels' %>

--- a/app/views/school/la_funded_places/show.html.erb
+++ b/app/views/school/la_funded_places/show.html.erb
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= render Computacenter::TechSourceOutOfStockComponent.new %>
-    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new %>
+    <%= render Computacenter::TechSourceMaintenanceBannerComponent.new(Computacenter::TechSource.new) %>
     <%= render partial: 'shared/half_term_delivery_suspension' %>
 
     <%= render DeviceCountComponent.new(school: @school) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,7 +185,7 @@ Rails.application.routes.draw do
       get '/', to: 'school/home#show', as: :home
       get '/before-you-can-order', to: 'school/before_can_order#edit'
       patch '/before-you-can-order', to: 'school/before_can_order#update'
-      get '/order-devices', to: 'school/devices#order', constraints: -> { false }
+      get '/order-devices', to: 'school/devices#order'
       get '/details', to: 'school/details#show', as: :details, constraints: -> { false }
       get '/chromebooks/edit', to: 'school/chromebooks#edit', constraints: -> { false }
       patch '/chromebooks', to: 'school/chromebooks#update'

--- a/spec/features/school/order_devices_spec.rb
+++ b/spec/features/school/order_devices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Order devices', skip: 'Disabled for 30 Jun 2021 service closure' do
+RSpec.feature 'Order devices' do
   include ViewHelper
 
   let(:school) { create(:school, :with_std_device_allocation) }


### PR DESCRIPTION
Re-enable ordering page for Schools.

This is simply to reinstate the current page as is for review, copy changes for the new service will be new PRs.

Fixed weird error for `Computacenter::TechSourceMaintenanceBannerComponent.new` requiring 1 param.

