### PR TITLE
Limit order index to exclude returns

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,7 +3,7 @@ class OrdersController < ApplicationController
 
   def index
     @title = 'Order history'
-    all_orders = policy_scope(Computacenter::Order).order(order_date: :desc)
+    all_orders = policy_scope(Computacenter::Order).is_not_return.order(order_date: :desc)
     @pagination, @orders = pagy(all_orders)
 
     respond_to do |format|

--- a/app/models/computacenter/order.rb
+++ b/app/models/computacenter/order.rb
@@ -14,4 +14,7 @@ class Computacenter::Order < ApplicationRecord
              foreign_key: :sold_to,
              inverse_of: :rb_orders,
              optional: true
+
+  scope :is_return, -> { where(is_return: true) }
+  scope :is_not_return, -> { where(is_return: false) }
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -21,6 +21,10 @@
     <p class="govuk-body">
       View and download the order history for organisations that you manage.
     </p>
+    <p class="govuk-body">
+      Device serial number information, including passwords for resetting DfE-Restricted Windows devices, can be found in the
+      <%= link_to 'asset search tool', assets_path %>.
+    </p>
   </div>
 </div>
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe OrdersController do
         expect(assigns(:orders)).to contain_exactly(*orders)
         expect(response).to render_template(:index)
       end
+
+      context 'valid orders' do
+        let!(:return_orders) { create_list(:computacenter_order, 2, is_return: true) }
+
+        it 'does not show returns' do
+          get :index
+          expect(assigns(:orders)).not_to include(*return_orders)
+        end
+      end
     end
 
     context 'computacenter user' do

--- a/spec/models/computacenter/order_spec.rb
+++ b/spec/models/computacenter/order_spec.rb
@@ -1,9 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Computacenter::Order, type: :model do
-  let(:order) { build_stubbed(:computacenter_order) }
-
   it 'returns an Order' do
+    let(:order) { build_stubbed(:computacenter_order) }
+
     expect(order).to be_a(described_class)
+  end
+
+  describe '.is_return' do
+    it 'returns orders that are returns' do
+      order = create(:computacenter_order, is_return: true)
+
+      expect(described_class.is_return).to include(order)
+    end
+
+    it 'returns orders that are not returns' do
+      order = create(:computacenter_order, is_return: false)
+
+      expect(described_class.is_not_return).to include(order)
+    end
+  end
+
+  describe '.is_not_return' do
+    it 'returns orders that are not returns' do
+      order = create(:computacenter_order, is_return: false)
+
+      expect(described_class.is_not_return).to include(order)
+    end
+
+    it 'returns orders that are returns' do
+      order = create(:computacenter_order, is_return: true)
+
+      expect(described_class.is_return).to include(order)
+    end
   end
 end

--- a/spec/models/computacenter/order_spec.rb
+++ b/spec/models/computacenter/order_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Computacenter::Order, type: :model do
-  it 'returns an Order' do
-    let(:order) { build_stubbed(:computacenter_order) }
+  let(:order) { build_stubbed(:computacenter_order) }
 
+  it 'returns an Order' do
     expect(order).to be_a(described_class)
   end
 


### PR DESCRIPTION
### Context

The `/orders` index should not show returns.

### Changes proposed in this pull request

Add a scope `is_not_return` to the `Order` model and apply it in the Orders controller.

### Guidance to review

Check the `/orders` page as admin and ensure returns are not listed. Returns will typically have negative quantity values.