### PR TITLE
Update rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-proxy (0.7.2)


### PR DESCRIPTION
### Context

Brakeman was failing specs due to a CVE for rack

### Changes proposed in this pull request

`bundle update rack` to update the rack version to a version that satisfies brakeman.

### Guidance to review

Check the Gemfile.lock for minimum version of rack 2.2.3.1 and see that GH tests pass.