### PR TITLE
First return cap borrowed from nowhere and then cap borrowed from vcap sibblings

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -191,10 +191,6 @@ class ResponsibleBody < ApplicationRecord
     active_schools.school_will_order_devices.that_can_order_now.any?
   end
 
-  def vcap_and_centrally_managed_schools?
-    vcap? && has_centrally_managed_schools?
-  end
-
   def humanized_type
     type.demodulize.underscore.humanize.downcase
   end
@@ -226,6 +222,11 @@ class ResponsibleBody < ApplicationRecord
       .first
   end
 
+  def over_order_reclaimed(device_type)
+    field = laptop?(device_type) ? :over_order_reclaimed_laptops : :over_order_reclaimed_routers
+    vcap_schools.sum(field)
+  end
+
   def schools_will_order_devices_by_default?
     default_who_will_order_devices_for_schools == 'school'
   end
@@ -250,6 +251,10 @@ class ResponsibleBody < ApplicationRecord
 
   def trust?
     type == 'Trust'
+  end
+
+  def vcap_and_centrally_managed_schools?
+    vcap? && has_centrally_managed_schools?
   end
 
   def vcap_schools

--- a/app/services/update_school_devices_service.rb
+++ b/app/services/update_school_devices_service.rb
@@ -137,7 +137,7 @@ private
     if reverting_over_ordered_laptops?
       @over_order_reclaimed_laptops = [laptops_ordered - (laptop_allocation + circumstances_laptops), 0].max
       returned = over_order_reclaimed_laptops - school.over_order_reclaimed_laptops
-      AllocationOverOrderRevertingService.new(school, returned, :laptop).call
+      AllocationOverOrderRevertingService.new(school, returned, :laptop).call if school.vcap?
     end
 
     update_device_ordering!(laptop_allocation, laptops_ordered, circumstances_laptops, over_order_reclaimed_laptops, :laptop)
@@ -157,7 +157,7 @@ private
     if reverting_over_ordered_routers?
       @over_order_reclaimed_routers = [routers_ordered - (router_allocation + circumstances_routers), 0].max
       returned = over_order_reclaimed_routers - school.over_order_reclaimed_routers
-      AllocationOverOrderRevertingService.new(school, returned, :router).call
+      AllocationOverOrderRevertingService.new(school, returned, :router).call if school.vcap?
     end
 
     update_device_ordering!(router_allocation, routers_ordered, circumstances_routers, over_order_reclaimed_routers, :router)

--- a/spec/services/update_school_devices_service_spec.rb
+++ b/spec/services/update_school_devices_service_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UpdateSchoolDevicesService do
+  describe '#call' do
+    before { stub_computacenter_outgoing_api_calls }
+
+    context 'case 1' do
+      let!(:rb) { create(:trust, :manages_centrally, :vcap) }
+      let!(:schools) do
+        [
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [5, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [3, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [2, 0, 0, 0]),
+        ]
+      end
+
+      before { rb.calculate_vcap(:laptop) }
+
+      it 'updates laptop allocation numbers' do
+        expect(schools[0].raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].raw_laptops_full).to eq([3, 0, 0, 0])
+        expect(schools[2].raw_laptops_full).to eq([2, 0, 0, 0])
+        expect(rb.laptops).to eq([10, 10, 0])
+        described_class.new(school: schools[2], laptops_ordered: 15, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, -5, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 13, 15])
+        expect(rb.reload.laptops).to eq([10, 15, 15])
+        described_class.new(school: schools[2], laptops_ordered: 14, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, -5, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 12, 14])
+        expect(rb.reload.laptops).to eq([10, 14, 14])
+        described_class.new(school: schools[2], laptops_ordered: 0, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, 0, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 0, 0])
+        expect(rb.reload.laptops).to eq([10, 10, 0])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

1.- Our system:
```
school A: allocation: 100,  cap: 100, ordered: 0
school B:  allocation: 100,  cap: 100, ordered: 0
total vcap: allocation: 200, cap: 200, ordered: 0 
```
We report CC:
```
school A: cap: 200
school B: cap: 200
```

2.- Over order happen: CC tell us schoolB ordered 400
Our system: (borrow 100 from school A and borrow 200 from nowhere)
```
school A: allocation: 100,  cap: 0, ordered: 0
school B:  allocation: 100,  cap: 400, ordered: 400
total vcap: allocation: 200, cap: 400, ordered: 400
```
We report CC:
```
school A: cap: 0
school B: cap: 400
```

3.- Over order cancellation happen: CC tell us schoolB ordered 200 instead of 400
Our system: (retuns the stolen cap (100) to school A and return 100 to nowhere)
```
school A: allocation: 100,  cap: 100, ordered: 0
school B:  allocation: 100,  cap: 200, ordered: 200
total vcap: allocation: 200, cap: 300, ordered: 200. <--- Wrong Cap left after undoing over-order
```
We tell CC:
```
school A: cap: 100 <--- Wrong Cap reported to CC
school B: cap: 300 <--- Wrong Cap reported to CC
```

### Changes proposed in this pull request

With this fix 3.- will change like this:
3.- Our system: (do not retun the stolen cap to sibbling schools until the very end: So first return the 200 borrowed from nowhere)
```
school A: allocation: 100,  cap: 0, ordered: 0
school B:  allocation: 100,  cap: 200, ordered: 200
total vcap: allocation: 200, cap: 200, ordered: 200
```
We tell CC:
```
school A: cap: 0
school B: cap: 200
```

### Guidance to review

