### PR TITLE
2490: add feature flag to enable/disable CC notifications about user …

### DIFF
--- a/app/models/computacenter/user_change_generator.rb
+++ b/app/models/computacenter/user_change_generator.rb
@@ -10,15 +10,18 @@ class Computacenter::UserChangeGenerator
       change = Computacenter::UserChange.new(consolidated_attributes)
       change.add_original_fields_from(last_change_for_user) if last_change_for_user.present?
       change.save!
-      notify_computacenter_via_api if computacenter_api_configured?
+      notify_computacenter_via_api if notify_computacenter?
       change
     end
   end
 
 private
 
-  def computacenter_api_configured?
-    Settings.computacenter.service_now_user_import_api.endpoint.present?
+  def notify_computacenter?
+    [
+      FeatureFlag.active?(:notify_cc_about_user_changes),
+      Settings.computacenter.service_now_user_import_api.endpoint.present?,
+    ].all?
   end
 
   def notify_computacenter_via_api

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     display_sign_in_token_links
     show_component_previews
     gias_data_stage_pause
+    notify_cc_about_user_changes
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+RSpec.describe User, type: :model, with_feature_flags: { notify_cc_about_user_changes: 'active' } do
   describe 'associations' do
     it { is_expected.to have_many(:email_audits).dependent(:destroy) }
   end


### PR DESCRIPTION
…changes

### Context
 When CC api stops accepting requests for user changes we get a lot of failed jobs in the Retries queue of sidekiq. [Computacenter::ServiceNowUserImportAPI::Error](https://trello.com/c/DzsQK1nh)

### Changes proposed in this pull request
  A new feature flag to enable/disable the generation of background jobs to hit CC api for user changes.

### Guidance to review

