### PR TITLE
Use quantity completed instead of ordered

### DIFF
--- a/app/models/computacenter/order_report.rb
+++ b/app/models/computacenter/order_report.rb
@@ -2,7 +2,7 @@ class Computacenter::OrderReport < TemplateClassCsv
   def self.headers
     %w[order_number
        order_date
-       quantity
+       quantity_completed
        device_type]
   end
 
@@ -25,7 +25,7 @@ private
   def csv_row(order)
     [order.customer_order_number,
      order.order_date,
-     order.quantity_ordered,
+     order.quantity_completed,
      order.persona]
   end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -55,7 +55,7 @@
   <tr class="govuk-table__row">
     <th class="govuk-table__header app-schools-table__column-30">Order number</th>
     <th class="govuk-table__header app-schools-table__column-20">Order date</th>
-    <th class="govuk-table__header app-schools-table__column-20">Devices ordered</th>
+    <th class="govuk-table__header app-schools-table__column-20">Devices delivered</th>
     <th class="govuk-table__header app-schools-table__column-30">Device type</th>
   </tr>
   </thead>
@@ -64,7 +64,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= order.customer_order_number %></td>
       <td class="govuk-table__cell"><%= order.order_date %></td>
-      <td class="govuk-table__cell"><%= order.quantity_ordered %></td>
+      <td class="govuk-table__cell"><%= order.quantity_completed %></td>
       <td class="govuk-table__cell"><%= order.persona %></td>
     </tr>
   <% end %>

--- a/spec/services/computacenter/export_orders_to_file_service_spec.rb
+++ b/spec/services/computacenter/export_orders_to_file_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Computacenter::ExportOrdersToFileService do
       end
 
       it 'has a quantity value equal to the order quantity_ordered' do
-        expect(order_csv_row['quantity']).to eq(order.quantity_ordered.to_s)
+        expect(order_csv_row['quantity_completed']).to eq(order.quantity_completed.to_s)
       end
 
       it 'has a device_type value equal to the order persona' do


### PR DESCRIPTION
### Context

Use quantity completed instead of ordered in the orders view and export

### Changes proposed in this pull request

Add `quantity_completed` as the preferred value when dealing with quantities for the orders view and export.

### Guidance to review

Orders view should now have the heading `Devices delivered`