### PR TITLE
Use find_each in the convert

### DIFF
--- a/app/services/computacenter/convert_raw_orders_service.rb
+++ b/app/services/computacenter/convert_raw_orders_service.rb
@@ -6,7 +6,7 @@ class Computacenter::ConvertRawOrdersService < ApplicationService
   end
 
   def call
-    scope.map do |raw_order|
+    scope.find_each do |raw_order|
       persist!(raw_order)
     end
   end


### PR DESCRIPTION
### Context

The covert task is bombing out after every 25k records on the `staging` server.

### Changes proposed in this pull request

Use the ActiveRecord `find_each` to batch the relation instead of the crude use of `map`

### Guidance to review

Try to process all 105k records on `staging`