### PR TITLE
Add school name column to orders view and export

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,7 +4,7 @@ class OrdersController < ApplicationController
   def index
     @title = 'Order history'
     policy_scope = Computacenter::OrderPolicy::Scope.new(impersonated_or_current_user, Computacenter::Order).resolve
-    all_orders = policy_scope.is_not_return.order(order_date: :desc)
+    all_orders = policy_scope.is_not_return.order(order_date: :desc).includes(:school)
     @pagination, @orders = pagy(all_orders)
 
     respond_to do |format|

--- a/app/models/computacenter/order.rb
+++ b/app/models/computacenter/order.rb
@@ -17,4 +17,6 @@ class Computacenter::Order < ApplicationRecord
 
   scope :is_return, -> { where(is_return: true) }
   scope :is_not_return, -> { where(is_return: false) }
+
+  delegate :name, to: :school, prefix: true, allow_nil: true
 end

--- a/app/models/computacenter/order_report.rb
+++ b/app/models/computacenter/order_report.rb
@@ -3,7 +3,8 @@ class Computacenter::OrderReport < TemplateClassCsv
     %w[order_number
        order_date
        quantity_completed
-       device_type]
+       device_type
+       school_name]
   end
 
 private
@@ -26,6 +27,7 @@ private
     [order.customer_order_number,
      order.order_date,
      order.quantity_completed,
-     order.persona]
+     order.persona,
+     order.school_name]
   end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -53,10 +53,11 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-    <th class="govuk-table__header app-schools-table__column-30">Order number</th>
-    <th class="govuk-table__header app-schools-table__column-20">Order date</th>
-    <th class="govuk-table__header app-schools-table__column-20">Devices delivered</th>
-    <th class="govuk-table__header app-schools-table__column-30">Device type</th>
+    <th class="govuk-table__header">Order number</th>
+    <th class="govuk-table__header">Order date</th>
+    <th class="govuk-table__header">Devices delivered</th>
+    <th class="govuk-table__header govuk-!-width-one-quarter">Device type</th>
+    <th class="govuk-table__header govuk-!-width-one-third">School name</th>
   </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -66,6 +67,7 @@
       <td class="govuk-table__cell"><%= order.order_date %></td>
       <td class="govuk-table__cell"><%= order.quantity_completed %></td>
       <td class="govuk-table__cell"><%= order.persona %></td>
+      <td class="govuk-table__cell"><%= order.school_name %></td>
     </tr>
   <% end %>
   </tbody>

--- a/spec/services/computacenter/export_orders_to_file_service_spec.rb
+++ b/spec/services/computacenter/export_orders_to_file_service_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Computacenter::ExportOrdersToFileService do
       it 'has a device_type value equal to the order persona' do
         expect(order_csv_row['device_type']).to eq(order.persona)
       end
+
+      it 'has a school_name value equal to the order school_name' do
+        expect(order_csv_row['school_name']).to eq(order.school_name)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Rb users were contacting support asking about which orders were for which schools.

### Changes proposed in this pull request

Add a school name column to the view and the export for `orders`.

### Guidance to review

Check that the school name column is present.

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/420873/170285649-f65e938c-b675-416e-a361-cd2747e417dd.png">

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/420873/170285923-05857031-77b8-4669-b077-b1b3a0f74972.png">
