### PR TITLE
2755: ignore orders_devices param for not eligible users

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -8,8 +8,9 @@ class Support::UsersController < Support::BaseController
 
   def new
     @form = Support::NewUserForm.new(school: @school, responsible_body: @responsible_body)
-    @user = User.new
+    @user = @school ? @school.users.new : User.new
     authorize @user
+    @change_order_devices = user_eligible_to_order_devices?
   end
 
   def create
@@ -157,5 +158,9 @@ private
       @responsible_body = ResponsibleBody.gias_status_open.find(params[:responsible_body_id])
       authorize @responsible_body, :show?
     end
+  end
+
+  def user_eligible_to_order_devices?(_user = @user)
+    SchoolPolicy.new(@user, @school).devices_orderable? if @school
   end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -34,7 +34,7 @@ class SchoolPolicy < SupportPolicy
 private
 
   def devolved_management_school_user?
-    record.orders_managed_by_school? && user.school_ids.include?(record.id)
+    record.orders_managed_by_school? && record.users.include?(user)
   end
 
   def responsible_body_user?

--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -32,7 +32,8 @@ class CreateUserService
   end
 
   def self.create_new_school_user!(user_params)
-    user = User.new(user_params)
+    orders_devices = user_params[:orders_devices].presence || false
+    user = User.new(user_params.merge(orders_devices: orders_devices))
     if user.save
       InviteSchoolUserMailer.with(user: user).nominated_contact_email.deliver_later
       user.school.refresh_preorder_status!

--- a/app/views/school/users/edit.html.erb
+++ b/app/views/school/users/edit.html.erb
@@ -17,7 +17,7 @@
     </h1>
     <%= form_for @user, url: school_user_path(@school, @user) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f, change_order_devices: @change_order_devices } %>
       <%= f.govuk_submit 'Save' %>
     <%- end %>
   </div>

--- a/app/views/school/users/new.html.erb
+++ b/app/views/school/users/new.html.erb
@@ -17,7 +17,7 @@
     <%= render partial: 'shared/invite_someone_who_can' %>
     <%= form_for @user, url: school_users_path(@school) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f, change_order_devices: @change_order_devices } %>
       <%= f.govuk_submit 'Send invite' %>
     <%- end %>
   </div>

--- a/app/views/school/welcome_wizard/will_other_order.html.erb
+++ b/app/views/school/welcome_wizard/will_other_order.html.erb
@@ -21,7 +21,7 @@
         <%= f.govuk_radio_button :invite_user,
                                  'yes',
                                  label: { text: t(:yes_label, scope: scope) } do %>
-        <%= render partial: 'shared/school_user_form', locals: { form: f, nested: true } %>
+        <%= render partial: 'shared/school_user_form', locals: { form: f, nested: true, change_order_devices: true } %>
       <%- end %>
       <%= f.govuk_radio_button :invite_user,
                                'no',

--- a/app/views/shared/_school_user_form.html.erb
+++ b/app/views/shared/_school_user_form.html.erb
@@ -10,12 +10,14 @@
                           width: 10,
                           label: { text: 'Telephone number', size: label_size } %>
 
-<%= form.govuk_collection_radio_buttons :orders_devices,
-                                        can_user_order_devices_options,
-                                        :value,
-                                        :label,
-                                        :hint,
-                                        legend: { text: t('page_titles.invite_school_user.will_they_order_devices'), size: label_size },
-                                        hint: { text: t('page_titles.invite_school_user.will_they_order_devices_hint') },
-                                        classes: 'govuk-!-margin-top-3'
-%>
+<% if change_order_devices %>
+  <%= form.govuk_collection_radio_buttons :orders_devices,
+                                          can_user_order_devices_options,
+                                          :value,
+                                          :label,
+                                          :hint,
+                                          legend: { text: t('page_titles.invite_school_user.will_they_order_devices'), size: label_size },
+                                          hint: { text: t('page_titles.invite_school_user.will_they_order_devices_hint') },
+                                          classes: 'govuk-!-margin-top-3'
+  %>
+<% end %>

--- a/app/views/support/users/edit.html.erb
+++ b/app/views/support/users/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= form_for @user, url: support_user_path(@user) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f, change_order_devices: true } %>
       <%= f.govuk_submit 'Save changes' %>
     <%- end %>
   </div>

--- a/app/views/support/users/new.html.erb
+++ b/app/views/support/users/new.html.erb
@@ -10,7 +10,7 @@
 
     <%= form_for @user, url: @form.submission_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= render partial: 'shared/school_user_form', locals: { form: f } %>
+      <%= render partial: 'shared/school_user_form', locals: { form: f, change_order_devices: @change_order_devices } %>
       <%= f.govuk_submit 'Send invite' %>
     <%- end %>
   </div>

--- a/spec/features/support/inviting_school_users_spec.rb
+++ b/spec/features/support/inviting_school_users_spec.rb
@@ -61,7 +61,6 @@ RSpec.feature 'Inviting school users' do
     new_school_user_page.name.set 'John Doe'
     new_school_user_page.email_address.set 'john@example.com'
     new_school_user_page.phone.set '020 1'
-    new_school_user_page.orders_devices_no.click
   end
 
   def when_i_fill_in_the_existing_users_details


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Extension of a previous [PR](https://github.com/DFE-Digital/get-help-with-tech/pull/2468) to:
- exclude the order_devices field from the form when inviting a user to a school centrally managed by its rb.
- ignore the orders_devices param in the update action for a non-order-devices-eligible school user.
- set a false default value on orders_devices property for non-order-devices-eligible users invited to a school.

### Guidance to review

