### PR TITLE
deliver login emails with top priority

### DIFF
--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -13,7 +13,7 @@ class SessionService
     if (user = find_user_by_lowercase_email(email_address))
       user.generate_token!
       logger.debug "found user #{user.id} - #{user.email_address}, granted token #{user.sign_in_token}"
-      SignInTokenMailer.with(user:).sign_in_token_email.deliver_later
+      SignInTokenMailer.with(user:).sign_in_token_email.deliver_later(queue: :login)
       user.sign_in_token
     else
       # silently ignore an incorrect email, to avoid inadvertently

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,9 @@
 :concurrency: 2
 :logfile: ./log/sidekiq.log
 :queues:
+  - login
   - [default, 50]
-  - [mailers, 250]
+  - [mailers, 500]
   - [scheduler, 1]
 :schedule:
   UpdateRemainingDevicesJob:


### PR DESCRIPTION
### Context
  emails with links for users to log into the system are sometimes delayed or stuck if heavy jobs are running in all the background workers

### Changes proposed in this pull request
  Create a top priority queue named :login and enqueue all login email jobs in that queue so a login link email will always be delivered first when a worker becomes free.


### Guidance to review

