### PR TITLE
2790: devolve management only to schools with no who_will_order_devices set

### DIFF
--- a/app/services/create_user_service.rb
+++ b/app/services/create_user_service.rb
@@ -81,7 +81,7 @@ class CreateUserService
 
   def self.devolve_ordering_if_needed!(user_params)
     school = School.find_by(id: user_params[:school_id])
-    SchoolSetWhoManagesOrdersService.new(school, :school).call if school
+    SchoolSetWhoManagesOrdersService.new(school, :school).call if school && school.who_will_order_devices.blank?
   end
 
   private_class_method :devolve_ordering_if_needed!


### PR DESCRIPTION
### Context
[Card](https://trello.com/c/mBOeEHcN)

### Changes proposed in this pull request
When a school user is invited to join GHwT, devolve management to the school only if it is not already set.

### Guidance to review

