### PR TITLE
2372 and 2373 display allocation component

### DIFF
--- a/app/components/tranche_allocation_component.html.erb
+++ b/app/components/tranche_allocation_component.html.erb
@@ -1,0 +1,19 @@
+<div id="tranche_allocation" class="app-card">
+  <% if @organisation.is_a?(ResponsibleBody) %>
+    <h2 id="intro" class="govuk-heading-m">
+      <%= intro_sentence %>
+    </h2>
+  <% end %>
+
+  <h2 id="available_summary" class="govuk-heading-l">
+    <%= available_to_order_summary %>
+  </h2>
+
+  <h2 id="ordered_summary">
+    <%= ordered_summary %>
+  </h2>
+
+  <div id="current_tranche">
+    <%= render GovukComponent::WarningTextComponent.new(text: 'These allocations are for the current winter 2021 Get help with tech programme. Devices received before 30 September 2021 are not included here.') %>
+  </div>
+</div>

--- a/app/components/tranche_allocation_component.rb
+++ b/app/components/tranche_allocation_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class TrancheAllocationComponent < ViewComponent::Base
+  def initialize(organisation:, devices_remaining:, routers_remaining:, devices_ordered:, routers_ordered:, devices_allocation:, routers_allocation:)
+    @organisation = organisation
+    @devices_remaining = devices_remaining
+    @routers_remaining = routers_remaining
+    @devices_ordered = devices_ordered
+    @routers_ordered = routers_ordered
+    @devices_allocation = devices_allocation
+    @routers_allocation = routers_allocation
+
+    sanity_check
+  end
+
+  def render?
+    @sane
+  end
+
+  def intro_sentence
+    if @organisation.is_a?(ResponsibleBody)
+      "#{@organisation.name} has:"
+    else
+      raise 'Invalid for school'
+    end
+  end
+
+  def available_to_order_summary
+    "#{pluralize(@devices_remaining, 'device')} and "\
+    "#{pluralize(@routers_remaining, 'router')} available to order"
+  end
+
+  def ordered_summary
+    "You&rsquo;ve ordered #{@devices_ordered} of #{pluralize(@devices_allocation, 'device')} and "\
+    "#{@routers_ordered} of #{pluralize(@routers_allocation, 'router')}".html_safe
+  end
+
+private
+
+  def sanity_check
+    @sane = true
+    flag_error_to_sentry('Contains negative number') if [@devices_remaining, @routers_remaining, @devices_ordered, @routers_ordered, @devices_allocation, @routers_allocation].any?(&:negative?)
+    flag_allocation_if_necessary(allocation: @devices_allocation, ordered: @devices_ordered, remaining: @devices_remaining)
+    flag_allocation_if_necessary(allocation: @routers_allocation, ordered: @routers_ordered, remaining: @routers_remaining)
+  end
+
+  def flag_error_to_sentry(message)
+    @sane = false
+
+    Sentry.with_scope do |scope|
+      scope.set_context('TrancheAllocationComponent.new', { organisation_id: @organisation&.id })
+      Sentry.capture_message(message)
+    end
+  end
+
+  def flag_allocation_if_necessary(allocation:, ordered:, remaining:)
+    flag_error_to_sentry(summation_error_message(allocation: allocation, ordered: ordered, remaining: remaining)) unless allocation == ordered + remaining
+  end
+
+  def summation_error_message(allocation:, ordered:, remaining:)
+    "Expected allocation == ordered + remaining, but #{allocation} != #{ordered} + #{remaining}"
+  end
+end

--- a/app/components/tranche_allocation_component_factory.rb
+++ b/app/components/tranche_allocation_component_factory.rb
@@ -1,0 +1,13 @@
+class TrancheAllocationComponentFactory
+  def self.create_component(organisation)
+    TrancheAllocationComponent.new(
+      organisation: organisation,
+      devices_remaining: organisation.laptops_available_to_order,
+      routers_remaining: organisation.routers_available_to_order,
+      devices_ordered: organisation.laptops_ordered,
+      routers_ordered: organisation.routers_ordered,
+      devices_allocation: organisation.laptop_allocation,
+      routers_allocation: organisation.router_allocation,
+    )
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,7 +102,7 @@ private
       support_home_path
     else
       # this should not happen - so let's tell Sentry
-      Sentry.configure_scope do |scope|
+      Sentry.with_scope do |scope|
         scope.set_context('ApplicationController#root_url_for', { user_id: user.id })
 
         Sentry.capture_message("Couldn't figure out root_url_for user")

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -271,6 +271,10 @@ class School < ApplicationRecord
     std_device_allocation&.devices_available_to_order?
   end
 
+  def laptops_available_to_order
+    std_device_allocation&.devices_available_to_order.to_i
+  end
+
   def laptops_ordered
     std_device_allocation&.devices_ordered.to_i
   end
@@ -385,6 +389,10 @@ class School < ApplicationRecord
 
   def routers_available_to_order?
     coms_device_allocation&.devices_available_to_order?
+  end
+
+  def routers_available_to_order
+    coms_device_allocation&.devices_available_to_order.to_i
   end
 
   def routers_ordered

--- a/app/services/trust_update_service.rb
+++ b/app/services/trust_update_service.rb
@@ -52,7 +52,7 @@ private
 
     return if trusts_with_schools.empty?
 
-    Sentry.configure_scope do |scope|
+    Sentry.with_scope do |scope|
       scope.set_context('TrustUpdateService#close_trusts', { trust_ids: trusts_with_schools })
 
       Sentry.capture_message('Skipped auto-closing Trusts as schools.size > 0')

--- a/app/views/responsible_body/home/show.html.erb
+++ b/app/views/responsible_body/home/show.html.erb
@@ -15,6 +15,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
+    <%= render TrancheAllocationComponentFactory.create_component(@responsible_body) %>
+
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.responsible_body_devices_home'), responsible_body_devices_path %>
     </h2>

--- a/app/views/school/home/show.html.erb
+++ b/app/views/school/home/show.html.erb
@@ -15,6 +15,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-grid-column-full">
+    <%= render TrancheAllocationComponentFactory.create_component(@school) %>
+
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <%= govuk_link_to t('page_titles.school_order_devices'), order_devices_school_path(@school) %>
     </h2>

--- a/spec/components/tranche_allocation_component_factory_spec.rb
+++ b/spec/components/tranche_allocation_component_factory_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe TrancheAllocationComponentFactory do
+  describe '.initialize' do
+    let(:organisation) { spy }
+
+    before { described_class.create_component(organisation) }
+
+    specify { expect(organisation).to have_received(:laptops_available_to_order) }
+    specify { expect(organisation).to have_received(:routers_available_to_order) }
+    specify { expect(organisation).to have_received(:laptops_ordered) }
+    specify { expect(organisation).to have_received(:routers_ordered) }
+    specify { expect(organisation).to have_received(:laptop_allocation) }
+    specify { expect(organisation).to have_received(:router_allocation) }
+
+    specify { expect(described_class.create_component(organisation)).to be_an_instance_of(TrancheAllocationComponent) }
+  end
+end

--- a/spec/components/tranche_allocation_component_spec.rb
+++ b/spec/components/tranche_allocation_component_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe TrancheAllocationComponent, type: :component do
+  let(:school) { build(:school) }
+  let(:rb) { build(:responsible_body) }
+
+  describe 'intro_sentence' do
+    context 'RB' do
+      let(:rb_with_name) { build(:responsible_body, name: 'Trent Trust') }
+
+      subject { described_class.new(organisation: rb_with_name, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+      it { is_expected.to have_attributes(intro_sentence: 'Trent Trust has:') }
+    end
+
+    context 'school' do
+      let(:component) { described_class.new(organisation: school, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+      specify { expect { component.intro_sentence }.to raise_error('Invalid for school') }
+    end
+  end
+
+  describe '#available_to_order_summary' do
+    context 'both zero' do
+      subject { described_class.new(organisation: nil, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+      it { is_expected.to have_attributes(available_to_order_summary: '0 devices and 0 routers available to order') }
+    end
+
+    context 'both one' do
+      subject { described_class.new(organisation: nil, devices_remaining: 1, routers_remaining: 1, devices_ordered: 0, routers_ordered: 0, devices_allocation: 1, routers_allocation: 1) }
+
+      it { is_expected.to have_attributes(available_to_order_summary: '1 device and 1 router available to order') }
+    end
+
+    context 'both two' do
+      subject { described_class.new(organisation: nil, devices_remaining: 2, routers_remaining: 2, devices_ordered: 0, routers_ordered: 0, devices_allocation: 2, routers_allocation: 2) }
+
+      it { is_expected.to have_attributes(available_to_order_summary: '2 devices and 2 routers available to order') }
+    end
+  end
+
+  describe '#ordered_summary' do
+    context 'both zero' do
+      subject(:component) { described_class.new(organisation: nil, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+      it { is_expected.to have_attributes(ordered_summary: 'You&rsquo;ve ordered 0 of 0 devices and 0 of 0 routers') }
+      specify { expect(component.ordered_summary).to be_html_safe }
+    end
+
+    context 'both one' do
+      subject { described_class.new(organisation: nil, devices_remaining: 1, routers_remaining: 1, devices_ordered: 0, routers_ordered: 0, devices_allocation: 1, routers_allocation: 1) }
+
+      it { is_expected.to have_attributes(ordered_summary: 'You&rsquo;ve ordered 0 of 1 device and 0 of 1 router') }
+    end
+
+    context 'both two' do
+      subject { described_class.new(organisation: nil, devices_remaining: 2, routers_remaining: 2, devices_ordered: 0, routers_ordered: 0, devices_allocation: 2, routers_allocation: 2) }
+
+      it { is_expected.to have_attributes(ordered_summary: 'You&rsquo;ve ordered 0 of 2 devices and 0 of 2 routers') }
+    end
+  end
+
+  describe 'component' do
+    describe '.new' do
+      let(:organisation) { school }
+      let(:sentry_scope) { double }
+
+      before do
+        allow(sentry_scope).to receive(:set_context)
+        allow(Sentry).to receive(:capture_message)
+        allow(Sentry).to receive(:with_scope).and_yield(sentry_scope)
+
+        render_inline(component)
+      end
+
+      context 'invalid' do
+        context 'negative number' do
+          let(:component) { described_class.new(organisation: nil, devices_remaining: -1, routers_remaining: 0, devices_ordered: 1, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+          specify { expect(sentry_scope).to have_received(:set_context).with('TrancheAllocationComponent.new', organisation_id: organisation.id) }
+          specify { expect(Sentry).to have_received(:capture_message).with('Contains negative number') }
+          specify { expect(rendered_component).to be_blank }
+        end
+
+        context 'summation wrong' do
+          let(:component) { described_class.new(organisation: organisation, devices_remaining: 2, routers_remaining: 0, devices_ordered: 2, routers_ordered: 0, devices_allocation: 5, routers_allocation: 0) }
+
+          specify { expect(sentry_scope).to have_received(:set_context).with('TrancheAllocationComponent.new', organisation_id: organisation.id) }
+          specify { expect(Sentry).to have_received(:capture_message).with('Expected allocation == ordered + remaining, but 5 != 2 + 2') }
+          specify { expect(rendered_component).to be_blank }
+        end
+      end
+
+      context 'valid' do
+        let(:component) { described_class.new(organisation: organisation, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0) }
+
+        specify { expect(sentry_scope).not_to have_received(:set_context) }
+        specify { expect(Sentry).not_to have_received(:capture_message) }
+        specify { expect(rendered_component).to be_present }
+      end
+    end
+
+    context 'RB' do
+      subject { render_inline(described_class.new(organisation: rb, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0)) }
+
+      it { is_expected.to have_css('#intro') }
+      it { is_expected.to have_css('#available_summary') }
+      it { is_expected.to have_css('#ordered_summary') }
+      it { is_expected.to have_css('#current_tranche') }
+    end
+
+    context 'school' do
+      subject { render_inline(described_class.new(organisation: school, devices_remaining: 0, routers_remaining: 0, devices_ordered: 0, routers_ordered: 0, devices_allocation: 0, routers_allocation: 0)) }
+
+      it { is_expected.to have_no_css('#intro') }
+      it { is_expected.to have_css('#available_summary') }
+      it { is_expected.to have_css('#ordered_summary') }
+      it { is_expected.to have_css('#current_tranche') }
+    end
+  end
+end

--- a/spec/features/responsible_body/home_spec.rb
+++ b/spec/features/responsible_body/home_spec.rb
@@ -43,6 +43,10 @@ RSpec.feature ResponsibleBody do
       it 'displays your account title' do
         expect(page).to have_content('Your account')
       end
+
+      it 'displays the tranche allocation' do
+        expect(page).to have_css('#tranche_allocation')
+      end
     end
 
     describe 'access support portal section' do

--- a/spec/features/school/view_school_details_spec.rb
+++ b/spec/features/school/view_school_details_spec.rb
@@ -6,14 +6,21 @@ RSpec.feature 'View school details' do
   let(:user) { create(:school_user, full_name: 'AAA Smith', school: school) }
 
   describe 'top of the page' do
+    let(:school_with_valid_allocation) { create(:school, :with_std_device_allocation, laptops_ordered: 1, preorder_information: preorder_information) }
+    let(:user) { create(:school_user, school: school_with_valid_allocation) }
+
     before { sign_in_as user }
 
     it 'displays the school name' do
-      expect(page).to have_content(school.name)
+      expect(page).to have_content(school_with_valid_allocation.name)
     end
 
     it 'displays your account title' do
       expect(page).to have_content('Your account')
+    end
+
+    it 'displays the tranche allocation' do
+      expect(page).to have_css('#tranche_allocation')
     end
   end
 

--- a/spec/services/trust_update_service_spec.rb
+++ b/spec/services/trust_update_service_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe TrustUpdateService, type: :model do
         allow(sentry_scope).to receive(:set_context)
 
         allow(Sentry).to receive(:capture_message)
-        allow(Sentry).to receive(:configure_scope).and_yield(sentry_scope)
+        allow(Sentry).to receive(:with_scope).and_yield(sentry_scope)
 
         service.update_trusts
 


### PR DESCRIPTION
### Context

https://trello.com/c/4K84Z98e
https://trello.com/c/bV64QkKj

`configure_scope` vs `with_scope`: https://docs.sentry.io/platforms/ruby/guides/rack/enriching-events/scopes/

### Changes proposed in this pull request

### Guidance to review

