### PR TITLE
Add a tick box for support audit export users

### DIFF
--- a/app/views/support/users/search.html.erb
+++ b/app/views/support/users/search.html.erb
@@ -37,11 +37,14 @@
         Generate a CSV file of all users.
       </p>
 
-      <%= button_to 'Download CSV',
-                    export_support_users_path(format: :csv),
-                    class: 'govuk-button',
-                    name: :export,
-                    method: :get %>
+      <%= form_with url: export_support_users_path(format: :csv) do |f| %>
+        <div class="govuk-form-group">
+          <%= f.govuk_check_box :include_audit_data, 1, 0, multiple: false, link_errors: true, label: { text: "Include audit data (soft deleted, support and supplier users)" } %>
+        </div>
+        <div class="govuk-form-group">
+          <%= f.govuk_submit 'Download CSV', name: :export %>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/support/users/search.html.erb
+++ b/app/views/support/users/search.html.erb
@@ -21,7 +21,7 @@
       <%= f.govuk_text_field :email_address_or_full_name,
                              label: { text: 'Email address or name', size: 'm' } %>
 
-      <%= f.govuk_submit 'Search' %>
+      <%= f.govuk_submit 'Search', name: :search %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,7 +294,7 @@ Rails.application.routes.draw do
     resources :users, only: %i[show edit update destroy] do
       collection do
         get 'search'
-        get 'export'
+        post 'export'
         post 'results'
       end
       member do

--- a/spec/features/support/exporting_users_spec.rb
+++ b/spec/features/support/exporting_users_spec.rb
@@ -5,33 +5,50 @@ RSpec.feature 'Exporting users' do
   let(:csv) { CSV.parse(page.body, headers: true) }
   let(:expected_headers) { Support::UserReport.headers }
   let(:relevant_users_count) { User.count }
+  let(:school_and_rb_users_count) { User.from_responsible_body_or_schools.count }
   let(:search_page) { PageObjects::Support::Users::SearchPage.new }
   let(:support_user) { create(:support_user) }
 
   scenario 'support user can export' do
     given_i_am_signed_in_as_a_support_user
-    and_there_are_school_and_responsible_body_users
+    and_there_are_school_responsible_body_support_and_supplier_users
 
     when_i_visit_the_user_search_page
     and_i_click_the_export_button
-    then_the_csv_should_contain_the_users
+    then_the_csv_should_contain_the_school_and_rb_users
+  end
+
+  scenario 'support user can export audit data' do
+    given_i_am_signed_in_as_a_support_user
+    and_there_are_school_responsible_body_support_and_supplier_users
+
+    when_i_visit_the_user_search_page
+    and_i_click_the_export_audit_data_checkbox
+    and_i_click_the_export_button
+    then_the_csv_should_contain_all_users
   end
 
   scenario 'Computacenter user can not export' do
     given_i_am_signed_in_as_a_computacenter_user
-    and_there_are_school_and_responsible_body_users
+    and_there_are_school_responsible_body_support_and_supplier_users
 
     when_i_visit_the_user_search_page
     then_i_do_not_see_the_export_button
+  end
+
+  def and_i_click_the_export_audit_data_checkbox
+    search_page.audit_data_checkbox.click
   end
 
   def and_i_click_the_export_button
     search_page.export_button.click
   end
 
-  def and_there_are_school_and_responsible_body_users
+  def and_there_are_school_responsible_body_support_and_supplier_users
     create_list(:school_user, 2)
     create_list(:local_authority_user, 2)
+    create_list(:computacenter_user, 2)
+    create_list(:support_user, 2)
   end
 
   def given_i_am_signed_in_as_a_support_user
@@ -46,9 +63,14 @@ RSpec.feature 'Exporting users' do
     expect(search_page).not_to have_export_button
   end
 
-  def then_the_csv_should_contain_the_users
+  def then_the_csv_should_contain_all_users
     expect(csv.headers).to match_array(expected_headers)
     expect(csv.size).to eq(relevant_users_count)
+  end
+
+  def then_the_csv_should_contain_the_school_and_rb_users
+    expect(csv.headers).to match_array(expected_headers)
+    expect(csv.size).to eq(school_and_rb_users_count)
   end
 
   def when_i_visit_the_user_search_page

--- a/spec/page_objects/support/users/search_page.rb
+++ b/spec/page_objects/support/users/search_page.rb
@@ -6,7 +6,8 @@ module PageObjects
 
         element :search_term, 'input[type=text]'
         element :submit, 'button[type=submit]'
-        element :export_button, 'input[name="export"]'
+        element :audit_data_checkbox, 'input[name="include_audit_data"]'
+        element :export_button, 'button[name="export"]'
       end
     end
   end

--- a/spec/page_objects/support/users/search_page.rb
+++ b/spec/page_objects/support/users/search_page.rb
@@ -5,7 +5,7 @@ module PageObjects
         set_url '/support/users/search'
 
         element :search_term, 'input[type=text]'
-        element :submit, 'button[type=submit]'
+        element :submit, 'button[name=search]'
         element :audit_data_checkbox, 'input[name="include_audit_data"]'
         element :export_button, 'button[name="export"]'
       end


### PR DESCRIPTION
### Context

Support want the ability to export only school and rb users

### Changes proposed in this pull request

Add a checkbox to the support export users form

### Guidance to review

<img width="849" alt="image" src="https://user-images.githubusercontent.com/420873/145839383-2f7f482c-5c5b-4672-b25c-1d94417ba17a.png">
