### PR TITLE
Hide rbs with zero schools from cc verify page

### DIFF
--- a/app/controllers/computacenter/home_controller.rb
+++ b/app/controllers/computacenter/home_controller.rb
@@ -1,3 +1,6 @@
 class Computacenter::HomeController < Computacenter::BaseController
-  def show; end
+  def show
+    @schools_requiring_a_new_computacenter_reference_count = School.requiring_a_new_computacenter_reference.size
+    @rbs_requiring_a_new_computacenter_reference_count = ResponsibleBody.requiring_a_new_computacenter_reference.size
+  end
 end

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -3,7 +3,7 @@ module Computacenter::ResponsibleBodyUrns
     def requiring_a_new_computacenter_reference
       gias_status_open
         .where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
-        .includes(:schools)
+        .joins(:schools)
         .distinct
     end
 

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -25,13 +25,13 @@
     <p class="govuk-body">Download a CSV file of Google Chromebook details for schools.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Changes to schools (#{School.requiring_a_new_computacenter_reference.count})", computacenter_school_changes_path %>
+      <%= govuk_link_to "Changes to schools (#{@schools_requiring_a_new_computacenter_reference_count})", computacenter_school_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Ship To references for schools that have changed.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Changes to responsible bodies (#{ResponsibleBody.requiring_a_new_computacenter_reference.count})", computacenter_responsible_body_changes_path %>
+      <%= govuk_link_to "Changes to responsible bodies (#{@rbs_requiring_a_new_computacenter_reference_count})", computacenter_responsible_body_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Sold To references for responsible bodies that have changed.</p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,19 @@ ActiveRecord::Schema.define(version: 2021_11_24_114339) do
     t.index ["batch_id"], name: "index_allocation_batch_jobs_on_batch_id"
   end
 
+  create_table "allocation_changes", force: :cascade do |t|
+    t.bigint "school_device_allocation_id", null: false
+    t.string "category"
+    t.integer "delta"
+    t.integer "prev_allocation"
+    t.integer "new_allocation"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category"], name: "index_allocation_changes_on_category"
+    t.index ["school_device_allocation_id"], name: "index_allocation_changes_on_school_device_allocation_id"
+  end
+
   create_table "api_tokens", force: :cascade do |t|
     t.bigint "user_id"
     t.string "name"
@@ -258,16 +271,16 @@ ActiveRecord::Schema.define(version: 2021_11_24_114339) do
   end
 
   create_table "preorder_information", force: :cascade do |t|
-    t.bigint "school_id", null: false
     t.string "who_will_order_devices", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"
     t.string "school_or_rb_domain"
     t.string "recovery_email_address"
     t.datetime "school_contacted_at"
+    t.bigint "school_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["school_contact_id"], name: "index_preorder_information_on_school_contact_id"
     t.index ["school_id"], name: "index_preorder_information_on_school_id"
     t.index ["status"], name: "index_preorder_information_on_status"

--- a/spec/models/computacenter/responsible_body_urns_spec.rb
+++ b/spec/models/computacenter/responsible_body_urns_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Computacenter::ResponsibleBodyUrns do
     end
   end
 
+  describe '#requiring_a_new_computacenter_reference' do
+    subject(:model) { ResponsibleBody }
+
+    it 'returns only rbs that have schools associated' do
+      create(:local_authority, :with_schools)
+      create(:local_authority)
+
+      expect(model.count).to eq(2)
+      expect(model.requiring_a_new_computacenter_reference.count).to eq(1)
+    end
+  end
+
   describe '#computacenter_name' do
     subject(:model) { fe_klass.new }
 


### PR DESCRIPTION
### Context

The device supplier was receiving new rbs to create even when said rbs had zero schools

### Changes proposed in this pull request

Update the filter for relevant rbs to also omit rbs with zero schools

### Guidance to review

Check the supplier portal to ensure that only rbs with associated schools appear in the list