### PR TITLE
Store batch xml payloads

### DIFF
--- a/app/controllers/computacenter/api/cap_usage_controller.rb
+++ b/app/controllers/computacenter/api/cap_usage_controller.rb
@@ -1,16 +1,31 @@
 class Computacenter::API::CapUsageController < Computacenter::API::BaseController
   def bulk_update
     logger.info "bulk_update, params = #{params}"
+
+    payload = Computacenter::API::CapUsageUpdatePayload.create!(payload_xml: @xml)
     validate_xml!('CapUsage.xsd')
-    @batch = build_batch(@parsed_xml)
+
+    @batch = build_batch(@parsed_xml, payload.id)
+    payload.update!(
+      payload_id: @batch.payload_id,
+      payload_timestamp: @batch.timestamp,
+      records_count: @batch.updates.count,
+    )
+
     @batch.process!
+    payload.completed!(
+      status: @batch.status,
+      succeeded_count: @batch.succeeded_updates.count,
+      failed_count: @batch.failed_updates.count,
+    )
+
     render status: status_code(@batch)
   end
 
 private
 
-  def build_batch(parsed_xml)
-    Computacenter::API::CapUsageUpdateBatch.new(parsed_xml['CapUsage'])
+  def build_batch(parsed_xml, payload_id)
+    Computacenter::API::CapUsageUpdateBatch.new(parsed_xml['CapUsage'], payload_id)
   end
 
   def status_code(batch)

--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -12,8 +12,8 @@ class Computacenter::API::CapUsageUpdate
     @error = nil
   end
 
-  def apply!(notify_decreases: true)
-    log_to_devices_ordered_updates
+  def apply!(notify_decreases: true, cap_usage_update_payload_id: nil)
+    log_to_devices_ordered_updates(cap_usage_update_payload_id)
     CapMismatch.new(school, device_type).warn(cap_amount) if cap_amount != school.allocation(device_type)
     cap_usage_change = cap_used - school.raw_devices_ordered(device_type)
     begin
@@ -82,12 +82,13 @@ private
     device_type.to_sym == :laptop
   end
 
-  def log_to_devices_ordered_updates
+  def log_to_devices_ordered_updates(cap_usage_update_payload_id)
     Computacenter::DevicesOrderedUpdate.create!(
       cap_type: cap_type,
       ship_to: ship_to,
       cap_amount: cap_amount,
       cap_used: cap_used,
+      cap_usage_update_payload_id: cap_usage_update_payload_id,
     )
   end
 

--- a/app/models/computacenter/api/cap_usage_update_payload.rb
+++ b/app/models/computacenter/api/cap_usage_update_payload.rb
@@ -1,0 +1,20 @@
+class Computacenter::API::CapUsageUpdatePayload < ApplicationRecord
+  self.table_name = 'computacenter_cap_usage_update_payloads'
+
+  has_many :devices_ordered_updates, dependent: :nullify
+
+  enum status: {
+    succeeded: 'succeeded',
+    partially_failed: 'partially_failed',
+    failed: 'failed',
+  }
+
+  def completed!(status:, succeeded_count:, failed_count:)
+    update!(
+      completed_at: Time.zone.now,
+      status: status,
+      succeeded_count: succeeded_count,
+      failed_count: failed_count,
+    )
+  end
+end

--- a/app/models/computacenter/devices_ordered_update.rb
+++ b/app/models/computacenter/devices_ordered_update.rb
@@ -5,5 +5,7 @@ module Computacenter
     belongs_to :school, primary_key: :computacenter_reference,
                         foreign_key: :ship_to,
                         optional: true
+
+    belongs_to :cap_usage_update_payload, class_name: 'Computacenter::API::CapUsageUpdatePayload', optional: true
   end
 end

--- a/db/migrate/20211106171214_create_cap_usage_update_payload.rb
+++ b/db/migrate/20211106171214_create_cap_usage_update_payload.rb
@@ -1,0 +1,17 @@
+class CreateCapUsageUpdatePayload < ActiveRecord::Migration[6.1]
+  def change
+    create_table :computacenter_cap_usage_update_payloads do |t|
+      t.string :payload_id
+      t.string :payload_xml
+      t.datetime :payload_timestamp
+      t.integer :records_count
+      t.integer :succeeded_count
+      t.integer :failed_count
+      t.string :status
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+    add_index :computacenter_cap_usage_update_payloads, :payload_id
+  end
+end

--- a/db/migrate/20211107180047_add_cap_usage_update_payload_id_to_devices_ordered_update.rb
+++ b/db/migrate/20211107180047_add_cap_usage_update_payload_id_to_devices_ordered_update.rb
@@ -1,0 +1,9 @@
+class AddCapUsageUpdatePayloadIdToDevicesOrderedUpdate < ActiveRecord::Migration[6.1]
+  def change
+    add_column :computacenter_devices_ordered_updates, :cap_usage_update_payload_id, :integer
+    add_foreign_key :computacenter_devices_ordered_updates, :computacenter_cap_usage_update_payloads,
+                    column: 'cap_usage_update_payload_id'
+    add_index :computacenter_devices_ordered_updates, :cap_usage_update_payload_id,
+              name: 'index_devices_ordered_updates_on_cap_usage_update_payload_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_224402) do
+ActiveRecord::Schema.define(version: 2021_11_07_180047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,13 +95,13 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   end
 
   create_table "cap_changes", force: :cascade do |t|
+    t.bigint "school_device_allocation_id"
     t.string "category"
     t.integer "prev_cap", default: 0, null: false
     t.integer "new_cap", default: 0, null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "school_device_allocation_id"
     t.bigint "school_id"
     t.string "device_type", default: "laptop", null: false
     t.index ["category"], name: "index_cap_changes_on_category"
@@ -109,15 +109,29 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   end
 
   create_table "cap_update_calls", force: :cascade do |t|
+    t.bigint "school_device_allocation_id"
     t.text "request_body"
     t.text "response_body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "failure", default: false
-    t.bigint "school_device_allocation_id"
     t.bigint "school_id"
     t.string "device_type", default: "laptop", null: false
     t.index ["school_device_allocation_id"], name: "index_cap_update_calls_on_school_device_allocation_id"
+  end
+
+  create_table "computacenter_cap_usage_update_payloads", force: :cascade do |t|
+    t.string "payload_id"
+    t.string "payload_xml"
+    t.datetime "payload_timestamp"
+    t.integer "records_count"
+    t.integer "succeeded_count"
+    t.integer "failed_count"
+    t.string "status"
+    t.datetime "completed_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["payload_id"], name: "index_computacenter_cap_usage_update_payloads_on_payload_id"
   end
 
   create_table "computacenter_devices_ordered_updates", force: :cascade do |t|
@@ -127,6 +141,8 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
     t.integer "cap_used"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "cap_usage_update_payload_id"
+    t.index ["cap_usage_update_payload_id"], name: "index_devices_ordered_updates_on_cap_usage_update_payload_id"
     t.index ["ship_to"], name: "index_computacenter_devices_ordered_updates_on_ship_to"
   end
 
@@ -246,16 +262,16 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   end
 
   create_table "preorder_information", force: :cascade do |t|
+    t.bigint "school_id", null: false
     t.string "who_will_order_devices", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"
     t.string "school_or_rb_domain"
     t.string "recovery_email_address"
     t.datetime "school_contacted_at"
-    t.bigint "school_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"
@@ -333,17 +349,17 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   end
 
   create_table "school_device_allocations", force: :cascade do |t|
+    t.bigint "school_id"
     t.string "device_type", null: false
+    t.integer "allocation", default: 0
+    t.integer "devices_ordered", default: 0
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.bigint "last_updated_by_user_id"
     t.bigint "created_by_user_id"
     t.integer "cap", default: 0, null: false
     t.datetime "cap_update_request_timestamp"
     t.string "cap_update_request_payload_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.bigint "school_id"
-    t.integer "allocation", default: 0
-    t.integer "devices_ordered", default: 0
     t.index ["cap"], name: "index_school_device_allocations_on_cap"
     t.index ["cap_update_request_payload_id"], name: "ix_allocations_cap_update_payload_id"
     t.index ["cap_update_request_timestamp"], name: "ix_allocations_cap_update_timestamp"
@@ -362,10 +378,10 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   end
 
   create_table "school_virtual_caps", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.bigint "virtual_cap_pool_id"
     t.bigint "school_device_allocation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["school_device_allocation_id"], name: "index_school_virtual_caps_on_school_device_allocation_id"
     t.index ["virtual_cap_pool_id"], name: "index_school_virtual_caps_on_virtual_cap_pool_id"
   end
@@ -423,15 +439,15 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
     t.datetime "school_contacted_at"
     t.string "who_will_order_devices"
     t.integer "raw_laptop_allocation", default: 0, null: false
+    t.integer "raw_laptop_cap", default: 0, null: false
     t.integer "raw_laptops_ordered", default: 0, null: false
     t.datetime "laptop_cap_update_request_timestamp"
     t.string "laptop_cap_update_request_payload_id"
     t.integer "raw_router_allocation", default: 0, null: false
+    t.integer "raw_router_cap", default: 0, null: false
     t.integer "raw_routers_ordered", default: 0, null: false
     t.datetime "router_cap_update_request_timestamp"
     t.string "router_cap_update_request_payload_id"
-    t.integer "raw_laptop_cap", default: 0, null: false
-    t.integer "raw_router_cap", default: 0, null: false
     t.integer "circumstances_laptops", default: 0, null: false
     t.integer "circumstances_routers", default: 0, null: false
     t.integer "over_order_reclaimed_laptops", default: 0, null: false
@@ -584,12 +600,12 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
 
   create_table "virtual_cap_pools", force: :cascade do |t|
     t.string "device_type", null: false
-    t.integer "allocation", default: 0, null: false
+    t.bigint "responsible_body_id", null: false
     t.integer "cap", default: 0, null: false
     t.integer "devices_ordered", default: 0, null: false
-    t.bigint "responsible_body_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "allocation", default: 0, null: false
     t.index ["device_type", "responsible_body_id"], name: "index_virtual_cap_pools_on_device_type_and_responsible_body_id", unique: true
     t.index ["responsible_body_id"], name: "index_virtual_cap_pools_on_responsible_body_id"
   end
@@ -597,6 +613,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_224402) do
   add_foreign_key "bt_wifi_voucher_allocations", "responsible_bodies"
   add_foreign_key "bt_wifi_vouchers", "responsible_bodies"
   add_foreign_key "cap_changes", "school_device_allocations"
+  add_foreign_key "computacenter_devices_ordered_updates", "computacenter_cap_usage_update_payloads", column: "cap_usage_update_payload_id"
   add_foreign_key "extra_mobile_data_requests", "responsible_bodies"
   add_foreign_key "extra_mobile_data_requests", "schools"
   add_foreign_key "preorder_information", "school_contacts"

--- a/spec/features/api/cap_usage_bulk_update_spec.rb
+++ b/spec/features/api/cap_usage_bulk_update_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Bulk cap usage update with XML', type: :request do
+  let(:user) { create(:computacenter_user) }
+  let(:api_token) { create(:api_token, status: :active, user: user) }
+  let(:headers) { { 'Authorization' => "Bearer #{api_token.token}" } }
+  let(:payload_id) { 'IDGAAC47B3HSQAQ2EH0LQ1G_SRI_TEST_123' }
+  let(:cap_usage_update_packet) do
+    <<~XML
+      <CapUsage payloadID="IDGAAC47B3HSQAQ2EH0LQ1G_SRI_TEST_123" dateTime="2020-06-18T09:20:45Z" >
+        <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="81060874" capAmount="100" usedCap="20"/>
+        <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="81060874" capAmount="200" usedCap="100"/>
+        <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="81060875" capAmount="300" usedCap="57"/>
+        <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="81060875" capAmount="400" usedCap="100"/>
+        <Record capType="DfE_RemainThresholdQty|Std_Device" shipTo="81060876" capAmount="500" usedCap="200"/>
+        <Record capType="DfE_RemainThresholdQty|Coms_Device" shipTo="81060876" capAmount="600" usedCap="267"/>
+      </CapUsage>
+    XML
+  end
+
+  context 'all the records processed' do
+    before do
+      create(:school, computacenter_reference: '81060874', laptops: [100, 100, 0], routers: [100, 100, 0])
+      create(:school, computacenter_reference: '81060875', laptops: [300, 100, 0], routers: [400, 100, 0])
+      create(:school, computacenter_reference: '81060876', laptops: [500, 100, 0], routers: [600, 100, 0])
+    end
+
+    it 'returns ok and expected XML' do
+      post computacenter_api_cap_usage_bulk_update_path(format: :xml), params: cap_usage_update_packet, headers: headers
+      parsed_xml = Hash.from_xml(response.body)
+
+      expect(response.status).to eq(200)
+      expect(parsed_xml['CapUsageResponse']['payloadId']).to eq(payload_id)
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['status']).to eq('succeeded')
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['FailedRecords']).to be_blank
+    end
+  end
+
+  context 'none of the shipTos exists on the platform' do
+    it 'returns unprocessable_entity and all failed records in the XML' do
+      post computacenter_api_cap_usage_bulk_update_path(format: :xml), params: cap_usage_update_packet, headers: headers
+      parsed_xml = Hash.from_xml(response.body)
+
+      expect(response.status).to eq(422)
+      expect(parsed_xml['CapUsageResponse']['payloadId']).to eq(payload_id)
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['status']).to eq('failed')
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['FailedRecords']['Record'].count).to eq(6)
+    end
+  end
+
+  context 'some schools do not exist' do
+    before do
+      create(:school, computacenter_reference: '81060874', laptops: [100, 100, 0], routers: [100, 100, 0])
+    end
+
+    it 'returns multi_status and the failed records in the XML' do
+      post computacenter_api_cap_usage_bulk_update_path(format: :xml), params: cap_usage_update_packet, headers: headers
+      parsed_xml = Hash.from_xml(response.body)
+
+      expect(response.status).to eq(207)
+      expect(parsed_xml['CapUsageResponse']['payloadId']).to eq(payload_id)
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['status']).to eq('partially_failed')
+      expect(parsed_xml['CapUsageResponse']['HeaderResult']['FailedRecords']['Record'].count).to eq(4)
+    end
+  end
+end

--- a/spec/models/computacenter/api/cap_usage_update_spec.rb
+++ b/spec/models/computacenter/api/cap_usage_update_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
   end
 
   describe '#apply!' do
+    let!(:cap_usage_update_payload) { Computacenter::API::CapUsageUpdatePayload.create!(payload_xml: '<xml></xml>') }
+
     let!(:school) do
       create(:school,
              :centrally_managed,
@@ -54,7 +56,7 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
 
     it 'logs to devices_ordered_updates' do
       expect {
-        cap_usage_update.apply!
+        cap_usage_update.apply!(cap_usage_update_payload_id: cap_usage_update_payload.id)
       }.to change { Computacenter::DevicesOrderedUpdate.count }.by(1)
 
       log = Computacenter::DevicesOrderedUpdate.last
@@ -63,6 +65,7 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
       expect(log.ship_to).to eql(args['shipTo'])
       expect(log.cap_amount).to eql(args['capAmount'])
       expect(log.cap_used).to eql(args['usedCap'])
+      expect(log.cap_usage_update_payload_id).to eq(cap_usage_update_payload.id)
 
       expect(log.school).to eql(school)
       expect(school.devices_ordered_updates).to include(log)


### PR DESCRIPTION
Doesn't interfere with the process just store the XML payloads and keep track of status and completion.

Todo:

- [x] Add extra metrics
- [x] Add tests for the XML response
- [x] Find a way to associate the individual updates the bulk update payload

