### PR TITLE
Scope orders to impersonated user

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,7 +3,8 @@ class OrdersController < ApplicationController
 
   def index
     @title = 'Order history'
-    all_orders = policy_scope(Computacenter::Order).is_not_return.order(order_date: :desc)
+    policy_scope = Computacenter::OrderPolicy::Scope.new(impersonated_or_current_user, Computacenter::Order).resolve
+    all_orders = policy_scope.is_not_return.order(order_date: :desc)
     @pagination, @orders = pagy(all_orders)
 
     respond_to do |format|

--- a/app/policies/computacenter/order_policy.rb
+++ b/app/policies/computacenter/order_policy.rb
@@ -5,7 +5,9 @@ class Computacenter::OrderPolicy < ApplicationPolicy
 
       return scope.all if user.is_support? || user.is_computacenter?
 
-      scope.where(id: user.orders.pluck(:id))
+      return scope.where(id: user.orders.pluck(:id)) if user.rb_level_access?
+
+      scope.where(id: user.schools_orders.pluck(:id))
     end
   end
 end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OrdersController do
 
     context 'RB A' do
       let(:rb_a) { create(:local_authority, :with_orders) }
-      let(:rb_a_user) { create(:local_authority_user, responsible_body: rb_a) }
+      let(:rb_a_user) { create(:local_authority_user, responsible_body: rb_a, rb_level_access: true) }
 
       before { sign_in_as rb_a_user }
 

--- a/spec/features/orders/index_spec.rb
+++ b/spec/features/orders/index_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'List orders' do
-  let(:user) { create(:trust_user) }
+  let(:user) { create(:local_authority_user, rb_level_access: true) }
   let!(:order) { create(:computacenter_order, sold_to: user.responsible_body.computacenter_reference) }
 
   scenario 'non logged-in users required sign in' do

--- a/spec/policies/computacenter/order_policy_spec.rb
+++ b/spec/policies/computacenter/order_policy_spec.rb
@@ -33,7 +33,7 @@ describe Computacenter::OrderPolicy do
       let(:current_user) { local_authority_user }
       let(:local_authority) { local_authority_user.rb }
       let!(:local_authority_order) { create(:computacenter_order, sold_to: local_authority.computacenter_reference) }
-      let(:local_authority_user) { create(:local_authority_user) }
+      let(:local_authority_user) { create(:local_authority_user, rb_level_access: true) }
 
       it 'returns only the local authority orders' do
         expect(scope).to match_array(local_authority_order)


### PR DESCRIPTION
### Context

Support users should be able to view the correct subset of orders whilst impersonating

### Changes proposed in this pull request

Add the impersonated user to the scope in the Orders controller

### Guidance to review

Impersonate a user and visit `/orders`