### PR TITLE
Fix magic link for preview env authentication

### DIFF
--- a/config/manifests/preview-manifest.yml
+++ b/config/manifests/preview-manifest.yml
@@ -20,6 +20,6 @@ applications:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile
     RAILS_LOG_TO_STDOUT: true
-    GHWT__HOSTNAME_FOR_URLS: preview-get-help-with-tech.education.gov.uk
+    GHWT__HOSTNAME_FOR_URLS: get-help-with-tech-preview.london.cloudapps.digital
     GHWT__SERVICE_NAME_SUFFIX: (preview)
     SERVICE_ENV: preview


### PR DESCRIPTION
### Context

The magic authentication link does not work in the preview environment.

`GHWT__HOSTNAME_FOR_URLS: preview-get-help-with-tech.education.gov.uk`

### Changes proposed in this pull request

In the manifest we have set:

`GHWT__HOSTNAME_FOR_URLS: get-help-with-tech-preview.london.cloudapps.digital`

### Guidance to review

Deploy and sign in on the `preview` env.
