### PR TITLE
2698: successor schools inherit order state from predecessors if not …

### DIFF
--- a/app/services/school_set_who_manages_orders_service.rb
+++ b/app/services/school_set_who_manages_orders_service.rb
@@ -14,8 +14,8 @@ class SchoolSetWhoManagesOrdersService
   def call
     school.orders_managed_by!(who, clear_preorder_information: clear_preorder_information)
     recalculate_vcaps! if recalculate_vcaps
-    notify_other_agents if notify
     school.refresh_preorder_status!
+    notify_other_agents if notify
     true
   rescue StandardError => e
     failed(e)

--- a/app/services/school_update_service.rb
+++ b/app/services/school_update_service.rb
@@ -24,6 +24,7 @@ class SchoolUpdateService
 
     add_school_links(staged_school, school)
     set_who_manages_orders(school)
+    inherit_order_state(school, staged_school) unless school.vcap?
 
     school
   end
@@ -56,6 +57,11 @@ private
   def find_predecessor(staged_school)
     last_link = staged_school.school_links.any_predecessor.order(created_at: :asc).last
     School.find_by(urn: last_link.link_urn) if last_link
+  end
+
+  def inherit_order_state(school, staged_school)
+    predecessor = find_predecessor(staged_school)
+    UpdateSchoolDevicesService.new(school: school, order_state: predecessor.order_state).call if predecessor
   end
 
   def set_who_manages_orders(school)

--- a/spec/services/school_update_service_spec.rb
+++ b/spec/services/school_update_service_spec.rb
@@ -158,6 +158,28 @@ RSpec.describe SchoolUpdateService, type: :model do
         expect(old_school.school_links.count).to be(1)
       end
 
+      context 'when the new school is in vcap' do
+        before do
+          local_authority.update!(vcap: true, default_who_will_order_devices_for_schools: 'responsible_body')
+        end
+
+        it 'disable orders' do
+          school = service.create_school!(staged_school)
+          expect(school).to be_cannot_order
+        end
+      end
+
+      context 'when the new school is not in vcap' do
+        before do
+          old_school.can_order!
+        end
+
+        it 'inherit order state from its predecessor' do
+          school = service.create_school!(staged_school)
+          expect(school).to be_can_order
+        end
+      end
+
       context 'when the predecessor is in a virtual cap pool' do
         let(:response) { OpenStruct.new(body: '<xml>test-response</xml>') }
 


### PR DESCRIPTION
…in a vcap

### Context
  Make successor schools inherit order_state when they are created if not in a vcap.
  [Card](https://trello.com/c/1kTmB2d8)

### Changes proposed in this pull request

### Guidance to review

