### PR TITLE
2921: restrict the potential values of user-type param of describe-yo…

### DIFF
--- a/app/form_objects/support_ticket/describe_yourself_form.rb
+++ b/app/form_objects/support_ticket/describe_yourself_form.rb
@@ -4,6 +4,13 @@ class SupportTicket::DescribeYourselfForm
   attr_accessor :user_type
 
   validates :user_type, presence: { message: 'Tell us which of these best describes you' }
+  validates :user_type, inclusion: { in: %w[college
+                                            local_authority
+                                            multi_academy_trust
+                                            other_type_of_user
+                                            parent_or_guardian_or_carer_or_pupil_or_care_leaver
+                                            school_or_single_academy_trust],
+                                     message: 'Wrong user type' }
 
   def options_and_suggestions
     @options_and_suggestions ||= SupportTicket::OptionsService.call(Rails.configuration.support_tickets[:describe_yourself_options])

--- a/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
+++ b/spec/controllers/support_ticket/describe_yourself_controller_spec.rb
@@ -60,5 +60,10 @@ RSpec.describe SupportTicket::DescribeYourselfController, type: :controller do
       post :save, params: { support_ticket_describe_yourself_form: { user_type: 'other_type_of_user' } }
       expect(response).to redirect_to(support_ticket_contact_details_path)
     end
+
+    it 'redirects back to the form for invalid type of user' do
+      post :save, params: { support_ticket_describe_yourself_form: { user_type: 'wrong' } }
+      expect(response).to render_template('support_tickets/describe_yourself')
+    end
   end
 end

--- a/spec/form_objects/support_ticket/describe_yourself_form_spec.rb
+++ b/spec/form_objects/support_ticket/describe_yourself_form_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe SupportTicket::DescribeYourselfForm, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:user_type).with_message('Tell us which of these best describes you') }
+
+    it {
+      expect(form).to validate_inclusion_of(:user_type)
+                        .in_array(%w[college
+                                     local_authority
+                                     multi_academy_trust
+                                     other_type_of_user
+                                     parent_or_guardian_or_carer_or_pupil_or_care_leaver
+                                     school_or_single_academy_trust])
+                        .with_message('Wrong user type')
+    }
   end
 
   describe '#descibe_yourself_options' do


### PR DESCRIPTION
…urself form

### Context
   Describe yourself form: some invalid form data re-renders the form whilst others throw an exception because it passes form validations and redirects user to nil.
   [Card](https://trello.com/c/EwDeHJWg)

### Changes proposed in this pull request
   - Validate inclusion of user-type param in a list of valid values.
   - Add tests

### Guidance to review

