### PR TITLE
2900 publish banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ GHWT__DATABASE_FIELD_ENCRYPTION__KEY              | Secret key for the encrytion
 GHWT__DATABASE_FIELD_ENCRYPTION__SALT             | Salt for the encryption field in the assets table                                                                                          | REQUIRED
 GHWT__SLUG_CHECKSUM_SECRET                        | A secret for hashing a checksum for IDs in the URL                                                                                         | REQUIRED
 GHWT__API_TOKEN_TTL                               | TTL in days after which API Tokens CC use will expire from creation date                                                                   | 90
-GHWT__SITE_BANNER_MESSAGE                         | Banner message text to appear at the top of all pages of the site                                                                          | (nil)
+GHWT__SITE_BANNER_MESSAGE                         | Banner message text to appear at the top of all pages of the site (has higher precence than the long form banner feature flag)             | (nil)
+GHWT__LONG_FORM_SITE_BANNER_MESSAGE_FLAG          | Boolean value, when true, displays the long form banner message text to appear at the top of all pages of the site from somefile.md        | false
+GHWT__LONG_FORM_SITE_BANNER_MESSAGE_PARTIAL       | Path to the markdown partial file containing the long form site banner message. Default resolves to site_banner/_long_form.md              | site_banner/long_form
 
 See the [settings.yaml file](config/settings.yml) for full details on configurable options.
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ GHWT__DATABASE_FIELD_ENCRYPTION__KEY              | Secret key for the encrytion
 GHWT__DATABASE_FIELD_ENCRYPTION__SALT             | Salt for the encryption field in the assets table                                                                                          | REQUIRED
 GHWT__SLUG_CHECKSUM_SECRET                        | A secret for hashing a checksum for IDs in the URL                                                                                         | REQUIRED
 GHWT__API_TOKEN_TTL                               | TTL in days after which API Tokens CC use will expire from creation date                                                                   | 90
-GHWT__SITE_BANNER_MESSAGE                         | Banner message text to appear at the top of all pages of the site (has higher precence than the long form banner feature flag)             | (nil)
+GHWT__SITE_BANNER_MESSAGE                         | Banner message text to appear at the top of all pages of the site                                                                          | (nil)
 GHWT__LONG_FORM_SITE_BANNER_MESSAGE_FLAG          | Boolean value, when true, displays the long form banner message text to appear at the top of all pages of the site from somefile.md        | false
 GHWT__LONG_FORM_SITE_BANNER_MESSAGE_PARTIAL       | Path to the markdown partial file containing the long form site banner message. Default resolves to site_banner/_long_form.md              | site_banner/long_form
 

--- a/app/components/site_banner_info_component.html.erb
+++ b/app/components/site_banner_info_component.html.erb
@@ -1,0 +1,12 @@
+<% if @message_partial %>
+  <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Important
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content" id="site-info-banner-content">
+      <%= render partial: @message_partial, as: :page %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/site_banner_info_component.rb
+++ b/app/components/site_banner_info_component.rb
@@ -1,0 +1,5 @@
+class SiteBannerInfoComponent < ViewComponent::Base
+  def initialize
+    @message_partial = Site.long_form_banner_message_flag? ? Site.long_form_site_banner_message_partial : nil
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,6 +2,14 @@
 
 class Site
   def self.banner_message
-    @banner_message ||= Settings.site_banner_message.presence
+    @short_form_banner_message ||= Settings.site_banner_message.presence
+  end
+
+  def self.long_form_banner_message_flag?
+    ActiveModel::Type::Boolean.new.cast(Settings.long_form_site_banner_message_flag&.to_s&.downcase) || false
+  end
+
+  def self.long_form_site_banner_message_partial
+    Settings.long_form_site_banner_message_partial
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,6 +82,15 @@
           </div>
         </div>
       <% end %>
+      <% if Site.long_form_banner_message_flag? %>
+        <div class="govuk-width-container">
+          <div class="govuk-grid-row" id="site-banner-info">
+            <div class="govuk-grid-column-full">
+              <%= render(SiteBannerInfoComponent.new) %>
+            </div>
+          </div>
+        </div>
+      <% end %>
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
         <% if impersonated_user %>

--- a/app/views/site_banner/_long_form.md
+++ b/app/views/site_banner/_long_form.md
@@ -1,0 +1,9 @@
+### TechSource
+
+From 31 May 2022, you will no longer be able to access TechSource.
+
+### Get help with technology
+
+Access to the Get help with technology service website will close on 23 June 2022.
+
+If you ordered DfE-restricted devices, you must download your BIOS/Admin data before 23 June 2022.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,6 +93,8 @@ service_name_suffix:
 sign_in_token_ttl_seconds: 1800
 
 site_banner_message:
+long_form_site_banner_message_flag:
+long_form_site_banner_message_partial: site_banner/long_form
 
 # how long CDNs and browsers should cache static assets for in production, in seconds.
 static_file_cache_ttl:

--- a/spec/features/site_banner_info_spec.rb
+++ b/spec/features/site_banner_info_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Site Info Banner', type: :feature do
+  context 'Default no site info banner message text present' do
+    before do
+      allow(Site).to receive(:long_form_banner_message_flag?).and_return(false)
+    end
+
+    scenario 'User cannot see the site info banner on the home page' do
+      visit root_path
+      expect(page).to have_no_css('#site-info-banner-content')
+    end
+  end
+
+  context 'Site info banner message text present' do
+    before do
+      allow(Site).to receive(:long_form_banner_message_flag?).and_return(true)
+    end
+
+    scenario 'User can see the site info banner on the home page' do
+      visit root_path
+      expect(page).to have_css('#site-info-banner-content')
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Site, type: :model do
+  describe '#banner_message' do
+    context 'default no site banner message text present' do
+      it 'returns the banner message from the settings' do
+        allow(Settings).to receive(:site_banner_message).and_return(nil)
+        expect(Site.banner_message).to eq(nil)
+      end
+    end
+
+    context 'site banner message text present' do
+      it 'returns the banner message from the settings' do
+        allow(Settings).to receive(:site_banner_message).and_return('This is a test short form banner message')
+        expect(Site.banner_message).to eq('This is a test short form banner message')
+      end
+    end
+  end
+
+  describe '#long_form_banner_message_flag?' do
+    it 'returns the long form banner message flag from the settings when "False"' do
+      allow(Settings).to receive(:long_form_site_banner_message_flag).and_return('False')
+      expect(Site.long_form_banner_message_flag?).to eq(false)
+    end
+
+    it 'returns the long form banner message flag from the settings when "0"' do
+      allow(Settings).to receive(:long_form_site_banner_message_flag).and_return('0')
+      expect(Site.long_form_banner_message_flag?).to eq(false)
+    end
+
+    it 'returns the long form banner message flag from the settings when "True"' do
+      allow(Settings).to receive(:long_form_site_banner_message_flag).and_return('True')
+      expect(Site.long_form_banner_message_flag?).to eq(true)
+    end
+
+    it 'returns the long form banner message flag from the settings when "1"' do
+      allow(Settings).to receive(:long_form_site_banner_message_flag).and_return('1')
+      expect(Site.long_form_banner_message_flag?).to eq(true)
+    end
+
+    it 'returns the long form banner message flag from the settings when "nil"' do
+      allow(Settings).to receive(:long_form_site_banner_message_flag).and_return(nil)
+      expect(Site.long_form_banner_message_flag?).to eq(false)
+    end
+  end
+
+  describe '#long_form_site_banner_message_partial' do
+    it 'returns the long form banner message partial' do
+      allow(Settings).to receive(:long_form_site_banner_message_partial).and_return('site_banner/long_form')
+      expect(Site.long_form_site_banner_message_partial).to eq('site_banner/long_form')
+    end
+  end
+end


### PR DESCRIPTION
### Context

A site wide header banner is required to share detailed and important information relating to service closure.

### Changes proposed in this pull request

Added the `SiteBannerInfoComponent` to be displayed on all pages.

Quirks:

1. The partial used for the message can be changed using an environment variable in case fast switching is required.
2. `Site.long_form_site_banner_message_partial` is used to expose `Settings.long_form_site_banner_message_partial`. Even though it feels redundant, it did not feel correct to use `Settings` directly in the ViewComponent.

### Guidance to review

Locally start the rails server:

`GHWT__LONG_FORM_SITE_BANNER_MESSAGE_FLAG=true bundle exec rails s`

Ensure that the info banner is displayed.

![image](https://user-images.githubusercontent.com/420873/170058541-35d8a0fb-a7b4-4f9f-9c33-a299103eaff2.png)

