### PR TITLE
Add multiple sold_tos for rb users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,18 @@ class User < ApplicationRecord
     user_schools.size == 1 && (responsible_body&.single_academy_trust? || responsible_body&.further_education_college?) && school.responsible_body_id == responsible_body.id
   end
 
+  def schools_sold_tos
+    schools.map(&:responsible_body).uniq.map(&:computacenter_reference).compact
+  end
+
+  def sold_tos
+    ([rb&.sold_to] + schools_sold_tos).flatten.compact.uniq
+  end
+
+  def ship_tos
+    schools.pluck(:computacenter_reference).compact
+  end
+
   # Wrapper methods to ease the transition from 'user belongs_to school',
   # to 'user has_many schools'
   def school

--- a/app/services/device_supplier/export_users_service.rb
+++ b/app/services/device_supplier/export_users_service.rb
@@ -81,10 +81,6 @@ module DeviceSupplier
       device_supplier_user_updated_at_timestamp(user)&.iso8601
     end
 
-    def rb_sold_to(user)
-      user.rb.sold_to
-    end
-
     def update_progress
       @progress_percentage += @per_user_percentage
       @count += 1
@@ -92,15 +88,15 @@ module DeviceSupplier
     end
 
     def user_default_sold_to_text(user)
-      return rb_sold_to(user) if user.responsible_body.present?
+      return user.rb.sold_to if user.rb.present?
 
-      return user_schools_sold_tos(user).first.to_s if user_schools_sold_tos(user).size == 1
+      return user.schools_sold_tos.first.to_s if user.schools_sold_tos.one?
 
       user_most_recently_used_sold_to(user)
     end
 
     def user_most_recently_used_ship_to(user)
-      Computacenter::DevicesOrderedUpdate.where(ship_to: user_ship_tos(user)).order(created_at: :desc).limit(1).first
+      Computacenter::DevicesOrderedUpdate.where(ship_to: user.ship_tos).order(created_at: :desc).limit(1).first
     end
 
     def user_most_recently_used_sold_to(user)
@@ -113,18 +109,8 @@ module DeviceSupplier
       school.sold_to
     end
 
-    def user_schools_sold_tos(user)
-      user.schools.map(&:responsible_body).uniq.map(&:computacenter_reference).compact
-    end
-
-    def user_ship_tos(user)
-      user.schools.pluck(:computacenter_reference).compact
-    end
-
     def user_sold_tos_text(user)
-      return rb_sold_to(user) if user.responsible_body.present?
-
-      user_schools_sold_tos(user)&.join('|') if user_schools_sold_tos(user).size.positive?
+      user.sold_tos.join('|')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1154,6 +1154,40 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#schools_sold_tos' do
+    it 'includes the sold_to of school that the user belongs to' do
+      user = create(:school_user)
+
+      expect(user.schools_sold_tos.size).to eq(1)
+      expect(user.schools_sold_tos).to include(*user.schools.map(&:sold_to).uniq)
+    end
+  end
+
+  describe '#sold_tos' do
+    let(:user) { create(:school_user) }
+    let(:rb) { create(:local_authority) }
+
+    before do
+      user.responsible_body = rb
+      user.save!
+    end
+
+    it 'includes the sold_tos of schools and rb that the user belongs to' do
+      expect(user.sold_tos.size).to eq(2)
+      expect(user.sold_tos).to include(*user.schools.map(&:sold_to).uniq)
+      expect(user.sold_tos).to include(user.responsible_body.sold_to)
+    end
+  end
+
+  describe '#schools_ship_tos' do
+    it 'includes the computacenter_reference of school the user belongs to' do
+      user = create(:school_user)
+
+      expect(user.ship_tos.size).to eq(1)
+      expect(user.ship_tos).to include(*user.schools.pluck(:computacenter_reference))
+    end
+  end
+
   describe '.search_by_email_address_or_full_name' do
     def user_search(search_string)
       User.search_by_email_address_or_full_name(search_string)


### PR DESCRIPTION
### Context

An rb user who is also an FE College user appeard in the suplier export to only have the rb sold_to

### Changes proposed in this pull request

RB users will also list associated school sold_tos

### Guidance to review

Specs were added to cover the exact scenario