### PR TITLE
Support scoped export users by schools

### DIFF
--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -55,6 +55,10 @@ class ResponsibleBody < ApplicationRecord
     )
   end
 
+  def self.where_school_id(school_ids)
+    where('EXISTS (SELECT 1 FROM schools s WHERE s.responsible_body_id = responsible_bodies.id AND s.id IN (?))', Array(school_ids))
+  end
+
   def self.with_at_least_one_preorder_information_completed
     where(
       "EXISTS(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,11 @@ class User < ApplicationRecord
     where('email_address ILIKE ? OR full_name ILIKE ?', "%#{search_term.strip}%", "%#{search_term.strip}%")
   }
 
+  scope :linked_to_school, ->(school_ids) { manages_school(school_ids).or(manages_school_through_rb(school_ids)) }
+  scope :manages_rb, ->(rb_ids) { where(responsible_body_id: rb_ids) }
+  scope :manages_school_through_rb, ->(school_ids) { manages_rb(ResponsibleBody.where_school_id(school_ids)) }
+  scope :manages_school, ->(school_ids) { left_joins(:user_schools).where(user_schools: { school_id: school_ids }) }
+
   def self.relevant_to_device_supplier
     where(is_computacenter: false, is_support: false).who_have_seen_privacy_notice.who_can_order_devices.not_deleted
   end

--- a/app/views/support/schools/results.html.erb
+++ b/app/views/support/schools/results.html.erb
@@ -65,11 +65,12 @@
 
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-one-third">
     <p class="govuk-body"><%= govuk_link_to 'Try another search', search_support_schools_path, classes: 'govuk-!-margin-top-8' %></p>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-two-thirds">
       <%- if @schools.present? %>
+
         <%= govuk_button_to('Download allocations as CSV',
                             results_support_schools_path(format: :csv),
                             params: {
@@ -85,6 +86,14 @@
                             },
                             method: :post,
                             form_class: 'govuk-!-display-inline-block search-results__new-search')  %>
+        <%= govuk_button_to('Download users as CSV',
+                            export_support_users_path(format: :csv),
+                            params: {
+                              scope_to_schools: true,
+                              school_ids: @schools.ids,
+                            },
+                            method: :post,
+                            form_class: 'govuk-!-display-inline-block')  %>
       <%- end %>
   </div>
 </div>

--- a/spec/features/support/searching_schools_spec.rb
+++ b/spec/features/support/searching_schools_spec.rb
@@ -77,6 +77,10 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     let(:trust_user) { create(:trust_user, email_address: 'user@trust.gov.uk', responsible_body: responsible_body) }
     let(:out_of_scope_school_user) { create(:school_user) }
 
+    before do
+      out_of_scope_school_user
+    end
+
     scenario 'support agent exports users as CSV' do
       given_i_am_signed_in_as_a_support_user
       and_multiple_schools_from_the_same_responsible_body_in_different_order_states

--- a/spec/features/support/searching_schools_spec.rb
+++ b/spec/features/support/searching_schools_spec.rb
@@ -71,6 +71,30 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     and_the_csv_contains_data_for_the_correct_schools
   end
 
+  context 'export of users scoped to schools' do
+    let(:school_user1) { create(:school_user, email_address: 'user@can-order-school.sch.uk', school: schools_who_can_order.first) }
+    let(:school_user2) { create(:school_user, email_address: 'user@another-can-order-school.sch.uk', school: schools_who_can_order.last) }
+    let(:trust_user) { create(:trust_user, email_address: 'user@trust.gov.uk', responsible_body: responsible_body) }
+    let(:out_of_scope_school_user) { create(:school_user) }
+
+    scenario 'support agent exports users as CSV' do
+      given_i_am_signed_in_as_a_support_user
+      and_multiple_schools_from_the_same_responsible_body_in_different_order_states
+      and_there_are_school_and_responsible_body_users
+      when_i_follow_the_links_to_find_schools
+      then_i_see_the_schools_search_page
+
+      when_i_choose_an_order_state_and_responsible_body
+      and_i_submit
+      then_i_see_the_results_page
+      and_i_see_a_button_to_download_users_as_csv
+
+      when_i_click_on_the_download_users_button
+      then_i_download_a_csv_of_users
+      and_the_csv_contains_data_for_the_correct_users
+    end
+  end
+
   def given_i_am_signed_in_as_a_support_user
     sign_in_as support_user
   end
@@ -78,6 +102,12 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
   def and_multiple_schools_from_the_same_responsible_body_in_different_order_states
     schools_who_can_order
     create_list(:school, 2, responsible_body: responsible_body, order_state: 'cannot_order')
+  end
+
+  def and_there_are_school_and_responsible_body_users
+    school_user1
+    school_user2
+    trust_user
   end
 
   def when_i_follow_the_links_to_find_schools
@@ -150,6 +180,19 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     expect(page.body).to include(AllocationsExporter.headings.join(','))
   end
 
+  def and_i_see_a_button_to_download_users_as_csv
+    expect(results_page).to have_button('Download users as CSV')
+  end
+
+  def when_i_click_on_the_download_users_button
+    click_on('Download users as CSV')
+  end
+
+  def then_i_download_a_csv_of_users
+    expect_download(content_type: 'text/csv')
+    expect(page.body).to include(Support::UserReport.headers.join(','))
+  end
+
   def and_the_csv_contains_data_for_the_searched_schools
     rows = page.body.split("\n")
     expect(rows.size).to eq(3)
@@ -160,6 +203,16 @@ RSpec.feature 'Searching for schools by URNs and other criteria' do
     rows = page.body.split("\n")
     expect(rows.size).to eq(3)
     expect(rows.map { |row| row.split(',').first }).to include('School URN', schools_who_can_order.first.urn.to_s, schools_who_can_order.last.urn.to_s)
+  end
+
+  def and_the_csv_contains_data_for_the_correct_users
+    rows = page.body.split("\n")
+    expect(rows.size).to eq(4)
+    expect(page.body).to have_content('email_address')
+    expect(page.body).to have_content(school_user1.email_address)
+    expect(page.body).to have_content(school_user2.email_address)
+    expect(page.body).to have_content(trust_user.email_address)
+    expect(page.body).not_to have_content(out_of_scope_school_user.email_address)
   end
 
   def when_i_click_on_perform_another_search


### PR DESCRIPTION
### Context

Given a batch of schools there is no method of retrieving related email addresses. This is required for the custom emails sent via Notify in the lead up to service closure.

### Changes proposed in this pull request

Add a `Download users as CSV` button to `Search for multiple schools by URN or UKPRN` results page.

### Guidance to review

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/420873/146389480-e675a087-c850-4bfa-b13e-9e8ec80a47b5.png">
