### PR TITLE
Fix target cf app name for preview env

### DIFF
--- a/.github/workflows/build-push-and-deploy-preview-container.yml
+++ b/.github/workflows/build-push-and-deploy-preview-container.yml
@@ -58,4 +58,4 @@ jobs:
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
           cf target -o dfe -s get-help-with-tech-dev
           DOCKER_IMAGE_ID=$((docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q)
-          cf push get-help-with-tech-dev --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=$DOCKER_IMAGE_ID --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling
+          cf push get-help-with-tech-preview --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=$DOCKER_IMAGE_ID --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling


### PR DESCRIPTION
### Context

The docker image is built and pushed to dockerhub correctly, but the deploy fails.

### Changes proposed in this pull request

The target app name in the cf command has been changed to `-preview`

### Guidance to review

Deploy and check `healthcheck.json`