### PR TITLE
2674: initialize AWS S3 explicitly from automatic envars

### DIFF
--- a/app/form_objects/support/bulk_allocation_form.rb
+++ b/app/form_objects/support/bulk_allocation_form.rb
@@ -30,7 +30,7 @@ private
   end
 
   def bucket_name
-    @bucket_name ||= Settings.aws.s3.bulk_allocation_uploads_bucket
+    @bucket_name ||= GhwtAws::AWS_S3_BUCKET_NAME
   end
 
   def cant_store_file(response)
@@ -57,7 +57,7 @@ private
   end
 
   def s3
-    @s3 ||= Aws::S3::Client.new unless Rails.env.development?
+    @s3 ||= GhwtAws::AWS_S3_CLIENT
   end
 
   def upload_scheduled?

--- a/app/jobs/bulk_allocation_job.rb
+++ b/app/jobs/bulk_allocation_job.rb
@@ -23,7 +23,7 @@ private
   end
 
   def bucket_name
-    @bucket_name ||= Settings.aws.s3.bulk_allocation_uploads_bucket
+    @bucket_name ||= GhwtAws::AWS_S3_BUCKET_NAME
   end
 
   def cant_read_file
@@ -66,7 +66,7 @@ private
   end
 
   def s3
-    @s3 ||= Aws::S3::Client.new unless Rails.env.development?
+    @s3 ||= GhwtAws::AWS_S3_CLIENT
   end
 
   def schedule_school(school, props)

--- a/config/initializers/aws_s3.rb
+++ b/config/initializers/aws_s3.rb
@@ -1,0 +1,19 @@
+require 'v_cap_services_config'
+
+module GhwtAws
+  s3_config = VCapServicesConfig.new.first_service_matching('aws-s3-bucket')
+
+  AWS_S3_CLIENT = if Rails.env.test?
+                    Aws::S3::Client.new(stub_responses: true)
+                  elsif !Rails.env.development? && s3_config
+                    Aws::S3::Client.new(access_key_id: s3_config['credentials']['aws_access_key_id'],
+                                        secret_access_key: s3_config['credentials']['aws_secret_access_key'],
+                                        region: s3_config['credentials']['aws_region'])
+                  end
+
+  AWS_S3_BUCKET_NAME = if Rails.env.test?
+                         'bulk_allocation_uploads'
+                       elsif !Rails.env.development? && s3_config
+                         s3_config['credentials']['bucket_name']
+                       end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,10 +10,6 @@
 active_job:
   default_wait: 2
 
-aws:
-  s3:
-    bulk_allocation_uploads_bucket: bulk_allocation_uploads
-
 computacenter:
   notify_email_address: departmentforeducation@computacenter.com
   techsource_url: https://techsource.computacenter.com/en/

--- a/lib/v_cap_services_config.rb
+++ b/lib/v_cap_services_config.rb
@@ -2,10 +2,12 @@ class VCapServicesConfig
   attr_accessor :config
 
   def initialize(config = ENV['VCAP_SERVICES'])
-    @config = JSON.parse(config)
+    @config = JSON.parse(config) if config.present?
   end
 
   def first_service_matching(name)
+    return unless config
+
     service_key = @config.keys.find { |svc| svc =~ /#{name}/i }
     @config[service_key].first
   end

--- a/spec/controllers/support/schools/devices/order_status_controller_spec.rb
+++ b/spec/controllers/support/schools/devices/order_status_controller_spec.rb
@@ -313,7 +313,6 @@ RSpec.describe Support::Schools::Devices::OrderStatusController do
     end
 
     before do
-      stub_s3
       create(:school, urn: 123_456)
       create(:school, ukprn: 12_345_678)
     end

--- a/spec/form_objects/support/bulk_allocation_form_spec.rb
+++ b/spec/form_objects/support/bulk_allocation_form_spec.rb
@@ -13,13 +13,9 @@ RSpec.describe Support::BulkAllocationForm, type: :model do
     end
 
     context 'when the file is not a valid .csv file' do
-      subject(:form) { described_class.new(upload: 'nofile.csv', send_notification: true) }
+      subject { described_class.new(upload: 'nofile.csv', send_notification: true).save }
 
-      it 'return false' do
-        stub_s3
-
-        expect(form.save).to be_falsey
-      end
+      it { is_expected.to be_falsey }
     end
 
     it 'enqueue a BulkAlocationJob to process the file' do

--- a/spec/support/aws_s3_helper.rb
+++ b/spec/support/aws_s3_helper.rb
@@ -1,19 +1,16 @@
 require 'csv'
 
 module AwsS3Helper
-  def stub_s3
-    allow(Aws::S3::Client).to receive(:new).and_return(Aws::S3::Client.new(stub_responses: true))
-  end
-
   def stub_file_storage(file)
-    allow(Aws::S3::Client).to receive(:new).and_return(
-      Aws::S3::Client.new(stub_responses: {
-        create_bucket: { location: 'Location' },
-        put_object: { etag: 'Etag' },
-        list_buckets: { buckets: [{ name: Settings.aws.s3.bulk_allocation_uploads_bucket }] },
-        get_object: { etag: 'Etag', body: file.read },
-      }),
-    )
+    stub_const('GhwtAws::AWS_S3_CLIENT',
+               Aws::S3::Client.new(
+                 stub_responses: {
+                   create_bucket: { location: 'Location' },
+                   put_object: { etag: 'Etag' },
+                   list_buckets: { buckets: [{ name: GhwtAws::AWS_S3_BUCKET_NAME }] },
+                   get_object: { etag: 'Etag', body: file.read },
+                 },
+               ))
   end
 end
 


### PR DESCRIPTION
### Context
  Adding and binding aws-s3-bucket service to the app automatically adds some envars but we still need to explicitly initialiase the client from those envars.

### Changes proposed in this pull request

### Guidance to review

