### PR TITLE
Hide rbs with zero schools

### DIFF
--- a/app/controllers/computacenter/home_controller.rb
+++ b/app/controllers/computacenter/home_controller.rb
@@ -1,3 +1,6 @@
 class Computacenter::HomeController < Computacenter::BaseController
-  def show; end
+  def show
+    @schools_requiring_a_new_computacenter_reference_count = School.requiring_a_new_computacenter_reference.size
+    @rbs_requiring_a_new_computacenter_reference_count = ResponsibleBody.requiring_a_new_computacenter_reference.size
+  end
 end

--- a/app/models/computacenter/responsible_body_urns.rb
+++ b/app/models/computacenter/responsible_body_urns.rb
@@ -3,7 +3,7 @@ module Computacenter::ResponsibleBodyUrns
     def requiring_a_new_computacenter_reference
       gias_status_open
         .where(computacenter_change: %w[new amended]).or(gias_status_open.where(computacenter_reference: nil))
-        .includes(:schools)
+        .joins(:schools)
         .distinct
     end
 

--- a/app/views/computacenter/home/show.html.erb
+++ b/app/views/computacenter/home/show.html.erb
@@ -25,13 +25,13 @@
     <p class="govuk-body">Download a CSV file of Google Chromebook details for schools.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Changes to schools (#{School.requiring_a_new_computacenter_reference.count})", computacenter_school_changes_path %>
+      <%= govuk_link_to "Changes to schools (#{@schools_requiring_a_new_computacenter_reference_count})", computacenter_school_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Ship To references for schools that have changed.</p>
 
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Changes to responsible bodies (#{ResponsibleBody.requiring_a_new_computacenter_reference.count})", computacenter_responsible_body_changes_path %>
+      <%= govuk_link_to "Changes to responsible bodies (#{@rbs_requiring_a_new_computacenter_reference_count})", computacenter_responsible_body_changes_path %>
     </h2>
 
     <p class="govuk-body">Review and update Sold To references for responsible bodies that have changed.</p>

--- a/spec/models/computacenter/responsible_body_urns_spec.rb
+++ b/spec/models/computacenter/responsible_body_urns_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Computacenter::ResponsibleBodyUrns do
     end
   end
 
+  describe '#requiring_a_new_computacenter_reference' do
+    subject(:model) { ResponsibleBody }
+
+    it 'returns only rbs that have schools associated' do
+      create(:local_authority, :with_schools)
+      create(:local_authority)
+
+      expect(model.count).to eq(2)
+      expect(model.requiring_a_new_computacenter_reference.count).to eq(1)
+    end
+  end
+
   describe '#computacenter_name' do
     subject(:model) { fe_klass.new }
 


### PR DESCRIPTION
### Context

The device supplier was receiving new rbs to create even when said rbs had zero schools

### Changes proposed in this pull request

Update the filter for relevant rbs to also omit rbs with zero schools

### Guidance to review

Check the supplier portal to ensure that only rbs with associated schools appear in the list