### PR TITLE
shorten vcap method names

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -91,11 +91,11 @@ private
   end
 
   def display_devices_ordered_row?
-    !@school.in_virtual_cap_pool? && @school.has_ordered_any_laptop?
+    !@school.vcap? && @school.has_ordered_any_laptop?
   end
 
   def display_routers_ordered_row?
-    !@school.in_virtual_cap_pool? && @school.has_ordered_any_router?
+    !@school.vcap? && @school.has_ordered_any_router?
   end
 
   def display_router_allocation_row?

--- a/app/controllers/responsible_body/devices/orders_controller.rb
+++ b/app/controllers/responsible_body/devices/orders_controller.rb
@@ -10,10 +10,10 @@ class ResponsibleBody::Devices::OrdersController < ResponsibleBody::BaseControll
         @schools_can_order_for_specific_circumstances = @schools.can_order_for_specific_circumstances
 
         # There is no seperate 'specific circumstances' page if we're using virtual caps.
-        if @responsible_body.vcap_feature_flag? || @schools.can_order.count.positive?
+        if @responsible_body.vcap? || @schools.can_order.count.positive?
 
           # There is no seperate 'cannot order anymore' page if we're not using virtual caps.
-          if !@responsible_body.vcap_feature_flag? || @responsible_body.devices_available_to_order?
+          if !@responsible_body.vcap? || @responsible_body.devices_available_to_order?
             render 'order_devices'
           else
             render 'cannot_order_anymore'

--- a/app/controllers/responsible_body/devices/schools_controller.rb
+++ b/app/controllers/responsible_body/devices/schools_controller.rb
@@ -25,6 +25,6 @@ private
   end
 
   def lacks_virtual_cap?
-    !@responsible_body.vcap_feature_flag?
+    !@responsible_body.vcap?
   end
 end

--- a/app/controllers/responsible_body/home_controller.rb
+++ b/app/controllers/responsible_body/home_controller.rb
@@ -16,7 +16,7 @@ class ResponsibleBody::HomeController < ResponsibleBody::BaseController
 private
 
   def device_count
-    responsible_body.vcap_feature_flag? ? devices_ordered_by_vcap_schools : devices_ordered_by_schools
+    responsible_body.vcap? ? devices_ordered_by_vcap_schools : devices_ordered_by_schools
   end
 
   def devices_ordered_by_schools

--- a/app/controllers/school/home_controller.rb
+++ b/app/controllers/school/home_controller.rb
@@ -2,7 +2,7 @@ class School::HomeController < School::BaseController
   def show
     @assistance_count = assistance_count
     @has_ordered = school.has_ordered?
-    @in_vcap_pool = school.in_virtual_cap_pool?
+    @in_vcap_pool = school.vcap?
   end
 
 private

--- a/app/form_objects/support/allocation_form.rb
+++ b/app/form_objects/support/allocation_form.rb
@@ -4,7 +4,7 @@
   attr_accessor :device_type, :school
   attr_reader :allocation
 
-  delegate :in_virtual_cap_pool?,
+  delegate :vcap?,
            :circumstances_devices,
            :over_order_reclaimed_devices,
            :raw_allocation,
@@ -29,7 +29,7 @@ private
   end
 
   def check_decrease_allowed
-    errors.add(:school, :decreasing_in_virtual_cap_pool) if decreasing? && in_virtual_cap_pool?
+    errors.add(:school, :decreasing_in_virtual_cap_pool) if decreasing? && vcap?
   end
 
   def check_minimum

--- a/app/form_objects/support/bulk_allocation_form.rb
+++ b/app/form_objects/support/bulk_allocation_form.rb
@@ -48,7 +48,7 @@ private
 
   def schedule_school(school, props)
     allocation_batch_job = create_allocation_batch_job(props)
-    if school.in_virtual_cap_pool?
+    if school.vcap?
       add_school_for_post_processing_of_vcaps(school)
     else
       AllocationJob.perform_later(allocation_batch_job)

--- a/app/form_objects/support/school/change_responsible_body_form.rb
+++ b/app/form_objects/support/school/change_responsible_body_form.rb
@@ -45,13 +45,13 @@ private
   end
 
   def pool_notified_agents?(device_type)
-    return false unless school.in_virtual_cap_pool?
+    return false unless school.vcap?
 
     school.raw_devices_ordered(device_type).positive? || school.raw_cap(device_type).positive?
   end
 
   def recompute_pool(responsible_body = school.responsible_body)
-    responsible_body.calculate_vcaps! if responsible_body.vcap_feature_flag?
+    responsible_body.calculate_vcaps! if responsible_body.vcap?
   end
 
   def responsible_bodies
@@ -60,10 +60,10 @@ private
 
   def responsible_body_changed?
     school.transaction do
-      original_pool = school.responsible_body if school.in_virtual_cap_pool?
+      original_pool = school.responsible_body if school.vcap?
       set_school_new_rb!
       recompute_pool(original_pool) if original_pool
-      recompute_pool if school.in_virtual_cap_pool?
+      recompute_pool if school.vcap?
       notify_other_agents
       school.refresh_preorder_status!
       true

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -127,7 +127,7 @@ class ResponsibleBody < ApplicationRecord
     logger.info("***=== recalculating caps ===*** responsible_body_id: #{id} - laptops")
     allocation, cap, ordered = compute_laptops
     update!(laptop_allocation: allocation, laptop_cap: cap, laptops_ordered: ordered)
-    if vcap_feature_flag? && (laptop_cap_previously_changed? || laptops_ordered_previously_changed?)
+    if vcap? && (laptop_cap_previously_changed? || laptops_ordered_previously_changed?)
       update_cap_on_computacenter(:laptop, **opts)
     end
   end
@@ -136,7 +136,7 @@ class ResponsibleBody < ApplicationRecord
     logger.info("***=== recalculating caps ===*** responsible_body_id: #{id} - routers")
     allocation, cap, ordered = compute_routers
     update!(router_allocation: allocation, router_cap: cap, routers_ordered: ordered)
-    if vcap_feature_flag? && (router_cap_previously_changed? || routers_ordered_previously_changed?)
+    if vcap? && (router_cap_previously_changed? || routers_ordered_previously_changed?)
       update_cap_on_computacenter(:router, **opts)
     end
   end
@@ -191,8 +191,8 @@ class ResponsibleBody < ApplicationRecord
     active_schools.school_will_order_devices.that_can_order_now.any?
   end
 
-  def has_virtual_cap_feature_flags_and_centrally_managed_schools?
-    vcap_feature_flag? && has_centrally_managed_schools?
+  def vcap_and_centrally_managed_schools?
+    vcap? && has_centrally_managed_schools?
   end
 
   def humanized_type
@@ -253,7 +253,7 @@ class ResponsibleBody < ApplicationRecord
   end
 
   def vcap_schools
-    return School.none unless vcap_feature_flag?
+    return School.none unless vcap?
 
     if will_order_devices_for_schools_by_default?
       schools.excluding_la_funded_provisions.school_not_set_to_order_devices

--- a/app/models/school_can_order_devices_notifications.rb
+++ b/app/models/school_can_order_devices_notifications.rb
@@ -54,7 +54,7 @@ private
       :user_can_order_but_action_needed
     elsif status?('rb_can_order', 'school_can_order', school: school) && user.orders_devices? && !user.seen_privacy_notice?
       :nudge_user_to_read_privacy_policy
-    elsif status?('rb_can_order', school: school) && school.responsible_body.vcap_feature_flag? && user.in?(school.order_users_with_active_techsource_accounts)
+    elsif status?('rb_can_order', school: school) && school.responsible_body.vcap? && user.in?(school.order_users_with_active_techsource_accounts)
       if school.can_order_routers_only_right_now?
         :user_can_order_routers_in_virtual_cap
       else

--- a/app/models/school_device_allocation.rb
+++ b/app/models/school_device_allocation.rb
@@ -70,7 +70,7 @@ class SchoolDeviceAllocation < ApplicationRecord
 private
 
   def vcap_enabled?
-    school&.responsible_body&.vcap_feature_flag?
+    school&.responsible_body&.vcap?
   end
 
   def over_order_occurred?

--- a/app/models/user_can_order_devices_notifications.rb
+++ b/app/models/user_can_order_devices_notifications.rb
@@ -31,7 +31,7 @@ private
   end
 
   def message_type_for_school(school)
-    if %w[rb_can_order].include?(school.preorder_status) && school.responsible_body.vcap_feature_flag?
+    if %w[rb_can_order].include?(school.preorder_status) && school.responsible_body.vcap?
       :user_can_order_in_virtual_cap
     elsif %w[rb_can_order school_can_order].include?(school.preorder_status)
       if school.responsible_body.new_fe_wave?

--- a/app/models/virtual_cap_pool.rb
+++ b/app/models/virtual_cap_pool.rb
@@ -33,7 +33,7 @@ class VirtualCapPool < ApplicationRecord
 private
 
   def enabled?
-    responsible_body.has_virtual_cap_feature_flags?
+    responsible_body.vcap?
   end
 
   def update_cap_on_computacenter

--- a/app/services/allocation_over_order_reverting_service.rb
+++ b/app/services/allocation_over_order_reverting_service.rb
@@ -8,7 +8,7 @@ class AllocationOverOrderRevertingService
   end
 
   def call
-    give_cap_back_across_virtual_cap_pool if school.in_virtual_cap_pool?
+    give_cap_back_across_virtual_cap_pool if school.vcap?
   end
 
 private

--- a/app/services/allocation_over_order_service.rb
+++ b/app/services/allocation_over_order_service.rb
@@ -8,7 +8,7 @@ class AllocationOverOrderService
   end
 
   def call
-    reclaim_cap_across_virtual_cap_pool if school.in_virtual_cap_pool?
+    reclaim_cap_across_virtual_cap_pool if school.vcap?
   end
 
 private

--- a/app/services/allocations_exporter.rb
+++ b/app/services/allocations_exporter.rb
@@ -63,15 +63,15 @@ private
         school.raw_allocation(:laptop),
         school.raw_cap(:laptop),
         school.raw_devices_ordered(:laptop),
-        (school.in_virtual_cap_pool? ? school.allocation(:laptop) : nil),
-        (school.in_virtual_cap_pool? ? school.cap(:laptop) : nil),
-        (school.in_virtual_cap_pool? ? school.devices_ordered(:laptop) : nil),
+        (school.vcap? ? school.allocation(:laptop) : nil),
+        (school.vcap? ? school.cap(:laptop) : nil),
+        (school.vcap? ? school.devices_ordered(:laptop) : nil),
         school.raw_allocation(:router),
         school.raw_cap(:router),
         school.raw_devices_ordered(:router),
-        (school.in_virtual_cap_pool? ? school.allocation(:router) : nil),
-        (school.in_virtual_cap_pool? ? school.cap(:router) : nil),
-        (school.in_virtual_cap_pool? ? school.devices_ordered(:router) : nil),
+        (school.vcap? ? school.allocation(:router) : nil),
+        (school.vcap? ? school.cap(:router) : nil),
+        (school.vcap? ? school.devices_ordered(:router) : nil),
       ]
     end
   end

--- a/app/services/device_supplier/export_allocations_service.rb
+++ b/app/services/device_supplier/export_allocations_service.rb
@@ -88,12 +88,12 @@ module DeviceSupplier
        school.raw_cap(:laptop),
        school.computacenter_cap(:laptop),
        school.raw_devices_ordered(:laptop),
-       rb_vcap_feature_flag_text(school),
+       rb_vcap_text(school),
        schools_vcap_enabled_text(school)]
     end
 
-    def rb_vcap_feature_flag_text(school)
-      school.responsible_body.vcap_feature_flag? ? 'Yes' : 'No'
+    def rb_vcap_text(school)
+      school.responsible_body.vcap? ? 'Yes' : 'No'
     end
 
     def school_allocation_and_rb_details(school)
@@ -105,7 +105,7 @@ module DeviceSupplier
     end
 
     def schools_vcap_enabled_text(school)
-      school.in_virtual_cap_pool? ? 'Yes' : 'No'
+      school.vcap? ? 'Yes' : 'No'
     end
 
     def update_progress

--- a/app/services/school_set_who_manages_orders_service.rb
+++ b/app/services/school_set_who_manages_orders_service.rb
@@ -36,7 +36,7 @@ private
 
   def notify_other_agents
     device_types = DEVICE_TYPES.reject do |device_type|
-      school.in_virtual_cap_pool? && school_impacts_computacenter_numbers?(device_type)
+      school.vcap? && school_impacts_computacenter_numbers?(device_type)
     end
 
     CapUpdateNotificationsService.new(school,

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -65,7 +65,7 @@ private
 
   def move_remaining_allocations(school, predecessor)
     rb = predecessor.responsible_body
-    unless rb.vcap_feature_flag? && rb.has_school_in_virtual_cap_pools?(predecessor)
+    unless rb.vcap? && rb.has_school_in_virtual_cap_pools?(predecessor)
       %i[laptop router].each do |device_type|
         alloc = predecessor.raw_allocation(device_type)
         ordered = predecessor.raw_devices_ordered(device_type)

--- a/app/services/update_school_devices_service.rb
+++ b/app/services/update_school_devices_service.rb
@@ -190,6 +190,6 @@ private
   end
 
   def vcaps?
-    recalculate_vcaps && school.in_virtual_cap_pool?
+    recalculate_vcaps && school.vcap?
   end
 end

--- a/app/views/responsible_body/devices/orders/order_devices.html.erb
+++ b/app/views/responsible_body/devices/orders/order_devices.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<% if @responsible_body.vcap_feature_flag? %>
+<% if @responsible_body.vcap? %>
   <%= render partial: 'place_order_for_virtual_pool' %>
 <% else %>
   <%= render partial: 'place_order_for_schools' %>

--- a/app/views/responsible_body/devices/schools/index.html.erb
+++ b/app/views/responsible_body/devices/schools/index.html.erb
@@ -25,7 +25,7 @@
   </div>
 </div>
 
-<% if @responsible_body.vcap_feature_flag? %>
+<% if @responsible_body.vcap? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render AllocationComponentFactory.create_component(@responsible_body) %>

--- a/app/views/responsible_body/devices/schools/show.html.erb
+++ b/app/views/responsible_body/devices/schools/show.html.erb
@@ -15,7 +15,7 @@
       <%= @school.name %>
     </h1>
 
-    <%- if @responsible_body.vcap_feature_flag? %>
+    <%- if @responsible_body.vcap? %>
       <%- if @school.can_order? || @school.can_order_for_specific_circumstances? %>
         <p class="govuk-body"><%= govuk_link_to 'Order devices now', responsible_body_devices_order_devices_path %></p>
       <%- end %>

--- a/app/views/shared/_change_who_will_order.html.erb
+++ b/app/views/shared/_change_who_will_order.html.erb
@@ -8,7 +8,7 @@
         <span class="govuk-caption-xl"><%= school.name %></span>
         <%= t('page_titles.change_who_will_order') %>
       </h1>
-      <% if school.responsible_body.vcap_feature_flag? %>
+      <% if school.responsible_body.vcap? %>
         <p class="govuk-body">
         If you choose to order for this <%= school.institution_type %>, its device allocation will be added to the total for all the schools and colleges you manage (because you are managing centrally).
         </p>

--- a/app/views/support/responsible_bodies/show.html.erb
+++ b/app/views/support/responsible_bodies/show.html.erb
@@ -17,7 +17,7 @@
       <% component.tab(label: 'Schools and colleges') do %>
         <h2 class="govuk-heading-l">Schools and colleges</h2>
 
-        <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+        <% if @responsible_body.vcap_and_centrally_managed_schools? %>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
               <h2 class="govuk-heading-l govuk-!-margin-top-9">Centrally managed schools and colleges</h2>
@@ -60,14 +60,14 @@
                 <td class="govuk-table__cell"><%= render SchoolPreorderStatusTagComponent.new(school: school) %></td>
                 <td class="govuk-table__cell">
                   <%= school.raw_allocation(:laptop) %> allocated<br>
-                  <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                  <% unless @responsible_body.vcap_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
                     <%= school.cap(:laptop) %> caps<br>
                     <%= school.devices_ordered(:laptop) %> ordered
                   <% end %>
                 </td>
                 <td class="govuk-table__cell">
                   <%= school.raw_allocation(:router) %> allocated<br>
-                  <% unless @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
+                  <% unless @responsible_body.vcap_and_centrally_managed_schools? && @responsible_body.has_school_in_virtual_cap_pools?(school) %>
                     <%= school.cap(:router)  %> caps<br>
                     <%= school.devices_ordered(:router) %> ordered
                   <% end %>
@@ -105,7 +105,7 @@
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"><%= govuk_link_to "#{school.name} (#{school.urn})", support_school_path(urn: school.urn) %><br><%= school.human_for_school_type %></td>
                   <td class="govuk-table__cell">
-                    <% if @responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools? %>
+                    <% if @responsible_body.vcap_and_centrally_managed_schools? %>
                       <% if @responsible_body.has_school_in_virtual_cap_pools?(school) %>
                         <%= govuk_tag text: 'In pool', colour: 'red' %>
                       <%- else %>

--- a/app/views/support/schools/devices/allocation/edit.html.erb
+++ b/app/views/support/schools/devices/allocation/edit.html.erb
@@ -18,7 +18,7 @@
         <%= t(@school.order_state, scope: %i[support allocation edit order_states], cap: @school.cap(@device_type), allocation: @school.allocation(@device_type)) %>
       </p>
 
-     <% if @form.in_virtual_cap_pool? %>
+     <% if @form.vcap? %>
       <%= render GovukComponent::WarningTextComponent.new(text: t(:is_in_virtual_cap_pool, scope: %i[support allocation edit])) %>
      <% end %>
 

--- a/db/migrate/20211116090552_rename_responsible_body_vcap_column.rb
+++ b/db/migrate/20211116090552_rename_responsible_body_vcap_column.rb
@@ -1,0 +1,5 @@
+class RenameResponsibleBodyVcapColumn < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :responsible_bodies, :vcap_feature_flag, :vcap
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_15_123649) do
+ActiveRecord::Schema.define(version: 2021_11_16_090552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -319,7 +319,7 @@ ActiveRecord::Schema.define(version: 2021_11_15_123649) do
     t.string "county"
     t.string "postcode"
     t.string "status", default: "open", null: false
-    t.boolean "vcap_feature_flag", default: false
+    t.boolean "vcap", default: false
     t.string "computacenter_change", default: "none", null: false
     t.boolean "new_fe_wave", default: false
     t.integer "laptop_allocation", default: 0, null: false

--- a/docs/support/add_missing_further_education_college.md
+++ b/docs/support/add_missing_further_education_college.md
@@ -60,7 +60,7 @@ rb.postcode = ...
  county: nil,
  postcode: "BN11 1RY",
  status: "open",
- vcap_feature_flag: false,
+ vcap: false,
  computacenter_change: "none",
  new_fe_wave: true>
 ```

--- a/docs/virtual_cap_pools.md
+++ b/docs/virtual_cap_pools.md
@@ -20,7 +20,7 @@ A `ResponsibleBody` can have one `VirtualCapPool` per device type. Currently we 
 
 The `SchoolVirtualCap` is a join table between a `SchoolDeviceAllocation` of a given type and the `VirtualCapPool` of the same type.
 
-Additionally, each `ResponsibleBody` instance has an attribute that determines whether or not the virtual cap pool functionality is enabled.  This attribute is a boolean value named `vcap_feature_flag`.  When this flag is set, the `allocation`, `cap` and `devices_ordered` values for the responsible body's centrally managed schools are taken from the virtual cap pool rather than the school.
+Additionally, each `ResponsibleBody` instance has an attribute that determines whether or not the virtual cap pool functionality is enabled.  This attribute is a boolean value named `vcap`.  When this flag is set, the `allocation`, `cap` and `devices_ordered` values for the responsible body's centrally managed schools are taken from the virtual cap pool rather than the school.
 
 ### Raw values
 
@@ -60,7 +60,7 @@ With virtual cap pools and the shared caps, we must also generate cap update req
 
 `ResponsibleBody` _must_
 
-* Have `vcap_feature_flag` set to `true`
+* Have `vcap` set to `true`
 
 `School` _must_
 

--- a/spec/components/display_devices_ordered_component_spec.rb
+++ b/spec/components/display_devices_ordered_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DisplayDevicesOrderedComponent, type: :component do
-  let(:trust) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+  let(:trust) { create(:trust, :manages_centrally, :vcap) }
   let(:school) { create(:school, :manages_orders, responsible_body: trust, laptops: [1, 0, 0], routers: [1, 0, 0]) }
   let(:another_school) { create(:school, :manages_orders, responsible_body: trust, laptops: [1, 0, 0], routers: [1, 0, 0]) }
 
@@ -27,7 +27,7 @@ RSpec.describe DisplayDevicesOrderedComponent, type: :component do
 
   context 'when not in a virtual pool' do
     before do
-      trust.update!(vcap_feature_flag: false)
+      trust.update!(vcap: false)
     end
 
     it 'renders the devices ordered' do

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -102,7 +102,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
   end
 
   context 'when the responsible body will place device orders' do
-    let(:rb) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:rb) { create(:trust, :manages_centrally, :vcap) }
     let(:school) { create(:school, :primary, :academy, :centrally_managed, responsible_body: rb) }
 
     it 'confirms that fact' do
@@ -172,7 +172,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         let(:school) { create(:school, :primary, :la_maintained, laptops: [100, 100, 3]) }
 
         before do
-          allow(school.responsible_body).to receive(:vcap_feature_flag?).and_return(true)
+          allow(school.responsible_body).to receive(:vcap?).and_return(true)
         end
 
         it 'shows devices ordered row with count' do
@@ -184,7 +184,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         let(:school) { create(:school, :centrally_managed, :primary, :la_maintained, laptops: [100, 100, 3]) }
 
         before do
-          allow(school.responsible_body).to receive(:vcap_feature_flag?).and_return(false)
+          allow(school.responsible_body).to receive(:vcap?).and_return(false)
         end
 
         it 'shows devices ordered row with count' do
@@ -196,7 +196,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         let(:school) { create(:school, :centrally_managed, :primary, :la_maintained, laptops: [100, 100, 3]) }
 
         before do
-          allow(school.responsible_body).to receive(:vcap_feature_flag?).and_return(true)
+          allow(school.responsible_body).to receive(:vcap?).and_return(true)
         end
 
         it 'does not show devices ordered row' do
@@ -218,7 +218,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         let(:school) { create(:school, :primary, :la_maintained, routers: [100, 100, 3]) }
 
         before do
-          allow(school.responsible_body).to receive(:vcap_feature_flag?).and_return(true)
+          allow(school.responsible_body).to receive(:vcap?).and_return(true)
         end
 
         it 'shows routers ordered row with count' do
@@ -238,7 +238,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         let(:school) { create(:school, :centrally_managed, :primary, :la_maintained, routers: [100, 100, 3]) }
 
         before do
-          allow(school.responsible_body).to receive(:vcap_feature_flag?).and_return(true)
+          allow(school.responsible_body).to receive(:vcap?).and_return(true)
         end
 
         it 'does not show routers ordered row' do

--- a/spec/components/school/school_details_summary_list_component_spec.rb
+++ b/spec/components/school/school_details_summary_list_component_spec.rb
@@ -45,7 +45,7 @@ describe School::SchoolDetailsSummaryListComponent do
   end
 
   context 'when the responsible body will place device orders' do
-    let(:rb) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:rb) { create(:trust, :manages_centrally, :vcap) }
     let(:school) { create(:school, :primary, :academy, :centrally_managed, responsible_body: rb) }
 
     it 'does not show the school contact even if the school contact is set' do

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -98,7 +98,7 @@ describe Support::SchoolDetailsSummaryListComponent do
   end
 
   context 'when the responsible body will place device orders' do
-    let(:rb) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:rb) { create(:trust, :manages_centrally, :vcap) }
     let(:school) { create(:school, :primary, :academy, :centrally_managed, responsible_body: rb) }
 
     it 'confirms that fact' do

--- a/spec/controllers/computacenter/responsible_body_changes_controller_spec.rb
+++ b/spec/controllers/computacenter/responsible_body_changes_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Computacenter::ResponsibleBodyChangesController do
   let(:rb) do
     create(:local_authority,
            :manages_centrally,
-           :vcap_feature_flag,
+           :vcap,
            name: 'RBName',
            computacenter_reference: '1000')
   end

--- a/spec/controllers/responsible_body/devices/schools_controller_spec.rb
+++ b/spec/controllers/responsible_body/devices/schools_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ResponsibleBody::Devices::SchoolsController do
   describe '#index' do
     context 'RB with virtual cap' do
       before do
-        user.responsible_body.update!(vcap_feature_flag: true, default_who_will_order_devices_for_schools: :responsible_body)
+        user.responsible_body.update!(vcap: true, default_who_will_order_devices_for_schools: :responsible_body)
         get :index
       end
 

--- a/spec/controllers/support/schools/devices/allocation_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/allocation_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Support::Schools::Devices::AllocationController do
     let(:rb) do
       create(:local_authority,
              :manages_centrally,
-             :vcap_feature_flag,
+             :vcap,
              computacenter_reference: '1000')
     end
 

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
     let(:rb) do
       create(:local_authority,
              :manages_centrally,
-             :vcap_feature_flag,
+             :vcap,
              computacenter_reference: '1000')
     end
 

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -24,8 +24,8 @@ FactoryBot.define do
       default_who_will_order_devices_for_schools { 'school' }
     end
 
-    trait :vcap_feature_flag do
-      vcap_feature_flag { true }
+    trait :vcap do
+      vcap { true }
     end
 
     trait :with_schools do

--- a/spec/features/huawei_password_spec.rb
+++ b/spec/features/huawei_password_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Huawei router password', type: :feature, skip: 'Disabled for 30 J
   let(:iss_provision) { create(:iss_provision, routers: [1, 0, 0]) }
   let(:user_for_organisation_without_router_allocation) { create(:school_user) }
   let(:user) { create(:school_user, school: school_with_router_allocation) }
-  let(:trust) { create(:trust, :multi_academy_trust, :vcap_feature_flag) }
+  let(:trust) { create(:trust, :multi_academy_trust, :vcap) }
   let(:school) { create(:school, routers: [1, 0, 0], responsible_body: trust) }
   let(:rb_user) { create(:local_authority_user, responsible_body: trust) }
   let(:la_user) { create(:la_funded_place_user, school: iss_provision) }

--- a/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
+++ b/spec/features/responsible_body/ordering_devices_in_pool_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Ordering devices within a virtual pool' do
 
   def given_my_order_information_is_up_to_date
     ResponsibleBodySetWhoWillOrderDevicesService.new(responsible_body, :responsible_body).call
-    responsible_body.update!(vcap_feature_flag: true)
+    responsible_body.update!(vcap: true)
     responsible_body.schools.update_all(will_need_chromebooks: 'no')
     SchoolSetWhoManagesOrdersService.new(schools[0], :responsible_body).call
     SchoolSetWhoManagesOrdersService.new(schools[1], :responsible_body).call

--- a/spec/features/responsible_body/ordering_via_a_school_spec.rb
+++ b/spec/features/responsible_body/ordering_via_a_school_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Ordering via a school' do
 
   context 'when the school is not in a virtual cap pool' do
     before do
-      allow(school).to receive(:in_virtual_cap_pool?).and_return(false)
+      allow(school).to receive(:vcap?).and_return(false)
     end
 
     context 'when school has no devices to order' do
@@ -60,7 +60,7 @@ RSpec.feature 'Ordering via a school' do
   end
 
   context 'when the school is in a virtual cap pool' do
-    let(:rb) { create(:trust, :manages_centrally, :vcap_feature_flag, schools: [school]) }
+    let(:rb) { create(:trust, :manages_centrally, :vcap, schools: [school]) }
 
     context 'when school has no devices to order' do
       scenario 'cannot order devices' do

--- a/spec/features/responsible_body/viewing_your_schools_spec.rb
+++ b/spec/features/responsible_body/viewing_your_schools_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Viewing your schools' do
 
   def given_my_order_information_is_up_to_date
     ResponsibleBodySetWhoWillOrderDevicesService.new(responsible_body, :responsible_body).call
-    responsible_body.update!(vcap_feature_flag: true)
+    responsible_body.update!(vcap: true)
     responsible_body.schools.update_all(will_need_chromebooks: 'no')
     SchoolSetWhoManagesOrdersService.new(schools[0], :responsible_body).call
     SchoolSetWhoManagesOrdersService.new(schools[1], :responsible_body).call

--- a/spec/features/support/changing_who_will_order_devices_for_a_school_spec.rb
+++ b/spec/features/support/changing_who_will_order_devices_for_a_school_spec.rb
@@ -58,11 +58,11 @@ RSpec.feature 'Changing who will order devices for a school' do
   end
 
   def given_a_responsible_body_without_virtual_caps_enabled
-    @local_authority = create(:local_authority, :manages_centrally, vcap_feature_flag: false)
+    @local_authority = create(:local_authority, :manages_centrally, vcap: false)
   end
 
   def given_a_responsible_body_with_virtual_caps_enabled
-    @local_authority = create(:local_authority, :manages_centrally, vcap_feature_flag: true)
+    @local_authority = create(:local_authority, :manages_centrally, vcap: true)
   end
 
   def given_a_school_that_is_centrally_managed

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Viewing responsible body information in the support area', type: :feature do
   let(:local_authority) { create(:local_authority, :devolves_management, name: 'Coventry') }
-  let(:local_authority_managing_centrally) { create(:trust, :manages_centrally, :vcap_feature_flag, name: 'Manchester') }
+  let(:local_authority_managing_centrally) { create(:trust, :manages_centrally, :vcap, name: 'Manchester') }
 
   let(:responsible_bodies_page) { PageObjects::Support::ResponsibleBodiesPage.new }
   let(:responsible_body_page) { PageObjects::Support::ResponsibleBodyPage.new }

--- a/spec/form_objects/computacenter/sold_to_form_spec.rb
+++ b/spec/form_objects/computacenter/sold_to_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Computacenter::SoldToForm, type: :model do
   let(:rb) do
     create(:local_authority,
            :manages_centrally,
-           :vcap_feature_flag,
+           :vcap,
            computacenter_reference: '1000')
   end
 

--- a/spec/form_objects/support/allocation_form_spec.rb
+++ b/spec/form_objects/support/allocation_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Support::AllocationForm, type: :model do
       let(:rb) do
         create(:local_authority,
                :manages_centrally,
-               :vcap_feature_flag,
+               :vcap,
                computacenter_reference: '1000')
       end
 

--- a/spec/form_objects/support/bulk_allocation_form_spec.rb
+++ b/spec/form_objects/support/bulk_allocation_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Support::BulkAllocationForm, type: :model do
 
   describe '#save' do
     let(:file) { fixture_file_upload('allocation_upload.csv', 'text/csv') }
-    let(:rb) { create(:trust, :vcap_feature_flag, :manages_centrally) }
+    let(:rb) { create(:trust, :vcap, :manages_centrally) }
     let(:attrs) do
       [
         {

--- a/spec/form_objects/support/school/change_responsible_body_form_spec.rb
+++ b/spec/form_objects/support/school/change_responsible_body_form_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school that manages orders to centrally managed no vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: false) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: false) }
 
       let!(:moving_school) do
         create(:school,
@@ -173,8 +173,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school that manages orders to centrally managed vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,
@@ -244,8 +244,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school that manages orders to school manages no vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap_feature_flag: false) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap: false) }
 
       let!(:moving_school) do
         create(:school,
@@ -316,8 +316,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school that manages orders to school manages vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,
@@ -388,8 +388,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed no vcap to centrally managed no vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: false) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: false) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: false) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: false) }
 
       let!(:moving_school) do
         create(:school,
@@ -460,8 +460,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed no vcap to centrally managed vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: false) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: false) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,
@@ -536,8 +536,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed not in vcap to an rb with vcap that devolves management to schools by default' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: false) }
-      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: false) }
+      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,
@@ -612,8 +612,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed vcap to centrally managed no vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: false) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: false) }
 
       let!(:moving_school) do
         create(:school,
@@ -700,8 +700,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed vcap to centrally managed vcap responsible body' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :manages_centrally, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,
@@ -792,8 +792,8 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
     context 'move school centrally managed vcap to an rb with vcap that devolves management to schools by default' do
       subject(:form) { described_class.new(school: moving_school, responsible_body_id: rb_b.id) }
 
-      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap_feature_flag: true) }
-      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap_feature_flag: true) }
+      let(:rb_a) { create(:local_authority, :manages_centrally, computacenter_reference: '1000', vcap: true) }
+      let(:rb_b) { create(:local_authority, :devolves_management, computacenter_reference: '2000', vcap: true) }
 
       let!(:moving_school) do
         create(:school,

--- a/spec/jobs/allocation_job_spec.rb
+++ b/spec/jobs/allocation_job_spec.rb
@@ -1366,7 +1366,7 @@ RSpec.describe AllocationJob do
   context 'when school is part of virtual cap pool' do
     let(:batch_job) { create(:allocation_batch_job, urn: school1.urn, allocation_delta: '3', order_state: 'can_order') }
 
-    let(:rb) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:rb) { create(:trust, :manages_centrally, :vcap) }
 
     let(:school1) { rb.schools.first }
     let(:school1_allocation) { school1.reload.allocation(:laptop) }

--- a/spec/jobs/calculate_vcap_job_spec.rb
+++ b/spec/jobs/calculate_vcap_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CalculateVcapJob do
 
   describe '#perform' do
     let(:batch_id) { SecureRandom.uuid }
-    let(:rb) { create(:trust, :vcap_feature_flag, :manages_centrally) }
+    let(:rb) { create(:trust, :vcap, :manages_centrally) }
     let(:schools) do
       create_list(:school, 2,
                   :centrally_managed,

--- a/spec/models/cap_change_spec.rb
+++ b/spec/models/cap_change_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CapChange, type: :model do
   end
 
   context 'when the allocation is pooled' do
-    let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag, :with_centrally_managed_schools) }
+    let(:responsible_body) { create(:trust, :manages_centrally, :vcap, :with_centrally_managed_schools) }
     let(:school) { responsible_body.schools.first }
 
     context 'when fewer devices than the allocation are ordered' do
@@ -62,7 +62,7 @@ RSpec.describe CapChange, type: :model do
         }
       end
       let(:sentry_scope) { instance_spy(Sentry::Scope, set_context: :great) }
-      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag, :with_centrally_managed_schools_fully_ordered) }
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap, :with_centrally_managed_schools_fully_ordered) }
 
       before do
         allow(Sentry).to receive(:capture_message)

--- a/spec/models/computacenter/api/cap_usage_update_spec.rb
+++ b/spec/models/computacenter/api/cap_usage_update_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Computacenter::API::CapUsageUpdate do
     end
 
     context 'if the devices_ordered update triggers a cap update' do
-      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
       let!(:school) { create(:school, :in_lockdown, :manages_orders, computacenter_reference: '123456', responsible_body: responsible_body) }
 
       let(:mock_request) { instance_double(Computacenter::OutgoingAPI::CapUpdateRequest) }

--- a/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
+++ b/spec/models/computacenter/outgoing_api/cap_update_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Computacenter::OutgoingAPI::CapUpdateRequest do
       let(:routers_ordered) { 3 }
 
       before do
-        trust.update!(vcap_feature_flag: true)
+        trust.update!(vcap: true)
         trust.calculate_vcaps!
         school_1.can_order!
         school_2.can_order!

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe ResponsibleBody, type: :model do
   end
 
   describe '#calculate_vcaps!' do
-    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
 
     let(:schools) do
       create_list(:school, 3,
@@ -407,7 +407,7 @@ RSpec.describe ResponsibleBody, type: :model do
   end
 
   describe '#has_school_in_virtual_cap_pools?' do
-    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
 
     let(:schools) do
       create_list(:school,
@@ -430,7 +430,7 @@ RSpec.describe ResponsibleBody, type: :model do
   end
 
   describe '#devices_available_to_order?' do
-    subject(:responsible_body) { create(:trust, :manages_centrally, vcap_feature_flag: true) }
+    subject(:responsible_body) { create(:trust, :manages_centrally, vcap: true) }
 
     let(:schools) do
       create_list(:school,
@@ -488,7 +488,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
   end
 
-  describe '#has_virtual_cap_feature_flags_and_centrally_managed_schools?' do
+  describe '#vcap_and_centrally_managed_schools?' do
     subject(:responsible_body) { create(:trust) }
 
     let(:schools) do
@@ -507,21 +507,21 @@ RSpec.describe ResponsibleBody, type: :model do
 
       context 'without any feature flags' do
         before do
-          responsible_body.update!(vcap_feature_flag: false)
+          responsible_body.update!(vcap: false)
         end
 
         it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
+          expect(responsible_body.vcap_and_centrally_managed_schools?).to be false
         end
       end
 
       context 'when responsible body flag is enabled' do
         before do
-          responsible_body.update!(vcap_feature_flag: true)
+          responsible_body.update!(vcap: true)
         end
 
         it 'returns true' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be true
+          expect(responsible_body.vcap_and_centrally_managed_schools?).to be true
         end
       end
     end
@@ -536,21 +536,21 @@ RSpec.describe ResponsibleBody, type: :model do
 
       context 'without any feature flags' do
         before do
-          responsible_body.update!(vcap_feature_flag: false)
+          responsible_body.update!(vcap: false)
         end
 
         it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
+          expect(responsible_body.vcap_and_centrally_managed_schools?).to be false
         end
       end
 
       context 'when responsible body flag is enabled' do
         before do
-          responsible_body.update!(vcap_feature_flag: true)
+          responsible_body.update!(vcap: true)
         end
 
         it 'returns false' do
-          expect(responsible_body.has_virtual_cap_feature_flags_and_centrally_managed_schools?).to be false
+          expect(responsible_body.vcap_and_centrally_managed_schools?).to be false
         end
       end
     end
@@ -677,7 +677,7 @@ RSpec.describe ResponsibleBody, type: :model do
   end
 
   describe '#vcap_schools' do
-    let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
     let(:centrally_managed_school) { create(:school, :centrally_managed, responsible_body: responsible_body) }
     let(:management_not_set_school) { create(:school, responsible_body: responsible_body, who_will_order_devices: nil) }
     let(:la_funded_place) { create(:iss_provision, responsible_body: responsible_body) }
@@ -689,7 +689,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
 
     context 'when the responsible body has vcaps disabled' do
-      let(:responsible_body) { create(:trust, vcap_feature_flag: false) }
+      let(:responsible_body) { create(:trust, vcap: false) }
 
       it 'returns no schools' do
         expect(responsible_body.vcap_schools).to eq(School.none)
@@ -703,7 +703,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
 
     context 'when the rb devolves device management to schools' do
-      let(:responsible_body) { create(:trust, :vcap_feature_flag, :devolves_management) }
+      let(:responsible_body) { create(:trust, :vcap, :devolves_management) }
 
       it 'only include schools centrally managed' do
         vcap_schools = responsible_body.vcap_schools
@@ -714,7 +714,7 @@ RSpec.describe ResponsibleBody, type: :model do
     end
 
     context 'when the rb defaults to centrally managed schools' do
-      let(:responsible_body) { create(:trust, :vcap_feature_flag, :manages_centrally) }
+      let(:responsible_body) { create(:trust, :vcap, :manages_centrally) }
 
       it 'include schools not managing devices themselves' do
         vcap_schools = responsible_body.vcap_schools

--- a/spec/models/school_can_order_devices_notifications_spec.rb
+++ b/spec/models/school_can_order_devices_notifications_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe SchoolCanOrderDevicesNotifications do
     end
 
     context 'when school ordering centrally in virtual cap which is ready changes from cannot_order to can_order' do
-      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
       let(:school) do
         create(:school,
                :centrally_managed,
@@ -319,7 +319,7 @@ RSpec.describe SchoolCanOrderDevicesNotifications do
     end
 
     context 'when an school in virtual cap can order routers' do
-      let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+      let(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
       let(:school) do
         create(:school,
                :centrally_managed,

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -254,8 +254,8 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe '#in_virtual_cap_pool?' do
-    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+  describe '#vcap?' do
+    subject(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
 
     let(:schools) do
       create_list(:school,
@@ -280,11 +280,11 @@ RSpec.describe School, type: :model do
     end
 
     it 'returns true for a school within the pool' do
-      expect(schools.first.in_virtual_cap_pool?).to be true
+      expect(schools.first.vcap?).to be true
     end
 
     it 'returns false for a school outside the pool' do
-      expect(schools.last.in_virtual_cap_pool?).to be false
+      expect(schools.last.vcap?).to be false
     end
   end
 
@@ -364,7 +364,7 @@ RSpec.describe School, type: :model do
 
   describe 'can_change_who_manages_orders?' do
     context 'when the school is centrally managed and the responsible body has virtual caps enabled' do
-      let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: true) }
+      let(:local_authority) { create(:local_authority, :manages_centrally, vcap: true) }
       let(:school) { create(:school, :centrally_managed, responsible_body: local_authority) }
 
       it 'returns false' do
@@ -373,7 +373,7 @@ RSpec.describe School, type: :model do
     end
 
     context 'when the school is centrally managed and the responsible body does not have virtual caps enabled' do
-      let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: false) }
+      let(:local_authority) { create(:local_authority, :manages_centrally, vcap: false) }
       let(:school) { create(:school, :centrally_managed, responsible_body: local_authority) }
 
       it 'returns true' do
@@ -382,7 +382,7 @@ RSpec.describe School, type: :model do
     end
 
     context 'when the school manages orders and the responsible body has virtual caps enabled' do
-      let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: true) }
+      let(:local_authority) { create(:local_authority, :manages_centrally, vcap: true) }
       let(:school) { create(:school, :manages_orders, responsible_body: local_authority) }
 
       it 'returns true' do
@@ -391,7 +391,7 @@ RSpec.describe School, type: :model do
     end
 
     context 'when the school manages orders and the responsible body has does not have virtual caps enabled' do
-      let(:local_authority) { create(:local_authority, :manages_centrally, vcap_feature_flag: false) }
+      let(:local_authority) { create(:local_authority, :manages_centrally, vcap: false) }
       let(:school) { create(:school, :manages_orders, responsible_body: local_authority) }
 
       it 'returns true' do

--- a/spec/models/user_can_order_devices_notifications_spec.rb
+++ b/spec/models/user_can_order_devices_notifications_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserCanOrderDevicesNotifications do
   end
 
   context 'when orders can be placed within a virtual cap' do
-    let(:responsible_body) { create(:trust, :manages_centrally, :vcap_feature_flag) }
+    let(:responsible_body) { create(:trust, :manages_centrally, :vcap) }
     let(:school) { create_schools_at_status(preorder_status: 'rb_can_order', responsible_body: responsible_body) }
     let(:user) { create(:trust_user, orders_devices: true, responsible_body: responsible_body) }
 

--- a/spec/services/allocation_over_order_service_spec.rb
+++ b/spec/services/allocation_over_order_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AllocationOverOrderService, type: :model do
   describe '#call' do
-    let(:rb) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
+    let(:rb) { create(:local_authority, :manages_centrally, :vcap) }
 
     before do
       stub_computacenter_outgoing_api_calls

--- a/spec/services/allocations_exporter_spec.rb
+++ b/spec/services/allocations_exporter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AllocationsExporter, type: :model do
   context 'when exporting schools in a virtual_cap_pool' do
     subject(:exporter) { described_class.new }
 
-    let(:trust) { create(:trust, :manages_centrally, :multi_academy_trust, :vcap_feature_flag) }
+    let(:trust) { create(:trust, :manages_centrally, :multi_academy_trust, :vcap) }
     let(:schools) { create_list(:school, 2, :in_lockdown, responsible_body: trust) }
     let(:csv) { CSV.parse(exporter.export(School.where(responsible_body_id: trust.id)), headers: true) }
     let(:mock_response) { instance_double(HTTP::Response) }

--- a/spec/services/cap_update_notifications_service_spec.rb
+++ b/spec/services/cap_update_notifications_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CapUpdateNotificationsService, type: :model do
     let(:rb) do
       create(:local_authority,
              :manages_centrally,
-             :vcap_feature_flag,
+             :vcap,
              computacenter_reference: rb_computacenter_reference)
     end
 

--- a/spec/services/device_supplier/export_allocations_service_spec.rb
+++ b/spec/services/device_supplier/export_allocations_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe DeviceSupplier::ExportAllocationsService, type: :model do
     end
 
     context 'when the devices are centrally managed' do
-      let(:rb) { create(:local_authority, :manages_centrally, :vcap_feature_flag) }
+      let(:rb) { create(:local_authority, :manages_centrally, :vcap) }
       let(:sibling_school_csv_row) { csv.find { |row| row['urn'] == sibling_schools.first.urn.to_s } }
 
       let!(:school) do

--- a/spec/services/school_update_service_spec.rb
+++ b/spec/services/school_update_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe SchoolUpdateService, type: :model do
 
         before do
           rb = old_school.responsible_body
-          rb.update!(vcap_feature_flag: true, default_who_will_order_devices_for_schools: 'responsible_body')
+          rb.update!(vcap: true, default_who_will_order_devices_for_schools: 'responsible_body')
           old_school.update!(who_will_order_devices: 'responsible_body')
           UpdateSchoolDevicesService.new(school: old_school, order_state: :can_order).call
         end
@@ -171,7 +171,7 @@ RSpec.describe SchoolUpdateService, type: :model do
         it 'does not transfer any spare allocation or adjust the original values' do
           school = service.create_school!(staged_school)
           old_school.reload
-          expect(old_school.in_virtual_cap_pool?).to be true
+          expect(old_school.vcap?).to be true
 
           expect(school.raw_allocation(:laptop)).to eq(0)
           expect(school.raw_allocation(:router)).to eq(0)

--- a/spec/support/school_and_rb_expectations_helper.rb
+++ b/spec/support/school_and_rb_expectations_helper.rb
@@ -19,7 +19,7 @@ module SchoolAndRbExpectationsHelper
     expect(school.responsible_body).to eq(responsible_body)
 
     if vcap
-      expect(school).to be_in_virtual_cap_pool
+      expect(school).to be_vcap
 
       expect_vcap_to_be(rb_id: responsible_body.id,
                         laptop_allocation: laptop_allocation,
@@ -29,7 +29,7 @@ module SchoolAndRbExpectationsHelper
                         router_cap: router_cap,
                         routers_ordered: routers_ordered)
     else
-      expect(school).not_to be_in_virtual_cap_pool
+      expect(school).not_to be_vcap
     end
 
     expect_school_to_be(school_id: school.id,
@@ -54,7 +54,7 @@ module SchoolAndRbExpectationsHelper
                         routers_ordered:)
     responsible_body = ResponsibleBody.find(rb_id)
 
-    expect(responsible_body).to be_vcap_feature_flag
+    expect(responsible_body).to be_vcap
 
     expect(responsible_body.allocation(:laptop)).to eq(laptop_allocation)
     expect(responsible_body.cap(:laptop)).to eq(laptop_cap)

--- a/spec/support/school_creator.rb
+++ b/spec/support/school_creator.rb
@@ -93,7 +93,7 @@ def create_schools_at_status(preorder_status:, count: 1, responsible_body: nil)
   else
     raise "Unknown preorder_status '#{preorder_status}'"
   end
-  rb.calculate_vcaps! if rb.vcap_feature_flag?
+  rb.calculate_vcaps! if rb.vcap?
   schools.each do |school|
     school.reload
     school.refresh_preorder_status!


### PR DESCRIPTION
### Context
Tired of making mistakes or taking too long typing `virtual_cap_pool`, `in_virtual_cap_pool?`, `vcap_feature_flag`, `has_virtual_cap_feature_flag`, `has_virtual_cap_feature_flags_and_centrally_managed_schools` or similar?

### Changes proposed in this pull request

### Guidance to review

