### PR TITLE
add weights to sidekiq queues to make them all be served in parallel.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,9 @@
 :concurrency: 2
 :logfile: ./log/sidekiq.log
 :queues:
-  - default
-  - mailers
-  - scheduler
+  - [default, 50]
+  - [mailers, 250]
+  - [scheduler, 1]
 :schedule:
   UpdateRemainingDevicesJob:
     cron: '55 23 * * * Europe/London'  # every day at 11:55pm


### PR DESCRIPTION
### Context
Currently `default` queue in sidekiq has top priority and no job in the rest of queues will be executed until it is fully empty. Similarly the `mailer` queue has full priority over `scheduler`: hierarchical definition.

This makes sometimes the `mailer` queue to acummulate thousands of pending emails and the `scheduler` queue to acummulate pending repetitive scheduled jobs.
 
Better make them all be served in parallel with weighted priorities.

### Changes proposed in this pull request

### Guidance to review

