### PR TITLE
Add GitHub action for mergers into reopening branch

### DIFF
--- a/.github/workflows/build-push-and-deploy-preview-container.yml
+++ b/.github/workflows/build-push-and-deploy-preview-container.yml
@@ -1,0 +1,61 @@
+---
+name: Build, push and deploy preview container
+
+on:
+  push:
+    branches:
+      - reopening
+
+jobs:
+  build-and-push-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Declare some variables
+        id: vars
+        shell: bash
+        run: |
+          echo "##[set-output name=branch;]$(git rev-parse --abbrev-ref HEAD)"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      # We can't use the `make build push` task for this,
+      # due to limitations in the way docker login works (or not) in non-TTY
+      # Github actions. Helpfully, there's an off-the-shelf 'official' docker
+      # action that does it for us
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v1
+        with:
+          build_args: GIT_COMMIT_SHA=${{ steps.vars.outputs.sha_short }},GIT_BRANCH=${{ steps.vars.outputs.branch }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: dfedigital/get-help-with-tech-dev
+          tags: preview
+
+  deploy-to-paas:
+    runs-on: ubuntu-latest
+    needs: build-and-push-container
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Install CloudFoundry CLI
+        shell: bash
+        id: install-cf-cli
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli
+      - name: Deploy to Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        env:
+          CF_DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          CF_DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
+          cf target -o dfe -s get-help-with-tech-dev
+          $(eval DOCKER_IMAGE_ID ?= $(shell (docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q) )
+          cf push get-help-with-tech-dev --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=${DOCKER_IMAGE_ID} --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, reopening ]
 
 jobs:
   build_and_test:

--- a/config/manifests/preview-manifest.yml
+++ b/config/manifests/preview-manifest.yml
@@ -1,0 +1,25 @@
+---
+applications:
+- name: get-help-with-tech-preview
+  processes:
+  - type: web
+    disk_quota: 2G
+    health-check-http-endpoint: /healthcheck.json
+    health-check-type: http
+    health-check-invocation-timeout: 10
+    instances: 1
+  - type: sidekiq
+    disk_quota: 2G
+    health-check-type: process
+    instances: 1
+    command: bundle exec sidekiq -C config/sidekiq.yml
+  services:
+    - get-help-with-tech-preview-db
+    - get-help-with-tech-preview-redis
+  env:
+    DOCKER_IMAGE_ID: ((docker_image_id))
+    ENV: $HOME/.profile
+    RAILS_LOG_TO_STDOUT: true
+    GHWT__HOSTNAME_FOR_URLS: preview-get-help-with-tech.education.gov.uk
+    GHWT__SERVICE_NAME_SUFFIX: (preview)
+    SERVICE_ENV: preview


### PR DESCRIPTION
### Context

The `reopening` branch will be used to manage all changes related to reopening the service.

PRs should be checked against the specs.

Mergers into the `reopening` branch should be automatically pushed to the `preview` app on PaaS.

### Changes proposed in this pull request

Updated the `build` GitHub action to run on PRs on the `reopening` branch.

Added the `build-push-deploy-preview-conatiner` GitHub action to deploy the `reopening` branch changes to the `preview` app on PaaS.

### Guidance to review

Check that the specs are run on the new PR.

After merger check that the `preview` app on PaaS is updated.