### PR TITLE
Make asset serial number search case-insensitive

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -21,6 +21,7 @@ class AssetsController < ApplicationController
 
     @assets = policy_scope(Asset).owned_by(setting)
     assets_requiring_updated_viewed_at = @assets.select { |asset| should_update_first_viewed_at?(asset) }
+    @multiple_serial_number_search = allow_multiple_serial_number_search?
 
     respond_to do |format|
       format.html
@@ -41,6 +42,7 @@ class AssetsController < ApplicationController
 
     @current_serial_number_search = params[:serial_number]
     @assets = policy_scope(Asset).search_by_serial_numbers(serial_numbers_for_user_role)
+    @multiple_serial_number_search = allow_multiple_serial_number_search?
 
     render :index
   end
@@ -81,7 +83,11 @@ private
   end
 
   def multiple_search_for_support_user_or_single_search_for_non_support_user
-    support_user? ? SearchSerialNumberParser.new(@current_serial_number_search).serial_numbers : @current_serial_number_search
+    SearchSerialNumberParser.new(serial_numbers_string: @current_serial_number_search, multiple: allow_multiple_serial_number_search?).serial_numbers
+  end
+
+  def allow_multiple_serial_number_search?
+    support_user?
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -87,7 +87,7 @@ class Asset < ApplicationRecord
     end
   }
 
-  scope :search_by_serial_numbers, ->(serial_numbers) { where(serial_number: serial_numbers) }
+  scope :search_by_serial_numbers, ->(serial_numbers) { where('serial_number ILIKE ANY (ARRAY[?])', serial_numbers) }
 
   scope :first_viewed_during_period, ->(period) { where(first_viewed_at: period) }
 

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -19,7 +19,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      Search any serial number in our database. You can search for up to 5 serial numbers at once. Use commas to separate each serial number.
+      Search any serial number in our database.
+      <% if @multiple_serial_number_search %>
+        You can search for up to 5 serial numbers at once. Use commas to separate each serial number.
+      <% end %>
     </p>
 
     <%= form_with url: search_assets_path do |f| %>

--- a/lib/search_serial_number_parser.rb
+++ b/lib/search_serial_number_parser.rb
@@ -1,7 +1,11 @@
 class SearchSerialNumberParser
   attr_reader :serial_numbers
 
-  def initialize(serial_numbers_string)
-    @serial_numbers = serial_numbers_string.blank? ? [] : serial_numbers_string.split(/,|,\s+|\s+/).reject(&:blank?)
+  def initialize(serial_numbers_string:, multiple:)
+    @serial_numbers = if serial_numbers_string.blank?
+                        []
+                      else
+                        multiple ? serial_numbers_string.split(/,|,\s+|\s+/).reject(&:blank?) : [serial_numbers_string.strip]
+                      end
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe AssetsController do
           post :search, params: { serial_number: '1,2' }
 
           expect(response).to be_successful
-          expect(Asset).to have_received(:search_by_serial_numbers).with('1,2')
+          expect(Asset).to have_received(:search_by_serial_numbers).with(['1,2'])
           expect(response).to render_template(:index)
         end
       end

--- a/spec/lib/search_serial_number_parser_spec.rb
+++ b/spec/lib/search_serial_number_parser_spec.rb
@@ -3,49 +3,89 @@ require 'search_serial_number_parser'
 
 RSpec.describe SearchSerialNumberParser do
   describe '#serial_numbers' do
-    context 'none' do
+    context 'only single allowed' do
       context 'nil' do
-        subject { described_class.new(nil) }
+        subject { described_class.new(serial_numbers_string: nil, multiple: false) }
 
         it { is_expected.to have_attributes(serial_numbers: be_empty) }
       end
 
       context 'empty' do
-        subject { described_class.new('') }
+        subject { described_class.new(serial_numbers_string: '', multiple: false) }
 
         it { is_expected.to have_attributes(serial_numbers: be_empty) }
       end
 
-      context 'whitespace' do
-        subject { described_class.new(' ') }
+      context 'blank' do
+        subject { described_class.new(serial_numbers_string: ' ', multiple: false) }
 
         it { is_expected.to have_attributes(serial_numbers: be_empty) }
       end
-    end
 
-    context 'one' do
-      subject { described_class.new('1234') }
+      context 'leading and trailing whitespace' do
+        subject { described_class.new(serial_numbers_string: ' 1234 ', multiple: false) }
 
-      it { is_expected.to have_attributes(serial_numbers: contain_exactly('1234')) }
-    end
-
-    context 'multiple' do
-      context 'comma-separated' do
-        subject { described_class.new('1,2') }
-
-        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1234')) }
       end
 
-      context 'space-separated' do
-        subject { described_class.new('1 2') }
+      context 'attempting multiple search' do
+        subject { described_class.new(serial_numbers_string: '1234, 5678', multiple: false) }
 
-        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1234, 5678')) }
+      end
+    end
+
+    context 'multiple allowed' do
+      context 'none' do
+        context 'nil' do
+          subject { described_class.new(serial_numbers_string: nil, multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: be_empty) }
+        end
+
+        context 'empty' do
+          subject { described_class.new(serial_numbers_string: '', multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: be_empty) }
+        end
+
+        context 'whitespace' do
+          subject { described_class.new(serial_numbers_string: ' ', multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: be_empty) }
+        end
       end
 
-      context 'comma- and space-separated' do
-        subject { described_class.new('1, 2') }
+      context 'one' do
+        subject { described_class.new(serial_numbers_string: '1234', multiple: true) }
 
-        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1234')) }
+      end
+
+      context 'one with leading and trailing whitespace' do
+        subject { described_class.new(serial_numbers_string: ' 1234 ', multiple: true) }
+
+        it { is_expected.to have_attributes(serial_numbers: contain_exactly('1234')) }
+      end
+
+      context 'multiple' do
+        context 'comma-separated' do
+          subject { described_class.new(serial_numbers_string: '1,2', multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        end
+
+        context 'space-separated' do
+          subject { described_class.new(serial_numbers_string: '1 2', multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        end
+
+        context 'comma- and space-separated' do
+          subject { described_class.new(serial_numbers_string: '1, 2', multiple: true) }
+
+          it { is_expected.to have_attributes(serial_numbers: contain_exactly('1', '2')) }
+        end
       end
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -175,6 +175,14 @@ RSpec.describe Asset, type: :model do
       specify { expect(Asset.search_by_serial_numbers([asset_1.serial_number])).to contain_exactly(asset_1) }
     end
 
+    context 'different case' do
+      let(:upper_case_serial_number) { 'Z1' }
+      let(:lower_case_serial_number) { 'z1' }
+      let!(:upper_case_serial_number_asset) { create(:asset, serial_number: upper_case_serial_number) }
+
+      specify { expect(Asset.search_by_serial_numbers(lower_case_serial_number)).to contain_exactly(upper_case_serial_number_asset) }
+    end
+
     context 'multiple matches of same serial number' do
       let!(:asset_3) { create(:asset, serial_number: asset_1.serial_number) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/v6vdcPH4

### Changes proposed in this pull request

Spotted a bug where single serial number didn't work if there was leading or trailing whitespace. Also it was telling all users they could do a multiple search in all cases, even if they couldn't

### Guidance to review

