### PR TITLE
clean over order reclaimed cap from schools that cannot order in vcap asap

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -229,7 +229,7 @@ class ResponsibleBody < ApplicationRecord
 
   def over_order_reclaimed(device_type)
     field = laptop?(device_type) ? :over_order_reclaimed_laptops : :over_order_reclaimed_routers
-    vcap_schools.where.not(order_state: :cannot_order).sum(field)
+    vcap_schools.sum(field)
   end
 
   def schools_will_order_devices_by_default?
@@ -261,6 +261,12 @@ class ResponsibleBody < ApplicationRecord
   def vcap_and_centrally_managed_schools?
     vcap? && has_centrally_managed_schools?
   end
+
+  def vcap_schools_that_can_lend_cap(device_type)
+    vcap_schools.that_can_order_now.with_available_cap(device_type)
+  end
+
+  delegate :with_over_order_reclaimed_cap, to: :vcap_schools, prefix: true
 
   def vcap_schools
     return School.none unless vcap?

--- a/app/services/allocation_over_order_reverting_service.rb
+++ b/app/services/allocation_over_order_reverting_service.rb
@@ -9,7 +9,7 @@ class AllocationOverOrderRevertingService
 
   def call
     ResponsibleBody.transaction do
-      failed_to_give_back = stolen_caps_in_the_vcap_pool.inject(returned) do |quantity, member|
+      failed_to_give_back = reclaimed_caps_in_the_vcap_pool.inject(returned) do |quantity, member|
         quantity -= give_cap_back_to_vcap_pool_member(member, quantity: quantity)
         quantity.negative? ? quantity : break
       end
@@ -30,8 +30,10 @@ private
     end
   end
 
-  def stolen_caps_in_the_vcap_pool
-    responsible_body.vcap_schools.with_over_order_stolen_cap(device_type)
+  def reclaimed_caps_in_the_vcap_pool
+    responsible_body
+      .vcap_schools_with_over_order_reclaimed_cap(device_type)
+      .order(Arel.sql("order_state = 'cannot_order' DESC"))
   end
 
   def give_cap_back_to_vcap_pool_member(member, quantity: 0)

--- a/app/services/allocation_over_order_service.rb
+++ b/app/services/allocation_over_order_service.rb
@@ -28,7 +28,7 @@ private
   end
 
   def available_caps_in_the_vcap_pool
-    responsible_body.vcap_schools.with_available_cap(device_type).to_a
+    responsible_body.vcap_schools_that_can_lend_cap(device_type)
   end
 
   def reclaim_cap_from_vcap_pool_member(member, quantity: 0)


### PR DESCRIPTION
### Context
After Friday observation of the status of all the schools and vcaps about routers I realized we could improve the over orders algorithm on schools set to cannot_order: we should return their reclaimed vcap first thing when balancing over order caps and should not reclaim their available cap when over orders happen. 

### Changes proposed in this pull request
The changes described above and some tests to confirm this was actually needed.

### Guidance to review

