### PR TITLE
Add support form specs

### DIFF
--- a/spec/features/support_ticket/create_support_ticket_spec.rb
+++ b/spec/features/support_ticket/create_support_ticket_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.feature 'Create support ticket' do
+  let(:school) { create(:school) }
+  let(:contact_details_name) { 'John Doe' }
+  let(:contact_details_email) { 'john.doe@example.com' }
+  let(:contact_details_telephone_number) { '0123456789' }
+  let(:support_details_message) { 'This is a test message' }
+  let(:get_support_page) { PageObjects::SupportTicket::GetSupportPage.new }
+  let(:describe_yourself_page) { PageObjects::SupportTicket::DescribeYourselfPage.new }
+  let(:school_details_page) { PageObjects::SupportTicket::SchoolDetailsPage.new }
+  let(:contact_details_page) { PageObjects::SupportTicket::ContactDetailsPage.new }
+  let(:support_needs_page) { PageObjects::SupportTicket::SupportNeedsPage.new }
+  let(:support_details_page) { PageObjects::SupportTicket::SupportDetailsPage.new }
+  let(:check_your_request_page) { PageObjects::SupportTicket::CheckYourRequestPage.new }
+  let(:thank_you_page) { PageObjects::SupportTicket::ThankYouPage.new }
+
+  scenario 'not signed in school user can create a support ticket' do
+    given_there_is_a_school
+
+    when_i_visit_the_get_support_page
+    and_i_click_the_start_now_button
+    then_the_describe_yourself_page_is_displayed
+    then_on_the_describe_yourself_page_i_select_that_i_work_for_a_school_or_trust
+    and_on_the_describe_yourself_page_i_click_the_continue_button
+    then_the_school_details_page_is_displayed
+    then_on_the_school_details_page_i_enter_the_school_name_and_urn
+    and_on_the_school_details_page_i_click_the_continue_button
+    then_the_contact_details_page_is_displayed
+    then_on_the_contact_details_page_i_enter_the_contact_details
+    and_on_the_contact_details_page_i_click_the_continue_button
+    then_the_support_needs_page_is_displayed
+    then_on_the_support_needs_page_i_select_laptops
+    and_on_the_support_needs_page_i_click_the_continue_button
+    then_the_support_details_page_is_displayed
+    then_on_the_support_details_page_i_enter_the_support_details
+    and_on_the_support_details_page_i_click_the_continue_button
+    then_the_check_your_request_page_is_displayed
+    and_the_check_your_request_page_has_the_correct_details
+    and_on_the_check_your_request_page_i_click_the_continue_button
+    then_the_thank_you_page_is_displayed
+    and_the_thank_you_page_has_the_confirmation_message
+  end
+
+  def and_i_click_the_start_now_button
+    get_support_page.start_now_button.click
+  end
+
+  def given_there_is_a_school
+    school
+  end
+
+  def and_on_the_check_your_request_page_i_click_the_continue_button
+    check_your_request_page.continue_button.click
+  end
+
+  def and_on_the_contact_details_page_i_click_the_continue_button
+    contact_details_page.continue_button.click
+  end
+
+  def and_on_the_describe_yourself_page_i_click_the_continue_button
+    describe_yourself_page.continue_button.click
+  end
+
+  def and_on_the_school_details_page_i_click_the_continue_button
+    school_details_page.continue_button.click
+  end
+
+  def and_on_the_support_details_page_i_click_the_continue_button
+    support_details_page.continue_button.click
+  end
+
+  def and_on_the_support_needs_page_i_click_the_continue_button
+    support_needs_page.continue_button.click
+  end
+
+  def and_the_check_your_request_page_has_the_correct_details
+    expect(check_your_request_page).to have_text "#{school.name} (URN: #{school.urn})"
+    expect(check_your_request_page).to have_text contact_details_name
+    expect(check_your_request_page).to have_text contact_details_email
+    expect(check_your_request_page).to have_text contact_details_telephone_number
+    expect(check_your_request_page).to have_text support_details_message
+  end
+
+  def and_the_thank_you_page_has_the_confirmation_message
+    expect(thank_you_page).to have_text 'Support request sent'
+  end
+
+  def then_on_the_contact_details_page_i_enter_the_contact_details
+    contact_details_page.your_full_name_field.set contact_details_name
+    contact_details_page.your_email_address_field.set contact_details_email
+    contact_details_page.telephone_number_field.set contact_details_telephone_number
+  end
+
+  def then_on_the_describe_yourself_page_i_select_that_i_work_for_a_school_or_trust
+    describe_yourself_page.school_radio_button.click
+  end
+
+  def then_on_the_school_details_page_i_enter_the_school_name_and_urn
+    school_details_page.school_name_field.set school.name
+    school_details_page.school_urn_field.set school.urn
+  end
+
+  def then_on_the_support_details_page_i_enter_the_support_details
+    support_details_page.message_field.set support_details_message
+  end
+
+  def then_on_the_support_needs_page_i_select_laptops
+    support_needs_page.laptops_checkbox_option.click
+  end
+
+  def then_the_check_your_request_page_is_displayed
+    expect(check_your_request_page).to be_displayed
+  end
+
+  def then_the_contact_details_page_is_displayed
+    expect(contact_details_page).to be_displayed
+  end
+
+  def then_the_describe_yourself_page_is_displayed
+    expect(describe_yourself_page).to be_displayed
+  end
+
+  def then_the_school_details_page_is_displayed
+    expect(school_details_page).to be_displayed
+  end
+
+  def then_the_support_details_page_is_displayed
+    expect(support_details_page).to be_displayed
+  end
+
+  def then_the_support_needs_page_is_displayed
+    expect(support_needs_page).to be_displayed
+  end
+
+  def then_the_thank_you_page_is_displayed
+    expect(thank_you_page).to be_displayed
+  end
+
+  def when_i_visit_the_get_support_page
+    get_support_page.load
+  end
+end

--- a/spec/page_objects/support_ticket/check_your_request_page.rb
+++ b/spec/page_objects/support_ticket/check_your_request_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module SupportTicket
+    class CheckYourRequestPage < PageObjects::BasePage
+      set_url '/get-support/check-your-request'
+
+      element :continue_button, :button, text: 'Submit request'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/contact_details_page.rb
+++ b/spec/page_objects/support_ticket/contact_details_page.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module SupportTicket
+    class ContactDetailsPage < PageObjects::BasePage
+      set_url '/get-support/contact-details'
+
+      element :your_full_name_field, '#support-ticket-contact-details-form-full-name-field'
+      element :your_email_address_field, '#support-ticket-contact-details-form-email-address-field'
+      element :telephone_number_field, '#support-ticket-contact-details-form-telephone-number-field'
+      element :continue_button, :button, text: 'Continue'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/describe_yourself_page.rb
+++ b/spec/page_objects/support_ticket/describe_yourself_page.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module SupportTicket
+    class DescribeYourselfPage < PageObjects::BasePage
+      set_url '/get-support/describe-yourself'
+
+      element :school_radio_button, '#support-ticket-describe-yourself-form-user-type-school-or-single-academy-trust-field'
+      element :mat_radio_button, '#support-ticket-describe-yourself-form-user-type-multi-academy-trust-field'
+      element :la_radio_button, '#support-ticket-describe-yourself-form-user-type-local-authority-field'
+      element :college_radio_button, '#support-ticket-describe-yourself-form-user-type-college-field'
+      element :individual_radio_button, '#support-ticket-describe-yourself-form-user-type-parent-or-guardian-or-carer-or-pupil-or-care-leaver-field'
+      element :none_above_radio_button, '#support-ticket-describe-yourself-form-user-type-other-type-of-user-field'
+      element :continue_button, :button, text: 'Continue'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/get_support_page.rb
+++ b/spec/page_objects/support_ticket/get_support_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module SupportTicket
+    class GetSupportPage < PageObjects::BasePage
+      set_url '/get-support'
+
+      element :start_now_button, 'a', text: 'Start now'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/school_details_page.rb
+++ b/spec/page_objects/support_ticket/school_details_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module SupportTicket
+    class SchoolDetailsPage < PageObjects::BasePage
+      set_url '/get-support/school-details'
+
+      element :school_name_field, '#support-ticket-school-details-form-school-name-field'
+      element :school_urn_field, '#support-ticket-school-details-form-school-urn-field'
+      element :continue_button, :button, text: 'Continue'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/support_details_page.rb
+++ b/spec/page_objects/support_ticket/support_details_page.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module SupportTicket
+    class SupportDetailsPage < PageObjects::BasePage
+      set_url '/get-support/support-details'
+
+      element :message_field, '#support-ticket-support-details-form-message-field'
+      element :continue_button, :button, text: 'Continue'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/support_needs_page.rb
+++ b/spec/page_objects/support_ticket/support_needs_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module SupportTicket
+    class SupportNeedsPage < PageObjects::BasePage
+      set_url '/get-support/support-needs'
+
+      element :laptops_checkbox_option, '#support-ticket-support-needs-form-support-topics-laptops-and-tablets-field'
+      element :routers_checkbox_option, '#support-ticket-support-needs-form-support-topics-4g-wireless-routers-and-internet-access-field'
+      element :platforms_checkbox_option, '#support-ticket-support-needs-form-support-topics-digital-education-platforms-field'
+      element :training_and_support_checkbox_option, '#support-ticket-support-needs-form-support-topics-technology-training-and-support-field'
+      element :something_else_checkbox_option, '#support-ticket-support-needs-form-support-topics-something-else-field'
+      element :continue_button, :button, text: 'Continue'
+    end
+  end
+end

--- a/spec/page_objects/support_ticket/thank_you_page.rb
+++ b/spec/page_objects/support_ticket/thank_you_page.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module SupportTicket
+    class ThankYouPage < PageObjects::BasePage
+      set_url '/get-support/thank-you'
+    end
+  end
+end


### PR DESCRIPTION
### Context

The support form is missing end-to-end specs

### Changes proposed in this pull request

Added basic spec covering the end-to-end creation and submission of a request using the support form

### Guidance to review

Only specs added, but the journey can be followed at /get-support