### PR TITLE
Add button to export all allocations

### DIFF
--- a/app/services/allocations_exporter.rb
+++ b/app/services/allocations_exporter.rb
@@ -59,7 +59,7 @@ private
         school.responsible_body.name,
         school.responsible_body.computacenter_identifier,
         school.order_state,
-        school.who_will_order_devices,
+        school.who_will_order_devices || school.responsible_body&.default_who_will_order_devices_for_schools,
         school.raw_allocation(:laptop),
         school.raw_cap(:laptop),
         school.raw_devices_ordered(:laptop),

--- a/app/views/support/home/schools.html.erb
+++ b/app/views/support/home/schools.html.erb
@@ -20,11 +20,27 @@
     <p class="govuk-body">Use this section to find one or more school, college or FE institution by URN or UKPRN.</p>
 
     <% if policy(School).edit? %>
-      <h2 class="govuk-heading-l govuk-!-font-size-27">
-        <%= govuk_link_to 'Bulk upload allocation updates', devices_enable_orders_for_many_schools_support_schools_path %>
-      </h2>
+      <div class="govuk-!-margin-top-9">
+        <h2 class="govuk-heading-xl">Bulk actions</h2>
+      
+        <p class="govuk-body">Use this section to update or export allocations for schools, colleges and FE institutions.</p>
+  
+        <h2 class="govuk-heading-l govuk-!-font-size-27">
+          <%= govuk_link_to 'Bulk upload allocation updates', devices_enable_orders_for_many_schools_support_schools_path %>
+        </h2>
+  
+        <p class="govuk-body">Follow this link to use the bulk allocation updater.</p>
+  
+        <h2 class="govuk-heading-l govuk-!-font-size-27">Export all allocations</h2>
+  
+        <p class="govuk-body">Export allocations for all schools using the button below.</p>
 
-      <p class="govuk-body">Use this section to update allocations on schools, colleges and FE institutions.</p>
+        <%= govuk_button_to('Download all allocations as CSV',
+                            results_support_schools_path(format: :csv),
+                            params: { all_schools: true },
+                            method: :post,
+                            form_class: 'govuk-!-display-inline-block')  %>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

Support require a periodical export of all school allocations.

### Changes proposed in this pull request

Add a button in the support area to download all school allocations as a csv file.

### Guidance to review

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/420873/146565474-e5296810-6263-40ca-a616-3ae20051a3a0.png">
