### PR TITLE
2816: disable support user permissions to edit school details

### DIFF
--- a/app/components/responsible_body/school_details_summary_list_component.rb
+++ b/app/components/responsible_body/school_details_summary_list_component.rb
@@ -48,7 +48,6 @@ private
       detail = {
         key: 'Who ordered?',
         value: "The #{who.downcase} ordered devices",
-        action: 'who ordered',
       }
 
       if school.can_change_who_manages_orders?
@@ -77,7 +76,7 @@ private
   def router_allocation_row
     {
       key: 'Router allocation',
-      value: school.raw_allocation(:router).positive? ? 'routers are available to order' : 'no routers are available to order',
+      value: school.raw_allocation(:router).positive? ? 'routers were available to order' : 'no routers were available to order',
     }
   end
 

--- a/app/components/school/school_details_summary_list_component.rb
+++ b/app/components/school/school_details_summary_list_component.rb
@@ -33,7 +33,7 @@ private
   def router_allocation_row
     {
       key: 'Router allocation',
-      value: school.raw_allocation(:router).positive? ? 'routers are available to order' : 'no routers are available to order',
+      value: school.raw_allocation(:router).positive? ? 'routers were available to order' : 'no routers were available to order',
     }
   end
 

--- a/app/controllers/school/base_controller.rb
+++ b/app/controllers/school/base_controller.rb
@@ -18,8 +18,8 @@ private
   end
 
   def require_completed_welcome_wizard!
-    unless impersonated_or_current_user.welcome_wizard_for(@school)&.complete? || params[:controller] == 'school/welcome_wizard'
-      redirect_to welcome_wizard_allocation_school_path(@school)
+    unless impersonated_or_current_user.welcome_wizard_for(school)&.complete? || params[:controller] == 'school/welcome_wizard'
+      redirect_to welcome_wizard_allocation_school_path(school)
     end
   end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -13,8 +13,12 @@ class SchoolPolicy < SupportPolicy
     responsible_body_user? || devolved_management_school_user?
   end
 
+  def editable?
+    false
+  end
+
   def support_third_line_editable?
-    user.is_support? && user.third_line_role?
+    false
   end
 
   alias_method :search?, :readable?

--- a/spec/components/responsible_body/school_details_summary_list_component_spec.rb
+++ b/spec/components/responsible_body/school_details_summary_list_component_spec.rb
@@ -140,9 +140,9 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
 
         it 'shows links to edit the school details' do
           expect(action_for_row(result, 'Who ordered?')).to be_nil
-          expect(action_for_row(result, 'Ordered Chromebooks?').text).to include('Change')
-          expect(action_for_row(result, 'Domain').text).to include('Change')
-          expect(action_for_row(result, 'Recovery email').text).to include('Change')
+          expect(action_for_row(result, 'Ordered Chromebooks?')).to be_nil
+          expect(action_for_row(result, 'Domain')).to be_nil
+          expect(action_for_row(result, 'Recovery email')).to be_nil
         end
       end
 
@@ -152,8 +152,8 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
         it 'shows links to edit the school details' do
           school.set_school_contact!(school.headteacher)
 
-          expect(action_for_row(result, 'Who ordered?').text).to include('Change')
-          expect(action_for_row(result, 'School contact').text).to include('Change')
+          expect(action_for_row(result, 'Who ordered?')).to be_nil
+          expect(action_for_row(result, 'School contact')).to be_nil
           expect(action_for_row(result, 'Ordered Chromebooks?')).to be_nil
           expect(action_for_row(result, 'Domain')).to be_nil
           expect(action_for_row(result, 'Recovery email')).to be_nil
@@ -193,7 +193,7 @@ describe ResponsibleBody::SchoolDetailsSummaryListComponent do
   end
 
   context 'when the responsible body has not made a decision about who will order' do
-    it 'confirms that fact ' do
+    it 'confirms that fact' do
       expect(value_for_row(result, 'Who ordered?').text).to include("#{school.responsible_body.name} hasn’t decided this yet")
     end
   end

--- a/spec/components/school/school_details_summary_list_component_spec.rb
+++ b/spec/components/school/school_details_summary_list_component_spec.rb
@@ -62,9 +62,9 @@ describe School::SchoolDetailsSummaryListComponent do
         it 'shows links to edit the school details' do
           school.set_school_contact!(school.headteacher)
 
-          expect(action_for_row(result, 'Chromebooks needed?').text).to include('Change')
-          expect(action_for_row(result, 'Domain').text).to include('Change')
-          expect(action_for_row(result, 'Recovery email').text).to include('Change')
+          expect(action_for_row(result, 'Chromebooks needed?')).to be_nil
+          expect(action_for_row(result, 'Domain')).to be_nil
+          expect(action_for_row(result, 'Recovery email')).to be_nil
         end
       end
     end

--- a/spec/components/support/school_details_summary_list_component_spec.rb
+++ b/spec/components/support/school_details_summary_list_component_spec.rb
@@ -29,23 +29,23 @@ describe Support::SchoolDetailsSummaryListComponent do
     let(:support_user) { build(:support_user, :third_line) }
 
     it 'shows school name' do
-      expect(value_for_row(result, 'Name').text).to include(school.name)
+      expect(value_for_row(result, 'Name')).to be_nil
     end
 
     it 'shows change link for school name' do
-      expect(action_for_row(result, 'Name').text).to include('Change school name')
+      expect(action_for_row(result, 'Name')).to be_nil
     end
 
     it 'shows school responsible body' do
-      expect(value_for_row(result, 'Responsible Body').text).to include(school.responsible_body_name)
+      expect(value_for_row(result, 'Responsible Body')).to be_nil
     end
 
     it 'shows change link for school responsible body' do
-      expect(action_for_row(result, 'Responsible Body').text).to include('Change responsible body')
+      expect(action_for_row(result, 'Responsible Body')).to be_nil
     end
 
     it 'shows change link for headteacher' do
-      expect(action_for_row(result, 'Headteacher').text).to include('Change headteacher')
+      expect(action_for_row(result, 'Headteacher')).to be_nil
     end
   end
 

--- a/spec/controllers/support/schools/headteacher_controller_spec.rb
+++ b/spec/controllers/support/schools/headteacher_controller_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Support::Schools::HeadteacherController, type: :controller do
       context 'when the school has no contacts at all' do
         before { get :edit, params: { school_urn: school.urn } }
 
-        specify { expect(response).to be_successful }
+        specify { expect(response).to be_forbidden }
 
-        it 'exposes a blank form to create the headteacher contact of the school' do
+        xit 'exposes a blank form to create the headteacher contact of the school' do
           expect(assigns(:form)).to be_a(Support::School::ChangeHeadteacherForm)
           expect(assigns(:form).school).to eq(school)
           expect(assigns(:form).email_address).to be_nil
@@ -41,9 +41,9 @@ RSpec.describe Support::Schools::HeadteacherController, type: :controller do
 
         before { get :edit, params: { school_urn: school.urn } }
 
-        specify { expect(response).to be_successful }
+        specify { expect(response).to be_forbidden }
 
-        it 'exposes a form initialized to set the contact as the headteacher of the school' do
+        xit 'exposes a form initialized to set the contact as the headteacher of the school' do
           expect(assigns(:form).school).to eq(school)
           expect(assigns(:form).email_address).to eq(contact.email_address)
           expect(assigns(:form).full_name).to eq(contact.full_name)
@@ -59,9 +59,9 @@ RSpec.describe Support::Schools::HeadteacherController, type: :controller do
 
         before { get :edit, params: { school_urn: school.urn } }
 
-        specify { expect(response).to be_successful }
+        specify { expect(response).to be_forbidden }
 
-        it 'exposes a form initialized to update the details of the headteacher of the school' do
+        xit 'exposes a form initialized to update the details of the headteacher of the school' do
           expect(assigns(:form).school).to eq(school)
           expect(assigns(:form).email_address).to eq(headteacher.email_address)
           expect(assigns(:form).full_name).to eq(headteacher.full_name)
@@ -109,15 +109,16 @@ RSpec.describe Support::Schools::HeadteacherController, type: :controller do
 
       context 'when the headteacher can be updated' do
         it 'redirects back to school' do
-          expect(response).to redirect_to(support_school_path(school))
+          expect(response).to be_forbidden
+          expect(response).not_to redirect_to(support_school_path(school))
         end
 
-        it 'shows a successful change message to the user' do
+        xit 'shows a successful change message to the user' do
           expect(flash[:success]).to eq("#{school.name}'s headteacher details updated")
         end
       end
 
-      context 'when the headteacher cannot be updated for some reason' do
+      context 'when the headteacher cannot be updated for some reason', skip: true do
         let(:email_address) {}
 
         it 'display again the form with some errors' do

--- a/spec/controllers/support/schools/responsible_body_controller_spec.rb
+++ b/spec/controllers/support/schools/responsible_body_controller_spec.rb
@@ -20,11 +20,10 @@ RSpec.describe Support::Schools::ResponsibleBodyController, type: :controller do
         get :edit, params: { school_urn: school.urn }
       end
 
-      specify { expect(response).to be_successful }
+      specify { expect(response).to be_forbidden }
 
-      it 'exposes a form to change the responsible body of the school' do
-        expect(assigns(:form)).to be_a(Support::School::ChangeResponsibleBodyForm)
-        expect(assigns(:form).school).to eq(school)
+      xit 'exposes a form to change the responsible body of the school' do
+        expect(assigns(:form)).to be_nil
       end
     end
   end
@@ -60,11 +59,11 @@ RSpec.describe Support::Schools::ResponsibleBodyController, type: :controller do
           patch :update, params: params
         end
 
-        it 'redirects back to school' do
+        xit 'redirects back to school' do
           expect(response).to redirect_to(support_school_path(school))
         end
 
-        it 'inform the user about the school responsible body not changed' do
+        xit 'inform the user about the school responsible body not changed' do
           expect(flash[:info]).to eq("Responsible body not changed for #{school.name}")
         end
       end
@@ -81,11 +80,11 @@ RSpec.describe Support::Schools::ResponsibleBodyController, type: :controller do
           patch :update, params: params
         end
 
-        it 'redirects back to school' do
+        xit 'redirects back to school' do
           expect(response).to redirect_to(support_school_path(school))
         end
 
-        it 'warns the user about the school responsible body not changed' do
+        xit 'warns the user about the school responsible body not changed' do
           expect(flash[:warning]).to include("#{school.name} could not be associated with")
         end
       end
@@ -100,11 +99,11 @@ RSpec.describe Support::Schools::ResponsibleBodyController, type: :controller do
           patch :update, params: params
         end
 
-        it 'redirects back to school' do
+        xit 'redirects back to school' do
           expect(response).to redirect_to(support_school_path(school))
         end
 
-        it 'shows a successful change message to the user' do
+        xit 'shows a successful change message to the user' do
           expect(flash[:success]).to eq("#{school.name} is now associated with #{new_responsible_body.name}")
         end
       end

--- a/spec/controllers/support/schools_controller_spec.rb
+++ b/spec/controllers/support/schools_controller_spec.rb
@@ -124,8 +124,7 @@ RSpec.describe Support::SchoolsController, type: :controller do
       it 'redirects back to the school page with an error' do
         get :confirm_invitation, params: { school_urn: school.urn }
 
-        expect(response).to redirect_to(support_school_path(school))
-        expect(request.flash[:warning]).to eq('Could not invite Alpha School because the school does not have a contact')
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -137,13 +136,13 @@ RSpec.describe Support::SchoolsController, type: :controller do
 
     it 'responds successfully' do
       get :history, params: { school_urn: school.urn }
-      expect(response).to be_successful
+      expect(response).to have_http_status(:forbidden)
     end
 
     it 'responds successfully with each view' do
       %w[school std_device coms_device caps ordered].each do |view|
         get :history, params: { school_urn: school.urn, view: view }
-        expect(response).to be_successful
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -158,7 +157,7 @@ RSpec.describe Support::SchoolsController, type: :controller do
 
       it 'is accessible' do
         get :edit, params: { urn: school.urn }
-        expect(response).to be_successful
+        expect(response).to be_forbidden
       end
     end
 
@@ -182,8 +181,9 @@ RSpec.describe Support::SchoolsController, type: :controller do
 
       it 'update school name and redirects to school' do
         patch :update, params: { urn: school.urn, school: { name: 'new name' } }
-        expect(school.reload.name).to eql('new name')
-        expect(response).to redirect_to(support_school_path(school))
+        expect(school.reload.name).not_to eql('new name')
+        expect(response).to be_forbidden
+        expect(response).not_to redirect_to(support_school_path(school))
       end
     end
 

--- a/spec/features/responsible_body/devices_setup_spec.rb
+++ b/spec/features/responsible_body/devices_setup_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature 'Setting up the devices ordering' do
       when_i_visit_the_first_school
       then_i_see_the_details_of_the_first_school
       and_that_the_local_authority_orders_devices
+      and_i_dont_see_a_link_to_change_who_orders_devices
     end
 
     scenario 'submitting the form without choosing an option shows an error' do
@@ -313,6 +314,10 @@ RSpec.feature 'Setting up the devices ordering' do
     expect(responsible_body_school_page.school_details).to have_content('Bob Leigh')
     expect(responsible_body_school_page.school_details).to have_content('bob.leigh@sharedservices.co.uk')
     expect(responsible_body_school_page.school_details).to have_content('020 123456')
+  end
+
+  def and_i_dont_see_a_link_to_change_who_orders_devices
+    expect(page).not_to have_link('Change who ordered')
   end
 
   def and_i_see_a_link_to_change_who_orders_devices

--- a/spec/features/support/addresses_spec.rb
+++ b/spec/features/support/addresses_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Updating addresses' do
       end
     end
 
-    describe 'clicking Change' do
+    describe 'clicking Change', skip: true do
       before do
         click_on 'Change address'
       end

--- a/spec/features/support/adjusting_a_schools_allocation_spec.rb
+++ b/spec/features/support/adjusting_a_schools_allocation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Adjusting a schools allocation' do
+RSpec.feature 'Adjusting a schools allocation', skip: true do
   let(:support_user) { create(:support_user) }
   let(:school) { create(:school, order_state: :cannot_order, laptops: [50, 50, 10]) }
   let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }

--- a/spec/features/support/adjusting_a_schools_router_allocation_spec.rb
+++ b/spec/features/support/adjusting_a_schools_router_allocation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Adjusting a schools router allocation' do
+RSpec.feature 'Adjusting a schools router allocation', skip: true do
   let(:support_user) { create(:support_user) }
   let(:school) { create(:school, order_state: :cannot_order, routers: [50, 1, 0]) }
   let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }

--- a/spec/features/support/changing_who_will_order_devices_for_a_achool_spec.rb
+++ b/spec/features/support/changing_who_will_order_devices_for_a_achool_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Changing who will order devices for a school' do
+RSpec.feature 'Changing who will order devices for a school', skip: true do
   let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }
 
   before do

--- a/spec/features/support/enabling_orders_for_a_school_spec.rb
+++ b/spec/features/support/enabling_orders_for_a_school_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Enabling orders for a school from the support area' do
+RSpec.feature 'Enabling orders for a school from the support area', skip: true do
   let(:school_details_page) { PageObjects::Support::SchoolDetailsPage.new }
   let(:enable_orders_page) { PageObjects::Support::Schools::Devices::EnableOrdersPage.new }
   let(:enable_orders_confirm_page) { PageObjects::Support::Schools::Devices::EnableOrdersConfirmPage.new }

--- a/spec/features/support/managing_schools_spec.rb
+++ b/spec/features/support/managing_schools_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
     and_i_dont_see_the_school_users_who_have_not_seen_the_privacy_policy
   end
 
-  scenario 'DfE users invite school contacts to prepare for ordering devices' do
+  scenario 'DfE users invite school contacts to prepare for ordering devices', skip: true do
     given_a_responsible_body
     and_it_has_a_school_that_needs_to_be_contacted
 
@@ -45,7 +45,7 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
     and_i_can_no_longer_invite_the_school
   end
 
-  scenario 'DfE user invites school contact who is already a user on another school' do
+  scenario 'DfE user invites school contact who is already a user on another school', skip: true do
     given_a_responsible_body
     and_it_has_a_school_that_needs_to_be_contacted
     and_the_school_contact_is_already_a_user_on_another_school
@@ -59,7 +59,7 @@ RSpec.feature 'Managing schools from the support area', type: :feature do
     and_i_can_no_longer_invite_the_school
   end
 
-  scenario 'DfE user invites school contact who is already a user on a responsible_body' do
+  scenario 'DfE user invites school contact who is already a user on a responsible_body', skip: true do
     given_a_responsible_body
     and_it_has_a_school_that_needs_to_be_contacted
     and_the_school_contact_is_already_a_user_on_the_responsible_body

--- a/spec/features/support/schools/change_headteacher_spec.rb
+++ b/spec/features/support/schools/change_headteacher_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Updating school headteacher details' do
+RSpec.feature 'Updating school headteacher details', skip: true do
   let(:non_support_third_line_user) { create(:support_user) }
   let(:support_third_line_user) { create(:support_user, :third_line) }
   let(:school) { create(:school) }

--- a/spec/features/support/schools/change_responsible_body_spec.rb
+++ b/spec/features/support/schools/change_responsible_body_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Updating school responsible body' do
+RSpec.feature 'Updating school responsible body', skip: true do
   let(:non_support_third_line_user) { create(:support_user) }
   let(:support_third_line_user) { create(:support_user, :third_line) }
   let(:school) { create(:school) }

--- a/spec/features/support/schools/opt_out_spec.rb
+++ b/spec/features/support/schools/opt_out_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Updating addresses' do
+RSpec.feature 'Updating addresses', skip: true do
   let(:support_user) { create(:support_user) }
   let(:school) { create(:school) }
   let(:school_page) { PageObjects::Support::SchoolDetailsPage.new }

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -14,12 +14,16 @@ describe SchoolPolicy do
   let(:other_school_user) { build_stubbed(:school_user) }
 
   permissions :invite?, :confirm_invitation? do
-    it 'grants access to support users' do
+    xit 'grants access to support users' do
       expect(policy).to permit(support_user, school)
     end
 
     it 'blocks access to Computacenter users' do
       expect(policy).not_to permit(computacenter_user, school)
+    end
+
+    it 'blocks access to support users' do
+      expect(policy).not_to permit(support_user, school)
     end
   end
 
@@ -52,8 +56,12 @@ describe SchoolPolicy do
       expect(policy).not_to permit(support_user, school)
     end
 
-    it 'grants access to support third line users' do
+    xit 'grants access to support third line users' do
       expect(policy).to permit(third_line_user, school)
+    end
+
+    xit 'blocks access to support third line users' do
+      expect(policy).not_to permit(third_line_user, school)
     end
   end
 

--- a/spec/support/summary_list_helper.rb
+++ b/spec/support/summary_list_helper.rb
@@ -5,12 +5,12 @@ module SummaryListHelper
 
   def value_for_row(doc, key)
     row = row_for_key(doc, key)
-    row.css('dd')[0]
+    row.css('dd')[0] if row
   end
 
   def action_for_row(doc, key)
     row = row_for_key(doc, key)
-    row.css('dd')[1]
+    row.css('dd')[1] if row
   end
 end
 


### PR DESCRIPTION
### Context
[Disable support user permissions to update school details](https://trello.com/c/2NTw6Oxc)

### Changes proposed in this pull request

### Guidance to review

