### PR TITLE
2816: revert disable support user permissions to edit school details

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -41,14 +41,24 @@ private
     who = @school.who_manages_orders_label
 
     if who.present?
-      {
+      detail = {
         key: 'Who ordered?',
         value: "The #{who.downcase} ordered devices",
+        action: 'who ordered',
       }
+
+      if @school.can_change_who_manages_orders?
+        detail.merge!(
+          change_path: responsible_body_devices_school_change_who_will_order_path(school_urn: @school.urn),
+        )
+      end
+      detail
     else
       {
         key: 'Who ordered?',
         value: "#{@school.responsible_body_name} hasn’t decided this yet",
+        action_path: responsible_body_devices_who_will_order_edit_path,
+        action: 'Set who ordered',
       }
     end
   end
@@ -63,7 +73,7 @@ private
   def router_allocation_row
     {
       key: 'Router allocation',
-      value: @school.raw_allocation(:router).positive? ? 'routers were available to order' : 'no routers were available to order',
+      value: @school.raw_allocation(:router).positive? ? 'routers are available to order' : 'no routers are available to order',
     }
   end
 
@@ -134,6 +144,8 @@ private
     {
       key: 'School contact',
       value: contact_lines.map { |line| h(line) }.join('<br>').html_safe,
+      change_path: responsible_body_devices_school_who_to_contact_edit_path(school_urn: @school.urn),
+      action: 'Change',
     }
   end
 

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -24,7 +24,7 @@ private
   def router_allocation_row
     {
       key: 'Router allocation',
-      value: @school.raw_allocation(:router).positive? ? 'routers were available to order' : 'no routers were available to order',
+      value: @school.raw_allocation(:router).positive? ? 'routers are available to order' : 'no routers are available to order',
     }
   end
 

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -144,8 +144,9 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
       context 'when the school manages orders' do
         let(:school) { create(:school, :primary, :academy, :manages_orders, responsible_body: rb) }
 
-        it 'confirms that fact' do
+        it 'confirms that fact and allow changes' do
           expect(value_for_row(result, 'Who ordered?').text).to include('The school or college ordered devices')
+          expect(action_for_row(result, 'Who ordered?').text).to include('Change')
         end
       end
 
@@ -161,8 +162,10 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
   end
 
   context 'when the responsible body has not made a decision about who will order' do
-    it 'confirms that fact' do
+    it 'confirms that fact and provides a link to make the decision' do
       expect(value_for_row(result, 'Who ordered?').text).to include("#{school.responsible_body.name} hasn’t decided this yet")
+      expect(action_for_row(result, 'Who ordered?').text).to include('Set who ordered')
+      expect(action_for_row(result, 'Who ordered?').css('a').attr('href').value).to eq(responsible_body_devices_who_will_order_edit_path)
     end
   end
 

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -52,6 +52,8 @@ RSpec.feature 'Setting up the devices ordering' do
       when_i_visit_the_first_school
       then_i_see_the_details_of_the_first_school
       and_that_the_school_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
+      and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
 
       when_i_select_to_contact_the_headteacher
       then_i_see_a_confirmation_and_the_headteacher_as_the_contact
@@ -81,7 +83,7 @@ RSpec.feature 'Setting up the devices ordering' do
       when_i_visit_the_first_school
       then_i_see_the_details_of_the_first_school
       and_that_the_local_authority_orders_devices
-      and_i_dont_see_a_link_to_change_who_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
     end
 
     scenario 'submitting the form without choosing an option shows an error' do
@@ -89,6 +91,34 @@ RSpec.feature 'Setting up the devices ordering' do
       click_on 'Continue'
       expect(page).to have_http_status(:unprocessable_entity)
       expect(page).to have_content('There is a problem')
+    end
+
+    scenario 'changing the settings for each school after making the choice about who will order' do
+      given_the_responsible_body_has_decided_to_order_centrally
+      when_i_visit_the_responsible_body_homepage
+      when_i_follow_the_get_devices_link
+      and_i_follow_the_your_schools_link
+      then_i_see_a_list_of_the_schools_i_am_responsible_for
+
+      when_i_visit_the_first_school
+      then_i_see_the_details_of_the_first_school
+      and_that_the_school_orders_devices
+      and_i_see_a_link_to_change_who_orders_devices
+
+      when_i_follow_the_change_who_will_order_link
+      then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+
+      when_i_select_orders_will_be_placed_centrally
+      then_i_see_the_details_of_the_first_school
+      and_that_the_local_authority_orders_devices
+
+      when_i_follow_the_change_who_will_order_link
+      then_i_am_prompted_to_choose_who_orders_devices_for_the_school
+
+      when_i_select_the_school_to_order_devices
+      then_i_see_the_details_of_the_first_school
+      and_that_the_school_orders_devices
+      and_that_i_am_prompted_to_choose_who_to_contact_at_the_school
     end
 
     scenario 'when the school has no headteacher contact (bug #537)' do
@@ -116,6 +146,11 @@ RSpec.feature 'Setting up the devices ordering' do
       and_in_the_allocation_guidance_we_ask_for_information
       when_i_select_to_contact_someone_else_and_save_their_details
       then_i_see_the_allocation_guidance_without_the_we_need_information_section
+
+      when_i_follow_the_change_who_will_order_link
+      when_i_select_orders_will_be_placed_centrally
+      then_i_see_guidance_about_why_there_is_no_allocation
+      and_in_the_allocation_guidance_we_ask_for_information
     end
   end
 
@@ -361,10 +396,6 @@ RSpec.feature 'Setting up the devices ordering' do
     expect(responsible_body_school_page.school_details).to have_content('Bob Leigh')
     expect(responsible_body_school_page.school_details).to have_content('bob.leigh@sharedservices.co.uk')
     expect(responsible_body_school_page.school_details).to have_content('020 123456')
-  end
-
-  def and_i_dont_see_a_link_to_change_who_orders_devices
-    expect(page).not_to have_link('Change who ordered')
   end
 
   def and_i_see_a_link_to_change_who_orders_devices

--- a/spec/features/support/changing_who_will_order_devices_for_a_school_spec.rb
+++ b/spec/features/support/changing_who_will_order_devices_for_a_school_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.feature 'Changing who will order devices for a school' do
+  let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }
+
+  before do
+    stub_computacenter_outgoing_api_calls
+    given_i_sign_in_as_a_support_user
+  end
+
+  scenario 'setting school will order devices when responsible body does not have vcap feature flag' do
+    given_a_responsible_body_without_virtual_caps_enabled
+    given_a_school_that_is_centrally_managed
+
+    when_i_navigate_to_the_school_page_in_support
+    and_i_click_the_change_link_for_who_will_order
+    then_i_do_not_see_content_warning_that_the_change_is_irreversible
+
+    when_i_change_who_will_order_to_the_school
+    then_the_who_will_order_details_show_that_the_school_orders_in_the_support_console
+  end
+
+  scenario 'setting responsible body will order devices when responsible body does not have vcap feature flag' do
+    given_a_responsible_body_without_virtual_caps_enabled
+    given_a_school_that_manages_orders
+
+    when_i_navigate_to_the_school_page_in_support
+    and_i_click_the_change_link_for_who_will_order
+    then_i_do_not_see_content_warning_that_the_change_is_irreversible
+
+    when_i_change_who_will_order_to_the_responsible_body
+    then_the_who_will_order_details_show_that_the_responsible_body_orders_in_the_support_console
+  end
+
+  scenario 'setting school will order devices when responsible body has vcap feature flag' do
+    given_a_responsible_body_with_virtual_caps_enabled
+    given_a_school_that_is_centrally_managed
+
+    when_i_navigate_to_the_school_page_in_support
+    then_i_cannot_see_the_change_link_for_who_will_order
+  end
+
+  scenario 'setting responsible body will order devices when responsible body has vcap feature flag' do
+    given_a_responsible_body_with_virtual_caps_enabled
+    given_a_school_that_manages_orders
+
+    when_i_navigate_to_the_school_page_in_support
+    and_i_click_the_change_link_for_who_will_order
+    then_i_see_content_warning_that_the_change_is_irreversible
+
+    when_i_change_who_will_order_to_the_responsible_body
+    then_the_who_will_order_details_show_that_the_responsible_body_orders_in_the_support_console
+    and_i_cannot_see_the_change_link_for_who_will_order
+  end
+
+  def given_i_sign_in_as_a_support_user
+    sign_in_as create(:support_user)
+  end
+
+  def given_a_responsible_body_without_virtual_caps_enabled
+    @local_authority = create(:local_authority, :manages_centrally, vcap: false)
+  end
+
+  def given_a_responsible_body_with_virtual_caps_enabled
+    @local_authority = create(:local_authority, :manages_centrally, vcap: true)
+  end
+
+  def given_a_school_that_is_centrally_managed
+    @school = create(:school, :centrally_managed, laptops: [1, 0, 0], responsible_body: @local_authority)
+  end
+
+  def given_a_school_that_manages_orders
+    @school = create(:school, :manages_orders, laptops: [1, 0, 0], responsible_body: @local_authority)
+  end
+
+  def when_i_navigate_to_the_school_page_in_support
+    visit support_school_path(@school.urn)
+    expect(school_details_page).to be_displayed
+  end
+
+  def and_i_click_the_change_link_for_who_will_order
+    school_details_page
+      .school_details['Who ordered?']
+      .follow_action_link
+  end
+
+  def when_i_change_who_will_order_to_the_school
+    choose 'The school will place their own orders'
+    click_on 'Continue'
+  end
+
+  def when_i_change_who_will_order_to_the_responsible_body
+    choose 'Orders will be placed centrally'
+    click_on 'Continue'
+  end
+
+  def then_i_do_not_see_content_warning_that_the_change_is_irreversible
+    expect(page).not_to have_text('You will not be able to transfer back ordering responsibility to the school once you’ve decided to do it this way')
+  end
+
+  def then_i_see_content_warning_that_the_change_is_irreversible
+    expect(page).to have_text('You will not be able to transfer back ordering responsibility to the school once you’ve decided to do it this way')
+  end
+
+  def then_the_who_will_order_details_show_that_the_school_orders_in_the_support_console
+    expect(school_details_page.school_details['Who ordered?'].value).to eq('The school or college ordered devices')
+  end
+
+  def then_the_who_will_order_details_show_that_the_responsible_body_orders_in_the_support_console
+    expect(school_details_page.school_details['Who ordered?'].value).to eq('The local authority ordered devices')
+  end
+
+  def then_i_cannot_see_the_change_link_for_who_will_order
+    expect(school_details_page.school_details['Who ordered?']).not_to have_link('Change')
+  end
+
+  alias_method :and_i_cannot_see_the_change_link_for_who_will_order, :then_i_cannot_see_the_change_link_for_who_will_order
+end


### PR DESCRIPTION
### Context
I merged this [PR](https://github.com/DFE-Digital/get-help-with-tech/pull/2507) into preview instead of main by mistake.
 
### Changes proposed in this pull request
This PR will revert the changes to disable support user permissions to edit school details.
These changes should go straight into main and not preview.

### Guidance to review

