### PR TITLE
Add device supplier allocations export service

### DIFF
--- a/app/services/device_supplier_export_allocations_service.rb
+++ b/app/services/device_supplier_export_allocations_service.rb
@@ -1,0 +1,119 @@
+# Service to export allocations data for the device supplier
+class DeviceSupplierExportAllocationsService
+  attr_reader :path
+  attr_accessor :progress_percentage, :count, :per_school_percentage
+
+  UPDATE_PROGRESS_DELAY = 200
+
+  def initialize(path = nil)
+    @path = path
+    @progress_percentage = 0
+    @count = 0
+    @per_school_percentage = 100.0 / School.count
+  end
+
+  def call(target_path = path)
+    raise 'No path specified' if target_path.nil?
+
+    CSV.open(target_path, 'wb') do |csv|
+      csv << csv_headers
+      School.includes(:std_device_allocation, :preorder_information, responsible_body: :virtual_cap_pools)
+            .find_each do |school|
+        update_progress
+        add_school_to_csv(csv, school)
+      end
+    end
+    Rails.logger.info "DeviceSupplierExportAllocationsService: Exported #{count} schools to #{path}"
+  end
+
+private
+
+  def add_school_to_csv(csv, school)
+    csv << school_allocation_and_rb_details(school)
+  end
+
+  def csv_headers
+    %w[urn
+       order_state
+       who_orders
+       ship_to
+       sold_to
+       school_name
+       school_address_1
+       school_address_2
+       school_address_3
+       school_town
+       school_county
+       school_postcode
+       responsible_body_id
+       responsible_body_name
+       rb_address_1
+       rb_address_2
+       rb_address_3
+       rb_town
+       rb_county
+       rb_postcode
+       allocation
+       cap
+       adjusted_cap_if_vcap_enabled
+       devices_ordered
+       virtual_cap_enabled?
+       school_in_virtual_cap?]
+  end
+
+  def csv_row(school, responsible_body, ship_to, sold_to)
+    [school.urn,
+     school.order_state,
+     school&.preorder_information&.who_will_order_devices,
+     ship_to,
+     sold_to,
+     school.name,
+     school.address_1,
+     school.address_2,
+     school.address_3,
+     school.town,
+     school.county,
+     school.postcode,
+     responsible_body.computacenter_identifier,
+     responsible_body.name,
+     responsible_body.address_1,
+     responsible_body.address_2,
+     responsible_body.address_3,
+     responsible_body.town,
+     responsible_body.county,
+     responsible_body.postcode,
+     school.raw_laptop_allocation,
+     school.raw_laptop_cap,
+     school.laptop_computacenter_cap,
+     school.raw_laptops_ordered,
+     rb_vcap_feature_flag_text(school),
+     schools_vcap_enabled_text(school)]
+  end
+
+  def rb_vcap_feature_flag_text(school)
+    school.responsible_body.vcap_feature_flag ? 'Yes' : 'No'
+  end
+
+  def school_allocation_and_rb_details(school)
+    responsible_body = school.responsible_body
+    ship_to = school.computacenter_reference
+    sold_to = responsible_body.computacenter_reference
+
+    csv_row(school, responsible_body, ship_to, sold_to)
+  end
+
+  def schools_vcap_enabled?(school)
+    school.responsible_body.vcap_feature_flag &&
+      school.responsible_body.virtual_cap_pools.any? { |pool| pool.has_school?(school) }
+  end
+
+  def schools_vcap_enabled_text(school)
+    schools_vcap_enabled?(school) ? 'Yes' : 'No'
+  end
+
+  def update_progress
+    @progress_percentage += @per_school_percentage
+    @count += 1
+    Rails.logger.info "\nDeviceSupplierExportAllocationsService percentage: #{@progress_percentage.to_i}%\n" if (@count % UPDATE_PROGRESS_DELAY).zero?
+  end
+end

--- a/spec/services/device_supplier_export_allocations_service_spec.rb
+++ b/spec/services/device_supplier_export_allocations_service_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe DeviceSupplierExportAllocationsService, type: :model do
+  describe '#call' do
+    let(:school) { create(:school, :manages_orders, :can_order, :with_std_device_allocation) }
+    let(:rb) { school.responsible_body }
+    let(:filename) { Rails.root.join('tmp/device_supplier_export_allocations_test_data.csv') }
+    let(:csv) { CSV.read(filename, headers: true) }
+    let(:school_csv_row) { csv[0] }
+    let(:service_call) { service.call }
+
+    after do
+      remove_file(filename)
+    end
+
+    subject(:service) { described_class.new(filename) }
+
+    context 'when given a filename' do
+      before do
+        school
+        service_call
+      end
+
+      it 'creates a CSV file' do
+        expect(File.exist?(filename)).to be true
+      end
+
+      it 'includes a heading row and all Schools in the CSV file' do
+        line_count = `wc -l "#{filename}"`.split.first.to_i
+        expect(line_count).to eq(School.count + 1)
+      end
+    end
+
+    context 'when devices are managed by the school' do
+      before do
+        school
+        service_call
+      end
+
+      it 'displays "school" in the "who_orders" column' do
+        expect(school_csv_row['who_orders']).to eq('school')
+      end
+
+      it 'has a ship_to value equal to the school computacenter_refernce' do
+        expect(school_csv_row['ship_to']).to eq(school.computacenter_reference)
+      end
+
+      it 'has a sold_to value equal to the school computacenter_refernce' do
+        expect(school_csv_row['sold_to']).to eq(rb.computacenter_reference)
+      end
+
+      it 'has an adjusted cap equal to cap' do
+        expect(school_csv_row['adjusted_cap_if_vcap_enabled']).to eq(school_csv_row['cap'])
+      end
+
+      it 'displays "No" in the "virtual_cap_enabled?" column' do
+        expect(school_csv_row['virtual_cap_enabled?']).to eq('No')
+      end
+
+      it 'displays "No" in the "school_in_virtual_cap?" column' do
+        expect(school_csv_row['school_in_virtual_cap?']).to eq('No')
+      end
+    end
+
+    context 'when the devices are centrally managed' do
+      let(:rb) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
+      let(:create_vcap_pool) { ([school] + sibling_schools).each { |school| AddSchoolToVirtualCapPoolService.new(school).call } }
+      let(:sibling_school_csv_row) { csv[-1] }
+
+      let!(:school) do
+        create(:school,
+               :centrally_managed,
+               :with_std_device_allocation,
+               responsible_body: rb,
+               laptop_allocation: 5, laptop_cap: 4, laptops_ordered: 3)
+      end
+
+      let(:sibling_schools) do
+        create_list(:school,
+                    2,
+                    :centrally_managed,
+                    :with_std_device_allocation,
+                    responsible_body: rb,
+                    laptop_allocation: 7, laptop_cap: 6, laptops_ordered: 4)
+      end
+
+      before do
+        stub_computacenter_outgoing_api_calls
+        create_vcap_pool
+        rb.reload
+        service_call
+      end
+
+      it 'displays "responsible_body" in the "who_orders" column' do
+        expect(school_csv_row['who_orders']).to eq('responsible_body')
+      end
+
+      it 'has a ship_to value equal to the school computacenter_refernce' do
+        expect(school_csv_row['ship_to']).to eq(school.computacenter_reference)
+      end
+
+      it 'has a sold_to value equal to the school computacenter_refernce' do
+        expect(school_csv_row['sold_to']).to eq(rb.computacenter_reference)
+      end
+
+      it 'displays "Yes" in the "virtual_cap_enabled?" column' do
+        expect(school_csv_row['virtual_cap_enabled?']).to eq('Yes')
+      end
+
+      it 'displays "Yes" in the "school_in_virtual_cap?" column' do
+        expect(school_csv_row['school_in_virtual_cap?']).to eq('Yes')
+      end
+
+      it 'includes both the raw numbers and pooled numbers' do
+        expect(sibling_school_csv_row['allocation'].to_i).to eq(7)
+        expect(sibling_school_csv_row['cap'].to_i).to eq(6)
+
+        expect(sibling_school_csv_row['adjusted_cap_if_vcap_enabled'].to_i).to eq(9)
+        expect(sibling_school_csv_row['devices_ordered'].to_i).to eq(4)
+
+        expect(school_csv_row['allocation'].to_i).to eq(5)
+        expect(school_csv_row['cap'].to_i).to eq(4)
+
+        expect(school_csv_row['adjusted_cap_if_vcap_enabled'].to_i).to eq(8)
+        expect(school_csv_row['devices_ordered'].to_i).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

On occasion the device supplier will request an export of allocation values for cross-checking their records against ours.

### Changes proposed in this pull request

We are introducing the DeviceSupplierExportAllocationsService to generate the csv file that can be shared with the device supplier.

### Guidance to review

In the test environment execute:

```
DeviceSupplierExportAllocationsService.new('/tmp/2021-10-12_device_supplier_allocations.csv').call
```

Check the file `/tmp/2021-10-12_device_supplier_allocations.csv`.