### PR TITLE
Add order views

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,15 @@
+class OrdersController < ApplicationController
+  before_action :require_sign_in!
+
+  def index
+    @title = 'Order history'
+    @pagination, @orders = pagy(policy_scope(Computacenter::Order).order(order_date: :desc))
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data Computacenter::ExportOrdersService.call(@orders.pluck(:id)), filename: "#{Time.zone.now.iso8601}_order_history_export.csv"
+      end
+    end
+  end
+end

--- a/app/models/computacenter/order_report.rb
+++ b/app/models/computacenter/order_report.rb
@@ -1,0 +1,31 @@
+class Computacenter::OrderReport < TemplateClassCsv
+  def self.headers
+    %w[order_number
+       order_date
+       quantity
+       device_type]
+  end
+
+private
+
+  def add_headers
+    csv << self.class.headers
+  end
+
+  def add_report_rows
+    Computacenter::Order.where(id: scope_ids).find_each do |order|
+      add_order_to_csv(csv, order)
+    end
+  end
+
+  def add_order_to_csv(csv, order)
+    csv << csv_row(order)
+  end
+
+  def csv_row(order)
+    [order.customer_order_number,
+     order.order_date,
+     order.quantity_ordered,
+     order.persona]
+  end
+end

--- a/app/models/computacenter/raw_order_map.rb
+++ b/app/models/computacenter/raw_order_map.rb
@@ -22,8 +22,8 @@ private
   def order_attributes
     {
       source: raw_order.source,
-      sold_to: raw_order.sold_to_account_no.to_i,
-      ship_to: raw_order.ship_to_account_no.to_i,
+      sold_to: raw_order.sold_to_account_no,
+      ship_to: raw_order.ship_to_account_no,
       sales_order_number: raw_order.sales_order_number.to_i,
       persona: raw_order.persona_cleaned,
       material_number: raw_order.material_number.to_i,

--- a/app/models/responsible_body.rb
+++ b/app/models/responsible_body.rb
@@ -27,6 +27,12 @@ class ResponsibleBody < ApplicationRecord
   has_many :users
   has_many :extra_mobile_data_requests
   has_many :schools, inverse_of: :responsible_body
+  has_many :rb_orders, class_name: 'Computacenter::Order', primary_key: :computacenter_reference, foreign_key: :sold_to
+  has_many :schools_orders, through: :schools, source: :orders
+
+  def orders
+    (rb_orders.to_a + schools_orders.to_a.flatten).uniq
+  end
 
   # no longer used - data retained for historical purposes
   has_many :donated_device_requests, dependent: :destroy

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -58,6 +58,7 @@ class School < ApplicationRecord
                                      foreign_key: :ship_to
   has_many :cap_changes, dependent: :destroy, inverse_of: :school
   has_many :cap_update_calls, dependent: :destroy, inverse_of: :school
+  has_many :orders, class_name: 'Computacenter::Order', primary_key: :computacenter_reference, foreign_key: :ship_to
 
   # Validations
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,16 @@ class User < ApplicationRecord
   has_many :downloads, dependent: :destroy
   has_one :last_user_change, -> { order('created_at DESC').limit(1) }, class_name: 'Computacenter::UserChange'
 
+  delegate :orders, to: :responsible_body, prefix: true, allow_nil: true
+
+  def orders
+    @orders ||= ((responsible_body_orders || []) + schools_orders).uniq
+  end
+
+  def schools_orders
+    @schools_orders ||= schools.map(&:orders).flatten
+  end
+
   belongs_to :mobile_network, optional: true
   belongs_to :responsible_body, optional: true
 

--- a/app/policies/computacenter/order_policy.rb
+++ b/app/policies/computacenter/order_policy.rb
@@ -1,0 +1,11 @@
+class Computacenter::OrderPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      return scope.none if user.nil?
+
+      return scope.all if user.is_support? || user.is_computacenter?
+
+      scope.where(id: user.orders.pluck(:id))
+    end
+  end
+end

--- a/app/services/computacenter/export_orders_service.rb
+++ b/app/services/computacenter/export_orders_service.rb
@@ -1,0 +1,9 @@
+require 'csv'
+
+# Service to export data
+class Computacenter::ExportOrdersService < ExportServiceBase
+  def initialize(scope_ids)
+    @report_class = Computacenter::OrderReport
+    @scope_ids = scope_ids
+  end
+end

--- a/app/services/computacenter/export_orders_to_file_service.rb
+++ b/app/services/computacenter/export_orders_to_file_service.rb
@@ -1,0 +1,10 @@
+require 'csv'
+
+# This service is used to export users to a CSV file.
+class Computacenter::ExportOrdersToFileService < ExportToFileServiceBase
+  def initialize(path, order_ids:)
+    @path = path
+    @report_service = Computacenter::ExportOrdersService
+    @scope_ids = order_ids
+  end
+end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,83 @@
+<% content_for :title, @title %>
+<% content_for :browser_title, @title %>
+
+<% content_for :before_content do %>
+  <% breadcrumbs([{ 'Home' => root_path },
+                  { 'View your device details' => orders_path },
+                  @title,
+                 ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= @title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      View and download the order history for organisations that you manage.
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-card">
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-2">
+        Download order history
+      </h2>
+      <p class="govuk-body">
+        Download the order history in a single CSV file.
+      </p>
+      <%= link_to "Export to CSV", orders_path(format: 'csv'), class: 'govuk-button govuk-button govuk-!-margin-bottom-0' %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-margin-top-5">
+      View order history
+    </h2>
+  </div>
+</div>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header app-schools-table__column-30">Order number</th>
+    <th class="govuk-table__header app-schools-table__column-20">Order date</th>
+    <th class="govuk-table__header app-schools-table__column-20">Devices ordered</th>
+    <th class="govuk-table__header app-schools-table__column-30">Device type</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @orders.each do |order| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= order.customer_order_number %></td>
+      <td class="govuk-table__cell"><%= order.order_date %></td>
+      <td class="govuk-table__cell"><%= order.quantity_ordered %></td>
+      <td class="govuk-table__cell"><%= order.persona %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      My order does not appear in the list
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Check you&rsquo;re signed in to the correct user account for the organisation connected to your order.
+    If you&rsquo;re still unable to find your order details visit
+    <%= govuk_link_to 'Get support', support_ticket_path %>.
+  </div>
+</details>
+
+<%= render partial: 'shared/pagination', locals: { pagination: @pagination } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :orders, only: %i[index]
+
   resources :viewed_assets, only: %i[new index]
 
   resources :sessions, only: %i[create destroy]

--- a/db/migrate/20220509152332_change_shipto_and_soldto_to_be_string_in_computacenter_orders.rb
+++ b/db/migrate/20220509152332_change_shipto_and_soldto_to_be_string_in_computacenter_orders.rb
@@ -1,0 +1,15 @@
+class ChangeShiptoAndSoldtoToBeStringInComputacenterOrders < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :computacenter_orders, :sold_to, :string
+        change_column :computacenter_orders, :ship_to, :string
+      end
+
+      dir.down do
+        change_column :computacenter_orders, :sold_to, :integer
+        change_column :computacenter_orders, :ship_to, :integer
+      end
+    end
+  end
+end

--- a/db/migrate/20220510115957_add_index_on_order_date_on_computacenter_orders.rb
+++ b/db/migrate/20220510115957_add_index_on_order_date_on_computacenter_orders.rb
@@ -1,0 +1,5 @@
+class AddIndexOnOrderDateOnComputacenterOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_index :computacenter_orders, :order_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,10 @@ ActiveRecord::Schema.define(version: 2022_05_10_115957) do
   end
 
   create_table "preorder_information", force: :cascade do |t|
+    t.bigint "school_id", null: false
     t.string "who_will_order_devices", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_27_141759) do
+ActiveRecord::Schema.define(version: 2022_05_10_115957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,8 +146,8 @@ ActiveRecord::Schema.define(version: 2022_04_27_141759) do
 
   create_table "computacenter_orders", force: :cascade do |t|
     t.string "source"
-    t.integer "sold_to"
-    t.integer "ship_to"
+    t.string "sold_to"
+    t.string "ship_to"
     t.bigint "sales_order_number"
     t.string "persona"
     t.integer "material_number"
@@ -164,6 +164,7 @@ ActiveRecord::Schema.define(version: 2022_04_27_141759) do
     t.bigint "raw_order_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_date"], name: "index_computacenter_orders_on_order_date"
     t.index ["raw_order_id"], name: "index_computacenter_orders_on_raw_order_id"
     t.index ["ship_to"], name: "index_computacenter_orders_on_ship_to"
     t.index ["sold_to"], name: "index_computacenter_orders_on_sold_to"
@@ -325,10 +326,7 @@ ActiveRecord::Schema.define(version: 2022_04_27_141759) do
   end
 
   create_table "preorder_information", force: :cascade do |t|
-    t.bigint "school_id", null: false
     t.string "who_will_order_devices", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.string "status", null: false
     t.bigint "school_contact_id"
     t.string "will_need_chromebooks"

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe OrdersController do
+  describe '#index' do
+    let!(:orders) { create_list(:computacenter_order, 2) }
+
+    context 'not logged in' do
+      it 'redirects to log in' do
+        get :index
+        expect(response).to redirect_to(sign_in_path)
+      end
+    end
+
+    context 'school A' do
+      let(:school_a) { create(:school, :with_orders) }
+      let(:school_a_user) { create(:school_user, schools: [school_a]) }
+
+      before { sign_in_as school_a_user }
+
+      it 'shows index of orders belonging to that school' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:orders)).to contain_exactly(*school_a.orders)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'RB A' do
+      let(:rb_a) { create(:local_authority, :with_orders) }
+      let(:rb_a_user) { create(:local_authority_user, responsible_body: rb_a) }
+
+      before { sign_in_as rb_a_user }
+
+      it 'shows index of orders belonging to that RB' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:orders)).to contain_exactly(*rb_a.orders)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'support user' do
+      let(:support_user) { create(:support_user) }
+
+      before do
+        sign_in_as support_user
+      end
+
+      it 'shows index of all orders' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:orders)).to contain_exactly(*orders)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'computacenter user' do
+      let(:computacenter_user) { create(:computacenter_user) }
+
+      before { sign_in_as computacenter_user }
+
+      it 'shows index of all orders' do
+        get :index
+        expect(response).to be_successful
+        expect(assigns(:orders)).to contain_exactly(*orders)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+end

--- a/spec/factories/computacenter/orders.rb
+++ b/spec/factories/computacenter/orders.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :computacenter_order, class: 'Computacenter::Order' do
-    source { 'Wave 1' }
-    sold_to { 81_000_001 }
-    ship_to { 81_000_002 }
-    sales_order_number { 5_000_000_001 }
+    source { "Wave #{Faker::Number.unique.number(digits: 1)}" }
+    sold_to { "81#{Faker::Number.unique.number(digits: 6)}" }
+    ship_to { "81#{Faker::Number.unique.number(digits: 6)}" }
+    sales_order_number { 5_000_000_000 + Faker::Number.unique.number(digits: 9) }
     persona { 'Chrome laptop' }
-    material_number { 4_100_001 }
+    material_number { 4_100_000 + Faker::Number.unique.number(digits: 5) }
     material_description { ':DFE:Dell Chrmbk3100 CelN4000 4/16 11 DD' }
     manufacturer { 'DELL Technologies' }
     quantity_ordered { 1 }
@@ -15,7 +15,7 @@ FactoryBot.define do
     despatch_date { Date.strptime('5/18/2020', '%m/%d/%Y') }
     order_completed { true }
     is_return { false }
-    customer_order_number { 'HYB-80000001' }
+    customer_order_number { "HYB-8#{Faker::Number.unique.number(digits: 7)}" }
     raw_order { build(:computacenter_raw_order) }
   end
 end

--- a/spec/factories/computacenter/raw_orders.rb
+++ b/spec/factories/computacenter/raw_orders.rb
@@ -1,17 +1,17 @@
 FactoryBot.define do
   factory :computacenter_raw_order, class: 'Computacenter::RawOrder' do
-    source { 'Wave 1' }
+    source { "Wave #{Faker::Number.unique.number(digits: 1)}" }
     responsible_body { 'East Sussex' }
     urn_cc { 'SC845' }
     category { 'Social care' }
-    sold_to_account_no { '81000001' }
+    sold_to_account_no { "81#{Faker::Number.unique.number(digits: 6)}" }
     sold_to_customer { 'East Sussex Social Care' }
     ship_to_urn { '845' }
-    ship_to_account_no { '81000002' }
+    ship_to_account_no { "81#{Faker::Number.unique.number(digits: 6)}" }
     ship_to_customer { '845 East Sussex Social Care' }
-    sales_order_number { '5000000001' }
+    sales_order_number { "5#{Faker::Number.unique.number(digits: 9)}" }
     persona_cleaned { 'Chrome laptop' }
-    material_number { '4100001' }
+    material_number { "41#{Faker::Number.unique.number(digits: 5)}" }
     material_description { ':DFE:Dell Chrmbk3100 CelN4000 4/16 11 DD' }
     manufacturer_cleaned { 'DELL Technologies' }
     quantity_ordered { '1' }
@@ -21,7 +21,7 @@ FactoryBot.define do
     despatch_date { '5/18/2020' }
     order_completed { 'TRUE' }
     is_return { 'FALSE' }
-    customer_order_number { 'HYB-80000001' }
+    customer_order_number { "HYB-8#{Faker::Number.unique.number(digits: 7)}" }
     processed_at { nil }
 
     trait :processed do

--- a/spec/factories/responsible_bodies.rb
+++ b/spec/factories/responsible_bodies.rb
@@ -71,6 +71,17 @@ FactoryBot.define do
         responsible_body.reload
       end
     end
+
+    trait :with_orders do
+      transient do
+        orders_count { 3 }
+      end
+
+      after(:create) do |trust, evaluator|
+        create_list(:computacenter_order, evaluator.orders_count, sold_to: trust.computacenter_reference)
+        trust.reload
+      end
+    end
   end
 
   factory :local_authority, parent: :responsible_body, class: 'LocalAuthority' do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -120,5 +120,16 @@ FactoryBot.define do
         school.reload
       end
     end
+
+    trait :with_orders do
+      transient do
+        orders_count { 2 }
+      end
+
+      after(:create) do |school, evaluator|
+        create_list(:computacenter_order, evaluator.orders_count, ship_to: school.computacenter_reference)
+        school.reload
+      end
+    end
   end
 end

--- a/spec/features/orders/index_spec.rb
+++ b/spec/features/orders/index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'List orders' do
+  let(:user) { create(:trust_user) }
+  let!(:order) { create(:computacenter_order, sold_to: user.responsible_body.computacenter_reference) }
+
+  scenario 'non logged-in users required sign in' do
+    visit orders_path
+
+    expect(page).to have_content('Sign in')
+  end
+
+  scenario 'logged-in users can see a list of their orders' do
+    sign_in_as user
+    visit orders_path
+
+    expect(page).to have_content(order.customer_order_number)
+  end
+end

--- a/spec/models/computacenter/raw_order_map_spec.rb
+++ b/spec/models/computacenter/raw_order_map_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Computacenter::RawOrderMap, type: :model do
       raw_order_map.persist!
       expect(raw_order_map.order).to have_attributes(
         source: raw_order.source,
-        sold_to: raw_order.sold_to_account_no.to_i,
-        ship_to: raw_order.ship_to_account_no.to_i,
+        sold_to: raw_order.sold_to_account_no,
+        ship_to: raw_order.ship_to_account_no,
         sales_order_number: raw_order.sales_order_number.to_i,
         persona: raw_order.persona_cleaned,
         material_number: raw_order.material_number.to_i,
@@ -42,8 +42,8 @@ RSpec.describe Computacenter::RawOrderMap, type: :model do
       raw_order_map.persist!
       expect(raw_order_map.order).to have_attributes(
         source: raw_order.source,
-        sold_to: raw_order.sold_to_account_no.to_i,
-        ship_to: raw_order.ship_to_account_no.to_i,
+        sold_to: raw_order.sold_to_account_no,
+        ship_to: raw_order.ship_to_account_no,
         sales_order_number: raw_order.sales_order_number.to_i,
         persona: raw_order.persona_cleaned,
         material_number: raw_order.material_number.to_i,

--- a/spec/models/responsible_body_spec.rb
+++ b/spec/models/responsible_body_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe ResponsibleBody, type: :model do
     stub_computacenter_outgoing_api_calls
   end
 
+  describe '#orders' do
+    it 'returns an empty array if the responsible body has no orders' do
+      responsible_body = create(:local_authority)
+      expect(responsible_body.orders).to eq([])
+    end
+
+    it 'returns the orders for the responsible body' do
+      responsible_body = create(:local_authority, :with_orders, orders_count: 2)
+      expect(responsible_body.orders.count).to eq(2)
+    end
+
+    it 'returns the orders for the responsible body\'s schools' do
+      responsible_body = create(:local_authority)
+      create(:school, :with_orders, orders_count: 2, responsible_body:)
+      expect(responsible_body.orders.count).to eq(2)
+    end
+
+    it 'returns the orders for the responsible body and the responsible body\'s schools' do
+      responsible_body = create(:local_authority, :with_orders, orders_count: 2)
+      create(:school, :with_orders, orders_count: 2, responsible_body:)
+      expect(responsible_body.orders.count).to eq(4)
+    end
+  end
+
   describe '#active_schools' do
     let!(:schools) { create(:school, responsible_body:) }
     let(:closed_schools) { create(:school, status: 'closed', responsible_body:) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,6 +65,60 @@ RSpec.describe User, type: :model, with_feature_flags: { notify_cc_about_user_ch
       end
     end
 
+    describe '#orders' do
+      it 'returns an empty array if the user has no schools or responsible body' do
+        user = build(:user, school: nil, responsible_body: nil)
+        expect(user.orders).to eq([])
+      end
+
+      it 'returns an empty array if the user has no schools that have orders' do
+        user = create(:user, schools: [create(:school)])
+        expect(user.orders).to eq([])
+      end
+
+      it 'returns the orders for the user\'s schools' do
+        user = create(:user, schools: [create(:school, :with_orders), create(:school, :with_orders)])
+        expect(user.orders).to eq(user.schools.map(&:orders).flatten)
+      end
+
+      it 'returns the orders for the user\'s responsible body' do
+        user = create(:user, responsible_body: create(:trust, :with_orders))
+        expect(user.orders).to eq(user.responsible_body.orders)
+      end
+
+      it 'returns an empty array if the responsible body has no orders' do
+        user = create(:user, responsible_body: create(:trust))
+        expect(user.orders).to eq([])
+      end
+
+      it 'returns the orders for the user\'s schools and the orders for the user\'s responsible_body' do
+        user = create(:user, schools: [create(:school, :with_orders)], responsible_body: create(:trust, :with_orders))
+        expect(user.orders.count).to eq(user.schools.map(&:orders).flatten.count + user.responsible_body.orders.count)
+      end
+    end
+
+    describe '#schools_orders' do
+      it 'returns an empty array if the user has no schools' do
+        user = build(:user, school: nil)
+        expect(user.schools_orders).to eq([])
+      end
+
+      it 'returns an empty array if the user has no schools that have orders' do
+        user = create(:user, schools: [create(:school)])
+        expect(user.schools_orders).to eq([])
+      end
+
+      it 'returns the orders for the user\'s schools' do
+        user = create(:user, schools: [create(:school, :with_orders), create(:school, :with_orders)])
+        expect(user.schools_orders).to eq(user.schools.map(&:orders).flatten)
+      end
+
+      it 'returns the orders for the user\'s school, but not the orders from the user\'s responsible body' do
+        user = create(:user, school: create(:school, :with_orders), responsible_body: create(:trust, :with_orders))
+        expect(user.schools_orders).to eq(user.school.orders)
+      end
+    end
+
     context 'when the user has a responsible_body and one school' do
       let(:school) { create(:school, :academy, responsible_body:) }
       let(:user) { create(:trust_user, schools: [school], responsible_body:, orders_devices: true) }

--- a/spec/policies/computacenter/order_policy_spec.rb
+++ b/spec/policies/computacenter/order_policy_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe Computacenter::OrderPolicy do
+  let!(:orders) { create_list(:computacenter_order, 2) }
+  let(:scope) { Pundit.policy_scope!(current_user, Computacenter::Order) }
+
+  describe 'scope' do
+    context 'when user is a support user' do
+      let(:current_user) { build(:support_user) }
+
+      it 'returns all orders' do
+        expect(scope).to match_array(orders)
+      end
+    end
+
+    context 'when user is a computacenter user' do
+      let(:current_user) { build(:computacenter_user) }
+
+      it 'returns all orders' do
+        expect(scope).to match_array(orders)
+      end
+    end
+
+    context 'when user is a local authority user and the local authority has no orders' do
+      let(:current_user) { build(:local_authority_user) }
+
+      it 'returns no orders' do
+        expect(scope).to be_empty
+      end
+    end
+
+    context 'when user is a local authority user and the local authority has orders' do
+      let(:current_user) { local_authority_user }
+      let(:local_authority) { local_authority_user.rb }
+      let!(:local_authority_order) { create(:computacenter_order, sold_to: local_authority.computacenter_reference) }
+      let(:local_authority_user) { create(:local_authority_user) }
+
+      it 'returns only the local authority orders' do
+        expect(scope).to match_array(local_authority_order)
+      end
+    end
+
+    context 'when user is a school user and the school has no orders' do
+      let(:current_user) { build(:school_user) }
+
+      it 'returns no orders' do
+        expect(scope).to be_empty
+      end
+    end
+
+    context 'when user is a school user and the school has orders' do
+      let(:current_user) { school_user }
+      let(:school) { school_user.school }
+      let!(:school_order) { create(:computacenter_order, ship_to: school.computacenter_reference) }
+      let(:school_user) { create(:school_user) }
+
+      it 'returns only the school orders' do
+        expect(scope).to match_array(school_order)
+      end
+    end
+  end
+end

--- a/spec/services/computacenter/convert_raw_orders_service_spec.rb
+++ b/spec/services/computacenter/convert_raw_orders_service_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Computacenter::ConvertRawOrdersService do
         service.call
         expect(raw_order.order).to have_attributes(
           source: raw_order.source,
-          sold_to: raw_order.sold_to_account_no.to_i,
-          ship_to: raw_order.ship_to_account_no.to_i,
+          sold_to: raw_order.sold_to_account_no,
+          ship_to: raw_order.ship_to_account_no,
           sales_order_number: raw_order.sales_order_number.to_i,
           persona: raw_order.persona_cleaned,
           material_number: raw_order.material_number.to_i,

--- a/spec/services/computacenter/export_orders_to_file_service_spec.rb
+++ b/spec/services/computacenter/export_orders_to_file_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Computacenter::ExportOrdersToFileService do
+  describe '#call' do
+    let(:csv) { CSV.read(filename, headers: true) }
+    let(:expected_headers) { Computacenter::OrderReport.headers }
+    let(:filename) { Rails.root.join('tmp/computacenter_export_orders_test_data.csv') }
+    let(:orders) { create_list(:computacenter_order, 2) }
+    let(:order_ids) { orders.map(&:id) }
+    let(:order_csv_row) { csv.first }
+    let(:service) { described_class.new(filename, order_ids:) }
+
+    after do
+      remove_file(filename)
+    end
+
+    context 'when given a filename' do
+      before do
+        service.call
+      end
+
+      it 'creates a CSV file' do
+        expect(File.exist?(filename)).to be true
+      end
+
+      it 'includes a heading row and all orders in the CSV file' do
+        line_count = `wc -l "#{filename}"`.split.first.to_i
+        expect(line_count).to eq(orders.count + 1)
+      end
+
+      it 'includes the correct headers' do
+        expect(csv.headers).to match_array(expected_headers)
+      end
+    end
+
+    context 'when orders are in scope' do
+      let(:order) { orders.first }
+      let(:orders) { create_list(:computacenter_order, 1) }
+
+      before do
+        service.call
+      end
+
+      it 'displays "customer_order_number" in the "order_number" column' do
+        expect(order_csv_row['order_number']).to eq(order.customer_order_number)
+      end
+
+      it 'has a order_date value equal to the order order_date' do
+        expect(order_csv_row['order_date']).to eq(order.order_date.to_s)
+      end
+
+      it 'has a quantity value equal to the order quantity_ordered' do
+        expect(order_csv_row['quantity']).to eq(order.quantity_ordered.to_s)
+      end
+
+      it 'has a device_type value equal to the order persona' do
+        expect(order_csv_row['device_type']).to eq(order.persona)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Users should be able to view and download orders associated with the schools and responsible bodies that they manage.

### Changes proposed in this pull request

Add a view to expose orders for a users related schools and responsible bodies.

### Guidance to review

check `/orders`

![image](https://user-images.githubusercontent.com/420873/167782059-f08271b1-8757-4c62-bbfd-c33d96081d60.png)


