### PR TITLE
2898: do not display asset tag on asset details view

### DIFF
--- a/app/views/assets/show.html.erb
+++ b/app/views/assets/show.html.erb
@@ -18,10 +18,6 @@
 
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header govuk-!-width-one-third">Asset tag</th>
-          <td class="govuk-table__cell"><%= @asset.tag.presence || '-' -%></td>
-        </tr>
-        <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-width-one-third">Serial/IMEI</th>
           <td class="govuk-table__cell"><%= @asset.serial_number.presence || '-' -%></td>
         </tr>

--- a/spec/features/assets/show_spec.rb
+++ b/spec/features/assets/show_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'Display asset properties' do
   let(:asset_page) { PageObjects::Assets::ShowPage.new }
   let(:asset_detail_labels) do
     [
-      'Asset tag',
       'Serial/IMEI',
     ]
   end
@@ -70,7 +69,7 @@ private
     expect(asset_page.asset_hardware_labels.map(&:text)).to eq(asset_hardware_labels)
 
     # values for each table
-    expect(asset_page.asset_detail_values.map(&:text)).to eq([asset.tag, asset.serial_number])
+    expect(asset_page.asset_detail_values.map(&:text)).to eq([asset.serial_number])
     expect(asset_page.asset_secrets_values.map(&:text)).to eq([
       bios_password_value(asset, download_bios_unlocker) || '-',
       asset.admin_password || '-',


### PR DESCRIPTION
### Context
[Card](https://trello.com/c/RjYliEYs)

### Changes proposed in this pull request
 Don´t display asset tag on asset details view

### Guidance to review

