### PR TITLE
Simplify CF push command

### DIFF
--- a/.github/workflows/build-push-and-deploy-preview-container.yml
+++ b/.github/workflows/build-push-and-deploy-preview-container.yml
@@ -57,5 +57,4 @@ jobs:
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
           cf target -o dfe -s get-help-with-tech-dev
-          DOCKER_IMAGE_ID=$((docker pull dfedigital/get-help-with-tech-dev:preview > /dev/null) && docker images dfedigital/get-help-with-tech-dev:preview -q)
-          cf push get-help-with-tech-preview --manifest ./config/manifests/preview-manifest.yml --var docker_image_id=$DOCKER_IMAGE_ID --docker-image dfedigital/get-help-with-tech-dev --docker-username ${CF_DOCKER_USERNAME} --strategy rolling
+          cf push get-help-with-tech-preview --docker-image dfedigital/get-help-with-tech-dev:preview --docker-username ${CF_DOCKER_USERNAME} --strategy rolling


### PR DESCRIPTION
### Context

The `cf push` command did not correctly use the `docker_image_id`. It always pushed `dfedigital/get-help-with-tech-dev:latest`, however we want to push `dfedigital/get-help-with-tech-dev:preview`.

### Changes proposed in this pull request

For simplicity we will use the simpler `cf push` command with the `--docker-image` param specifying the `preview` tag and without a manifest.

### Guidance to review

Deploy and check the `commit_sha` on [healthcheck.json](https://get-help-with-tech-preview.london.cloudapps.digital/healthcheck.json).

Cross check with the reopening branch on [GitHub](https://github.com/DFE-Digital/get-help-with-tech/tree/reopening) or check the `preview` tagged image on [DockerHub](https://hub.docker.com/r/dfedigital/get-help-with-tech-dev/tags?page=1&ordering=last_updated) and look for line 48 `ENV GIT_COMMIT_SHA=`