### PR TITLE
Rename reopening branch for automation to preview

### DIFF
--- a/.github/workflows/build-push-and-deploy-preview-container.yml
+++ b/.github/workflows/build-push-and-deploy-preview-container.yml
@@ -4,7 +4,7 @@ name: Build, push and deploy preview container
 on:
   push:
     branches:
-      - reopening
+      - preview
 
 jobs:
   build-and-push-container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, reopening ]
+    branches: [ main, preview ]
 
 jobs:
   build_and_test:


### PR DESCRIPTION
### Context

In the buildup to the winter 2021 reopening of the service we used branch named `reopening` to automatically run the test suite and deploy to a `preview` environment.

### Changes proposed in this pull request

Rename `reopening` to `preview` in the GH workflows.

### Guidance to review

Create a `preview` branch and see that the test suite runs and the `preview` env is deployed.

The `preview` env is configured in [config/manifests/preview-manifest.yml](https://github.com/DFE-Digital/get-help-with-tech/blob/main/config/manifests/preview-manifest.yml).