### PR TITLE
2636: notify CC when zero allocation cannot_order schools are open to…

### DIFF
--- a/app/services/update_school_devices_service.rb
+++ b/app/services/update_school_devices_service.rb
@@ -55,11 +55,11 @@ private
   end
 
   def notify_device?(device_type)
-    ordering?(device_type) && initial_raw_cap(device_type) != school.raw_cap(device_type)
+    update_state? || (ordering?(device_type) && initial_raw_cap(device_type) != school.raw_cap(device_type))
   end
 
   def notify_other_agents?
-    notify_computacenter && (school.cannot_order? || !vcaps?)
+    notify_computacenter && (school.cannot_order? || update_state? || !vcaps?)
   end
 
   def notify_other_agents

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -211,8 +211,6 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
         [
           [
             { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => '11', 'capAmount' => '3' },
-          ],
-          [
             { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => '11', 'capAmount' => '2' },
           ],
         ]
@@ -226,14 +224,16 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
         expect_to_have_sent_caps_to_computacenter(requests, check_number_of_calls: false)
       end
 
-      it 'do not notify Computacenter of laptops cap change by email' do
+      it 'notify Computacenter of laptops cap change by email' do
         expect { patch :update, params: params }
-          .not_to have_enqueued_mail(ComputacenterMailer)
+          .to have_enqueued_mail(ComputacenterMailer, :notify_of_devices_cap_change)
+                .with(params: { school: school, new_cap_value: 4 }, args: []).once
       end
 
-      it "do not notify support if no school's organizational users" do
+      it "notify support if no school's organizational users" do
         expect { patch :update, params: params }
-          .not_to have_enqueued_mail(CanOrderDevicesMailer)
+          .to have_enqueued_mail(CanOrderDevicesMailer, :notify_support_school_can_order_but_no_one_contacted)
+                .with(params: { school: school }, args: []).once
       end
     end
   end

--- a/spec/services/update_school_devices_service_spec.rb
+++ b/spec/services/update_school_devices_service_spec.rb
@@ -73,5 +73,41 @@ RSpec.describe UpdateSchoolDevicesService do
         expect(rb.reload.laptops).to eq([10, 5, 0])
       end
     end
+
+    context 'case 3' do
+      let!(:rb) { create(:trust, :manages_centrally, :vcap) }
+      let!(:schools) do
+        [
+          create(:school, :centrally_managed, responsible_body: rb, laptops: [0, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [3, 0, 0, 0]),
+          create(:school, :centrally_managed, :in_lockdown, responsible_body: rb, laptops: [3, 0, 0, 0]),
+        ]
+      end
+      let(:requests) do
+        [
+          [
+            { 'capType' => 'DfE_RemainThresholdQty|Std_Device', 'shipTo' => schools[0].ship_to, 'capAmount' => '6' },
+            { 'capType' => 'DfE_RemainThresholdQty|Coms_Device', 'shipTo' => schools[0].ship_to, 'capAmount' => '0' },
+          ],
+        ]
+      end
+
+      before do
+        described_class.new(school: schools[0], laptops_ordered: 6, notify_school: false, notify_computacenter: false).call
+      end
+
+      it 'updates laptop allocation numbers' do
+        expect(schools[0].reload.raw_laptops_full).to eq([0, 0, 6, 6])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(rb.laptops).to eq([6, 6, 6])
+        described_class.new(school: schools[0], order_state: :can_order).call
+        expect(schools[0].reload.raw_laptops_full).to eq([0, 0, 6, 6])
+        expect(schools[1].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(schools[2].reload.raw_laptops_full).to eq([3, 0, -3, 0])
+        expect(rb.reload.laptops).to eq([6, 6, 6])
+        expect_to_have_sent_caps_to_computacenter(requests, check_number_of_calls: false)
+      end
+    end
   end
 end


### PR DESCRIPTION
… order

### Context
[Card 2636](https://trello.com/c/KQiLnIQi)

BUG: CC doesn't get notified when a zero allocation school in a vcap with cap = devices ordered is open to order.

### Changes proposed in this pull request

### Guidance to review

