### PR TITLE
Fix inclusion of deleted users in non-audit export

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -91,7 +91,7 @@ private
   end
 
   def export_scope
-    export_params['include_audit_data'].to_i == 1 ? :all : :from_responsible_body_or_schools
+    export_params['include_audit_data'].to_i == 1 ? :all : :not_deleted_from_responsible_body_or_schools
   end
 
   # this is necessary to turn orders_devices=true/false into 0/1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ApplicationRecord
   scope :signed_in_at_least_once, -> { where('sign_in_count > 0') }
   scope :responsible_body_users, -> { where.not(responsible_body: nil) }
   scope :from_responsible_body_or_schools, -> { left_joins(:user_schools).where('responsible_body_id IS NOT NULL or user_schools.id IS NOT NULL') }
+  scope :not_deleted_from_responsible_body_or_schools, -> { not_deleted.from_responsible_body_or_schools }
   scope :mno_users, -> { where.not(mobile_network: nil) }
   scope :who_can_order_devices, -> { where(orders_devices: true) }
   scope :with_techsource_account_confirmed, -> { where.not(techsource_account_confirmed_at: nil) }

--- a/spec/features/support/exporting_users_spec.rb
+++ b/spec/features/support/exporting_users_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Exporting users' do
   let(:csv) { CSV.parse(page.body, headers: true) }
   let(:expected_headers) { Support::UserReport.headers }
   let(:relevant_users_count) { User.count }
-  let(:school_and_rb_users_count) { User.from_responsible_body_or_schools.count }
+  let(:school_and_rb_users_count) { User.not_deleted_from_responsible_body_or_schools.count }
   let(:search_page) { PageObjects::Support::Users::SearchPage.new }
   let(:support_user) { create(:support_user) }
 


### PR DESCRIPTION
### Context

The non-audit user export includes soft-deleted users.

### Changes proposed in this pull request

Add the `not_deleted` scope to the query.

### Guidance to review

Check the non-audit user export for soft-deleted users.