### PR TITLE
Fix retrieval of Docker image ID in GH action

### DIFF
--- a/.github/workflows/build-push-and-deploy-preview-container.yml
+++ b/.github/workflows/build-push-and-deploy-preview-container.yml
@@ -57,5 +57,5 @@ jobs:
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
           cf target -o dfe -s get-help-with-tech-dev
-          $(eval DOCKER_IMAGE_ID ?= $(shell (docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q) )
-          cf push get-help-with-tech-dev --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=${DOCKER_IMAGE_ID} --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling
+          DOCKER_IMAGE_ID=$((docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q)
+          cf push get-help-with-tech-dev --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=$DOCKER_IMAGE_ID --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling


### PR DESCRIPTION
### Context

There is an error in the preview deploy GitHub action during the retrieval of the Docker image ID

```
/home/runner/work/_temp/8a10a5af-ffca-4eee-b9ac-25fe92a6c085.sh: command substitution: line 5: syntax error near unexpected token `docker'
/home/runner/work/_temp/8a10a5af-ffca-4eee-b9ac-25fe92a6c085.sh: command substitution: line 5: `shell (docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q)'
```

### Changes proposed in this pull request

Simplified the command

### Guidance to review

Test for success or failure on merge into `reopening`
