### PR TITLE
2891: fix error when rendering the forbidden template

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -24,8 +24,10 @@ class ErrorsController < ApplicationController
   end
 
   def forbidden
-    format.html { render status: :not_authorized }
-    format.json { render json: { error: 'Not Authorized' }, status: :not_authorized }
-    format.all { render status: :not_authorized, body: nil }
+    respond_to do |format|
+      format.html { render status: :forbidden }
+      format.json { render json: { error: 'Forbidden' }, status: :forbidden }
+      format.all { render status: :forbidden, body: nil }
+    end
   end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -21,4 +21,11 @@ RSpec.describe ErrorsController, type: :controller do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe 'GET #forbidden' do
+    before { get :forbidden }
+
+    specify { expect(response).to have_http_status(:forbidden) }
+    specify { expect(response).to render_template(:forbidden) }
+  end
 end


### PR DESCRIPTION
### Context
  The service is throwing an exception everytime the forbidden template needs to be rendered.

  [Card](https://trello.com/c/ryjJWYcP)

### Changes proposed in this pull request

  - Redefine the controller action following Rails conventions. 
  - Add a couple of tests to make sure no exception is raised and the template is rendered successfully.

### Guidance to review

