### PR TITLE
Improve over orders

### DIFF
--- a/app/form_objects/support/allocation_form.rb
+++ b/app/form_objects/support/allocation_form.rb
@@ -25,7 +25,9 @@
 private
 
   def allocation_updated?
-    UpdateSchoolDevicesService.new(school: school, "#{device_type}_allocation".to_sym => allocation).call
+    UpdateSchoolDevicesService.new(school: school,
+                                   "#{device_type}_allocation".to_sym => allocation,
+                                   cap_change_category: :allocation_change).call
   end
 
   def check_decrease_allowed

--- a/app/form_objects/support/enable_orders_form.rb
+++ b/app/form_objects/support/enable_orders_form.rb
@@ -69,7 +69,8 @@ private
   end
 
   def orders_enabled?
-    opts = cap_required? ? circumstances_props : {}
+    opts = { cap_change_category: :enable_orders }
+    opts.merge!(circumstances_props) if cap_required?
     UpdateSchoolDevicesService.new(school: school, order_state: order_state, **opts).call
   end
 

--- a/app/jobs/allocation_job.rb
+++ b/app/jobs/allocation_job.rb
@@ -49,6 +49,7 @@ private
       notify_computacenter: notify_computacenter,
       notify_school: notify_school,
       recalculate_vcaps: recalculate_vcaps,
+      cap_change_category: :allocation_job,
     ).call
   end
 end

--- a/app/models/cap_change.rb
+++ b/app/models/cap_change.rb
@@ -2,12 +2,15 @@ class CapChange < ApplicationRecord
   belongs_to :school
 
   enum category: {
-    allocation_error_reversal: 'allocation_error_reversal',
-    increase: 'increase',
-    over_order: 'over_order',
+    allocation_change: 'allocation_change',
+    allocation_job: 'allocation_job',
+    cap_usage: 'cap_usage',
+    enable_orders: 'enable_orders',
+    get_allocations_from_predecessor: 'get_allocations_from_predecessor',
+    give_allocations_to_successor: 'give_allocations_to_successor',
+    import_device_allocations: 'import_device_allocations',
     over_order_pool_rollback: 'over_order_pool_rollback',
     over_order_pool_reclaim: 'over_order_pool_reclaim',
     service_closure: 'service_closure',
-    unused_allocation_reclaim: 'unused_allocation_reclaim',
   }
 end

--- a/app/models/computacenter/api/cap_usage_update.rb
+++ b/app/models/computacenter/api/cap_usage_update.rb
@@ -21,7 +21,8 @@ class Computacenter::API::CapUsageUpdate
         UpdateSchoolDevicesService.new(school: school,
                                        devices_ordered_field(device_type) => cap_used,
                                        notify_computacenter: false,
-                                       notify_school: false).call
+                                       notify_school: false,
+                                       cap_change_category: :cap_usage).call
       end
     rescue Computacenter::OutgoingAPI::Error => e
       # Don't raise failure if a cascading cap update to CC fails

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -125,8 +125,10 @@ class ResponsibleBody < ApplicationRecord
 
   def calculate_laptop_vcap(**opts)
     logger.info("***=== recalculating caps ===*** responsible_body_id: #{id} - laptops")
+    balance_over_ordered_cap(:laptop)
     allocation, cap, ordered = compute_laptops
     update!(laptop_allocation: allocation, laptop_cap: cap, laptops_ordered: ordered)
+
     if vcap? && (laptop_cap_previously_changed? || laptops_ordered_previously_changed?)
       update_cap_on_computacenter(:laptop, **opts)
     end
@@ -134,6 +136,7 @@ class ResponsibleBody < ApplicationRecord
 
   def calculate_router_vcap(**opts)
     logger.info("***=== recalculating caps ===*** responsible_body_id: #{id} - routers")
+    balance_over_ordered_cap(:router)
     allocation, cap, ordered = compute_routers
     update!(router_allocation: allocation, router_cap: cap, routers_ordered: ordered)
     if vcap? && (router_cap_previously_changed? || routers_ordered_previously_changed?)
@@ -283,6 +286,12 @@ class ResponsibleBody < ApplicationRecord
   end
 
 private
+
+  def balance_over_ordered_cap(device_type)
+    over_ordered = over_order_reclaimed(device_type)
+    AllocationOverOrderService.new(self, over_ordered, device_type).call if over_ordered.positive?
+    AllocationOverOrderRevertingService.new(self, over_ordered, device_type).call if over_ordered.negative?
+  end
 
   def compute_laptops
     sums = vcap_schools.pick(Arel.sql("SUM(raw_laptop_allocation),

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -224,7 +224,7 @@ class ResponsibleBody < ApplicationRecord
 
   def over_order_reclaimed(device_type)
     field = laptop?(device_type) ? :over_order_reclaimed_laptops : :over_order_reclaimed_routers
-    vcap_schools.sum(field)
+    vcap_schools.where.not(order_state: :cannot_order).sum(field)
   end
 
   def schools_will_order_devices_by_default?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -85,7 +85,8 @@ class School < ApplicationRecord
   scope :where_urn_or_ukprn, ->(identifier) { where('urn = ? OR ukprn = ?', identifier, identifier) }
   scope :where_urn_or_ukprn_or_provision_urn, ->(identifier) { where('urn = ? OR ukprn = ? OR provision_urn = ?', identifier.to_i, identifier.to_i, identifier.to_s) }
   scope :with_over_order_stolen_cap, lambda { |device_type|
-    laptop?(device_type) ? where('over_order_reclaimed_laptops < 0') : where('over_order_reclaimed_routers < 0')
+    query = where.not(order_state: :cannot_order)
+    laptop?(device_type) ? query.where('over_order_reclaimed_laptops < 0') : query.where('over_order_reclaimed_routers < 0')
   }
   scope :school_not_set_to_order_devices, -> { where(who_will_order_devices: [nil, :responsible_body]) }
 

--- a/app/services/allocation_over_order_service.rb
+++ b/app/services/allocation_over_order_service.rb
@@ -1,38 +1,34 @@
 class AllocationOverOrderService
-  attr_reader :cap, :device_type, :over_order, :school
+  attr_reader :cap, :device_type, :over_order, :responsible_body
 
-  def initialize(school, over_order, device_type)
+  def initialize(responsible_body, over_order, device_type)
     @device_type = device_type
     @over_order = over_order
-    @school = school
+    @responsible_body = responsible_body
   end
 
   def call
-    reclaim_cap_across_virtual_cap_pool if school.vcap?
-  end
-
-private
-
-  def alert_pool_cap_reclaim_failed(remaining_over_ordered_quantity)
-    Sentry.with_scope do |scope|
-      scope.set_context('AllocationOverOrderService#reclaim_cap_across_virtual_cap_pool', { school_id: school.id, device_type: device_type, remaining_over_ordered_quantity: remaining_over_ordered_quantity })
-
-      Sentry.capture_message('Unable to reclaim all of the cap in the vcap to cover the over-order')
-    end
-  end
-
-  def available_caps_in_the_vcap_pool
-    school.responsible_body.vcap_schools.with_available_cap(device_type).to_a - [school]
-  end
-
-  def reclaim_cap_across_virtual_cap_pool
-    School.transaction do
+    ResponsibleBody.transaction do
       failed_to_reclaim = available_caps_in_the_vcap_pool.inject(over_order) do |quantity, member|
         quantity -= reclaim_cap_from_vcap_pool_member(member, quantity: quantity)
         quantity.positive? ? quantity : break
       end
       alert_pool_cap_reclaim_failed(failed_to_reclaim) if failed_to_reclaim
     end
+  end
+
+private
+
+  def alert_pool_cap_reclaim_failed(remaining_over_ordered_quantity)
+    Sentry.with_scope do |scope|
+      scope.set_context('AllocationOverOrderService#reclaim_cap_across_virtual_cap_pool', { responsible_body_id: responsible_body.id, device_type: device_type, remaining_over_ordered_quantity: remaining_over_ordered_quantity })
+
+      Sentry.capture_message('Unable to reclaim all of the cap in the vcap to cover the over-order')
+    end
+  end
+
+  def available_caps_in_the_vcap_pool
+    responsible_body.vcap_schools.with_available_cap(device_type).to_a
   end
 
   def reclaim_cap_from_vcap_pool_member(member, quantity: 0)

--- a/app/services/import_device_allocations_service.rb
+++ b/app/services/import_device_allocations_service.rb
@@ -10,7 +10,9 @@ class ImportDeviceAllocationsService
       school = School.find_by(urn: allocation[:urn])
 
       if school
-        UpdateSchoolDevicesService.new(school: school, laptop_allocation: allocation[:y3_10]).call
+        UpdateSchoolDevicesService.new(school: school,
+                                       laptop_allocation: allocation[:y3_10],
+                                       cap_change_category: :import_device_allocations).call
       else
         Rails.logger.warn("Could not find school (#{allocation[:urn]} - #{allocation[:name]})")
       end

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -77,12 +77,14 @@ private
                                          "#{device_type}_allocation".to_sym => spare_allocation,
                                          "#{device_type}_cap".to_sym => spare_allocation,
                                          recalculate_vcaps: false,
-                                         notify_computacenter: false).call
+                                         notify_computacenter: false,
+                                         cap_change_category: :get_allocations_from_predecessor).call
           UpdateSchoolDevicesService.new(school: predecessor,
                                          "#{device_type}_allocation".to_sym => ordered,
                                          "#{device_type}_cap".to_sym => ordered,
                                          recalculate_vcaps: false,
-                                         notify_computacenter: false).call
+                                         notify_computacenter: false,
+                                         cap_change_category: :give_allocations_to_successor).call
         end
       end
     end

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -61,20 +61,15 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
     let(:router_cap) { '2' }
     let(:who_manages) { :manages_orders }
 
-    let(:rb) do
-      create(:local_authority,
-             :manages_centrally,
-             :vcap,
-             computacenter_reference: '1000')
-    end
+    let(:rb) { create(:local_authority, :manages_centrally, :vcap, computacenter_reference: '1000') }
 
     let!(:school) do
       create(:school,
              who_manages,
              computacenter_reference: '11',
              responsible_body: rb,
-             laptops: [5, 4, 1],
-             routers: [5, 4, 1])
+             laptops: [5, 5, 1],
+             routers: [5, 5, 1])
     end
 
     let(:params) do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
     raw_laptops_ordered { laptops.size == 4 ? laptops[3].to_i : laptops[2].to_i }
 
     raw_router_allocation { routers[0].to_i }
-    circumstances_routers { can_order_for_specific_circumstances? ? routers[1].to_i - raw_router_allocation : 0 }
+    circumstances_routers { routers.size == 4 ? routers[1].to_i : 0 }
     over_order_reclaimed_routers { routers.size == 4 ? routers[2].to_i : routers[1].to_i - raw_router_allocation }
     raw_routers_ordered { routers[2].to_i }
 

--- a/spec/features/support/viewing_responsible_body_info_spec.rb
+++ b/spec/features/support/viewing_responsible_body_info_spec.rb
@@ -213,7 +213,8 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
                   laptops: [5, 3, 1],
                   routers: [4, 2, 0])
     beta.can_order!
-    local_authority_managing_centrally.calculate_vcaps!
+    local_authority_managing_centrally.update!(laptop_allocation: 15, laptop_cap: 5, laptops_ordered: 3,
+                                               router_allocation: 8, router_cap: 6, routers_ordered: 0)
   end
 
   def and_it_has_all_centrally_managed_schools
@@ -245,7 +246,8 @@ RSpec.feature 'Viewing responsible body information in the support area', type: 
     beta.can_order!
     closed.can_order!
     closed.gias_status_closed!
-    local_authority_managing_centrally.calculate_vcaps!
+    local_authority_managing_centrally.update!(laptop_allocation: 20, laptop_cap: 8, laptops_ordered: 4,
+                                               router_allocation: 12, router_cap: 8, routers_ordered: 0)
   end
 
   def when_i_sign_in_as_a_dfe_user

--- a/spec/jobs/allocation_job_spec.rb
+++ b/spec/jobs/allocation_job_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe AllocationJob do
           notify_computacenter: true,
           notify_school: false,
           recalculate_vcaps: true,
+          cap_change_category: :allocation_job,
         )
       end
 
@@ -52,6 +53,7 @@ RSpec.describe AllocationJob do
           notify_computacenter: true,
           notify_school: true,
           recalculate_vcaps: true,
+          cap_change_category: :allocation_job,
         )
       end
 

--- a/spec/jobs/calculate_vcap_job_spec.rb
+++ b/spec/jobs/calculate_vcap_job_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe CalculateVcapJob do
     let(:batch_id) { SecureRandom.uuid }
     let(:rb) { create(:trust, :vcap, :manages_centrally) }
     let(:schools) do
-      create_list(:school, 2,
-                  :centrally_managed,
-                  responsible_body: rb,
-                  laptops: [2, 1, 1],
-                  routers: [2, 1, 1])
+      [create(:school, :centrally_managed, responsible_body: rb, laptops: [2, 2, 0], routers: [2, 2, 0]),
+       create(:school, :centrally_managed, responsible_body: rb, laptops: [2, 2, 2], routers: [2, 2, 2])]
     end
 
     let!(:batch_jobs) do
@@ -42,8 +39,8 @@ RSpec.describe CalculateVcapJob do
       described_class.perform_now(responsible_body_id: rb.id, batch_id: batch_id)
       rb.reload
 
-      expect(rb.laptops).to eq([10, 8, 2])
-      expect(rb.routers).to eq([4, 2, 2])
+      expect(rb.laptops).to eq([10, 10, 2])
+      expect(rb.routers).to eq([4, 4, 2])
     end
   end
 end

--- a/spec/services/allocation_over_order_service_spec.rb
+++ b/spec/services/allocation_over_order_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe AllocationOverOrderService, type: :model do
           {
             device_type: :laptop,
             remaining_over_ordered_quantity: non_allocated_but_ordered_devices,
-            school_id: school.id,
+            responsible_body_id: rb.id,
           }
         end
         let(:sentry_scope) { instance_spy(Sentry::Scope, set_context: :great) }

--- a/spec/services/cap_update_notifications_service_spec.rb
+++ b/spec/services/cap_update_notifications_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe CapUpdateNotificationsService, type: :model do
              :in_lockdown,
              computacenter_reference: '11',
              responsible_body: rb,
-             laptops: [2, 1, 0],
-             routers: [2, 1, 1])
+             laptops: [1, 1, 0],
+             routers: [1, 1, 1])
     end
 
     subject(:service) do

--- a/spec/services/device_supplier/export_allocations_service_spec.rb
+++ b/spec/services/device_supplier/export_allocations_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe DeviceSupplier::ExportAllocationsService, type: :model do
 
       before do
         stub_computacenter_outgoing_api_calls
-        rb.calculate_vcaps!
+        rb.update!(laptop_allocation: 19, laptop_cap: 16, laptops_ordered: 11)
         service.call
       end
 

--- a/spec/services/update_school_devices_service_spec.rb
+++ b/spec/services/update_school_devices_service_spec.rb
@@ -38,5 +38,40 @@ RSpec.describe UpdateSchoolDevicesService do
         expect(rb.reload.laptops).to eq([10, 10, 0])
       end
     end
+
+    context 'case 2' do
+      let!(:rb) { create(:trust, :manages_centrally, :vcap) }
+      let!(:schools) do
+        [
+          create(:school, :centrally_managed, responsible_body: rb, laptops: [5, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [3, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [2, 0, 0, 0]),
+        ]
+      end
+
+      before { rb.calculate_vcap(:laptop) }
+
+      it 'updates laptop allocation numbers' do
+        expect(schools[0].raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].raw_laptops_full).to eq([3, 0, 0, 0])
+        expect(schools[2].raw_laptops_full).to eq([2, 0, 0, 0])
+        expect(rb.laptops).to eq([10, 5, 0])
+        described_class.new(school: schools[2], laptops_ordered: 15, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 13, 15])
+        expect(rb.reload.laptops).to eq([10, 15, 15])
+        described_class.new(school: schools[2], laptops_ordered: 14, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 12, 14])
+        expect(rb.reload.laptops).to eq([10, 14, 14])
+        described_class.new(school: schools[2], laptops_ordered: 0, notify_school: false, notify_computacenter: false).call
+        expect(schools[0].reload.raw_laptops_full).to eq([5, 0, 0, 0])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, 0, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([2, 0, 0, 0])
+        expect(rb.reload.laptops).to eq([10, 5, 0])
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
Allocation numbers of schools in vcaps need adjustment not only when a school allocation numbers change but also when a school is added or removed to/from a vcap to another, a school changes rb, a school changes who will order devices, etc.

This leads us to think the adjustments of cap should be done at vcap level (when recomputing vcaps) rather than when updating school allocations (UpdateSchoolDeviceService).

This should avoid automatically some of the defects we had been having these days in some cases of over ordering and rollbacks, schools in and out of vcaps, vcaps with some schools that can order and some not, ...

### Changes proposed in this pull request
This PR:
- moves the lend/borrowing cap mechanism inside vcaps 
- automatically rebalance vcaps over order numbers whenever the vcap numbers need recalculation
- Register ALL raw_cap changes for a school rather than only over-order related as currently.
-  New cap change categories has been added as args to calls to UpdateSchoolDevicesService
- Expect Sentry messages anytime a vcap is recalculated and lend/borrowing numbers can´t be balanced.

### Guidance to review

