### PR TITLE
2371 clean feature flags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,9 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - ./lib/rubocop/cop/lint/unknown_feature_flag.rb
 
 AllCops:
   Exclude:

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,20 +1,15 @@
 class FeatureFlag
-  PERMANENT_SETTINGS = %i[
-    rate_limiting
+  FEATURES = %i[
     display_sign_in_token_links
-    show_component_previews
-    gias_data_stage_pause
-    notify_cc_about_user_changes
-  ].freeze
-
-  TEMPORARY_FEATURE_FLAGS = %i[
-    half_term_delivery_suspension
     donated_devices
-    rb_level_access_notification
+    gias_data_stage_pause
+    half_term_delivery_suspension
+    notify_cc_about_user_changes
     notify_when_cap_usage_decreases
+    rate_limiting
+    rb_level_access_notification
+    show_component_previews
   ].freeze
-
-  FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
 
   def self.activate(feature_name)
     raise unless feature_name.in?(FEATURES)
@@ -36,28 +31,6 @@ class FeatureFlag
 
   def self.inactive?(feature_name)
     !active?(feature_name)
-  end
-
-  def self.temporarily_activate(*feature_names)
-    original_values = {}
-    Array(feature_names).each do |name|
-      original_values[name] = FeatureFlag.active?(name)
-      activate(name)
-    end
-    return_value = yield
-    feature_names.each { |name| FeatureFlag.deactivate(name) unless original_values[name] }
-    return_value
-  end
-
-  def self.temporarily_deactivate(*feature_names)
-    original_values = {}
-    Array(feature_names).each do |name|
-      original_values[name] = FeatureFlag.active?(name)
-      deactivate(name)
-    end
-    return_value = yield
-    feature_names.each { |name| FeatureFlag.activate(name) if original_values[name] }
-    return_value
   end
 
   def self.set_temporary_flags(features = {})

--- a/lib/rubocop/cop/lint/unknown_feature_flag.rb
+++ b/lib/rubocop/cop/lint/unknown_feature_flag.rb
@@ -1,0 +1,49 @@
+require 'rubocop'
+require_relative '../../../../app/services/feature_flag'
+
+module RuboCop
+  module Cop
+    module Lint
+      # Check if the code still references deleted feature flags.
+      #
+      # @example
+      #   # good
+      #   FeatureFlag::FEATURES = [:display_sign_in_token_links, :rate_limiting]
+      #
+      #   if FeatureFlag.active?(:display_sign_in_token_links)
+      #      user = User.find_by(email_address: @token_form.email_address)
+      #      identifier = user.sign_in_identifier(user.sign_in_token)
+      #      flash[:sign_in] = "<a href='#{token_url}'>Click to sign-in</a>"
+      #   end
+      #
+      #   # bad
+      #   FeatureFlag::FEATURES = [:rate_limiting]
+      #
+      #   if FeatureFlag.active?(:display_sign_in_token_links)
+      #      user = User.find_by(email_address: @token_form.email_address)
+      #      identifier = user.sign_in_identifier(user.sign_in_token)
+      #      flash[:sign_in] = "<a href='#{token_url}'>Click to sign-in</a>"
+      #   end
+      class UnknownFeatureFlag < RuboCop::Cop::Cop
+        FEATURE_FLAGS = FeatureFlag::FEATURES
+        MSG = 'Unknown feature flag `%<flag>s`'.freeze
+        NODE_PATTERN = '(send (const nil? :FeatureFlag) {:active? | :inactive?} (sym $_))'.freeze
+        RESTRICT_ON_SEND = %i[active? inactive?].freeze
+
+        def_node_matcher :on_feature_flag, NODE_PATTERN
+
+        def on_send(node)
+          on_feature_flag(node) do |flag|
+            add_offense(node, message: error_message(flag)) unless FEATURE_FLAGS.include?(flag.to_sym)
+          end
+        end
+
+      private
+
+        def error_message(flag)
+          sprintf(MSG, flag: flag)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/support/users_controller_spec.rb
+++ b/spec/controllers/support/users_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Support::UsersController do
     end
 
     it 'returns all matching school and RB users who have seen the privacy notice for Computacenter users' do
-      sign_in_as create(:computacenter_user)
+      sign_in_as create(:computacenter_user, full_name: 'Ralph Wort')
       post :results, params: { support_user_search_form: { email_address_or_full_name: 'Smith' } }
 
       expect(assigns[:results]).to contain_exactly(user_who_has_seen_privacy_notice)

--- a/spec/lib/rubocop/cop/lint/unknown_feature_flag_spec.rb
+++ b/spec/lib/rubocop/cop/lint/unknown_feature_flag_spec.rb
@@ -5,14 +5,14 @@ describe RuboCop::Cop::Lint::UnknownFeatureFlag, :config do
   subject(:cop) { described_class.new }
 
   context 'when the feature flag is not defined' do
-    it 'registers an offense when code calls checks the feature flag is active' do
+    it 'registers an offense when the code checks the feature flag is active' do
       expect_offense(<<~RUBY)
         FeatureFlag.active?(:no_existent_feature_flag)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown feature flag `no_existent_feature_flag`
       RUBY
     end
 
-    it 'registers an offense when code calls checks the feature flag is inactive' do
+    it 'registers an offense when the code checks the feature flag is inactive' do
       expect_offense(<<~RUBY)
         FeatureFlag.inactive?(:no_existent_feature_flag)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown feature flag `no_existent_feature_flag`

--- a/spec/lib/rubocop/cop/lint/unknown_feature_flag_spec.rb
+++ b/spec/lib/rubocop/cop/lint/unknown_feature_flag_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'rubocop/cop/lint/unknown_feature_flag'
+
+describe RuboCop::Cop::Lint::UnknownFeatureFlag, :config do
+  subject(:cop) { described_class.new }
+
+  context 'when the feature flag is not defined' do
+    it 'registers an offense when code calls checks the feature flag is active' do
+      expect_offense(<<~RUBY)
+        FeatureFlag.active?(:no_existent_feature_flag)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown feature flag `no_existent_feature_flag`
+      RUBY
+    end
+
+    it 'registers an offense when code calls checks the feature flag is inactive' do
+      expect_offense(<<~RUBY)
+        FeatureFlag.inactive?(:no_existent_feature_flag)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown feature flag `no_existent_feature_flag`
+      RUBY
+    end
+  end
+
+  context 'when the feature flag is defined' do
+    it 'does not register an offense when the code checks the feature flag is active' do
+      expect_no_offenses(<<~RUBY)
+        FeatureFlag.active?(:gias_data_stage_pause)
+      RUBY
+    end
+
+    it 'does not register an offense when the code checks the feature flag is inactive' do
+      expect_no_offenses(<<~RUBY)
+        FeatureFlag.inactive?(:gias_data_stage_pause)
+      RUBY
+    end
+  end
+end

--- a/spec/support/rubocop.rb
+++ b/spec/support/rubocop.rb
@@ -1,0 +1,6 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+end


### PR DESCRIPTION
### Context
Some envars to enable/disable legacy feature flags still exist on all enviroments.
When we undefine a feature flag, the code calling it must be refactored as well.

### Changes proposed in this pull request
- Rubocop custom cop to detect when code is still checking the status of feature flags that have been removed.
- Review all FEATURES_* envars in the existing environments to remove the legacy ones.
- A single list of feature flag keys is enough to cope with our needs. Temporary list is not needed anymore.

### Guidance to review

