### PR TITLE
2674: store tranche files into S3 to be able to share them with Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version').chomp
 
+gem 'aws-sdk-s3', '~> 1'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,22 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.549.0)
+    aws-sdk-core (3.125.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.53.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.111.1)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -233,6 +249,7 @@ GEM
     i18n-debug (1.2.0)
       i18n (< 2)
     inflection (1.0.0)
+    jmespath (1.5.0)
     jwt (2.2.3)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -530,6 +547,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)

--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -17,6 +17,7 @@ applications:
   services:
     - get-help-with-tech-dev-db
     - get-help-with-tech-dev-redis
+    - get-help-with-tech-dev-aws-s3-bucket
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile

--- a/config/manifests/preview-manifest.yml
+++ b/config/manifests/preview-manifest.yml
@@ -16,6 +16,7 @@ applications:
   services:
     - get-help-with-tech-preview-db
     - get-help-with-tech-preview-redis
+    - get-help-with-tech-preview-aws-s3-bucket
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile

--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -16,6 +16,7 @@ applications:
   services:
     - get-help-with-tech-prod-db
     - get-help-with-tech-prod-redis
+    - get-help-with-tech-prod-aws-s3-bucket
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -16,6 +16,7 @@ applications:
   services:
     - get-help-with-tech-staging-db
     - get-help-with-tech-staging-redis
+    - get-help-with-tech-staging-aws-s3-bucket
   env:
     DOCKER_IMAGE_ID: ((docker_image_id))
     ENV: $HOME/.profile

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,10 @@
 active_job:
   default_wait: 2
 
+aws:
+  s3:
+    bulk_allocation_uploads_bucket: bulk_allocation_uploads
+
 computacenter:
   notify_email_address: departmentforeducation@computacenter.com
   techsource_url: https://techsource.computacenter.com/en/

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
     end
 
     before do
+      stub_s3
       create(:school, urn: 123_456)
       create(:school, ukprn: 12_345_678)
     end

--- a/spec/support/aws_s3_helper.rb
+++ b/spec/support/aws_s3_helper.rb
@@ -1,0 +1,22 @@
+require 'csv'
+
+module AwsS3Helper
+  def stub_s3
+    allow(Aws::S3::Client).to receive(:new).and_return(Aws::S3::Client.new(stub_responses: true))
+  end
+
+  def stub_file_storage(file)
+    allow(Aws::S3::Client).to receive(:new).and_return(
+      Aws::S3::Client.new(stub_responses: {
+        create_bucket: { location: 'Location' },
+        put_object: { etag: 'Etag' },
+        list_buckets: { buckets: [{ name: Settings.aws.s3.bulk_allocation_uploads_bucket }] },
+        get_object: { etag: 'Etag', body: file.read },
+      }),
+    )
+  end
+end
+
+RSpec.configure do |c|
+  c.include AwsS3Helper
+end


### PR DESCRIPTION
### Context
  Tranches uploaded by a support user needs to made accessible to Sidekiq to read and process them. 
Govuk Paas allows the use of S3 as a backend service for our apps. 

### Changes proposed in this pull request
- Added [aws-s3-bucket service](https://docs.cloud.service.gov.uk/deploying_services/s3/#amazon-s3) manually to our apps in all envs
- Bind services - apps in the manifest files.
- Change the logic of bulk allocation uploads to write and read the user file to/from S3.

### Guidance to review
 I would like to isolate S3 stuff into our own wrapper class so the entities using it (`BulkAllocationForm`  and `BulkAllocationJob`) don't have to deal with the S3 client itself. 

Due to deadline restrictions I will leave it for the future. 

