### PR TITLE
2835 support form issue

### DIFF
--- a/app/controllers/support_ticket/base_controller.rb
+++ b/app/controllers/support_ticket/base_controller.rb
@@ -18,6 +18,7 @@ private
   end
 
   def support_ticket
+    session[:init] = true if session.id.blank?
     @support_ticket ||= SupportTicket.find_or_create_by!(session_id: session.id.to_s)
   end
 end


### PR DESCRIPTION
### Context

There is an edge case in a support form when a user clears their session information (cookies etc) before submitting the form.

### Changes proposed in this pull request

We will force creation of a session before trying to find or create a support ticket based on a session_id.

### Guidance to review

1.  Visit the support form at /get-support/support-details.
2. Clear session info from the browser.
3. Complete the form and submit.
4. There should be a session_id value stored in the new SupportTicket record.
