### PR TITLE
do not notify CC devices for schools that cannot order in vcaps

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -330,7 +330,9 @@ private
   end
 
   def update_cap_on_computacenter(device_type, notify_computacenter: false, notify_school: false)
-    schools = vcap_schools.map { |school| school.tap(&:refresh_preorder_status!) }
+    schools = vcap_schools
+                .map { |school| school.tap(&:refresh_preorder_status!) }
+                .reject(&:cannot_order?)
 
     CapUpdateNotificationsService.new(*schools,
                                       device_types: [device_type],

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -184,7 +184,7 @@ class School < ApplicationRecord
   end
 
   def computacenter_cap(device_type)
-    return cap(device_type) unless vcap?
+    return raw_cap(device_type) if cannot_order? || !vcap?
 
     vcap_cap(device_type) - vcap_devices_ordered(device_type) + raw_devices_ordered(device_type)
   end

--- a/app/services/update_school_devices_service.rb
+++ b/app/services/update_school_devices_service.rb
@@ -37,7 +37,7 @@ class UpdateSchoolDevicesService
       update_router_allocations! if ordering?(:router)
       school.calculate_vcap(:router) if recalculate_device_vcap?(:router)
       school.refresh_preorder_status!
-      notify_other_agents if notify_computacenter && !vcaps?
+      notify_other_agents if notify_other_agents?
       true
     end
   end
@@ -56,6 +56,10 @@ private
 
   def notify_device?(device_type)
     ordering?(device_type) && initial_raw_cap(device_type) != school.raw_cap(device_type)
+  end
+
+  def notify_other_agents?
+    notify_computacenter && (school.cannot_order? || !vcaps?)
   end
 
   def notify_other_agents

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -211,11 +211,9 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
         [
           [
             { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => '11', 'capAmount' => '3' },
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => '12', 'capAmount' => '3' },
           ],
           [
             { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => '11', 'capAmount' => '2' },
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => '12', 'capAmount' => '2' },
           ],
         ]
       end

--- a/spec/form_objects/support/allocation_form_spec.rb
+++ b/spec/form_objects/support/allocation_form_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe Support::AllocationForm, type: :model do
         let(:requests) do
           [
             [
-              { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => '11', 'capAmount' => '4' },
               { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => '12', 'capAmount' => '4' },
             ],
           ]

--- a/spec/form_objects/support/school/change_responsible_body_form_spec.rb
+++ b/spec/form_objects/support/school/change_responsible_body_form_spec.rb
@@ -466,6 +466,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
       let!(:moving_school) do
         create(:school,
                :centrally_managed,
+               :in_lockdown,
                computacenter_reference: 'MOVING',
                responsible_body: rb_a,
                laptops: [5, 4, 1],
@@ -483,6 +484,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                routers: [5, 4, 1])
 
         create(:school,
+               :in_lockdown,
                :centrally_managed,
                responsible_body: rb_b,
                computacenter_reference: 'BBB',
@@ -495,10 +497,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_a.id,
                                   vcap: false,
                                   laptop_allocation: 5,
-                                  laptop_cap: 1,
+                                  laptop_cap: 4,
                                   laptops_ordered: 1,
                                   router_allocation: 5,
-                                  router_cap: 1,
+                                  router_cap: 4,
                                   routers_ordered: 1,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -506,12 +508,12 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         requests = [
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '9' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '9' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '9' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '9' },
           ],
         ]
 
@@ -522,10 +524,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_b.id,
                                   vcap: true,
                                   laptop_allocation: 10,
-                                  laptop_cap: 2,
+                                  laptop_cap: 10,
                                   laptops_ordered: 2,
                                   router_allocation: 10,
-                                  router_cap: 2,
+                                  router_cap: 10,
                                   routers_ordered: 2,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -541,6 +543,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
       let!(:moving_school) do
         create(:school,
+               :in_lockdown,
                :centrally_managed,
                computacenter_reference: 'MOVING',
                responsible_body: rb_a,
@@ -571,10 +574,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_a.id,
                                   vcap: false,
                                   laptop_allocation: 5,
-                                  laptop_cap: 1,
+                                  laptop_cap: 4,
                                   laptops_ordered: 1,
                                   router_allocation: 5,
-                                  router_cap: 1,
+                                  router_cap: 4,
                                   routers_ordered: 1,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -582,12 +585,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         requests = [
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '5' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '5' },
           ],
         ]
 
@@ -598,10 +599,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_b.id,
                                   vcap: true,
                                   laptop_allocation: 10,
-                                  laptop_cap: 2,
+                                  laptop_cap: 6,
                                   laptops_ordered: 2,
                                   router_allocation: 10,
-                                  router_cap: 2,
+                                  router_cap: 6,
                                   routers_ordered: 2,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -663,12 +664,6 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
             { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
             { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
           ],
-          [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
-          ],
-          [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
-          ],
         ]
 
         expect(form.save).to be_truthy
@@ -706,6 +701,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
       let!(:moving_school) do
         create(:school,
                :centrally_managed,
+               :in_lockdown,
                computacenter_reference: 'MOVING',
                responsible_body: rb_a,
                laptops: [5, 4, 1],
@@ -717,6 +713,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         create(:school,
                :centrally_managed,
+               :in_lockdown,
                computacenter_reference: 'AAA',
                responsible_body: rb_a,
                laptops: [5, 4, 1],
@@ -724,6 +721,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         create(:school,
                :centrally_managed,
+               :in_lockdown,
                responsible_body: rb_b,
                computacenter_reference: 'BBB',
                laptops: [5, 4, 1],
@@ -737,10 +735,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_a.id,
                                   vcap: true,
                                   laptop_allocation: 10,
-                                  laptop_cap: 2,
+                                  laptop_cap: 10,
                                   laptops_ordered: 2,
                                   router_allocation: 10,
-                                  router_cap: 2,
+                                  router_cap: 10,
                                   routers_ordered: 2,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -748,18 +746,18 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         requests = [
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'AAA', 'capAmount' => '5' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'AAA', 'capAmount' => '5' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '9' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '9' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '9' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '9' },
           ],
         ]
 
@@ -770,10 +768,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_b.id,
                                   vcap: true,
                                   laptop_allocation: 10,
-                                  laptop_cap: 2,
+                                  laptop_cap: 10,
                                   laptops_ordered: 2,
                                   router_allocation: 10,
-                                  router_cap: 2,
+                                  router_cap: 10,
                                   routers_ordered: 2,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -781,10 +779,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         expect_vcap_to_be(rb_id: rb_a.id,
                           laptop_allocation: 5,
-                          laptop_cap: 1,
+                          laptop_cap: 5,
                           laptops_ordered: 1,
                           router_allocation: 5,
-                          router_cap: 1,
+                          router_cap: 5,
                           routers_ordered: 1)
       end
     end
@@ -808,6 +806,7 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
         allow(moving_school).to receive(:refresh_preorder_status!).and_call_original
 
         create(:school,
+               :in_lockdown,
                :centrally_managed,
                computacenter_reference: 'AAA',
                responsible_body: rb_a,
@@ -829,10 +828,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
                                   rb_id: rb_a.id,
                                   vcap: true,
                                   laptop_allocation: 10,
-                                  laptop_cap: 2,
+                                  laptop_cap: 6,
                                   laptops_ordered: 2,
                                   router_allocation: 10,
-                                  router_cap: 2,
+                                  router_cap: 6,
                                   routers_ordered: 2,
                                   centrally_managed: true,
                                   manages_orders: false,
@@ -840,18 +839,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         requests = [
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'AAA', 'capAmount' => '5' },
           ],
           [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'AAA', 'capAmount' => '1' },
-          ],
-          [
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
-          ],
-          [
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'MOVING', 'capAmount' => '1' },
-            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'BBB', 'capAmount' => '1' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => 'AAA', 'capAmount' => '5' },
           ],
         ]
 
@@ -873,10 +864,10 @@ RSpec.describe Support::School::ChangeResponsibleBodyForm, type: :model do
 
         expect_vcap_to_be(rb_id: rb_a.id,
                           laptop_allocation: 5,
-                          laptop_cap: 1,
+                          laptop_cap: 5,
                           laptops_ordered: 1,
                           router_allocation: 5,
-                          router_cap: 1,
+                          router_cap: 5,
                           routers_ordered: 1)
       end
     end


### PR DESCRIPTION
### Context
Users keep ordering the full allocation of a vcap besides we are sending CC a cap lower than that due to schools that cannot_order.

At the same time, on Friday I found an rb that placed not only an over-order for routers but on a school in the vcap that cannot_order.

### Changes proposed in this pull request
This PR will not send CapUpdateCall records to CC api for schools in a vcap that cannot_order.
At least this should prevent orders placed on such schools and maybe this also helps to reduce the number of over-orders in Techsource.

After we put this live we should go to the console and send records to CC api for these schools so they receive 0 devices available

### Guidance to review

