### PR TITLE
Add a site wide banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ GHWT__DATABASE_FIELD_ENCRYPTION__KEY              | Secret key for the encrytion
 GHWT__DATABASE_FIELD_ENCRYPTION__SALT             | Salt for the encryption field in the assets table                                                                                          | REQUIRED
 GHWT__SLUG_CHECKSUM_SECRET                        | A secret for hashing a checksum for IDs in the URL                                                                                         | REQUIRED
 GHWT__API_TOKEN_TTL                               | TTL in days after which API Tokens CC use will expire from creation date                                                                   | 90
+GHWT__SITE_BANNER_MESSAGE                         | Banner message text to appear at the top of all pages of the site                                                                          | (nil)
 
 See the [settings.yaml file](config/settings.yml) for full details on configurable options.
 

--- a/app/components/site_banner_component.html.erb
+++ b/app/components/site_banner_component.html.erb
@@ -1,0 +1,10 @@
+
+<% if @message %>
+  <div class="govuk-warning-text  govuk-!-margin-bottom-0" data-module="app-tech-source-maintenance-banner" id="site-banner-component">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= @message %>
+      </strong>
+  </div>
+<% end %>

--- a/app/components/site_banner_component.rb
+++ b/app/components/site_banner_component.rb
@@ -1,0 +1,5 @@
+class SiteBannerComponent < ViewComponent::Base
+  def initialize(message: nil)
+    @message = message
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,11 @@ private
     Sentry.set_user(id: current_user&.id)
   end
 
+  def site_banner_message
+    Site.banner_message
+  end
+  helper_method :site_banner_message
+
   def impersonated_user
     @impersonated_user = if session[:impersonated_user_id].blank?
                            nil

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,6 +2,6 @@
 
 class Site
   def self.banner_message
-    @banner_message ||= Settings.site_banner_message
+    @banner_message ||= Settings.site_banner_message.presence
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Site
+  def self.banner_message
+    @banner_message ||= Settings.site_banner_message
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,6 +71,17 @@
       </div>
     </div>
     <main class="govuk-main-wrapper " id="main-content" role="main">
+      <% if site_banner_message %>
+        <div class="govuk-width-container">
+          <div class="govuk-grid-row govuk-!-margin-bottom-9" id="site-banner-app-card">
+            <div class="govuk-grid-column-full">
+              <div class="app-card">
+                  <%= render(SiteBannerComponent.new(message: site_banner_message)) %>
+                </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
         <% if impersonated_user %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -84,6 +84,8 @@ service_name_suffix:
 # Sign-in tokens will expire after this many seconds
 sign_in_token_ttl_seconds: 1800
 
+site_banner_message:
+
 # how long CDNs and browsers should cache static assets for in production, in seconds.
 static_file_cache_ttl:
 

--- a/spec/components/site_banner_component_spec.rb
+++ b/spec/components/site_banner_component_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SiteBannerComponent, type: :component do
+  subject { render_inline(described_class.new(message: 'Site wide banner message text')) }
+
+  context 'banner message present' do
+    it { is_expected.to have_css('#site-banner-component') }
+  end
+
+  context 'no banner message present' do
+    subject { render_inline(described_class.new) }
+
+    it { is_expected.to have_no_css('#site-banner-component') }
+  end
+end

--- a/spec/features/site_banner_spec.rb
+++ b/spec/features/site_banner_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.feature 'Site Banner', type: :feature do
+  context 'Default no site banner message text present' do
+    scenario 'User cannot see the site banner on the home page' do
+      visit root_path
+      expect(page).to have_no_css('#site-banner-app-card')
+    end
+
+    scenario 'User cannot see the site banner on the device guidance page' do
+      visit devices_guidance_index_path
+      expect(page).to have_no_css('#site-banner-app-card')
+    end
+  end
+
+  context 'Site banner message text present' do
+    before do
+      allow(Site).to receive(:banner_message).and_return('This is a test message')
+    end
+
+    scenario 'User can see the site banner on the home page' do
+      visit root_path
+      expect(page).to have_css('#site-banner-app-card')
+    end
+
+    scenario 'User can see the site banner on the device guidance page' do
+      visit devices_guidance_index_path
+      expect(page).to have_css('#site-banner-app-card')
+    end
+  end
+end


### PR DESCRIPTION
### Context

For the upcoming Christmas period a site wide banner is required to notify site visitors that deliveries will be paused.

### Changes proposed in this pull request

The optional env var `GHWT__SITE_BANNER_MESSAGE` can be used to set the text for a site wide banner message.

### Guidance to review

In local dev launch the app with the env var present:
`GHWT__SITE_BANNER_MESSAGE=hello bundle exec rails s`