### PR TITLE
Temporarily remove API route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,9 +327,6 @@ Rails.application.routes.draw do
     resources :school_device_allocations, only: %i[index], path: '/school-device-allocations' do
       put '/', to: 'school_device_allocations#bulk_update', on: :collection
     end
-    namespace :api do
-      post '/cap-usage/bulk-update', to: 'cap_usage#bulk_update'
-    end
   end
 
   get '/healthcheck', to: 'monitoring#healthcheck', as: :healthcheck

--- a/spec/controllers/computacenter/api/cap_usage_controller_spec.rb
+++ b/spec/controllers/computacenter/api/cap_usage_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Computacenter::API::CapUsageController do
     XML
   end
 
-  describe 'Authentication' do
+  xdescribe 'Authentication' do
     context 'with no Authorization header' do
       it 'responds with :unauthorized' do
         post :bulk_update, format: :xml, body: cap_usage_update_packet
@@ -40,7 +40,7 @@ RSpec.describe Computacenter::API::CapUsageController do
     end
   end
 
-  describe 'POST bulk_update with valid auth but invalid XML' do
+  xdescribe 'POST bulk_update with valid auth but invalid XML' do
     let(:invalid_xml) do
       <<~XML
         <Broken Tag Structure>
@@ -106,7 +106,7 @@ RSpec.describe Computacenter::API::CapUsageController do
     end
   end
 
-  describe 'POST bulk_update with valid auth and valid XML' do
+  xdescribe 'POST bulk_update with valid auth and valid XML' do
     let(:cap_usage_update_packet) do
       <<~XML
         <CapUsage payloadID="IDGAAC47B3HSQAQ2EH0LQ1G_SRI_TEST_123" dateTime="2020-06-18T09:20:45Z" >


### PR DESCRIPTION
### Context

Temporarily remove API route to stop CC repeatedly calling our API (and generating new e-mails from our system)

### Changes proposed in this pull request

### Guidance to review

