### PR TITLE
add high weight to login queue to prioritize login emails

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,7 @@
 :concurrency: 2
 :logfile: ./log/sidekiq.log
 :queues:
-  - login
+  - [login, 10000]
   - [default, 50]
   - [mailers, 500]
   - [scheduler, 1]


### PR DESCRIPTION
### Context
  As it is now the login queue still don´t have top priority. 
  We need to add high weight or dedicate a worker exclusively to their jobs.

### Changes proposed in this pull request
   Add very hight weight to login queue

### Guidance to review

